### PR TITLE
fix(ci): Fix worker secret conflicts and R2 credential error handling

### DIFF
--- a/.github/workflows/setup-control-plane.yaml
+++ b/.github/workflows/setup-control-plane.yaml
@@ -231,14 +231,13 @@ jobs:
               else
                 echo "⚠️  Failed to auto-save secrets: $SECRET_ERROR"
                 echo ""
-                echo "╔══════════════════════════════════════════════════════════════════════════════╗"
-                echo "║  Save these credentials manually as GitHub Secrets:                        ║"
-                echo "╠══════════════════════════════════════════════════════════════════════════════╣"
-                echo "║  R2_ACCESS_KEY_ID=$R2_ACCESS_KEY_ID"
-                echo "║  R2_SECRET_ACCESS_KEY=$R2_SECRET_ACCESS_KEY"
-                echo "╚══════════════════════════════════════════════════════════════════════════════╝"
+                echo "  Please save these credentials manually as GitHub Secrets:"
                 echo ""
-                echo "Or configure GH_SECRETS_TOKEN with 'repo' scope and 'Secrets: Read and Write' permission"
+                echo "  R2_ACCESS_KEY_ID=$R2_ACCESS_KEY_ID"
+                echo "  R2_SECRET_ACCESS_KEY=$R2_SECRET_ACCESS_KEY"
+                echo ""
+                echo "  To enable auto-saving, configure GH_SECRETS_TOKEN:"
+                echo "  Fine-grained PAT with Secrets (Read and Write) permission"
               fi
             else
               echo ""

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -124,7 +124,7 @@ Add these secrets to your GitHub repository:
 
 | Secret Name | Description |
 |-------------|-------------|
-| `GH_SECRETS_TOKEN` | GitHub PAT for auto-saving R2 credentials (see below) |
+| `GH_SECRETS_TOKEN` | GitHub PAT for R2 auto-save and Cloudflare runtime (see below) |
 | `TF_VAR_user_email` | User - all services except SSH |
 | `RESEND_API_KEY` | Email notifications via Resend |
 | `DOCKERHUB_USERNAME` | Docker Hub username (higher pull limits) |
@@ -132,13 +132,15 @@ Add these secrets to your GitHub repository:
 
 #### GH_SECRETS_TOKEN
 
-This token allows the initial setup workflow to automatically save R2 credentials as GitHub Secrets. Without it, you must manually copy the credentials from the workflow logs after the first run.
+This token allows the initial setup workflow to automatically save R2 credentials as GitHub Secrets. It is also used as the runtime `GITHUB_TOKEN` in Cloudflare (for the scheduled teardown worker and Control Plane), so it must be able to dispatch workflows. Without it, you must manually copy the credentials from the workflow logs after the first run, and Cloudflare-based automation that triggers GitHub Actions will fail.
 
 **How to create:**
 1. Go to **GitHub** → **Settings** → **Developer settings** → **Personal access tokens** → **Fine-grained tokens**
 2. Click **"Generate new token"**
 3. **Repository access**: Select your Nexus-Stack repository
-4. **Permissions**: Repository permissions → **Secrets** → **Read and Write**
+4. **Permissions** (Repository permissions):
+   - **Secrets** → **Read and write**
+   - **Actions** → **Read and write** (required so Cloudflare workers can dispatch workflows)
 5. Copy the token and save it as `GH_SECRETS_TOKEN` in your repository secrets
 
 ### Optional Repository Variables


### PR DESCRIPTION
## Summary

Fixes two bugs in the `setup-control-plane.yaml` workflow related to secret management.

### Issue #280: Worker secret "Binding name already in use" on re-run

**Root cause:** `GITHUB_OWNER`, `GITHUB_REPO`, `DOMAIN`, and `ADMIN_EMAIL` were defined as `plain_text_binding` in Terraform (`tofu/control-plane/main.tf`) AND also set as wrangler secrets in the workflow. Cloudflare rejects this with error 10053 because a secret cannot share a name with an existing env var binding.

**Fix:**
- Remove duplicate `wrangler secret put` calls for variables already managed by Terraform
- Same cleanup for Pages secrets step (env vars managed by Terraform `environment_variables`)
- Keep only true secrets via wrangler: `GITHUB_TOKEN`, `RESEND_API_KEY`
- Fail loudly when `GITHUB_TOKEN` cannot be set (critical for Worker and Control Plane)

### Issue #279: R2 credentials silently lost

**Root cause:** `gh secret set ... 2>&1 | tee /tmp/...` — the pipe exit code comes from `tee` (always 0), not from `gh secret set`. So a 403 error is never detected and "Saved" is printed even on failure.

**Fix:**
- Replace pipe-to-tee with command substitution to capture output and exit code correctly
- Show credentials in a visible box on failure so they are not silently lost
- Document `GH_SECRETS_TOKEN` in the setup guide with step-by-step creation instructions

## How to Test

1. Run `setup-control-plane.yaml` on an **existing deployment** (re-run scenario):
   ```bash
   gh workflow run setup-control-plane.yaml --ref fix/control-plane-secrets
   ```
2. Verify no "Binding name already in use" errors in the Worker secrets step
3. Verify the Control Plane secrets step only sets `GITHUB_TOKEN` and `RESEND_API_KEY`
4. For R2 credential testing: run `initial-setup.yaml` without `GH_SECRETS_TOKEN` — credentials should appear in logs (not silently lost)

Closes #279
Closes #280
