### PR TITLE
fix: Add credentials to fetch calls for Cloudflare Access

### DIFF
--- a/control-panel/pages/index.html
+++ b/control-panel/pages/index.html
@@ -544,7 +544,7 @@
         // Fetch and display status
         async function fetchStatus() {
             try {
-                const response = await fetch(`${API_URL}/api/status`);
+                const response = await fetch(`${API_URL}/api/status`, { credentials: 'same-origin' });
                 const data = await response.json();
                 
                 if (data.success) {
@@ -658,7 +658,7 @@
             };
             
             try {
-                const response = await fetch(`${API_URL}/api/${action}`, { method: 'POST' });
+                const response = await fetch(`${API_URL}/api/${action}`, { method: 'POST', credentials: 'same-origin' });
                 const data = await response.json();
                 
                 if (data.success) {


### PR DESCRIPTION
## Problem
The Control Panel buttons don't work after logging in via Cloudflare Access. The API calls return the Access login page instead of JSON.

## Root Cause
The `fetch()` calls were not including `credentials: 'same-origin'`, so the `CF-Authorization` cookie was not being sent with API requests.

## Fix
Added `credentials: 'same-origin'` to all fetch calls as per [Cloudflare documentation](https://developers.cloudflare.com/cloudflare-one/identity/authorization-cookie/cors/#troubleshooting):

> Ensure that the application has set `credentials: 'same-origin'` in all fetch or XHR requests.