### PR TITLE
feat(stacks): Add Kafdrop Kafka/Redpanda web UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ flowchart LR
     end
 ```
 
-## Available Stacks (53)
+## Available Stacks (54)
 
 ![AKHQ](https://img.shields.io/badge/AKHQ-000000?logo=apachekafka&logoColor=white)
 ![Adminer](https://img.shields.io/badge/Adminer-34567C?logo=adminer&logoColor=white)
@@ -114,6 +114,7 @@ flowchart LR
 ![Infisical](https://img.shields.io/badge/Infisical-000000?logo=infisical&logoColor=white)
 ![IT-Tools](https://img.shields.io/badge/IT--Tools-5D5D5D?logo=homeassistant&logoColor=white)
 ![Jupyter](https://img.shields.io/badge/Jupyter-F37726?logo=jupyter&logoColor=white)
+![Kafdrop](https://img.shields.io/badge/Kafdrop-000000?logo=apachekafka&logoColor=white)
 ![Kafka-UI](https://img.shields.io/badge/Kafka--UI-000000?logo=apachekafka&logoColor=white)
 ![Kestra](https://img.shields.io/badge/Kestra-6047EC?logo=kestra&logoColor=white)
 ![LakeFS](https://img.shields.io/badge/LakeFS-00B4D8?logo=git&logoColor=white)
@@ -170,6 +171,7 @@ flowchart LR
 | **Infisical** | Open-source secret management platform | [infisical.com](https://infisical.com) |
 | **IT-Tools** | Collection of handy online tools for developers | [it-tools.tech](https://it-tools.tech) |
 | **Jupyter** | Interactive PySpark notebook platform with Spark SQL support and cluster connectivity | [jupyter.org](https://jupyter.org) |
+| **Kafdrop** | Lightweight Kafka/Redpanda web UI for browsing topics and consumer groups | [GitHub](https://github.com/obsidiandynamics/kafdrop) |
 | **Kafka-UI** | Modern web UI for Apache Kafka / Redpanda management | [kafka-ui.provectus.io](https://docs.kafka-ui.provectus.io/) |
 | **Kestra** | Modern workflow orchestration for data pipelines & automation | [kestra.io](https://kestra.io) |
 | **LakeFS** | Git-like version control for data lakes (Hetzner Object Storage backend) | [lakefs.io](https://lakefs.io) |

--- a/docs/stacks/README.md
+++ b/docs/stacks/README.md
@@ -29,6 +29,7 @@ Images are pinned to **major versions** where supported for automatic security p
 | OpenMetadata Ingestion | `docker.getcollate.io/openmetadata/ingestion` | `1.6.6` | Exact ¹ |
 | Elasticsearch (OpenMetadata) | `docker.elastic.co/elasticsearch/elasticsearch` | `8.11.4` | Exact ¹ |
 | PostgreSQL (OpenMetadata DB) | `postgres` | `16-alpine` | Major |
+| Kafdrop | `obsidiandynamics/kafdrop` | `4.2.0` | Exact ¹ |
 | Kafka-UI | `provectuslabs/kafka-ui` | `latest` | Latest ² |
 | Kestra | `kestra/kestra` | `v1` | Major |
 | Infisical | `infisical/infisical` | `v0.155.5` | Exact ¹ |
@@ -128,6 +129,7 @@ Images are pinned to **major versions** where supported for automatic security p
 | **Infisical** | Secret management platform | [infisical.md](infisical.md) |
 | **IT-Tools** | Developer tools collection | [it-tools.md](it-tools.md) |
 | **Jupyter PySpark** | Interactive PySpark notebook | [jupyter.md](jupyter.md) |
+| **Kafdrop** | Lightweight Kafka/Redpanda web UI | [kafdrop.md](kafdrop.md) |
 | **Kafka-UI** | Kafka/Redpanda management UI | [kafka-ui.md](kafka-ui.md) |
 | **Kestra** | Workflow orchestration | [kestra.md](kestra.md) |
 | **LakeFS** | Git-like version control for data lakes | [lakefs.md](lakefs.md) |

--- a/docs/stacks/kafdrop.md
+++ b/docs/stacks/kafdrop.md
@@ -1,0 +1,26 @@
+## Kafdrop
+
+![Kafdrop](https://img.shields.io/badge/Kafdrop-000000?logo=apachekafka&logoColor=white)
+
+**Lightweight Kafka/Redpanda web UI for browsing topics, consumer groups, and cluster health**
+
+Kafdrop is a simple, fast web UI for monitoring Apache Kafka and Redpanda clusters. Features include:
+- Topic listing with partition and replica details
+- Message browsing with key/value deserialization
+- Consumer group monitoring with lag tracking
+- Schema Registry support (Avro, JSON Schema, Protobuf)
+- Broker and cluster health overview
+- Lightweight footprint (low memory usage)
+
+| Setting | Value |
+|---------|-------|
+| Default Port | `8095` |
+| Suggested Subdomain | `kafdrop` |
+| Public Access | No (cluster management) |
+| Source | [GitHub](https://github.com/obsidiandynamics/kafdrop) |
+
+### Pre-configured Connection
+
+Kafdrop is automatically configured to connect to the Redpanda cluster:
+- **Bootstrap Servers:** `redpanda:9092`
+- **Schema Registry:** `http://redpanda:8081`

--- a/services.yaml
+++ b/services.yaml
@@ -194,6 +194,13 @@ services:
     description: "Interactive PySpark notebook platform with Spark SQL support and cluster connectivity."
     image: "quay.io/jupyter/pyspark-notebook:python-3.13"
 
+  kafdrop:
+    subdomain: "kafdrop"
+    port: 8095
+    public: false
+    description: "Lightweight Kafka/Redpanda web UI for browsing topics, consumer groups, and cluster health."
+    image: "obsidiandynamics/kafdrop:4.2.0"
+
   kafka-ui:
     subdomain: "kafka-ui"
     port: 8181

--- a/stacks/kafdrop/docker-compose.yml
+++ b/stacks/kafdrop/docker-compose.yml
@@ -1,0 +1,32 @@
+# =============================================================================
+# Kafdrop - Lightweight Kafka/Redpanda Web UI
+# =============================================================================
+# Simple web UI for browsing Kafka/Redpanda topics, consumer groups, and
+# cluster health. Lightweight alternative to Kafka-UI and AKHQ.
+#
+# Access: https://kafdrop.<domain>
+# Docs: https://github.com/obsidiandynamics/kafdrop
+# =============================================================================
+
+services:
+  kafdrop:
+    image: ${IMAGE_KAFDROP:-obsidiandynamics/kafdrop:4.2.0}
+    container_name: kafdrop
+    restart: unless-stopped
+    ports:
+      - "8095:9000"
+    environment:
+      - KAFKA_BROKERCONNECT=redpanda:9092
+      - SCHEMAREGISTRY_CONNECT=http://redpanda:8081
+      - JVM_OPTS=-Xms32M -Xmx128M
+    networks:
+      - app-network
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+networks:
+  app-network:
+    external: true


### PR DESCRIPTION
## Summary

- Add Kafdrop as a lightweight Kafka/Redpanda web UI for browsing topics, consumer groups, and cluster health
- Pre-configured to connect to the Redpanda cluster with schema registry support
- Pinned to version 4.2.0 on port 8095

## Test plan

- [ ] Enable Kafdrop via Control Plane
- [ ] Access `https://kafdrop.<domain>` and verify UI loads
- [ ] Verify Redpanda cluster is connected and topics are visible
- [ ] Check consumer groups and schema registry tabs work

Closes #40
