### PR TITLE
feat(stacks): Add Python, uv, and Jupyter to code-server

### DIFF
--- a/stacks/code-server/Dockerfile
+++ b/stacks/code-server/Dockerfile
@@ -7,13 +7,13 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends python3 python3-venv python3-pip && \
     rm -rf /var/lib/apt/lists/*
 
-# Install uv (fast Python package manager)
-RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR=/usr/local/bin sh
+# Install uv (fast Python package manager) - pinned version
+RUN curl -LsSf https://astral.sh/uv/0.6.12/install.sh | env UV_INSTALL_DIR=/usr/local/bin sh
 
 USER coder
 
 # Install JupyterLab via uv (provides the jupyter CLI)
-RUN uv tool install jupyterlab
+RUN uv tool install jupyterlab==4.3.6
 
 # Add uv tool bin to PATH
 ENV PATH="/home/coder/.local/bin:${PATH}"

--- a/stacks/code-server/docker-compose.yml
+++ b/stacks/code-server/docker-compose.yml
@@ -15,7 +15,7 @@
 services:
   code-server:
     build: .
-    image: nexus-code-server:latest
+    image: ${IMAGE_CODE_SERVER:-nexus-code-server:latest}
     container_name: code-server
     restart: unless-stopped
     entrypoint: >


### PR DESCRIPTION
## Summary

- Custom Dockerfile for code-server that pre-installs Python 3, uv, and JupyterLab
- Tools are available immediately on container start (no manual setup needed)
- `duckdb` and other project-specific packages can be installed per-venv via `uv pip install`

## Test plan

- [ ] Run spin-up and verify `python3 --version`, `uv --version`, `jupyter --version` work in code-server
- [ ] Verify `uv venv && source .venv/bin/activate && uv pip install duckdb` works
