### PR TITLE
fix(stacks): Fix Jupyter crash due to nounset flag in sourced hook

### DIFF
--- a/stacks/jupyter/setup-s3a-jars.sh
+++ b/stacks/jupyter/setup-s3a-jars.sh
@@ -1,13 +1,17 @@
 #!/bin/bash
-set -eo pipefail
 # =============================================================================
 # Download and install hadoop-aws + AWS SDK v2 JARs for S3A filesystem support.
 # Runs as root via Jupyter's before-notebook.d hook (before user switch).
+#
+# This script is sourced (not subshelled) by Jupyter's start.sh, so we must
+# save and restore shell options to avoid leaking them to the parent process.
 #
 # JARs are cached in the persistent volume (.spark-jars/) so the ~642MB
 # download (hadoop-aws ~1MB + AWS SDK v2 bundle ~641MB) only happens on
 # first start.
 # =============================================================================
+_SAVED_OPTS=$(set +o)
+set -eo pipefail
 JARS_CACHE=/home/jovyan/work/.spark-jars
 HADOOP_AWS="$JARS_CACHE/hadoop-aws-3.4.2.jar"
 AWS_BUNDLE="$JARS_CACHE/bundle-2.29.52.jar"
@@ -24,3 +28,6 @@ if [ ! -f "$HADOOP_AWS" ] || [ ! -f "$AWS_BUNDLE" ]; then
 fi
 cp -n "$HADOOP_AWS" /usr/local/spark/jars/
 cp -n "$AWS_BUNDLE" /usr/local/spark/jars/
+
+# Restore caller's shell options so we don't leak -eo pipefail to start.sh
+eval "$_SAVED_OPTS"


### PR DESCRIPTION
## Summary

- Fix Jupyter container restart loop caused by `set -euo pipefail` in `setup-s3a-jars.sh`
- The hook is **sourced** (not subshelled) by Jupyter's `start.sh`, so the `-u` (nounset) flag persists and crashes `start.sh` on `${JUPYTER_DOCKER_STACKS_QUIET}` which has no default value
- Fix: `set -euo pipefail` → `set -eo pipefail`

## Test plan

- [x] Identified root cause via `docker logs jupyter` (`JUPYTER_DOCKER_STACKS_QUIET: unbound variable`)
- [ ] Run `spin-up.yml` on this branch
- [ ] Verify Jupyter container is healthy: `ssh nexus "docker ps --filter name=jupyter"`
- [ ] Verify https://jupyter.nexus-stack.ch loads
