### PR TITLE
feat(stacks): Add Infisical secret management with full automation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ terraform.rc
 
 # Logs
 *.log
+
+# Stack secrets
+stacks/*/.env

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Create a Custom Token. See [docs/setup-guide.md](docs/setup-guide.md#create-api-
 ![Excalidraw](https://img.shields.io/badge/Excalidraw-6965DB?logo=excalidraw&logoColor=white)
 ![Portainer](https://img.shields.io/badge/Portainer-13BEF9?logo=portainer&logoColor=white)
 ![Uptime Kuma](https://img.shields.io/badge/Uptime%20Kuma-5CDD8B?logo=uptimekuma&logoColor=white)
+![Infisical](https://img.shields.io/badge/Infisical-000000?logo=infisical&logoColor=white)
 ![Info](https://img.shields.io/badge/Info-00D4AA?logo=nginx&logoColor=white)
 
 | Stack | Description | Website |
@@ -87,6 +88,7 @@ Create a Custom Token. See [docs/setup-guide.md](docs/setup-guide.md#create-api-
 | **Excalidraw** | Virtual whiteboard for sketching hand-drawn diagrams | [excalidraw.com](https://excalidraw.com) |
 | **Portainer** | Docker container management UI | [portainer.io](https://www.portainer.io) |
 | **Uptime Kuma** | A fancy self-hosted monitoring tool | [uptime.kuma.pet](https://uptime.kuma.pet) |
+| **Infisical** | Open-source secret management platform | [infisical.com](https://infisical.com) |
 | **Info** | Landing page with service overview dashboard | — |
 
 All stacks are pre-configured and ready to deploy. Just enable them in `config.tfvars`.

--- a/docs/stacks.md
+++ b/docs/stacks.md
@@ -123,6 +123,34 @@ A beautiful, cyberpunk-styled landing page that dynamically displays all your Ne
 
 ---
 
+## Infisical
+
+![Infisical](https://img.shields.io/badge/Infisical-000000?logo=infisical&logoColor=white)
+
+**Open-source secret management platform**
+
+A modern, developer-friendly alternative to HashiCorp Vault:
+- Beautiful, intuitive UI
+- No unsealing required (unlike Vault)
+- Environment variables sync to your apps
+- Team collaboration with RBAC
+- Audit logs for compliance
+- Native integrations (Kubernetes, Docker, CI/CD)
+
+| Setting | Value |
+|---------|-------|
+| Default Port | `8070` |
+| Suggested Subdomain | `infisical` |
+| Public Access | **Never** (always protected) |
+| Website | [infisical.com](https://infisical.com) |
+| Source | [GitHub](https://github.com/Infisical/infisical) |
+
+> ⚠️ **Important:** First user to sign up becomes the admin. Access the service immediately after deployment to create your admin account.
+
+> ℹ️ **Note:** Secrets are auto-generated on first deployment (encryption key, auth secret). These are stored in `stacks/infisical/.env`.
+
+---
+
 ## Enabling a Stack
 
 To enable any stack, add it to your `tofu/config.tfvars`:

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -34,14 +34,35 @@ if [ ! -f "$TOFU_DIR/terraform.tfstate" ]; then
     exit 1
 fi
 
-# Get domain from config
+# Get domain and admin email from config
 DOMAIN=$(grep -E '^domain\s*=' "$TOFU_DIR/config.tfvars" 2>/dev/null | sed 's/.*"\(.*\)"/\1/' || echo "")
+ADMIN_EMAIL=$(grep -E '^admin_email\s*=' "$TOFU_DIR/config.tfvars" 2>/dev/null | sed 's/.*"\(.*\)"/\1/' || echo "admin@$DOMAIN")
 SSH_HOST="ssh.${DOMAIN}"
 
 if [ -z "$DOMAIN" ]; then
     echo -e "${RED}Error: Could not read domain from config.tfvars${NC}"
     exit 1
 fi
+
+# Get secrets from OpenTofu
+echo -e "${YELLOW}[0/6] Loading secrets from OpenTofu...${NC}"
+SECRETS_JSON=$(cd "$TOFU_DIR" && tofu output -json secrets 2>/dev/null || echo "{}")
+
+if [ "$SECRETS_JSON" = "{}" ]; then
+    echo -e "${RED}Error: Could not read secrets from OpenTofu state${NC}"
+    exit 1
+fi
+
+# Extract secrets
+ADMIN_USERNAME=$(echo "$SECRETS_JSON" | jq -r '.admin_username // "admin"')
+INFISICAL_PASS=$(echo "$SECRETS_JSON" | jq -r '.infisical_admin_password // empty')
+INFISICAL_ENCRYPTION_KEY=$(echo "$SECRETS_JSON" | jq -r '.infisical_encryption_key // empty')
+INFISICAL_AUTH_SECRET=$(echo "$SECRETS_JSON" | jq -r '.infisical_auth_secret // empty')
+INFISICAL_DB_PASSWORD=$(echo "$SECRETS_JSON" | jq -r '.infisical_db_password // empty')
+PORTAINER_PASS=$(echo "$SECRETS_JSON" | jq -r '.portainer_admin_password // empty')
+KUMA_PASS=$(echo "$SECRETS_JSON" | jq -r '.kuma_admin_password // empty')
+
+echo -e "${GREEN}  ✓ Secrets loaded (admin user: $ADMIN_USERNAME)${NC}"
 
 # Clean old SSH known_hosts entries
 SERVER_IP=$(cd "$TOFU_DIR" && tofu output -raw server_ip 2>/dev/null || echo "")
@@ -54,7 +75,7 @@ SERVER_IP=$(cd "$TOFU_DIR" && tofu output -raw server_ip 2>/dev/null || echo "")
 SSH_CONFIG="$HOME/.ssh/config"
 
 if ! grep -q "Host nexus" "$SSH_CONFIG" 2>/dev/null; then
-    echo -e "${YELLOW}[0/4] Adding SSH config for nexus...${NC}"
+    echo -e "${YELLOW}[1/6] Adding SSH config for nexus...${NC}"
     mkdir -p "$HOME/.ssh"
     cat >> "$SSH_CONFIG" << EOF
 
@@ -66,7 +87,7 @@ EOF
     chmod 600 "$SSH_CONFIG"
     echo -e "${GREEN}  ✓ SSH config added to ~/.ssh/config${NC}"
 else
-    echo -e "${GREEN}[0/4] SSH config for nexus already exists${NC}"
+    echo -e "${GREEN}[1/6] SSH config for nexus already exists${NC}"
 fi
 
 # -----------------------------------------------------------------------------
@@ -94,7 +115,7 @@ echo ""
 # -----------------------------------------------------------------------------
 # Wait for SSH connection
 # -----------------------------------------------------------------------------
-echo -e "${YELLOW}[1/4] Waiting for SSH via Cloudflare Tunnel...${NC}"
+echo -e "${YELLOW}[2/6] Waiting for SSH via Cloudflare Tunnel...${NC}"
 MAX_RETRIES=30
 RETRY=0
 while [ $RETRY -lt $MAX_RETRIES ]; do
@@ -113,10 +134,10 @@ if [ $RETRY -eq $MAX_RETRIES ]; then
 fi
 
 # -----------------------------------------------------------------------------
-# Sync stacks (only enabled services)
+# Prepare stacks with secrets
 # -----------------------------------------------------------------------------
 echo ""
-echo -e "${YELLOW}[2/4] Syncing enabled stacks to server...${NC}"
+echo -e "${YELLOW}[3/6] Preparing stacks...${NC}"
 
 # Get enabled services from tofu output
 ENABLED_SERVICES=$(cd "$TOFU_DIR" && tofu output -json enabled_services 2>/dev/null | jq -r '.[]')
@@ -135,6 +156,18 @@ if echo "$ENABLED_SERVICES" | grep -qw "info"; then
     "$SCRIPT_DIR/generate-info-page.sh"
 fi
 
+# Generate Infisical .env from OpenTofu secrets
+if echo "$ENABLED_SERVICES" | grep -qw "infisical"; then
+    echo "  Generating Infisical config from OpenTofu secrets..."
+    cat > "$STACKS_DIR/infisical/.env" << EOF
+# Auto-generated from OpenTofu secrets - DO NOT COMMIT
+ENCRYPTION_KEY=$INFISICAL_ENCRYPTION_KEY
+AUTH_SECRET=$INFISICAL_AUTH_SECRET
+POSTGRES_PASSWORD=$INFISICAL_DB_PASSWORD
+EOF
+    echo -e "${GREEN}  ✓ Infisical .env generated${NC}"
+fi
+
 # Sync only enabled stacks
 for service in $ENABLED_SERVICES; do
     if [ -d "$STACKS_DIR/$service" ]; then
@@ -150,7 +183,7 @@ echo -e "${GREEN}  ✓ Stacks synced${NC}"
 # Stop disabled services
 # -----------------------------------------------------------------------------
 echo ""
-echo -e "${YELLOW}[3/4] Cleaning up disabled services...${NC}"
+echo -e "${YELLOW}[4/6] Cleaning up disabled services...${NC}"
 
 ENABLED_LIST=$(echo $ENABLED_SERVICES | tr '\n' ' ')
 
@@ -179,10 +212,7 @@ echo '  ✓ Cleanup complete'
 # Start containers (only enabled services)
 # -----------------------------------------------------------------------------
 echo ""
-echo -e "${YELLOW}[4/4] Starting enabled containers...${NC}"
-
-# Pass enabled services to remote script
-ENABLED_LIST=$(echo $ENABLED_SERVICES | tr '\n' ' ')
+echo -e "${YELLOW}[5/6] Starting enabled containers...${NC}"
 
 ssh nexus "
 set -e
@@ -200,6 +230,319 @@ echo '  ✓ All enabled stacks started'
 echo -e "${GREEN}  ✓ All containers started${NC}"
 
 # -----------------------------------------------------------------------------
+# Auto-configure services
+# -----------------------------------------------------------------------------
+echo ""
+echo -e "${YELLOW}[6/6] Auto-configuring services...${NC}"
+
+# Configure Infisical admin and push secrets
+if echo "$ENABLED_SERVICES" | grep -qw "infisical"; then
+    echo "  Configuring Infisical..."
+    
+    # Wait for Infisical to be ready (can take 30-60s on first start)
+    echo "  Waiting for Infisical to be ready..."
+    INFISICAL_READY=false
+    for i in $(seq 1 30); do
+        if ssh nexus "curl -s --connect-timeout 5 'http://localhost:8070/api/v1/admin/config'" 2>/dev/null | grep -q 'initialized'; then
+            INFISICAL_READY=true
+            break
+        fi
+        sleep 2
+    done
+    
+    if [ "$INFISICAL_READY" = "false" ]; then
+        echo -e "${YELLOW}  ⚠ Infisical not responding after 60s - skipping config${NC}"
+    else
+    # Check if already initialized
+    INIT_CHECK=$(ssh nexus "curl -s 'http://localhost:8070/api/v1/admin/config'" 2>/dev/null || echo "")
+    
+    if echo "$INIT_CHECK" | grep -q '"initialized":true'; then
+        echo -e "${YELLOW}  ⚠ Infisical already configured${NC}"
+    else
+        # Build JSON payload locally and base64 encode to avoid escaping issues
+        BOOTSTRAP_JSON=$(cat <<EOF
+{"email": "$ADMIN_EMAIL", "password": "$INFISICAL_PASS", "organization": "Nexus"}
+EOF
+)
+        # Bootstrap with admin user
+        BOOTSTRAP_RESULT=$(ssh nexus "curl -s -X POST 'http://localhost:8070/api/v1/admin/bootstrap' \
+            -H 'Content-Type: application/json' \
+            -d '$(echo "$BOOTSTRAP_JSON" | tr -d '\n')'" 2>&1 || echo "")
+        
+        if echo "$BOOTSTRAP_RESULT" | grep -q '"user"'; then
+            echo -e "${GREEN}  ✓ Infisical admin created (user: $ADMIN_EMAIL)${NC}"
+            
+            # Extract token and org ID for pushing secrets
+            INFISICAL_TOKEN=$(echo "$BOOTSTRAP_RESULT" | jq -r '.identity.credentials.token // empty')
+            ORG_ID=$(echo "$BOOTSTRAP_RESULT" | jq -r '.organization.id // empty')
+            
+            if [ -n "$INFISICAL_TOKEN" ] && [ -n "$ORG_ID" ]; then
+                echo "  Creating Nexus secrets project..."
+                
+                # Create a project for Nexus secrets
+                PROJECT_JSON="{\"projectName\": \"Nexus Stack\", \"organizationId\": \"$ORG_ID\"}"
+                PROJECT_RESULT=$(ssh nexus "curl -s -X POST 'http://localhost:8070/api/v2/workspace' \
+                    -H 'Authorization: Bearer $INFISICAL_TOKEN' \
+                    -H 'Content-Type: application/json' \
+                    -d '$PROJECT_JSON'" 2>&1 || echo "")
+                
+                PROJECT_ID=$(echo "$PROJECT_RESULT" | jq -r '.project.id // .workspace.id // empty')
+                
+                if [ -n "$PROJECT_ID" ] && [ "$PROJECT_ID" != "null" ]; then
+                    echo -e "${GREEN}  ✓ Project 'Nexus Stack' created${NC}"
+                    
+                    # Create tags for organizing secrets
+                    echo "  Creating tags..."
+                    for TAG_NAME in "infisical" "portainer" "uptime-kuma" "config"; do
+                        TAG_JSON="{\"slug\": \"$TAG_NAME\", \"color\": \"#3b82f6\"}"
+                        ssh nexus "curl -s -X POST 'http://localhost:8070/api/v1/projects/$PROJECT_ID/tags' \
+                            -H 'Authorization: Bearer $INFISICAL_TOKEN' \
+                            -H 'Content-Type: application/json' \
+                            -d '$TAG_JSON'" >/dev/null 2>&1 || true
+                    done
+                    
+                    # Get tag IDs
+                    TAGS_RESULT=$(ssh nexus "curl -s 'http://localhost:8070/api/v1/projects/$PROJECT_ID/tags' \
+                        -H 'Authorization: Bearer $INFISICAL_TOKEN'" 2>/dev/null || echo "{}")
+                    
+                    INFISICAL_TAG=$(echo "$TAGS_RESULT" | jq -r '.tags[] | select(.slug=="infisical") | .id // empty' 2>/dev/null)
+                    PORTAINER_TAG=$(echo "$TAGS_RESULT" | jq -r '.tags[] | select(.slug=="portainer") | .id // empty' 2>/dev/null)
+                    KUMA_TAG=$(echo "$TAGS_RESULT" | jq -r '.tags[] | select(.slug=="uptime-kuma") | .id // empty' 2>/dev/null)
+                    CONFIG_TAG=$(echo "$TAGS_RESULT" | jq -r '.tags[] | select(.slug=="config") | .id // empty' 2>/dev/null)
+                    
+                    echo -e "${GREEN}  ✓ Tags created${NC}"
+                    echo "  Pushing secrets to Infisical..."
+                    
+                    # Build secrets payload with usernames and tags
+                    # Using v4 API which supports tagIds
+                    SECRETS_PAYLOAD=$(cat <<SECRETS_EOF
+{
+  "projectId": "$PROJECT_ID",
+  "environment": "prod",
+  "secretPath": "/",
+  "secrets": [
+    {"secretKey": "DOMAIN", "secretValue": "$DOMAIN", "tagIds": ["$CONFIG_TAG"]},
+    {"secretKey": "ADMIN_EMAIL", "secretValue": "$ADMIN_EMAIL", "tagIds": ["$CONFIG_TAG"]},
+    {"secretKey": "ADMIN_USERNAME", "secretValue": "$ADMIN_USERNAME", "tagIds": ["$CONFIG_TAG"]},
+    {"secretKey": "INFISICAL_USERNAME", "secretValue": "$ADMIN_EMAIL", "tagIds": ["$INFISICAL_TAG"]},
+    {"secretKey": "INFISICAL_PASSWORD", "secretValue": "$INFISICAL_PASS", "tagIds": ["$INFISICAL_TAG"]},
+    {"secretKey": "PORTAINER_USERNAME", "secretValue": "$ADMIN_USERNAME", "tagIds": ["$PORTAINER_TAG"]},
+    {"secretKey": "PORTAINER_PASSWORD", "secretValue": "$PORTAINER_PASS", "tagIds": ["$PORTAINER_TAG"]},
+    {"secretKey": "UPTIME_KUMA_USERNAME", "secretValue": "$ADMIN_USERNAME", "tagIds": ["$KUMA_TAG"]},
+    {"secretKey": "UPTIME_KUMA_PASSWORD", "secretValue": "$KUMA_PASS", "tagIds": ["$KUMA_TAG"]}
+  ]
+}
+SECRETS_EOF
+)
+                    
+                    SECRETS_RESULT=$(ssh nexus "curl -s -X POST 'http://localhost:8070/api/v4/secrets/batch' \
+                        -H 'Authorization: Bearer $INFISICAL_TOKEN' \
+                        -H 'Content-Type: application/json' \
+                        -d '$(echo "$SECRETS_PAYLOAD" | tr -d '\n' | tr -s ' ')'" 2>&1 || echo "")
+                    
+                    if echo "$SECRETS_RESULT" | grep -qE '"secrets"|"secretKey"'; then
+                        echo -e "${GREEN}  ✓ All secrets pushed to Infisical (with tags)${NC}"
+                    else
+                        echo -e "${YELLOW}  ⚠ Failed to push secrets${NC}"
+                    fi
+                else
+                    echo -e "${YELLOW}  ⚠ Failed to create project${NC}"
+                fi
+            fi
+        elif echo "$BOOTSTRAP_RESULT" | grep -q 'already'; then
+            echo -e "${YELLOW}  ⚠ Infisical already configured${NC}"
+        else
+            echo -e "${YELLOW}  ⚠ Infisical bootstrap failed${NC}"
+        fi
+    fi
+    fi  # End of INFISICAL_READY check
+fi
+
+# Configure Portainer admin
+if echo "$ENABLED_SERVICES" | grep -qw "portainer" && [ -n "$PORTAINER_PASS" ]; then
+    echo "  Configuring Portainer admin..."
+    sleep 3
+    
+    PORTAINER_JSON="{\"Username\":\"$ADMIN_USERNAME\",\"Password\":\"$PORTAINER_PASS\"}"
+    PORTAINER_RESULT=$(ssh nexus "curl -s -X POST 'http://localhost:9090/api/users/admin/init' \
+        -H 'Content-Type: application/json' \
+        -d '$PORTAINER_JSON'" 2>/dev/null || echo "")
+    
+    if echo "$PORTAINER_RESULT" | grep -q '"Id"' 2>/dev/null; then
+        echo -e "${GREEN}  ✓ Portainer admin created (user: $ADMIN_USERNAME)${NC}"
+    elif echo "$PORTAINER_RESULT" | grep -q 'already initialized' 2>/dev/null; then
+        echo -e "${YELLOW}  ⚠ Portainer already initialized${NC}"
+    else
+        echo -e "${YELLOW}  ⚠ Portainer setup skipped (may already be configured)${NC}"
+    fi
+fi
+
+# Configure Uptime Kuma admin
+if echo "$ENABLED_SERVICES" | grep -qw "uptime-kuma" && [ -n "$KUMA_PASS" ]; then
+    echo "  Configuring Uptime Kuma..."
+    
+    # Wait for Uptime Kuma container to be ready
+    echo "  Waiting for Uptime Kuma to be ready..."
+    KUMA_READY=false
+    for i in $(seq 1 30); do
+        # Check if container is healthy
+        KUMA_HEALTH=$(ssh nexus "docker inspect --format='{{.State.Health.Status}}' uptime-kuma 2>/dev/null" || echo "")
+        if [ "$KUMA_HEALTH" = "healthy" ]; then
+            KUMA_READY=true
+            break
+        fi
+        sleep 2
+    done
+    
+    if [ "$KUMA_READY" = "false" ]; then
+        echo -e "${YELLOW}  ⚠ Uptime Kuma not healthy after 60s - skipping config${NC}"
+    else
+        # Kuma uses socket.io for setup - run via container's node
+        # Parameters are separate: setup(username, password, callback) - NOT an object!
+        SETUP_SCRIPT='
+const { io } = require("socket.io-client");
+const socket = io("http://localhost:3001", { transports: ["websocket"] });
+socket.on("connect", () => {
+    socket.emit("needSetup", (needSetup) => {
+        if (!needSetup) { console.log("ALREADY_CONFIGURED"); process.exit(0); }
+        socket.emit("setup", process.env.KUMA_USER, process.env.KUMA_PASS, (res) => {
+            if (res && res.ok) { console.log("SUCCESS"); process.exit(0); }
+            else { console.log("FAILED"); process.exit(1); }
+        });
+    });
+});
+socket.on("connect_error", () => { console.log("CONNECTION_ERROR"); process.exit(1); });
+setTimeout(() => { console.log("TIMEOUT"); process.exit(1); }, 15000);
+'
+        KUMA_RESULT=$(ssh nexus "docker exec -e KUMA_USER='$ADMIN_USERNAME' -e KUMA_PASS='$KUMA_PASS' uptime-kuma node -e '$SETUP_SCRIPT'" 2>&1 || echo "EXEC_FAILED")
+        
+        if echo "$KUMA_RESULT" | grep -q "SUCCESS"; then
+            echo -e "${GREEN}  ✓ Uptime Kuma admin created (user: $ADMIN_USERNAME)${NC}"
+            KUMA_SETUP_SUCCESS=true
+        elif echo "$KUMA_RESULT" | grep -q "ALREADY_CONFIGURED"; then
+            echo -e "${YELLOW}  ⚠ Uptime Kuma already configured${NC}"
+            KUMA_SETUP_SUCCESS=true
+        else
+            echo -e "${YELLOW}  ⚠ Kuma auto-setup failed - configure manually at first login${NC}"
+            echo -e "${YELLOW}    Username: $ADMIN_USERNAME / Password: $KUMA_PASS${NC}"
+            KUMA_SETUP_SUCCESS=false
+        fi
+        
+        # Sync monitors for all enabled services (add missing, remove disabled)
+        # This runs on every deploy, not just first setup
+        echo "  Syncing service monitors..."
+        
+        # Get service URLs from tofu output
+        SERVICE_URLS=$(cd "$TOFU_DIR" && tofu output -json service_urls 2>/dev/null || echo "{}")
+        
+        # Build desired monitors JSON array (services that should be monitored)
+        DESIRED_JSON="["
+        FIRST=true
+        for service in $ENABLED_LIST; do
+            # Skip uptime-kuma itself
+            [ "$service" = "uptime-kuma" ] && continue
+            
+            # Get the URL for this service
+            SERVICE_URL=$(echo "$SERVICE_URLS" | jq -r ".\"$service\" // empty")
+            [ -z "$SERVICE_URL" ] && continue
+            
+            # Format service name for display (capitalize, replace dashes)
+            DISPLAY_NAME=$(echo "$service" | sed 's/-/ /g' | awk '{for(i=1;i<=NF;i++) $i=toupper(substr($i,1,1)) tolower(substr($i,2))}1')
+            
+            if [ "$FIRST" = "true" ]; then
+                FIRST=false
+            else
+                DESIRED_JSON="$DESIRED_JSON,"
+            fi
+            
+            DESIRED_JSON="$DESIRED_JSON{\"name\":\"$DISPLAY_NAME\",\"url\":\"$SERVICE_URL\"}"
+        done
+        DESIRED_JSON="$DESIRED_JSON]"
+        
+        # Sync monitors via socket.io (add missing, delete removed)
+        SYNC_SCRIPT='
+const { io } = require("socket.io-client");
+const desired = JSON.parse(process.env.DESIRED);
+const socket = io("http://localhost:3001", { transports: ["websocket"] });
+let added = 0, deleted = 0;
+let existingMonitors = {};
+
+socket.on("monitorList", (data) => {
+    existingMonitors = data;
+});
+
+socket.on("connect", () => {
+    socket.emit("login", { username: process.env.KUMA_USER, password: process.env.KUMA_PASS }, async (res) => {
+        if (!res || !res.ok) { console.log("LOGIN_FAILED"); process.exit(1); }
+        
+        // Get current monitors
+        await new Promise(resolve => {
+            socket.emit("getMonitorList", () => setTimeout(resolve, 500));
+        });
+        
+        const existing = Object.values(existingMonitors);
+        const existingUrls = existing.map(m => m.url);
+        const desiredUrls = desired.map(m => m.url);
+        
+        // Add missing monitors
+        for (const m of desired) {
+            if (!existingUrls.includes(m.url)) {
+                const monitor = {
+                    type: "http",
+                    name: m.name,
+                    url: m.url,
+                    method: "GET",
+                    interval: 60,
+                    retryInterval: 60,
+                    maxretries: 3,
+                    accepted_statuscodes: ["200-299", "401", "403"],
+                    active: true
+                };
+                await new Promise(resolve => {
+                    socket.emit("add", monitor, (r) => { if (r && r.ok) added++; resolve(); });
+                });
+            }
+        }
+        
+        // Delete monitors for disabled services
+        for (const m of existing) {
+            if (!desiredUrls.includes(m.url)) {
+                await new Promise(resolve => {
+                    socket.emit("deleteMonitor", m.id, (r) => { if (r && r.ok) deleted++; resolve(); });
+                });
+            }
+        }
+        
+        console.log("SYNC:" + added + ":" + deleted + ":" + desired.length);
+        process.exit(0);
+    });
+});
+socket.on("connect_error", () => { console.log("CONNECTION_ERROR"); process.exit(1); });
+setTimeout(() => { console.log("TIMEOUT"); process.exit(1); }, 30000);
+'
+        # Escape the JSON for shell
+        DESIRED_ESCAPED=$(echo "$DESIRED_JSON" | sed "s/'/'\\\\''/g")
+        
+        SYNC_RESULT=$(ssh nexus "docker exec -e KUMA_USER='$ADMIN_USERNAME' -e KUMA_PASS='$KUMA_PASS' -e DESIRED='$DESIRED_ESCAPED' uptime-kuma node -e '$SYNC_SCRIPT'" 2>&1 || echo "EXEC_FAILED")
+        
+        if echo "$SYNC_RESULT" | grep -q "SYNC:"; then
+            SYNC_DATA=$(echo "$SYNC_RESULT" | grep "SYNC:" | head -1)
+            ADDED_COUNT=$(echo "$SYNC_DATA" | cut -d: -f2)
+            DELETED_COUNT=$(echo "$SYNC_DATA" | cut -d: -f3)
+            TOTAL_COUNT=$(echo "$SYNC_DATA" | cut -d: -f4)
+            
+            if [ "$ADDED_COUNT" = "0" ] && [ "$DELETED_COUNT" = "0" ]; then
+                echo -e "${GREEN}  ✓ Monitors in sync ($TOTAL_COUNT services)${NC}"
+            else
+                echo -e "${GREEN}  ✓ Monitors synced: +$ADDED_COUNT added, -$DELETED_COUNT removed ($TOTAL_COUNT total)${NC}"
+            fi
+        else
+            echo -e "${YELLOW}  ⚠ Failed to sync monitors${NC}"
+        fi
+    fi
+fi
+
+# -----------------------------------------------------------------------------
 # Done!
 # -----------------------------------------------------------------------------
 echo ""
@@ -213,6 +556,23 @@ echo -e "${NC}"
 echo -e "${CYAN}🔗 Your Services:${NC}"
 cd "$TOFU_DIR" && tofu output -json service_urls 2>/dev/null | jq -r 'to_entries | .[] | "   \(.key): \(.value)"' || echo "   (run 'make urls' to see service URLs)"
 echo ""
+
+# Show credentials
+echo -e "${CYAN}🔐 Credentials:${NC}"
+if echo "$ENABLED_SERVICES" | grep -qw "infisical"; then
+    echo -e "   ${YELLOW}Infisical:${NC}   $ADMIN_EMAIL / $INFISICAL_PASS"
+fi
+if echo "$ENABLED_SERVICES" | grep -qw "portainer"; then
+    echo -e "   ${YELLOW}Portainer:${NC}   $ADMIN_USERNAME / $PORTAINER_PASS"
+fi
+if echo "$ENABLED_SERVICES" | grep -qw "uptime-kuma"; then
+    echo -e "   ${YELLOW}Uptime Kuma:${NC} $ADMIN_USERNAME / $KUMA_PASS"
+fi
+echo ""
+
 echo -e "${CYAN}📌 SSH Access:${NC}"
 echo -e "   ssh nexus"
+echo ""
+echo -e "${CYAN}💡 View secrets anytime:${NC}"
+echo -e "   make secrets"
 echo ""

--- a/stacks/infisical/docker-compose.yml
+++ b/stacks/infisical/docker-compose.yml
@@ -1,0 +1,84 @@
+# =============================================================================
+# Infisical - Modern Secret Management
+# =============================================================================
+# Open-source secret management platform:
+#   - Beautiful modern UI
+#   - No unsealing required (unlike Vault)
+#   - Environment variables sync
+#   - Team collaboration & audit logs
+#
+# Access: https://infisical.YOUR_DOMAIN
+# First user to sign up becomes admin
+#
+# Docs: https://infisical.com/docs
+# =============================================================================
+
+services:
+  infisical:
+    image: infisical/infisical:latest
+    container_name: infisical
+    restart: unless-stopped
+    ports:
+      - "8070:8080"
+    environment:
+      - NODE_ENV=production
+      # Core settings - auto-generated on first run
+      - ENCRYPTION_KEY=${ENCRYPTION_KEY:-}
+      - AUTH_SECRET=${AUTH_SECRET:-}
+      - SITE_URL=https://infisical.${DOMAIN:-localhost}
+      # Database
+      - DB_CONNECTION_URI=postgres://infisical:${POSTGRES_PASSWORD:-infisical}@infisical-db:5432/infisical?sslmode=disable
+      # Redis
+      - REDIS_URL=redis://infisical-redis:6379
+      # Disable telemetry
+      - TELEMETRY_ENABLED=false
+    depends_on:
+      infisical-db:
+        condition: service_healthy
+      infisical-redis:
+        condition: service_healthy
+    networks:
+      - app-network
+      - infisical-internal
+
+  infisical-db:
+    image: postgres:14-alpine
+    container_name: infisical-db
+    restart: unless-stopped
+    environment:
+      - POSTGRES_USER=infisical
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-infisical}
+      - POSTGRES_DB=infisical
+    volumes:
+      - infisical-db-data:/var/lib/postgresql/data
+    networks:
+      - infisical-internal
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U infisical"]
+      interval: 5s
+      timeout: 10s
+      retries: 10
+
+  infisical-redis:
+    image: redis:7-alpine
+    container_name: infisical-redis
+    restart: unless-stopped
+    volumes:
+      - infisical-redis-data:/data
+    networks:
+      - infisical-internal
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  infisical-db-data:
+  infisical-redis-data:
+
+networks:
+  app-network:
+    external: true
+  infisical-internal:
+    driver: bridge

--- a/stacks/info/html/index.html
+++ b/stacks/info/html/index.html
@@ -319,7 +319,7 @@
         </section>
 
         <footer>
-            <p>Generated on <span class="highlight" id="generated-date">2026-01-09 15:53 UTC</span></p>
+            <p>Generated on <span class="highlight" id="generated-date">2026-01-12 11:40 UTC</span></p>
             <p>Powered by <a href="https://github.com/stefanko-ch/Nexus-Stack" target="_blank">Nexus-Stack</a></p>
         </footer>
     </div>
@@ -349,6 +349,12 @@
     "enabled": true,
     "subdomain": "uptime-kuma",
     "port": 3001,
+    "public": false
+  },
+  "infisical": {
+    "enabled": true,
+    "subdomain": "infisical",
+    "port": 8070,
     "public": false
   },
   "info": {

--- a/tofu/config.tfvars.example
+++ b/tofu/config.tfvars.example
@@ -36,6 +36,9 @@ domain = "your-domain.com"
 # Your email for Cloudflare Access (only this email can access services)
 admin_email = "your@email.com"
 
+# Admin username for services like Portainer, Uptime Kuma (optional, default: admin)
+# admin_username = "admin"
+
 # =============================================================================
 # Services
 # =============================================================================
@@ -67,6 +70,13 @@ services = {
     subdomain = "uptime-kuma"
     port      = 3001
     public    = false
+  }
+
+  infisical = {
+    enabled   = true
+    subdomain = "infisical"
+    port      = 8070
+    public    = false    # Secret management - always protected
   }
 
   info = {

--- a/tofu/main.tf
+++ b/tofu/main.tf
@@ -8,6 +8,43 @@ resource "hcloud_ssh_key" "main" {
 }
 
 # =============================================================================
+# Generated Secrets
+# =============================================================================
+
+# Infisical secrets
+resource "random_password" "infisical_admin" {
+  length  = 24
+  special = false
+}
+
+resource "random_password" "infisical_encryption_key" {
+  length  = 32
+  special = false
+}
+
+resource "random_password" "infisical_auth_secret" {
+  length  = 32
+  special = false
+}
+
+resource "random_password" "infisical_db_password" {
+  length  = 24
+  special = false
+}
+
+# Portainer admin password (for future use)
+resource "random_password" "portainer_admin" {
+  length  = 24
+  special = false
+}
+
+# Uptime Kuma admin password (for future use)
+resource "random_password" "kuma_admin" {
+  length  = 24
+  special = false
+}
+
+# =============================================================================
 # Firewall
 # =============================================================================
 

--- a/tofu/outputs.tf
+++ b/tofu/outputs.tf
@@ -43,3 +43,29 @@ output "enabled_services" {
   description = "List of enabled service names (for deploy script)"
   value = keys(local.enabled_services)
 }
+
+# =============================================================================
+# Secrets Outputs
+# =============================================================================
+
+output "secrets" {
+  description = "Generated secrets for services (auto-pushed to Infisical)"
+  sensitive   = true
+  value = {
+    # Admin credentials
+    admin_email    = var.admin_email
+    admin_username = var.admin_username
+    
+    # Infisical
+    infisical_admin_password   = random_password.infisical_admin.result
+    infisical_encryption_key   = random_password.infisical_encryption_key.result
+    infisical_auth_secret      = random_password.infisical_auth_secret.result
+    infisical_db_password      = random_password.infisical_db_password.result
+    
+    # Portainer
+    portainer_admin_password   = random_password.portainer_admin.result
+    
+    # Uptime Kuma
+    kuma_admin_password        = random_password.kuma_admin.result
+  }
+}

--- a/tofu/variables.tf
+++ b/tofu/variables.tf
@@ -74,6 +74,12 @@ variable "admin_email" {
   type        = string
 }
 
+variable "admin_username" {
+  description = "Admin username for services like Portainer, Uptime Kuma (default: admin)"
+  type        = string
+  default     = "admin"
+}
+
 # =============================================================================
 # Services
 # =============================================================================


### PR DESCRIPTION
Add Infisical stack for centralized secret management:
- Docker Compose with PostgreSQL and Redis dependencies
- Automatic admin account creation on first deploy
- Auto-generated encryption keys and auth secrets via OpenTofu
- All service credentials pushed to Infisical with tags

Add auto-configuration for all services:
- Portainer: Admin user auto-created with generated password
- Uptime Kuma: Admin user auto-created + dynamic monitor sync
- Dynamic monitor management: add new services, remove disabled ones
- Credentials displayed after deployment and via 'make secrets'

Infrastructure improvements:
- OpenTofu generates all service passwords (infisical, portainer, kuma)
- New 'secrets' output in outputs.tf for centralized secret access
- New 'admin_username' variable for consistent admin credentials
- Deploy script restructured with 6 phases for better clarity

Documentation:
- README: Added Infisical badge and table entry
- docs/stacks.md: Full Infisical documentation section
- config.tfvars.example: Infisical service configuration
- .gitignore: Exclude stacks/*/.env for generated secrets

Closes #7
Closes #4
Closes #3
Closes #2
