### PR TITLE
fix(ci): remove SSH key masking that corrupts R2 credentials

### DIFF
--- a/.github/workflows/setup-control-plane.yaml
+++ b/.github/workflows/setup-control-plane.yaml
@@ -113,12 +113,10 @@ jobs:
           echo "ssh_pubkey=$(cat ~/.ssh/id_ed25519.pub)" >> $GITHUB_OUTPUT
 
           # Export private key for output (for initial-setup passthrough to spin-up)
-          # This follows the same pattern as r2_secret_access_key
-          # Mask the private key so it never appears in logs
-          echo "::add-mask::$(base64 -w0 < ~/.ssh/id_ed25519)"
-          while IFS= read -r line; do
-            echo "::add-mask::$line"
-          done < ~/.ssh/id_ed25519
+          # Note: Don't mask private key here - masking prevents it from being
+          # passed as workflow output (GitHub blocks outputs containing masked values)
+          # AND can corrupt R2 credentials if base64 substrings match.
+          # The key will be masked by the receiving workflow (spin-up.yml) when used
           {
             echo "ssh_private_key<<SSHEOF"
             cat ~/.ssh/id_ed25519


### PR DESCRIPTION
## Summary

- Remove `::add-mask::` for SSH private key lines in `setup-control-plane.yaml` that corrupted R2 credentials by replacing matching base64 substrings with `***` job-wide
- Follows the same pattern already used for R2 credentials (don't mask in producer, mask in consumer)

## Root Cause

After a `destroy-all` + `setup-control-plane` cycle, the R2 credentials stored in GitHub Secrets caused `tofu init` to fail with `401 Unauthorized`. The `::add-mask::` registered SSH key fragments job-wide, which could corrupt R2 credential values and also blocked all workflow outputs (`Skip output ... since it may contain secret`).

## Test plan

- [x] Delete stale R2 Secrets (`gh secret delete R2_ACCESS_KEY_ID && gh secret delete R2_SECRET_ACCESS_KEY`)
- [ ] Run `initial-setup.yaml` on this branch
- [ ] Verify `tofu init` succeeds with `Successfully configured the backend "s3"!`
- [ ] Verify `ssh_private_key` output is passed to spin-up workflow
- [ ] Verify spin-up completes successfully
