### PR TITLE
chore: Configure Release Please for v1.x releases

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,6 +3,8 @@
   "release-type": "simple",
   "include-v-in-tag": true,
   "include-component-in-tag": false,
+  "bump-minor-pre-major": true,
+  "bump-patch-for-minor-pre-major": false,
   "changelog-sections": [
     { "type": "feat", "section": "🚀 Features" },
     { "type": "fix", "section": "🐛 Bug Fixes" },


### PR DESCRIPTION
## Summary

Configure Release Please to treat breaking changes as minor version bumps, keeping us on v1.x.

## Changes

- Add `bump-minor-pre-major: true` - Breaking changes bump minor version (not major)
- Add `bump-patch-for-minor-pre-major: false` - Features still bump minor

## Why

The old commit history contains breaking change markers from before v1.0.0. Without this config, Release Please would jump to v2.0.0.

## Result

Next release will be **v1.1.0** instead of v2.0.0.