### PR TITLE
fix(ci): add timestamp to R2 token name, cleanup tokens on destroy-all

### DIFF
--- a/.github/workflows/destroy-all.yml
+++ b/.github/workflows/destroy-all.yml
@@ -107,6 +107,25 @@ jobs:
             echo "   Run: gh secret delete R2_ACCESS_KEY_ID && gh secret delete R2_SECRET_ACCESS_KEY"
           fi
 
+      - name: Cleanup R2 API tokens from Cloudflare
+        run: |
+          echo "🔐 Cleaning up R2 API tokens from Cloudflare..."
+          # Find and delete all nexus-r2-terraform-state tokens
+          TOKENS=$(curl -s "https://api.cloudflare.com/client/v4/user/tokens" \
+            -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" \
+            | jq -r '.result[] | select(.name | startswith("nexus-r2-terraform-state")) | .id')
+          
+          if [ -n "$TOKENS" ]; then
+            for token_id in $TOKENS; do
+              echo "  Deleting token: $token_id"
+              curl -s -X DELETE "https://api.cloudflare.com/client/v4/user/tokens/$token_id" \
+                -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" > /dev/null
+            done
+            echo "✅ R2 API tokens deleted"
+          else
+            echo "  No R2 tokens found to delete"
+          fi
+
       - name: Confirm destruction
         run: |
           echo ""
@@ -116,6 +135,7 @@ jobs:
           echo "   - Cloudflare DNS records"
           echo "   - Cloudflare Access policies"
           echo "   - R2 state bucket and contents"
+          echo "   - R2 API tokens from Cloudflare"
           echo "   - R2 GitHub Secrets (if GH_SECRETS_TOKEN configured)"
           echo ""
           echo "To redeploy, run the Deploy workflow."

--- a/scripts/init-r2-state.sh
+++ b/scripts/init-r2-state.sh
@@ -135,14 +135,18 @@ echo -e "  ${YELLOW}→${NC} Creating R2 API token..."
 # ID verified from Cloudflare docs: https://developers.cloudflare.com/r2/api/tokens/
 R2_STORAGE_WRITE_PERMISSION_ID="bf7481a1826f439697cb59a20b22293e"
 
+# Generate unique token name with timestamp to avoid duplicates
+TOKEN_NAME="nexus-r2-terraform-state-$(date +%Y%m%d-%H%M%S)"
+
 # Create User API token for R2 with account-level R2 permissions
 # Using account resource instead of bucket-specific resource for broader access
+# No expiration - token must remain valid for state access
 TOKEN_RESPONSE=$(curl -s -X POST \
     "https://api.cloudflare.com/client/v4/user/tokens" \
     -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
     -H "Content-Type: application/json" \
     -d "{
-        \"name\": \"nexus-r2-terraform-state\",
+        \"name\": \"${TOKEN_NAME}\",
         \"policies\": [
             {
                 \"effect\": \"allow\",


### PR DESCRIPTION
Fixes duplicate R2 token name issue by adding timestamp to token name.

Changes:
- Token name now includes timestamp: `nexus-r2-terraform-state-20260113-183600`
- destroy-all workflow now also deletes R2 API tokens from Cloudflare
- Prevents 'unknown API error' when token with same name already exists