### PR TITLE
feat(stacks): Add Budibase low-code platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,10 +92,11 @@ flowchart LR
     end
 ```
 
-## Available Stacks (54)
+## Available Stacks (55)
 
 ![AKHQ](https://img.shields.io/badge/AKHQ-000000?logo=apachekafka&logoColor=white)
 ![Adminer](https://img.shields.io/badge/Adminer-34567C?logo=adminer&logoColor=white)
+![Budibase](https://img.shields.io/badge/Budibase-9981F5?logo=budibase&logoColor=white)
 ![CloudBeaver](https://img.shields.io/badge/CloudBeaver-3776AB?logo=dbeaver&logoColor=white)
 ![ClickHouse](https://img.shields.io/badge/ClickHouse-FFCC00?logo=clickhouse&logoColor=black)
 ![code-server](https://img.shields.io/badge/code--server-007ACC?logo=visualstudiocode&logoColor=white)
@@ -153,6 +154,7 @@ flowchart LR
 |-------|-------------|--------|
 | **AKHQ** | Kafka/Redpanda management GUI for topics, consumer groups, schema registry, and Kafka Connect | [akhq.io](https://akhq.io) |
 | **Adminer** | Lightweight database management tool (supports PostgreSQL, MySQL, SQLite, etc.) | [adminer.org](https://www.adminer.org) |
+| **Budibase** | Open-source low-code platform for building internal tools and dashboards | [budibase.com](https://budibase.com) |
 | **CloudBeaver** | Web-based database management tool | [dbeaver.com/cloudbeaver](https://dbeaver.com/cloudbeaver/) |
 | **ClickHouse** | Fast columnar database for real-time analytics and OLAP queries | [clickhouse.com](https://clickhouse.com) |
 | **code-server** | VS Code in the browser for remote development | [coder.com](https://coder.com) |

--- a/docs/stacks/README.md
+++ b/docs/stacks/README.md
@@ -10,6 +10,7 @@ Images are pinned to **major versions** where supported for automatic security p
 |---------|-------|-----|----------|
 | AKHQ | `tchiotludo/akhq` | `0.27.0` | Exact ¹ |
 | Adminer | `adminer` | `latest` | Latest ² |
+| Budibase | `budibase/budibase` | `latest` | Latest ² |
 | CloudBeaver | `dbeaver/cloudbeaver` | `24` | Major |
 | ClickHouse | `clickhouse/clickhouse-server` | `25.8.16.34` | Exact ¹ |
 | code-server | `codercom/code-server` | `latest` | Latest ² |
@@ -111,6 +112,7 @@ Images are pinned to **major versions** where supported for automatic security p
 | **AKHQ** | Kafka/Redpanda management GUI | [akhq.md](akhq.md) |
 | **Adminer** | Lightweight database management tool | [adminer.md](adminer.md) |
 | **Apache Spark** | Distributed data processing engine | [spark.md](spark.md) |
+| **Budibase** | Low-code platform for internal tools | [budibase.md](budibase.md) |
 | **CloudBeaver** | Web-based database management tool | [cloudbeaver.md](cloudbeaver.md) |
 | **ClickHouse** | Columnar database for real-time analytics | [clickhouse.md](clickhouse.md) |
 | **code-server** | VS Code in the browser | [code-server.md](code-server.md) |

--- a/docs/stacks/budibase.md
+++ b/docs/stacks/budibase.md
@@ -1,0 +1,29 @@
+## Budibase
+
+![Budibase](https://img.shields.io/badge/Budibase-9981F5?logo=budibase&logoColor=white)
+
+**Open-source low-code platform for building internal tools, CRUD apps, and dashboards**
+
+Budibase is a low-code development platform for creating internal business applications. Features include:
+- Drag-and-drop UI builder for forms, tables, charts, and custom components
+- Native data source connectors (PostgreSQL, MySQL, MongoDB, REST/GraphQL APIs)
+- Server-side automation with scheduled jobs and webhook triggers
+- Built-in user management with role-based access control
+- Custom React/JSX components and plugin system
+- All-in-one container (CouchDB, Redis, MinIO bundled)
+
+| Setting | Value |
+|---------|-------|
+| Default Port | `8096` |
+| Suggested Subdomain | `budibase` |
+| Public Access | No |
+| Website | [budibase.com](https://budibase.com) |
+| Source | [GitHub](https://github.com/Budibase/budibase) |
+
+### First-Time Setup
+
+On first access, Budibase prompts you to create an admin account. No pre-configured credentials are needed.
+
+### Persistent Data
+
+All data (apps, databases, files) is stored in the `budibase_data` Docker volume and persists across container restarts.

--- a/services.yaml
+++ b/services.yaml
@@ -40,6 +40,13 @@ services:
     description: "Web-based database management tool supporting PostgreSQL, MySQL, SQL Server, and more."
     image: "dbeaver/cloudbeaver:24"
 
+  budibase:
+    subdomain: "budibase"
+    port: 8096
+    public: false
+    description: "Open-source low-code platform for building internal tools, CRUD apps, and dashboards."
+    image: "budibase/budibase:latest"
+
   clickhouse:
     subdomain: "clickhouse"
     port: 8123

--- a/stacks/budibase/docker-compose.yml
+++ b/stacks/budibase/docker-compose.yml
@@ -1,0 +1,33 @@
+# =============================================================================
+# Budibase - Low-Code Platform for Internal Tools
+# =============================================================================
+# Open-source low-code platform for building internal tools, CRUD apps, and
+# dashboards. All-in-one container with built-in CouchDB, Redis, and MinIO.
+#
+# Access: https://budibase.<domain>
+# Docs: https://docs.budibase.com/
+# =============================================================================
+
+services:
+  budibase:
+    image: ${IMAGE_BUDIBASE:-budibase/budibase:latest}
+    container_name: budibase
+    restart: unless-stopped
+    ports:
+      - "8096:80"
+    volumes:
+      - budibase_data:/data
+    networks:
+      - app-network
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:80"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+volumes:
+  budibase_data:
+
+networks:
+  app-network:
+    external: true


### PR DESCRIPTION
## Summary

- Add Budibase as an open-source low-code platform for building internal tools, CRUD apps, and dashboards
- All-in-one container (bundles CouchDB, Redis, MinIO internally) on port 8096
- Admin account created on first access via setup wizard

## Test plan

- [ ] Enable Budibase via Control Plane
- [ ] Access `https://budibase.<domain>` and verify setup wizard loads
- [ ] Create admin account and verify UI works
- [ ] Test creating a simple app with a data source

Closes #246
