### PR TITLE
fix(ci): Fix missing newline causing last service (Wetty) to be skipped

### DIFF
--- a/.github/scripts/sync-deployed-state.sh
+++ b/.github/scripts/sync-deployed-state.sh
@@ -101,9 +101,13 @@ for name, config in services.items():
 # Write to temp files
 with open('/tmp/init_services.sql', 'w') as f:
     f.write('\n'.join(insert_statements))
+    if insert_statements:  # Ensure file ends with newline
+        f.write('\n')
 
 with open('/tmp/update_services.sql', 'w') as f:
     f.write('\n'.join(update_statements))
+    if update_statements:  # Ensure file ends with newline
+        f.write('\n')
 
 print(f"  Generated {len(insert_statements)} service insert statements")
 print(f"  Generated {len(update_statements)} service update statements")


### PR DESCRIPTION
## Problem

The sync-deployed-state.sh script was skipping the last service (Wetty) because:

1. Python writes SQL statements with `'\n'.join()` which doesn't add a newline at the end of the file
2. `wc -l` counts only lines ending with newline → counted 17 instead of 18
3. `while IFS= read -r sql` doesn't read the last line if it has no newline → Wetty was skipped

## Solution

Added explicit newline at end of SQL files to ensure all services are processed.

## Evidence from Logs

- "Generated 18 service insert statements" (Python count)
- "Found 17 INSERT statements" (wc -l count - missing one!)
- Wetty was in "Services found" list but never appeared in INSERT processing
- Final verification showed "Found 0 services in D1" (all INSERTs failed verification)

This fix ensures the last service in the list is also processed.
