### PR TITLE
feat(stacks): Add workspace Git repo fork from GitHub mirror

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -2795,7 +2795,6 @@ if echo "$ENABLED_SERVICES" | grep -qw "gitea" \
                 # Fork the first mirror as the user's workspace repo (idempotent)
                 # FORKED_WORKSPACE flag ensures we only fork once (the first mirror)
                 if [ "${FORKED_WORKSPACE:-}" != "1" ] && [ -n "${GITEA_USER_USERNAME:-}" ]; then
-                    FORKED_WORKSPACE=1
                     ORIG_NAME=$(basename "$REPO_URL" .git)
                     GITEA_USER_SANITIZED="${GITEA_USER_USERNAME//[^a-zA-Z0-9]/_}"
                     FORK_NAME="${ORIG_NAME}_${GITEA_USER_SANITIZED}"
@@ -2822,8 +2821,10 @@ if echo "$ENABLED_SERVICES" | grep -qw "gitea" \
                             -d '{\"name\":\"$FORK_NAME\"}'")
                         if [ "$FORK_RESULT" = "202" ]; then
                             echo -e "${GREEN}  ✓ Forked into ${GITEA_USER_USERNAME}/${FORK_NAME}${NC}"
+                            FORKED_WORKSPACE=1
                         elif [ "$FORK_RESULT" = "409" ]; then
                             echo -e "${YELLOW}  ⚠ Fork ${GITEA_USER_USERNAME}/${FORK_NAME} already exists${NC}"
+                            FORKED_WORKSPACE=1
                         else
                             echo -e "${YELLOW}  ⚠ Fork returned HTTP $FORK_RESULT${NC}"
                         fi


### PR DESCRIPTION
## Summary

- Adds optional Gitea workspace repo that is automatically forked from a GitHub mirror when `GH_MIRROR_REPOS` is set
- Fork is created in the user's namespace (`user/RepoName_username`) with a personal Gitea token so it doesn't land under the admin account
- Fork name is derived automatically from the first mirror URL and the user's username (e.g. `Bsc_EDS_GIS_FS2026_stefan_koch`)
- git-integrated services (Jupyter, Marimo, code-server, Meltano, Prefect) clone the fork on startup and open directly in that directory
- Fully idempotent: re-deploys handle existing mirrors, existing forks (HTTP 409), and re-sync the collaborator access

## Fixes

- Fork was only attempted when the mirror was **newly created** — on re-deploys (`mirror already exists → continue`) the fork was silently skipped. Now the fork runs whenever the mirror is available.
- Services were restarted **before** the mirror block ran, so code-server tried to clone a fork URL that didn't exist yet. Restart is now deferred to after fork creation when `GH_MIRROR_REPOS` is set.

## How to Test

1. Set `GH_MIRROR_TOKEN` and `GH_MIRROR_REPOS` secrets in the repository
2. Run spin-up:
   ```bash
   gh workflow run spin-up.yml --ref feat/workspace-git-repo
   ```
3. After deployment, open Gitea and verify:
   - Mirror `admin/mirror-readonly-<RepoName>` exists
   - Fork `<username>/<RepoName>_<username>` exists in the user's namespace
4. Open code-server — it should open directly in the cloned repo folder
