### PR TITLE
chore(ci): Update GitHub Actions from Node.js 20 to Node.js 24

### DIFF
--- a/.github/workflows/cleanup-orphaned-resources.yml
+++ b/.github/workflows/cleanup-orphaned-resources.yml
@@ -18,7 +18,7 @@ jobs:
     
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install jq
         run: sudo apt-get update && sudo apt-get install -y jq

--- a/.github/workflows/destroy-all.yml
+++ b/.github/workflows/destroy-all.yml
@@ -50,10 +50,10 @@ jobs:
           echo "⚠️  DESTRUCTION CONFIRMED - This will delete ALL infrastructure and state!"
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install OpenTofu
-        uses: opentofu/setup-opentofu@v1
+        uses: opentofu/setup-opentofu@v2
         with:
           tofu_version: 1.10.0
 

--- a/.github/workflows/initial-setup.yaml
+++ b/.github/workflows/initial-setup.yaml
@@ -41,7 +41,7 @@ jobs:
       DOMAIN: ${{ secrets.DOMAIN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Build enabled services list
         id: build-list

--- a/.github/workflows/setup-control-plane.yaml
+++ b/.github/workflows/setup-control-plane.yaml
@@ -57,10 +57,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install OpenTofu
-        uses: opentofu/setup-opentofu@v1
+        uses: opentofu/setup-opentofu@v2
         with:
           tofu_version: 1.10.0
 

--- a/.github/workflows/spin-up.yml
+++ b/.github/workflows/spin-up.yml
@@ -77,7 +77,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Log workflow start
         env:
@@ -91,7 +91,7 @@ jobs:
           fi
 
       - name: Install OpenTofu
-        uses: opentofu/setup-opentofu@v1
+        uses: opentofu/setup-opentofu@v2
         with:
           tofu_version: 1.10.0
 

--- a/.github/workflows/teardown.yml
+++ b/.github/workflows/teardown.yml
@@ -45,7 +45,7 @@ jobs:
           echo "   - Keep the Control Plane active for re-deployment"
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Log teardown start
         env:
@@ -59,7 +59,7 @@ jobs:
           fi
 
       - name: Install OpenTofu
-        uses: opentofu/setup-opentofu@v1
+        uses: opentofu/setup-opentofu@v2
         with:
           tofu_version: 1.10.0
 

--- a/.github/workflows/validate-workflows.yaml
+++ b/.github/workflows/validate-workflows.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Validate workflow files
         uses: raven-actions/actionlint@v2


### PR DESCRIPTION
## Summary

- Update `actions/checkout` from v4 to v5 (Node.js 24)
- Update `opentofu/setup-opentofu` from v1 to v2 (Node.js 24)
- Affects all 7 workflow files

Eliminates the Node.js 20 deprecation warning that appears on every workflow run.

## Test plan

- [ ] Run any workflow and verify no Node.js 20 deprecation warning appears

Closes #251
