### PR TITLE
feat(stacks): Add Portainer container management

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@
 ![OpenTofu](https://img.shields.io/badge/OpenTofu-FFDA18?logo=opentofu&logoColor=black)
 ![Hetzner](https://img.shields.io/badge/Hetzner-D50C2D?logo=hetzner&logoColor=white)
 
+**Available Stacks:**
+![IT-Tools](https://img.shields.io/badge/IT--Tools-5D5D5D?logo=homeassistant&logoColor=white)
+![Excalidraw](https://img.shields.io/badge/Excalidraw-6965DB?logo=excalidraw&logoColor=white)
+![Portainer](https://img.shields.io/badge/Portainer-13BEF9?logo=portainer&logoColor=white)
+
 🚀 **One-command deployment: Hetzner server + Cloudflare Tunnel + Docker - fully automated.**
 
 > ⚠️ **Disclaimer:** This project was developed and tested on macOS. Use at your own risk. While care has been taken to ensure security, you are responsible for reviewing the code and understanding what it does before running it.
@@ -76,6 +81,16 @@ Create a Custom Token with these permissions:
 - **Zone → DNS → Edit**
 - **Account → Cloudflare Tunnel → Edit**
 - **Account → Access: Apps and Policies → Edit**
+
+## Available Stacks
+
+| Stack | Description | Website |
+|-------|-------------|---------||
+| **IT-Tools** | Collection of handy online tools for developers | [it-tools.tech](https://it-tools.tech) |
+| **Excalidraw** | Virtual whiteboard for sketching hand-drawn diagrams | [excalidraw.com](https://excalidraw.com) |
+| **Portainer** | Docker container management UI | [portainer.io](https://www.portainer.io) |
+
+All stacks are pre-configured and ready to deploy. Just enable them in `config.tfvars`.
 
 ## Commands
 

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -63,15 +63,24 @@ ssh-keygen -t ed25519 -C "nexus"
 
 1. Go to **My Profile** → **API Tokens**
 2. Click **"Create Token"**
-3. Use template: **"Edit zone DNS"**
-4. Permissions:
-   - Zone → DNS → Edit
-   - Zone → Zone → Read
-   - Account → Cloudflare Tunnel → Edit
-   - Account → Access: Apps and Policies → Edit
-5. Zone Resources: Include → Specific Zone → Your domain
-6. Click **"Continue to summary"** → **"Create Token"**
-7. **Copy the token!**
+3. Use template: **"Create Custom Token"**
+4. Token name: `nexus-stack`
+5. **Permissions:**
+
+   | Scope | Resource | Permission |
+   |-------|----------|------------|
+   | Account | Cloudflare Tunnel | Edit |
+   | Account | Access: Apps and Policies | Edit |
+   | Account | Access: Organizations, Identity Providers, and Groups | Edit |
+   | Zone | DNS | Edit |
+   | Zone | Zone | Read |
+
+   > **Note:** The "Access: Organizations" permission is required for revoking Zero Trust sessions during `make down`.
+
+6. **Account Resources:** Include → All accounts (or specific)
+7. **Zone Resources:** Include → Specific Zone → Your domain
+8. Click **"Continue to summary"** → **"Create Token"**
+9. **Copy the token!**
 
 ---
 
@@ -81,10 +90,10 @@ ssh-keygen -t ed25519 -C "nexus"
 
 ```bash
 cd tofu
-cp nexus.tfvars.example nexus.tfvars
+cp config.tfvars.example config.tfvars
 ```
 
-### Edit nexus.tfvars
+### Edit config.tfvars
 
 ```hcl
 # Hetzner Cloud

--- a/stacks/portainer/docker-compose.yml
+++ b/stacks/portainer/docker-compose.yml
@@ -1,0 +1,26 @@
+# =============================================================================
+# Portainer - Docker Container Management UI
+# =============================================================================
+# https://www.portainer.io/
+# Provides a web-based UI for managing Docker containers, images, and volumes
+# =============================================================================
+
+services:
+  portainer:
+    image: portainer/portainer-ce:latest
+    container_name: portainer
+    restart: unless-stopped
+    ports:
+      - "9090:9000"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - portainer_data:/data
+    networks:
+      - app-network
+
+volumes:
+  portainer_data:
+
+networks:
+  app-network:
+    external: true

--- a/tofu/config.tfvars.example
+++ b/tofu/config.tfvars.example
@@ -54,6 +54,13 @@ services = {
     port      = 8080
     public    = false    # false = requires login, true = public access
   }
+
+  portainer = {
+    enabled   = true
+    subdomain = "portainer"
+    port      = 9090
+    public    = false    # Docker management should always be protected
+  }
   
   # Example: Add more services like this:
   # excalidraw = {


### PR DESCRIPTION
This pull request introduces Portainer as a new pre-configured stack, improves documentation for available stacks, and updates the setup guide to clarify token permissions and configuration. It also adds a security enhancement to the `make down` process by revoking Cloudflare Zero Trust sessions when tearing down infrastructure.

**Portainer Stack Addition:**
- Added a new Portainer stack with a ready-to-use `docker-compose.yml` for Docker container management, including configuration for volumes, ports, and networks.
- Updated `config.tfvars.example` to include Portainer as a configurable service, with default settings and security notes.

**Documentation Improvements:**
- Updated `README.md` with badges and a new "Available Stacks" section, listing IT-Tools, Excalidraw, and Portainer, along with descriptions and links. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R15-R19) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R85-R94)
- Enhanced setup instructions in `docs/setup-guide.md` to clarify the process for creating a custom Cloudflare API token, specifying the required permissions (including the new permission needed for session revocation), and updating references from `nexus.tfvars` to `config.tfvars`. [[1]](diffhunk://#diff-4fc7e78a455625ec3780f4d7a9d807b461b71cd4ee0c73cf9be551bfa397ec29L66-R83) [[2]](diffhunk://#diff-4fc7e78a455625ec3780f4d7a9d807b461b71cd4ee0c73cf9be551bfa397ec29L84-R96)

**Security and Automation Enhancements:**
- Modified the `Makefile` to automatically revoke Cloudflare Zero Trust sessions for the admin user during the `make down` process, improving security when destroying infrastructure.- Add Portainer docker-compose stack (port 9090)
- Add Portainer to config.tfvars.example
- Add session revocation on make down
- Update setup-guide with complete API token permissions
- Add Available Stacks section with badges to README
