### PR TITLE
feat(stacks): Add Redpanda streaming platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ After deployment you'll have:
 ![Marimo](https://img.shields.io/badge/Marimo-1C1C1C?logo=python&logoColor=white)
 ![Mailpit](https://img.shields.io/badge/Mailpit-F36F21?logo=maildotru&logoColor=white)
 ![Metabase](https://img.shields.io/badge/Metabase-509EE3?logo=metabase&logoColor=white)
+![Redpanda](https://img.shields.io/badge/Redpanda-E4405F?logo=redpanda&logoColor=white)
 ![Info](https://img.shields.io/badge/Info-00D4AA?logo=nginx&logoColor=white)
 
 | Stack | Description | Website |
@@ -88,6 +89,7 @@ After deployment you'll have:
 | **Marimo** | Reactive Python notebook with SQL support | [marimo.io](https://marimo.io) |
 | **Mailpit** | Email & SMTP testing tool - catch and inspect emails | [mailpit.axllent.org](https://mailpit.axllent.org) |
 | **Metabase** | Open-source business intelligence and analytics tool | [metabase.com](https://www.metabase.com) |
+| **Redpanda** | Kafka-compatible streaming platform with Console UI | [redpanda.com](https://redpanda.com) |
 | **Info** | Landing page with service overview dashboard | — |
 
 → See [docs/stacks.md](docs/stacks.md) for detailed stack documentation and how to add new services.

--- a/docs/stacks.md
+++ b/docs/stacks.md
@@ -24,6 +24,8 @@ Images are pinned to **major versions** where supported for automatic security p
 | IT-Tools | `corentinth/it-tools` | `latest` | Latest ² |
 | Excalidraw | `excalidraw/excalidraw` | `latest` | Latest ² |
 | Marimo | `ghcr.io/marimo-team/marimo` | `latest-sql` | Latest ² |
+| Redpanda | `redpandadata/redpanda` | `v24.3` | Minor |
+| Redpanda Console | `redpandadata/console` | `v2.8` | Minor |
 | Nginx (Info) | `nginx` | `alpine` | Rolling |
 
 ¹ No major version tags available, requires manual updates.  
@@ -351,6 +353,56 @@ Marimo is a reactive Python notebook that's reproducible, git-friendly, and depl
 | Public Access | No (contains notebooks/code) |
 | Website | [marimo.io](https://marimo.io) |
 | Source | [GitHub](https://github.com/marimo-team/marimo) |
+
+---
+
+## Redpanda
+
+![Redpanda](https://img.shields.io/badge/Redpanda-E4405F?logo=redpanda&logoColor=white)
+
+**Kafka-compatible streaming platform**
+
+Redpanda is a Kafka-compatible streaming data platform that is simpler, faster, and more cost-effective than Apache Kafka. Features include:
+- 10x faster than Kafka with lower latency
+- No JVM, no ZooKeeper dependencies
+- 100% Kafka API compatible
+- Built-in Schema Registry and HTTP Proxy
+- Single binary deployment
+- WebAssembly data transforms
+
+| Setting | Value |
+|---------|-------|
+| Default Port (Admin) | `9644` |
+| Kafka Port | `9092` |
+| Schema Registry Port | `8081` |
+| Suggested Subdomain | `redpanda` |
+| Public Access | No (streaming infrastructure) |
+| Website | [redpanda.com](https://redpanda.com) |
+| Source | [GitHub](https://github.com/redpanda-data/redpanda) |
+
+---
+
+## Redpanda Console
+
+![Redpanda Console](https://img.shields.io/badge/Redpanda_Console-E4405F?logo=redpanda&logoColor=white)
+
+**Web UI for Redpanda/Kafka management**
+
+Redpanda Console is a developer-friendly web UI for managing and debugging your Kafka/Redpanda workloads. Features include:
+- Browse topics, partitions, and messages
+- View consumer groups and their lag
+- Manage schemas in Schema Registry
+- Execute ksqlDB queries
+- Monitor cluster health and performance
+- Produce and consume test messages
+
+| Setting | Value |
+|---------|-------|
+| Default Port | `8180` |
+| Suggested Subdomain | `redpanda-console` |
+| Public Access | No (cluster management) |
+| Website | [redpanda.com](https://redpanda.com) |
+| Source | [GitHub](https://github.com/redpanda-data/console) |
 
 ---
 

--- a/stacks/redpanda-console/docker-compose.yml
+++ b/stacks/redpanda-console/docker-compose.yml
@@ -1,0 +1,37 @@
+# =============================================================================
+# Redpanda Console - Web UI for Redpanda/Kafka
+# =============================================================================
+# Access via: https://redpanda-console.${domain}
+# Redpanda Console is a developer-friendly web UI for managing and debugging
+# your Kafka/Redpanda workloads.
+# =============================================================================
+
+services:
+  redpanda-console:
+    image: ${REDPANDA_CONSOLE_IMAGE:-redpandadata/console:v2.8.0}
+    container_name: redpanda-console
+    entrypoint: /bin/sh
+    command: -c 'echo "$$CONSOLE_CONFIG_FILE" > /tmp/config.yml; /app/console'
+    environment:
+      CONFIG_FILEPATH: /tmp/config.yml
+      CONSOLE_CONFIG_FILE: |
+        kafka:
+          brokers: ["redpanda:9092"]
+          schemaRegistry:
+            enabled: true
+            urls: ["http://redpanda:8081"]
+        redpanda:
+          adminApi:
+            enabled: true
+            urls: ["http://redpanda:9644"]
+    ports:
+      - "8180:8080"
+    networks:
+      - app-network
+    depends_on:
+      - redpanda
+    restart: unless-stopped
+
+networks:
+  app-network:
+    external: true

--- a/stacks/redpanda/docker-compose.yml
+++ b/stacks/redpanda/docker-compose.yml
@@ -1,0 +1,44 @@
+# =============================================================================
+# Redpanda - Kafka-compatible streaming platform
+# =============================================================================
+# Access via: https://redpanda.${domain}
+# Redpanda is a Kafka-compatible streaming data platform that is simpler,
+# faster, and more cost-effective than Apache Kafka.
+# =============================================================================
+
+services:
+  redpanda:
+    image: ${REDPANDA_IMAGE:-redpandadata/redpanda:v24.3.1}
+    container_name: redpanda
+    command:
+      - redpanda
+      - start
+      - --kafka-addr internal://0.0.0.0:9092,external://0.0.0.0:19092
+      - --advertise-kafka-addr internal://redpanda:9092,external://redpanda:19092
+      - --pandaproxy-addr internal://0.0.0.0:8082,external://0.0.0.0:18082
+      - --advertise-pandaproxy-addr internal://redpanda:8082,external://redpanda:18082
+      - --schema-registry-addr internal://0.0.0.0:8081,external://0.0.0.0:18081
+      - --rpc-addr redpanda:33145
+      - --advertise-rpc-addr redpanda:33145
+      - --mode dev-container
+      - --smp 1
+      - --default-log-level=info
+    volumes:
+      - redpanda-data:/var/lib/redpanda/data
+    networks:
+      - app-network
+    healthcheck:
+      test: ["CMD-SHELL", "rpk cluster health | grep -E 'Healthy:.+true' || exit 1"]
+      interval: 15s
+      timeout: 3s
+      retries: 5
+      start_period: 5s
+    restart: unless-stopped
+
+volumes:
+  redpanda-data:
+    driver: local
+
+networks:
+  app-network:
+    external: true

--- a/tofu/image-versions.tfvars
+++ b/tofu/image-versions.tfvars
@@ -17,17 +17,19 @@ image_versions = {
   # -------------------------------------------------------------------------
   # Main Services (major version pinning where supported)
   # -------------------------------------------------------------------------
-  excalidraw  = "excalidraw/excalidraw:latest"          # No semver tags available
-  grafana     = "grafana/grafana:12"                    # Major: 12.x.x
-  infisical   = "infisical/infisical:v0.155.5"          # No major tags, exact only
-  it-tools    = "corentinth/it-tools:latest"            # Date-based tags only
-  kestra      = "kestra/kestra:v1.0"                    # Minor series: v1.0 (LTS)
-  mailpit     = "axllent/mailpit:v1.28"                 # Minor stream: v1.28 (tracks latest 1.28.x patch)
-  marimo      = "ghcr.io/marimo-team/marimo:latest-sql" # SQL variant with DuckDB
-  metabase    = "metabase/metabase:v0.58.x"             # Minor: v0.58.x.x
-  n8n         = "n8nio/n8n:1"                           # Major: 1.x.x
-  portainer   = "portainer/portainer-ce:lts"            # LTS: Long-term support
-  uptime-kuma = "louislam/uptime-kuma:2"                # Major: 2.x.x
+  excalidraw       = "excalidraw/excalidraw:latest"          # No semver tags available
+  grafana          = "grafana/grafana:12"                    # Major: 12.x.x
+  infisical        = "infisical/infisical:v0.155.5"          # No major tags, exact only
+  it-tools         = "corentinth/it-tools:latest"            # Date-based tags only
+  kestra           = "kestra/kestra:v1.0"                    # Minor series: v1.0 (LTS)
+  mailpit          = "axllent/mailpit:v1.28"                 # Minor stream: v1.28 (tracks latest 1.28.x patch)
+  marimo           = "ghcr.io/marimo-team/marimo:latest-sql" # SQL variant with DuckDB
+  metabase         = "metabase/metabase:v0.58.x"             # Minor: v0.58.x.x
+  n8n              = "n8nio/n8n:1"                           # Major: 1.x.x
+  portainer        = "portainer/portainer-ce:lts"            # LTS: Long-term support
+  redpanda         = "redpandadata/redpanda:v24.3"           # Minor: v24.3.x
+  redpanda-console = "redpandadata/console:v2.8"             # Minor: v2.8.x
+  uptime-kuma      = "louislam/uptime-kuma:2"                # Major: 2.x.x
 
   # -------------------------------------------------------------------------
   # Grafana Stack Components

--- a/tofu/services.tfvars
+++ b/tofu/services.tfvars
@@ -119,4 +119,20 @@ services = {
     public      = false
     description = "Open-source business intelligence and analytics tool for data visualization."
   }
+
+  redpanda = {
+    enabled     = false
+    subdomain   = "redpanda"
+    port        = 9644
+    public      = false
+    description = "Kafka-compatible streaming platform that is simpler, faster, and more cost-effective."
+  }
+
+  redpanda-console = {
+    enabled     = false
+    subdomain   = "redpanda-console"
+    port        = 8180
+    public      = false
+    description = "Web UI for managing and debugging Redpanda/Kafka workloads."
+  }
 }


### PR DESCRIPTION
## Summary

Add Redpanda and Redpanda Console as new stacks for Kafka-compatible streaming.

## Changes

- **Redpanda broker**: Kafka-compatible, no JVM/ZooKeeper required
- **Redpanda Console**: Web UI for cluster management
- Services disabled by default (opt-in)
- Image versions: v24.3 (Redpanda), v2.8 (Console)

## Ports

| Service | Port | Use |
|---------|------|-----|
| Redpanda | 9092 | Kafka protocol (internal) |
| Redpanda | 8081 | Schema Registry (internal) |
| Redpanda | 9644 | Admin API (via Tunnel) |
| Console | 8180 | Web UI (via Tunnel) |

## Access

- **Internal**: n8n, Kestra can connect via `redpanda:9092`
- **External**: Only Console UI via Cloudflare Tunnel (Kafka protocol not supported through tunnel)

## Testing

- [ ] Enable services in Control Plane
- [ ] Verify Console UI accessible
- [ ] Test internal Kafka connectivity from n8n/Kestra

Closes #38
Closes #39