### PR TITLE
fix: Use clean UPPERCASE secret names in workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,14 @@ jobs:
   deploy:
     name: Deploy Nexus-Stack
     runs-on: ubuntu-latest
+    env:
+      TF_VAR_cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      TF_VAR_cloudflare_account_id: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      TF_VAR_cloudflare_zone_id: ${{ secrets.CLOUDFLARE_ZONE_ID }}
+      TF_VAR_hcloud_token: ${{ secrets.HCLOUD_TOKEN }}
+      TF_VAR_domain: ${{ secrets.DOMAIN }}
+      TF_VAR_access_emails: ${{ secrets.ACCESS_EMAILS }}
+      TF_VAR_infisical_token: ${{ secrets.INFISICAL_TOKEN }}
     
     steps:
       - name: Checkout
@@ -29,18 +37,6 @@ jobs:
           curl -fsSL https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64 -o cloudflared
           chmod +x cloudflared
           sudo mv cloudflared /usr/local/bin/
-
-      - name: Create .env file from secrets
-        run: |
-          cat > .env << EOF
-          TF_VAR_cloudflare_api_token="${{ secrets.TF_VAR_CLOUDFLARE_API_TOKEN }}"
-          TF_VAR_cloudflare_account_id="${{ secrets.TF_VAR_CLOUDFLARE_ACCOUNT_ID }}"
-          TF_VAR_cloudflare_zone_id="${{ secrets.TF_VAR_CLOUDFLARE_ZONE_ID }}"
-          TF_VAR_hcloud_token="${{ secrets.TF_VAR_HCLOUD_TOKEN }}"
-          TF_VAR_domain="${{ secrets.TF_VAR_DOMAIN }}"
-          TF_VAR_access_emails="${{ secrets.TF_VAR_ACCESS_EMAILS }}"
-          TF_VAR_infisical_token="${{ secrets.TF_VAR_INFISICAL_TOKEN }}"
-          EOF
 
       - name: Check if R2 credentials exist
         id: check_r2
@@ -109,7 +105,7 @@ jobs:
           
           cat > tofu/backend.hcl << EOF
           endpoints = {
-            s3 = "https://${{ secrets.TF_VAR_CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com"
+            s3 = "https://${{ secrets.CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com"
           }
           EOF
 

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -20,6 +20,14 @@ jobs:
     name: Destroy All Nexus-Stack Resources
     runs-on: ubuntu-latest
     if: github.event.inputs.confirm == 'DESTROY'
+    env:
+      TF_VAR_cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      TF_VAR_cloudflare_account_id: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      TF_VAR_cloudflare_zone_id: ${{ secrets.CLOUDFLARE_ZONE_ID }}
+      TF_VAR_hcloud_token: ${{ secrets.HCLOUD_TOKEN }}
+      TF_VAR_domain: ${{ secrets.DOMAIN }}
+      TF_VAR_access_emails: ${{ secrets.ACCESS_EMAILS }}
+      TF_VAR_infisical_token: ${{ secrets.INFISICAL_TOKEN }}
     
     steps:
       - name: Validate confirmation
@@ -38,18 +46,6 @@ jobs:
         with:
           tofu_version: 1.10.0
 
-      - name: Create .env file from secrets
-        run: |
-          cat > .env << EOF
-          TF_VAR_cloudflare_api_token="${{ secrets.TF_VAR_CLOUDFLARE_API_TOKEN }}"
-          TF_VAR_cloudflare_account_id="${{ secrets.TF_VAR_CLOUDFLARE_ACCOUNT_ID }}"
-          TF_VAR_cloudflare_zone_id="${{ secrets.TF_VAR_CLOUDFLARE_ZONE_ID }}"
-          TF_VAR_hcloud_token="${{ secrets.TF_VAR_HCLOUD_TOKEN }}"
-          TF_VAR_domain="${{ secrets.TF_VAR_DOMAIN }}"
-          TF_VAR_access_emails="${{ secrets.TF_VAR_ACCESS_EMAILS }}"
-          TF_VAR_infisical_token="${{ secrets.TF_VAR_INFISICAL_TOKEN }}"
-          EOF
-
       - name: Create R2 credentials from secrets
         run: |
           mkdir -p tofu
@@ -60,7 +56,7 @@ jobs:
           
           cat > tofu/backend.hcl << EOF
           endpoints = {
-            s3 = "https://${{ secrets.TF_VAR_CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com"
+            s3 = "https://${{ secrets.CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com"
           }
           EOF
 

--- a/.github/workflows/down.yml
+++ b/.github/workflows/down.yml
@@ -14,6 +14,14 @@ jobs:
   down:
     name: Stop Nexus-Stack
     runs-on: ubuntu-latest
+    env:
+      TF_VAR_cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      TF_VAR_cloudflare_account_id: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      TF_VAR_cloudflare_zone_id: ${{ secrets.CLOUDFLARE_ZONE_ID }}
+      TF_VAR_hcloud_token: ${{ secrets.HCLOUD_TOKEN }}
+      TF_VAR_domain: ${{ secrets.DOMAIN }}
+      TF_VAR_access_emails: ${{ secrets.ACCESS_EMAILS }}
+      TF_VAR_infisical_token: ${{ secrets.INFISICAL_TOKEN }}
     
     steps:
       - name: Checkout
@@ -23,18 +31,6 @@ jobs:
         uses: opentofu/setup-opentofu@v1
         with:
           tofu_version: 1.10.0
-
-      - name: Create .env file from secrets
-        run: |
-          cat > .env << EOF
-          TF_VAR_cloudflare_api_token="${{ secrets.TF_VAR_CLOUDFLARE_API_TOKEN }}"
-          TF_VAR_cloudflare_account_id="${{ secrets.TF_VAR_CLOUDFLARE_ACCOUNT_ID }}"
-          TF_VAR_cloudflare_zone_id="${{ secrets.TF_VAR_CLOUDFLARE_ZONE_ID }}"
-          TF_VAR_hcloud_token="${{ secrets.TF_VAR_HCLOUD_TOKEN }}"
-          TF_VAR_domain="${{ secrets.TF_VAR_DOMAIN }}"
-          TF_VAR_access_emails="${{ secrets.TF_VAR_ACCESS_EMAILS }}"
-          TF_VAR_infisical_token="${{ secrets.TF_VAR_INFISICAL_TOKEN }}"
-          EOF
 
       - name: Create R2 credentials from secrets
         run: |
@@ -46,7 +42,7 @@ jobs:
           
           cat > tofu/backend.hcl << EOF
           endpoints = {
-            s3 = "https://${{ secrets.TF_VAR_CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com"
+            s3 = "https://${{ secrets.CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com"
           }
           EOF
 

--- a/README.md
+++ b/README.md
@@ -288,8 +288,8 @@ Deploy entirely via CI - no local tools required!
 ### Quick Start
 
 1. Add secrets to your repo (Settings → Secrets → Actions):
-   - `TF_VAR_CLOUDFLARE_API_TOKEN`, `TF_VAR_CLOUDFLARE_ACCOUNT_ID`, `TF_VAR_CLOUDFLARE_ZONE_ID`
-   - `TF_VAR_HCLOUD_TOKEN`, `TF_VAR_DOMAIN`, `TF_VAR_ACCESS_EMAILS`
+   - `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_ZONE_ID`
+   - `HCLOUD_TOKEN`, `DOMAIN`, `ACCESS_EMAILS`
 
 2. Run first deployment:
    ```bash

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -267,13 +267,13 @@ Add these secrets to your repo:
 
 | Secret Name | Source | Description |
 |-------------|--------|-------------|
-| `TF_VAR_CLOUDFLARE_API_TOKEN` | Cloudflare dashboard | API access |
-| `TF_VAR_CLOUDFLARE_ACCOUNT_ID` | Cloudflare dashboard | Account ID |
-| `TF_VAR_CLOUDFLARE_ZONE_ID` | Cloudflare dashboard | Zone ID |
-| `TF_VAR_HCLOUD_TOKEN` | Hetzner console | API token |
-| `TF_VAR_DOMAIN` | Your domain | e.g. `example.com` |
-| `TF_VAR_ACCESS_EMAILS` | Allowed emails | Comma-separated |
-| `TF_VAR_INFISICAL_TOKEN` | Infisical dashboard | Optional |
+| `CLOUDFLARE_API_TOKEN` | Cloudflare dashboard | API access |
+| `CLOUDFLARE_ACCOUNT_ID` | Cloudflare dashboard | Account ID |
+| `CLOUDFLARE_ZONE_ID` | Cloudflare dashboard | Zone ID |
+| `HCLOUD_TOKEN` | Hetzner console | API token |
+| `DOMAIN` | Your domain | e.g. `example.com` |
+| `ACCESS_EMAILS` | Allowed emails | Comma-separated |
+| `INFISICAL_TOKEN` | Infisical dashboard | Optional |
 
 ### First Deployment
 


### PR DESCRIPTION
## Changes

- Rename GitHub Secrets to clean UPPERCASE format (Best Practice):
  - `TF_VAR_CLOUDFLARE_API_TOKEN` → `CLOUDFLARE_API_TOKEN`
  - `TF_VAR_HCLOUD_TOKEN` → `HCLOUD_TOKEN`
  - etc.

- Workflows now map secrets to `TF_VAR_lowercase` format for OpenTofu compatibility
- Remove redundant .env file creation steps (using job-level env block instead)
- Update documentation with new secret names

## Why

- GitHub Secrets convention: SCREAMING_SNAKE_CASE
- OpenTofu requirement: `TF_VAR_` prefix with exact case match to variable names
- Mapping in workflow separates these concerns cleanly