### PR TITLE
fix: Control Panel custom domain, logo distortion, add to Info Page

### DIFF
--- a/control-panel/pages/index.html
+++ b/control-panel/pages/index.html
@@ -76,7 +76,7 @@
         .logo {
             display: block;
             width: 120px;
-            height: 120px;
+            height: auto;
             margin: 0 auto 1.5rem;
             filter: drop-shadow(0 0 20px rgba(0, 255, 136, 0.5));
         }

--- a/stacks/info/html/index.template.html
+++ b/stacks/info/html/index.template.html
@@ -76,7 +76,7 @@
         .logo {
             display: block;
             width: 120px;
-            height: 120px;
+            height: auto;
             margin: 0 auto 1.5rem;
             filter: drop-shadow(0 0 20px rgba(0, 255, 136, 0.5));
         }
@@ -381,6 +381,14 @@
         const activeGrid = document.getElementById('active-services');
         const disabledGrid = document.getElementById('disabled-services');
 
+        // Add Control Panel as special service (hosted on Cloudflare Pages, not Docker)
+        const controlPanel = {
+            subdomain: 'control',
+            description: 'Infrastructure control panel - deploy, teardown, and destroy your Nexus Stack.',
+            enabled: true
+        };
+        activeGrid.appendChild(createServiceCard('control', controlPanel, true));
+
         // Sort and display active services (info last)
         activeServices
             .sort((a, b) => {
@@ -391,6 +399,9 @@
             .forEach(([name, service]) => {
                 activeGrid.appendChild(createServiceCard(name, service, true));
             });
+
+        // Update count to include Control Panel
+        document.getElementById('active-count').textContent = activeServices.length + 1;
 
         disabledServices.forEach(([name, service]) => {
             disabledGrid.appendChild(createServiceCard(name, service, false));

--- a/tofu/control-panel.tf
+++ b/tofu/control-panel.tf
@@ -51,6 +51,13 @@ resource "cloudflare_record" "control_panel" {
   ttl     = 1
 }
 
+# Custom Domain for Cloudflare Pages
+resource "cloudflare_pages_domain" "control_panel" {
+  account_id   = var.cloudflare_account_id
+  project_name = cloudflare_pages_project.control_panel.name
+  domain       = "control.${var.domain}"
+}
+
 # -----------------------------------------------------------------------------
 # Cloudflare Access Protection
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Problem
- control.nexus-stack.ch not working (DNS_PROBE_FINISHED_NXDOMAIN)
- Logo distorted on Control Panel and Info Page
- Control Panel not shown in Info Page dashboard

## Root Cause
Missing `cloudflare_pages_domain` resource. The DNS CNAME record alone is not enough - Cloudflare Pages needs to know that the custom domain belongs to the project.

## Fix
- Added `cloudflare_pages_domain` resource to register `control.domain` with Cloudflare Pages
- Fixed logo distortion: `height: auto` instead of fixed `120px`
- Added Control Panel as special service in Info Page
