### PR TITLE
docs(ci): Add website sync trigger to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -256,11 +256,15 @@ jobs:
           fi
           
           # Trigger the update-content workflow in nexus-stack.ch repo
-          curl -X POST \
+          # Using jq for safe JSON encoding and --fail for proper error handling
+          if curl --fail -X POST \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer $WEBSITE_TOKEN" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/stefanko-ch/nexus-stack.ch/dispatches \
-            -d "{\"event_type\":\"nexus-stack-release\",\"client_payload\":{\"version\":\"$NEW_VERSION\",\"repository\":\"Nexus-Stack\"}}"
-          
-          echo "✅ Triggered nexus-stack.ch website update"
+            -d "$(jq -n --arg version "$NEW_VERSION" '{event_type:"nexus-stack-release", client_payload:{version:$version, repository:"Nexus-Stack"}}')"; then
+            echo "✅ Triggered nexus-stack.ch website update"
+          else
+            echo "❌ Failed to trigger website update (HTTP error)"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

Adds automatic triggering of the nexus-stack.ch website update workflow when a new release is created.

## Changes

- Added new step to `release.yml` that sends a `repository_dispatch` event to the nexus-stack.ch repo after a successful release
- Uses `WEBSITE_DISPATCH_TOKEN` secret (needs to be configured)

## Setup Required

1. Create a Fine-grained PAT with `Contents: Read and write` permission for the `nexus-stack.ch` repo
2. Add it as `WEBSITE_DISPATCH_TOKEN` secret in this repo

## Related

- Corresponding workflow in nexus-stack.ch: https://github.com/stefanko-ch/nexus-stack.ch/blob/main/.github/workflows/update-content.yml

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Automates website sync after releases.
> 
> - Adds `Trigger nexus-stack.ch website update` step in `release.yml` to POST a `repository_dispatch` with `event_type: "nexus-stack-release"` and `version` payload
> - Uses `WEBSITE_DISPATCH_TOKEN`; safely no-ops if unset and exits on HTTP errors
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 288ee6e26aba5bb47a69e7a5bc85dfaeefc3ead6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->