### PR TITLE
feat(stacks): Add Uptime Kuma monitoring stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,15 +7,10 @@
 ![GitHub pull requests](https://img.shields.io/github/issues-pr/stefanko-ch/Nexus-Stack)
 ![GitHub last commit](https://img.shields.io/github/last-commit/stefanko-ch/Nexus-Stack)
 
-![Docker](https://img.shields.io/badge/Docker-2496ED?logo=docker&logoColor=white)
-![Cloudflare](https://img.shields.io/badge/Cloudflare-F38020?logo=cloudflare&logoColor=white)
 ![OpenTofu](https://img.shields.io/badge/OpenTofu-FFDA18?logo=opentofu&logoColor=black)
 ![Hetzner](https://img.shields.io/badge/Hetzner-D50C2D?logo=hetzner&logoColor=white)
-
-**Available Stacks:**
-![IT-Tools](https://img.shields.io/badge/IT--Tools-5D5D5D?logo=homeassistant&logoColor=white)
-![Excalidraw](https://img.shields.io/badge/Excalidraw-6965DB?logo=excalidraw&logoColor=white)
-![Portainer](https://img.shields.io/badge/Portainer-13BEF9?logo=portainer&logoColor=white)
+![Cloudflare](https://img.shields.io/badge/Cloudflare-F38020?logo=cloudflare&logoColor=white)
+![Docker](https://img.shields.io/badge/Docker-2496ED?logo=docker&logoColor=white)
 
 🚀 **One-command deployment: Hetzner server + Cloudflare Tunnel + Docker - fully automated.**
 
@@ -76,21 +71,25 @@ Edit `tofu/config.tfvars`:
 
 ### Cloudflare API Token Permissions
 
-Create a Custom Token with these permissions:
-- **Zone → Zone → Read**
-- **Zone → DNS → Edit**
-- **Account → Cloudflare Tunnel → Edit**
-- **Account → Access: Apps and Policies → Edit**
+Create a Custom Token. See [docs/setup-guide.md](docs/setup-guide.md#create-api-token) for the complete list of required permissions.
 
 ## Available Stacks
 
+![IT-Tools](https://img.shields.io/badge/IT--Tools-5D5D5D?logo=homeassistant&logoColor=white)
+![Excalidraw](https://img.shields.io/badge/Excalidraw-6965DB?logo=excalidraw&logoColor=white)
+![Portainer](https://img.shields.io/badge/Portainer-13BEF9?logo=portainer&logoColor=white)
+![Uptime Kuma](https://img.shields.io/badge/Uptime%20Kuma-5CDD8B?logo=uptimekuma&logoColor=white)
+
 | Stack | Description | Website |
-|-------|-------------|---------||
+|-------|-------------|--------|
 | **IT-Tools** | Collection of handy online tools for developers | [it-tools.tech](https://it-tools.tech) |
 | **Excalidraw** | Virtual whiteboard for sketching hand-drawn diagrams | [excalidraw.com](https://excalidraw.com) |
 | **Portainer** | Docker container management UI | [portainer.io](https://www.portainer.io) |
+| **Uptime Kuma** | A fancy self-hosted monitoring tool | [uptime.kuma.pet](https://uptime.kuma.pet) |
 
 All stacks are pre-configured and ready to deploy. Just enable them in `config.tfvars`.
+
+→ See [docs/stacks.md](docs/stacks.md) for detailed stack documentation.
 
 ## Commands
 
@@ -222,12 +221,6 @@ Host nexus
   User root
   ProxyCommand cloudflared access ssh --hostname %h
 ```
-
-## Cost
-
-- **Hetzner CAX11**: ~€3.79/month (ARM, 2 vCPU, 4GB RAM)
-- **Cloudflare**: Free (including Zero Trust for up to 50 users)
-- **Total**: ~€4/month
 
 ## Security
 

--- a/docs/stacks.md
+++ b/docs/stacks.md
@@ -1,0 +1,128 @@
+# 📦 Available Stacks
+
+This document provides detailed information about all available Docker stacks in Nexus-Stack.
+
+---
+
+## IT-Tools
+
+![IT-Tools](https://img.shields.io/badge/IT--Tools-5D5D5D?logo=homeassistant&logoColor=white)
+
+**Collection of handy online tools for developers**
+
+A comprehensive collection of 80+ tools for developers, including:
+- Encoders/Decoders (Base64, URL, JWT, etc.)
+- Converters (JSON ↔ YAML, Unix timestamp, etc.)
+- Generators (UUID, Hash, Password, etc.)
+- Network tools (IPv4/IPv6 subnets, MAC lookup, etc.)
+- Text utilities (Lorem ipsum, text diff, etc.)
+
+| Setting | Value |
+|---------|-------|
+| Default Port | `8080` |
+| Suggested Subdomain | `it-tools` |
+| Public Access | Optional (works both ways) |
+| Website | [it-tools.tech](https://it-tools.tech) |
+| Source | [GitHub](https://github.com/CorentinTh/it-tools) |
+
+---
+
+## Excalidraw
+
+![Excalidraw](https://img.shields.io/badge/Excalidraw-6965DB?logo=excalidraw&logoColor=white)
+
+**Virtual whiteboard for sketching hand-drawn diagrams**
+
+A collaborative whiteboard tool that lets you create beautiful hand-drawn like diagrams. Features include:
+- Hand-drawn style graphics
+- Real-time collaboration
+- Export to PNG, SVG, or JSON
+- Libraries of shapes and icons
+- End-to-end encryption for collaboration
+
+| Setting | Value |
+|---------|-------|
+| Default Port | `8082` |
+| Suggested Subdomain | `draw` or `excalidraw` |
+| Public Access | Recommended for sharing |
+| Website | [excalidraw.com](https://excalidraw.com) |
+| Source | [GitHub](https://github.com/excalidraw/excalidraw) |
+
+---
+
+## Portainer
+
+![Portainer](https://img.shields.io/badge/Portainer-13BEF9?logo=portainer&logoColor=white)
+
+**Docker container management UI**
+
+A lightweight management UI that allows you to easily manage your Docker environments:
+- Container management (start, stop, restart, logs)
+- Image management (pull, build, delete)
+- Volume and network management
+- Stack deployment with Docker Compose
+- User access control
+
+| Setting | Value |
+|---------|-------|
+| Default Port | `9090` (→ internal 9000) |
+| Suggested Subdomain | `portainer` |
+| Public Access | **Never** (always protected) |
+| Website | [portainer.io](https://www.portainer.io) |
+| Source | [GitHub](https://github.com/portainer/portainer) |
+
+> ⚠️ **Important:** Portainer requires initial setup within 5 minutes of first start. Access it immediately after deployment to create your admin account.
+
+---
+
+## Uptime Kuma
+
+![Uptime Kuma](https://img.shields.io/badge/Uptime%20Kuma-5CDD8B?logo=uptimekuma&logoColor=white)
+
+**A fancy self-hosted monitoring tool**
+
+A beautiful, self-hosted monitoring tool similar to "Uptime Robot":
+- Monitor uptime for HTTP(s), TCP, Ping, DNS, and more
+- Fancy reactive dashboard
+- Notifications via Telegram, Discord, Slack, Email, and 90+ services
+- Multi-language support
+- Status page with incident management
+
+| Setting | Value |
+|---------|-------|
+| Default Port | `3001` |
+| Suggested Subdomain | `uptime-kuma` |
+| Public Access | Optional (status page can be public) |
+| Website | [uptime.kuma.pet](https://uptime.kuma.pet) |
+| Source | [GitHub](https://github.com/louislam/uptime-kuma) |
+
+---
+
+## Enabling a Stack
+
+To enable any stack, add it to your `tofu/config.tfvars`:
+
+```hcl
+services = {
+  # ... existing services ...
+  
+  uptime-kuma = {
+    enabled   = true
+    subdomain = "uptime-kuma"    # → https://uptime-kuma.yourdomain.com
+    port      = 3001        # Must match docker-compose port
+    public    = false       # false = requires login
+  }
+}
+```
+
+Then deploy:
+
+```bash
+make up
+```
+
+---
+
+## Creating Custom Stacks
+
+See the [Adding More Services](../README.md#adding-more-services) section in the README for instructions on creating your own stacks.

--- a/stacks/uptime-kuma/docker-compose.yml
+++ b/stacks/uptime-kuma/docker-compose.yml
@@ -1,0 +1,26 @@
+# =============================================================================
+# Uptime Kuma - A fancy self-hosted monitoring tool
+# https://github.com/louislam/uptime-kuma
+# =============================================================================
+# Access via: https://uptime-kuma.your-domain.com
+# Default port: 3001
+# =============================================================================
+
+services:
+  uptime-kuma:
+    image: louislam/uptime-kuma:latest
+    container_name: uptime-kuma
+    restart: unless-stopped
+    ports:
+      - "3001:3001"
+    volumes:
+      - uptime_kuma_data:/app/data
+    networks:
+      - app-network
+
+networks:
+  app-network:
+    external: true
+
+volumes:
+  uptime_kuma_data:

--- a/tofu/config.tfvars.example
+++ b/tofu/config.tfvars.example
@@ -61,6 +61,13 @@ services = {
     port      = 9090
     public    = false    # Docker management should always be protected
   }
+
+  uptime-kuma = {
+    enabled   = true
+    subdomain = "uptime-kuma"
+    port      = 3001
+    public    = false
+  }
   
   # Example: Add more services like this:
   # excalidraw = {


### PR DESCRIPTION
## Summary
Adds Uptime Kuma as a new stack for self-hosted monitoring.

## Changes
- ✨ New `stacks/uptime-kuma/docker-compose.yml`
- 📝 Added Uptime Kuma to `config.tfvars.example`
- 📚 Created `docs/stacks.md` with detailed stack documentation
- 🔧 Fixed README Available Stacks table formatting
- 🏷️ Reorganized badges (Infrastructure vs Stacks)
- 🗑️ Removed Cost section from README
- 🔗 API permissions now link to docs/setup-guide.md

## Testing
- [x] `make plan` - validates correctly
- [x] `make up` - deploys successfully
- [x] Uptime Kuma accessible via https://uptime-kuma.nexus-stack.ch
- [x] `make down` - session revocation works ✅

## Related Issues
- Created #2 (Auto-configure Uptime Kuma monitors)
- Created #4 (Auto-configure Portainer admin user)
