### PR TITLE
fix(ci): Create .ssh directory before writing SSH key files

### DIFF
--- a/.github/workflows/setup-control-plane.yaml
+++ b/.github/workflows/setup-control-plane.yaml
@@ -62,6 +62,9 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_SECRETS_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
+          # Ensure .ssh directory exists
+          mkdir -p ~/.ssh
+          
           # Check if SSH key already exists in secrets
           if [ -n "${{ secrets.SSH_PRIVATE_KEY }}" ]; then
             echo "✅ SSH key already exists in secrets - reusing"


### PR DESCRIPTION
## Problem

Initial Setup workflow failed with:
```
/home/runner/.ssh/id_ed25519: No such file or directory
```

The SSH key was successfully stored in GitHub Secrets, but when reusing it on subsequent runs, the `~/.ssh` directory didn't exist yet.

## Root Cause

The `mkdir -p ~/.ssh` command was only in the `else` branch (new key generation), not in the `if` branch (reusing existing key from secrets).

## Solution

Move `mkdir -p ~/.ssh` to the beginning of the script so the directory always exists regardless of which branch is executed.

## Testing

- [ ] Run Initial Setup workflow
- [ ] Verify SSH key is reused from secrets
- [ ] Verify Control Plane deployment succeeds
