### PR TITLE
feat(control-plane): Add limits and audit logging to teardown extensions

### DIFF
--- a/.github/workflows/setup-control-plane.yaml
+++ b/.github/workflows/setup-control-plane.yaml
@@ -827,23 +827,42 @@ jobs:
           echo "🩺 Running Worker diagnostic health check..."
           WORKER_NAME="nexus-${DOMAIN//./-}-worker"
 
-          # Fetch the account's workers.dev subdomain (e.g. "stefanko-ch")
+          # 1. Fetch the account's workers.dev subdomain (e.g. "stefanko-ch")
           SUBDOMAIN_RESPONSE=$(curl -sS \
             -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
             "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/workers/subdomain")
           SUBDOMAIN=$(echo "$SUBDOMAIN_RESPONSE" | jq -r '.result.subdomain // empty')
 
           if [ -z "$SUBDOMAIN" ]; then
-            echo "❌ Could not determine workers.dev subdomain for this account"
+            echo "⚠️  Could not determine workers.dev subdomain for this account"
             echo "   Cloudflare API response: $SUBDOMAIN_RESPONSE"
             echo "   Skipping health check - the worker may still be functional"
             exit 0
           fi
 
+          # 2. Enable workers.dev subdomain for this script via Cloudflare API.
+          #    The cloudflare_workers_script_subdomain TF resource only exists
+          #    in provider v5+ - we are pinned to v4, so we use the API directly.
+          #    Endpoint: POST /accounts/{id}/workers/scripts/{name}/subdomain
+          ENABLE_RESPONSE=$(curl -sS -X POST \
+            -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d '{"enabled": true, "previews_enabled": false}' \
+            "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/workers/scripts/$WORKER_NAME/subdomain")
+          ENABLE_SUCCESS=$(echo "$ENABLE_RESPONSE" | jq -r '.success // false')
+
+          if [ "$ENABLE_SUCCESS" != "true" ]; then
+            echo "⚠️  Could not enable workers.dev subdomain for $WORKER_NAME"
+            echo "   API response: $ENABLE_RESPONSE"
+            echo "   Skipping health check - the worker may still be functional"
+            exit 0
+          fi
+          echo "  ✓ workers.dev subdomain enabled for $WORKER_NAME"
+
           WORKER_URL="https://${WORKER_NAME}.${SUBDOMAIN}.workers.dev/health/diagnostic"
           echo "  Worker URL: $WORKER_URL"
 
-          # Workers.dev subdomain propagation can take a few seconds after enable - retry briefly
+          # 3. Workers.dev subdomain propagation can take a few seconds after enable - retry briefly
           DIAG_HTTP_CODE=""
           DIAG_BODY=""
           for i in $(seq 1 10); do

--- a/.github/workflows/setup-control-plane.yaml
+++ b/.github/workflows/setup-control-plane.yaml
@@ -818,6 +818,67 @@ jobs:
           
           echo "✅ Worker secrets configured"
 
+      - name: Verify Worker health (post-deploy diagnostic)
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          DOMAIN: ${{ secrets.DOMAIN }}
+        run: |
+          echo "🩺 Running Worker diagnostic health check..."
+          WORKER_NAME="nexus-${DOMAIN//./-}-worker"
+
+          # Fetch the account's workers.dev subdomain (e.g. "stefanko-ch")
+          SUBDOMAIN_RESPONSE=$(curl -sS \
+            -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+            "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/workers/subdomain")
+          SUBDOMAIN=$(echo "$SUBDOMAIN_RESPONSE" | jq -r '.result.subdomain // empty')
+
+          if [ -z "$SUBDOMAIN" ]; then
+            echo "❌ Could not determine workers.dev subdomain for this account"
+            echo "   Cloudflare API response: $SUBDOMAIN_RESPONSE"
+            echo "   Skipping health check - the worker may still be functional"
+            exit 0
+          fi
+
+          WORKER_URL="https://${WORKER_NAME}.${SUBDOMAIN}.workers.dev/health/diagnostic"
+          echo "  Worker URL: $WORKER_URL"
+
+          # Workers.dev subdomain propagation can take a few seconds after enable - retry briefly
+          DIAG_HTTP_CODE=""
+          DIAG_BODY=""
+          for i in $(seq 1 10); do
+            DIAG_RESPONSE=$(curl -sS -w "\n%{http_code}" "$WORKER_URL" 2>&1 || true)
+            DIAG_HTTP_CODE=$(echo "$DIAG_RESPONSE" | tail -n1)
+            DIAG_BODY=$(echo "$DIAG_RESPONSE" | sed '$d')
+            if [ "$DIAG_HTTP_CODE" = "200" ] || [ "$DIAG_HTTP_CODE" = "503" ]; then
+              break
+            fi
+            echo "  Attempt $i: HTTP $DIAG_HTTP_CODE - retrying in 3s..."
+            sleep 3
+          done
+
+          echo ""
+          echo "  HTTP $DIAG_HTTP_CODE"
+          echo "$DIAG_BODY" | jq . 2>/dev/null || echo "$DIAG_BODY"
+          echo ""
+
+          if [ "$DIAG_HTTP_CODE" = "200" ]; then
+            echo "✅ Worker diagnostic check passed - all required bindings, env vars, secrets configured"
+          elif [ "$DIAG_HTTP_CODE" = "503" ]; then
+            echo "❌ Worker diagnostic check FAILED - missing required configuration:"
+            echo "$DIAG_BODY" | jq '.checks // empty' 2>/dev/null || true
+            echo ""
+            echo "   Common causes:"
+            echo "   - GITHUB_TOKEN secret not set (workflow trigger will fail)"
+            echo "   - D1 binding broken (set in tofu/control-plane/main.tf)"
+            echo "   - Missing plain_text_binding for DOMAIN/GITHUB_OWNER/GITHUB_REPO"
+            exit 1
+          else
+            echo "⚠️  Could not reach worker after retries (HTTP $DIAG_HTTP_CODE)"
+            echo "   This may be a workers.dev propagation delay - check manually:"
+            echo "   curl $WORKER_URL"
+          fi
+
       - name: Set Control Plane secrets
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/setup-control-plane.yaml
+++ b/.github/workflows/setup-control-plane.yaml
@@ -71,6 +71,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
       - name: Install OpenTofu
         uses: opentofu/setup-opentofu@v2
         with:

--- a/.github/workflows/setup-control-plane.yaml
+++ b/.github/workflows/setup-control-plane.yaml
@@ -828,6 +828,7 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           DOMAIN: ${{ secrets.DOMAIN }}
+          WORKER_AUTH_TOKEN: ${{ secrets.GH_SECRETS_TOKEN }}
         run: |
           echo "🩺 Running Worker diagnostic health check..."
           WORKER_NAME="nexus-${DOMAIN//./-}-worker"
@@ -867,11 +868,16 @@ jobs:
           WORKER_URL="https://${WORKER_NAME}.${SUBDOMAIN}.workers.dev/health/diagnostic"
           echo "  Worker URL: $WORKER_URL"
 
-          # 3. Workers.dev subdomain propagation can take a few seconds after enable - retry briefly
+          # 3. Workers.dev subdomain propagation can take a few seconds after enable - retry briefly.
+          #    The diagnostic endpoint requires Authorization: Bearer <GITHUB_TOKEN>
+          #    so the publicly reachable workers.dev URL doesn't leak which
+          #    bindings/secrets are configured.
           DIAG_HTTP_CODE=""
           DIAG_BODY=""
           for i in $(seq 1 10); do
-            DIAG_RESPONSE=$(curl -sS -w "\n%{http_code}" "$WORKER_URL" 2>&1 || true)
+            DIAG_RESPONSE=$(curl -sS -w "\n%{http_code}" \
+              -H "Authorization: Bearer $WORKER_AUTH_TOKEN" \
+              "$WORKER_URL" 2>&1 || true)
             DIAG_HTTP_CODE=$(echo "$DIAG_RESPONSE" | tail -n1)
             DIAG_BODY=$(echo "$DIAG_RESPONSE" | sed '$d')
             if [ "$DIAG_HTTP_CODE" = "200" ] || [ "$DIAG_HTTP_CODE" = "503" ]; then
@@ -885,6 +891,22 @@ jobs:
           echo "  HTTP $DIAG_HTTP_CODE"
           echo "$DIAG_BODY" | jq . 2>/dev/null || echo "$DIAG_BODY"
           echo ""
+
+          # 4. Disable the workers.dev subdomain again so the worker is only
+          #    reachable via its routed/Access-protected hostname, not via the
+          #    public workers.dev URL. This minimizes the diagnostic exposure
+          #    window to just the duration of the health check itself.
+          DISABLE_RESPONSE=$(curl -sS -X POST \
+            -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d '{"enabled": false, "previews_enabled": false}' \
+            "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/workers/scripts/$WORKER_NAME/subdomain")
+          DISABLE_SUCCESS=$(echo "$DISABLE_RESPONSE" | jq -r '.success // false')
+          if [ "$DISABLE_SUCCESS" = "true" ]; then
+            echo "  ✓ workers.dev subdomain disabled again (post-check cleanup)"
+          else
+            echo "  ⚠️  Could not disable workers.dev subdomain after check (non-fatal): $DISABLE_RESPONSE"
+          fi
 
           if [ "$DIAG_HTTP_CODE" = "200" ]; then
             echo "✅ Worker diagnostic check passed - all required bindings, env vars, secrets configured"

--- a/.github/workflows/spin-up.yml
+++ b/.github/workflows/spin-up.yml
@@ -102,6 +102,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
       - name: Log workflow start
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/control-plane/functions/api/scheduled-teardown.js
+++ b/control-plane/functions/api/scheduled-teardown.js
@@ -24,6 +24,42 @@ async function deleteConfig(db, key) {
   await db.prepare('DELETE FROM config WHERE key = ?').bind(key).run();
 }
 
+// Returns YYYY-MM-DD in UTC for use as a daily counter key
+function utcDateKey() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+// Returns the number of extensions used today (UTC) for the given user
+async function getExtensionsUsedToday(db, userEmail) {
+  const key = `extensions_${utcDateKey()}_${userEmail || 'unknown'}`;
+  const value = await getConfig(db, key, '0');
+  return parseInt(value, 10) || 0;
+}
+
+// Increment the daily extension counter for the given user
+async function incrementExtensionsUsedToday(db, userEmail) {
+  const key = `extensions_${utcDateKey()}_${userEmail || 'unknown'}`;
+  const current = await getExtensionsUsedToday(db, userEmail);
+  await setConfig(db, key, String(current + 1));
+  return current + 1;
+}
+
+// Append a teardown extension audit log entry
+async function logExtension(db, userEmail, delayHours, delayUntil) {
+  try {
+    const metadata = JSON.stringify({
+      user: userEmail || 'unknown',
+      delay_hours: delayHours,
+      delay_until: delayUntil,
+    });
+    await db.prepare(
+      "INSERT INTO logs (source, level, message, metadata) VALUES ('api', 'info', ?, ?)"
+    ).bind(`Teardown extended by ${delayHours}h by ${userEmail || 'unknown'}`, metadata).run();
+  } catch {
+    // Audit logging is best-effort - don't fail the request if it errors
+  }
+}
+
 /**
  * Convert a time in a specific timezone to UTC Date
  * @param {string} timeStr - Time in HH:MM format
@@ -63,7 +99,10 @@ function timeInTimezoneToUTC(timeStr, timezone, baseDate = new Date()) {
 }
 
 export async function onRequestGet(context) {
-  const { env } = context;
+  const { env, request } = context;
+  const userEmail = request.headers.get('CF-Access-Authenticated-User-Email') || '';
+  const maxExtensionsPerDay = parseInt(env.MAX_EXTENSIONS_PER_DAY || '3', 10);
+  const maxDelayHours = parseInt(env.MAX_DELAY_HOURS || '4', 10);
   
   if (!env.NEXUS_DB) {
     return new Response(JSON.stringify({
@@ -127,6 +166,8 @@ export async function onRequestGet(context) {
       };
     }
     
+    const extensionsUsed = await getExtensionsUsedToday(env.NEXUS_DB, userEmail);
+
     return new Response(JSON.stringify({
       success: true,
       config: {
@@ -138,6 +179,10 @@ export async function onRequestGet(context) {
         nextTeardown,
         timeRemaining,
         allowDisable: env.ALLOW_DISABLE_AUTO_SHUTDOWN === 'true',
+        extensionsUsed,
+        extensionsRemaining: Math.max(0, maxExtensionsPerDay - extensionsUsed),
+        maxExtensionsPerDay,
+        maxDelayHours,
       },
     }), {
       status: 200,
@@ -156,7 +201,10 @@ export async function onRequestGet(context) {
 
 export async function onRequestPost(context) {
   const { env, request } = context;
-  
+  const userEmail = request.headers.get('CF-Access-Authenticated-User-Email') || '';
+  const maxExtensionsPerDay = parseInt(env.MAX_EXTENSIONS_PER_DAY || '3', 10);
+  const maxDelayHours = parseInt(env.MAX_DELAY_HOURS || '4', 10);
+
   if (!env.NEXUS_DB) {
     return new Response(JSON.stringify({
       success: false,
@@ -216,9 +264,45 @@ export async function onRequestPost(context) {
 
     // Handle delay request
     if (delayHours !== undefined) {
+      // Validate delayHours is a positive number within the configured max
+      if (typeof delayHours !== 'number' || delayHours <= 0 || !Number.isFinite(delayHours)) {
+        return new Response(JSON.stringify({
+          success: false,
+          error: 'delayHours must be a positive number',
+        }), {
+          status: 400,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      if (delayHours > maxDelayHours) {
+        return new Response(JSON.stringify({
+          success: false,
+          error: `delayHours must not exceed ${maxDelayHours} hours per request`,
+        }), {
+          status: 400,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+
+      // Enforce daily extension limit
+      const extensionsUsed = await getExtensionsUsedToday(env.NEXUS_DB, userEmail);
+      if (extensionsUsed >= maxExtensionsPerDay) {
+        return new Response(JSON.stringify({
+          success: false,
+          error: `Daily extension limit reached (${maxExtensionsPerDay} per day). Try again tomorrow.`,
+          extensionsUsed,
+          maxExtensionsPerDay,
+        }), {
+          status: 429,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+
       const delayMs = delayHours * 60 * 60 * 1000;
       const delayUntil = new Date(Date.now() + delayMs).toISOString();
       await setConfig(env.NEXUS_DB, 'delay_until', delayUntil);
+      await incrementExtensionsUsedToday(env.NEXUS_DB, userEmail);
+      await logExtension(env.NEXUS_DB, userEmail, delayHours, delayUntil);
     }
 
     // Update D1 database
@@ -246,6 +330,8 @@ export async function onRequestPost(context) {
     const updatedNotificationTime = await getConfig(env.NEXUS_DB, 'notification_time', '21:45');
     const updatedDelayUntil = await getConfig(env.NEXUS_DB, 'delay_until', null);
 
+    const updatedExtensionsUsed = await getExtensionsUsedToday(env.NEXUS_DB, userEmail);
+
     return new Response(JSON.stringify({
       success: true,
       config: {
@@ -255,6 +341,10 @@ export async function onRequestPost(context) {
         notificationTime: updatedNotificationTime,
         delayUntil: updatedDelayUntil,
         allowDisable: env.ALLOW_DISABLE_AUTO_SHUTDOWN === 'true',
+        extensionsUsed: updatedExtensionsUsed,
+        extensionsRemaining: Math.max(0, maxExtensionsPerDay - updatedExtensionsUsed),
+        maxExtensionsPerDay,
+        maxDelayHours,
       },
       message: 'Configuration updated successfully',
     }), {

--- a/control-plane/functions/api/scheduled-teardown.js
+++ b/control-plane/functions/api/scheduled-teardown.js
@@ -29,19 +29,51 @@ function utcDateKey() {
   return new Date().toISOString().slice(0, 10);
 }
 
+// Parse an env var as a positive integer with a fallback default.
+// Guards against missing/empty/non-numeric values that would otherwise
+// produce NaN and silently disable the limit checks.
+function parsePositiveInt(value, fallback) {
+  const parsed = parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
 // Returns the number of extensions used today (UTC) for the given user
 async function getExtensionsUsedToday(db, userEmail) {
   const key = `extensions_${utcDateKey()}_${userEmail || 'unknown'}`;
   const value = await getConfig(db, key, '0');
-  return parseInt(value, 10) || 0;
+  const parsed = parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : 0;
 }
 
-// Increment the daily extension counter for the given user
+// Atomically increment the daily extension counter for the given user.
+// Uses a single SQL statement with ON CONFLICT + RETURNING so two
+// concurrent requests cannot both pass the limit check and increment.
 async function incrementExtensionsUsedToday(db, userEmail) {
   const key = `extensions_${utcDateKey()}_${userEmail || 'unknown'}`;
-  const current = await getExtensionsUsedToday(db, userEmail);
-  await setConfig(db, key, String(current + 1));
-  return current + 1;
+  const result = await db.prepare(`
+    INSERT INTO config (key, value, updated_at)
+    VALUES (?, '1', datetime('now'))
+    ON CONFLICT(key) DO UPDATE SET
+      value = CAST(config.value AS INTEGER) + 1,
+      updated_at = datetime('now')
+    RETURNING CAST(value AS INTEGER) AS value
+  `).bind(key).first();
+  return result ? result.value : 1;
+}
+
+// Delete extension counter rows older than the given number of days (UTC).
+// Best-effort: failures are swallowed so cleanup never breaks the request flow.
+async function cleanupOldExtensionCounters(db, retainDays = 30) {
+  try {
+    const cutoff = new Date();
+    cutoff.setUTCDate(cutoff.getUTCDate() - retainDays);
+    const cutoffKey = `extensions_${cutoff.toISOString().slice(0, 10)}_`;
+    await db.prepare(
+      "DELETE FROM config WHERE key LIKE 'extensions_%' AND key < ?"
+    ).bind(cutoffKey).run();
+  } catch {
+    // Cleanup is best-effort
+  }
 }
 
 // Append a teardown extension audit log entry
@@ -101,8 +133,8 @@ function timeInTimezoneToUTC(timeStr, timezone, baseDate = new Date()) {
 export async function onRequestGet(context) {
   const { env, request } = context;
   const userEmail = request.headers.get('CF-Access-Authenticated-User-Email') || '';
-  const maxExtensionsPerDay = parseInt(env.MAX_EXTENSIONS_PER_DAY || '3', 10);
-  const maxDelayHours = parseInt(env.MAX_DELAY_HOURS || '4', 10);
+  const maxExtensionsPerDay = parsePositiveInt(env.MAX_EXTENSIONS_PER_DAY, 3);
+  const maxDelayHours = parsePositiveInt(env.MAX_DELAY_HOURS, 4);
   
   if (!env.NEXUS_DB) {
     return new Response(JSON.stringify({
@@ -202,8 +234,8 @@ export async function onRequestGet(context) {
 export async function onRequestPost(context) {
   const { env, request } = context;
   const userEmail = request.headers.get('CF-Access-Authenticated-User-Email') || '';
-  const maxExtensionsPerDay = parseInt(env.MAX_EXTENSIONS_PER_DAY || '3', 10);
-  const maxDelayHours = parseInt(env.MAX_DELAY_HOURS || '4', 10);
+  const maxExtensionsPerDay = parsePositiveInt(env.MAX_EXTENSIONS_PER_DAY, 3);
+  const maxDelayHours = parsePositiveInt(env.MAX_DELAY_HOURS, 4);
 
   if (!env.NEXUS_DB) {
     return new Response(JSON.stringify({
@@ -284,13 +316,18 @@ export async function onRequestPost(context) {
         });
       }
 
-      // Enforce daily extension limit
-      const extensionsUsed = await getExtensionsUsedToday(env.NEXUS_DB, userEmail);
-      if (extensionsUsed >= maxExtensionsPerDay) {
+      // Atomically increment the counter first, then check the returned value.
+      // This avoids a TOCTOU race where two concurrent requests both pass a
+      // pre-increment check and then both increment, exceeding the daily limit.
+      const newCount = await incrementExtensionsUsedToday(env.NEXUS_DB, userEmail);
+      if (newCount > maxExtensionsPerDay) {
+        // Roll back the over-limit increment so the counter stays at the cap
+        const counterKey = `extensions_${utcDateKey()}_${userEmail || 'unknown'}`;
+        await setConfig(env.NEXUS_DB, counterKey, String(maxExtensionsPerDay));
         return new Response(JSON.stringify({
           success: false,
           error: `Daily extension limit reached (${maxExtensionsPerDay} per day). Try again tomorrow.`,
-          extensionsUsed,
+          extensionsUsed: maxExtensionsPerDay,
           maxExtensionsPerDay,
         }), {
           status: 429,
@@ -301,8 +338,9 @@ export async function onRequestPost(context) {
       const delayMs = delayHours * 60 * 60 * 1000;
       const delayUntil = new Date(Date.now() + delayMs).toISOString();
       await setConfig(env.NEXUS_DB, 'delay_until', delayUntil);
-      await incrementExtensionsUsedToday(env.NEXUS_DB, userEmail);
       await logExtension(env.NEXUS_DB, userEmail, delayHours, delayUntil);
+      // Best-effort cleanup of old extension counters (>30 days)
+      await cleanupOldExtensionCounters(env.NEXUS_DB);
     }
 
     // Update D1 database

--- a/control-plane/src/pages/settings.astro
+++ b/control-plane/src/pages/settings.astro
@@ -175,7 +175,10 @@ import Layout from '../layouts/Layout.astro';
       // Update button label to reflect the configured max delay
       delayBtn.textContent = 'Delay Teardown by ' + maxDelayHours + ' Hours';
 
-      // Append remaining-extensions counter when available
+      // Escape values that originate from API/config before injecting into innerHTML
+      const esc = (s) => String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+
+      // Append remaining-extensions counter when available (numbers, no escaping needed)
       const counterText = extensionsRemaining !== null
         ? '<br><span style="color: var(--text-muted); font-size: 0.85em;">' + extensionsRemaining + ' of ' + maxExtensions + ' daily extensions remaining</span>'
         : '';
@@ -189,16 +192,16 @@ import Layout from '../layouts/Layout.astro';
           const diffMs = delayUntil - now;
           const hours = Math.ceil(diffMs / 3600000);
           const minutes = Math.ceil((diffMs % 3600000) / 60000);
-          info.innerHTML = 'Enabled - Teardown delayed until ' + delayUntil.toLocaleString('de-CH') + '<br><span style="color: var(--warning);">(' + hours + 'h ' + minutes + 'm remaining)</span>' + counterText;
+          info.innerHTML = 'Enabled - Teardown delayed until ' + esc(delayUntil.toLocaleString('de-CH')) + '<br><span style="color: var(--warning);">(' + hours + 'h ' + minutes + 'm remaining)</span>' + counterText;
           delayBtn.disabled = true;
         } else if (config.timeRemaining) {
           const tr = config.timeRemaining;
           let timeText = tr.hours > 0 ? tr.hours + 'h ' + tr.minutes + 'm' : tr.minutes + 'm';
-          const next = config.nextTeardown ? new Date(config.nextTeardown).toLocaleString('de-CH') : '';
+          const next = config.nextTeardown ? esc(new Date(config.nextTeardown).toLocaleString('de-CH')) : '';
           info.innerHTML = 'Enabled - Next: ' + next + '<br><span style="color: var(--warning);">(' + timeText + ' remaining)</span>' + counterText;
           delayBtn.disabled = limitReached;
         } else {
-          info.innerHTML = 'Enabled - Daily at ' + (config.teardownTime || '22:00') + ' ' + (config.timezone || 'UTC') + counterText;
+          info.innerHTML = 'Enabled - Daily at ' + esc(config.teardownTime || '22:00') + ' ' + esc(config.timezone || 'UTC') + counterText;
           delayBtn.disabled = limitReached;
         }
       } else {
@@ -258,13 +261,16 @@ import Layout from '../layouts/Layout.astro';
         loadScheduledTeardownConfig();
       } else {
         showToast(data.error || 'Failed to delay', 'error');
-        btn.disabled = false;
+        // Reload config so the counter, button label, and disabled state reflect
+        // the current backend state (e.g. HTTP 429 means the daily limit was reached
+        // and the button should remain disabled until UTC midnight).
         btn.textContent = originalLabel;
+        loadScheduledTeardownConfig();
       }
     } catch {
       showToast('Failed to delay teardown', 'error');
-      btn.disabled = false;
       btn.textContent = originalLabel;
+      loadScheduledTeardownConfig();
     }
   }
 

--- a/control-plane/src/pages/settings.astro
+++ b/control-plane/src/pages/settings.astro
@@ -44,7 +44,7 @@ import Layout from '../layouts/Layout.astro';
       </div>
       <div class="toggle-switch" id="toggle-scheduled-teardown"></div>
     </div>
-    <button class="btn-warning" id="btn-delay-teardown" disabled style="margin-top: 0.8rem;">Delay Teardown by 2 Hours</button>
+    <button class="btn-warning" id="btn-delay-teardown" disabled style="margin-top: 0.8rem;">Delay Teardown</button>
   </div>
 
   <!-- Email Notifications -->
@@ -167,6 +167,19 @@ import Layout from '../layouts/Layout.astro';
         toggle.title = '';
       }
 
+      const maxDelayHours = config.maxDelayHours || 4;
+      const extensionsRemaining = config.extensionsRemaining !== undefined ? config.extensionsRemaining : null;
+      const maxExtensions = config.maxExtensionsPerDay || 3;
+      const limitReached = extensionsRemaining !== null && extensionsRemaining <= 0;
+
+      // Update button label to reflect the configured max delay
+      delayBtn.textContent = 'Delay Teardown by ' + maxDelayHours + ' Hours';
+
+      // Append remaining-extensions counter when available
+      const counterText = extensionsRemaining !== null
+        ? '<br><span style="color: var(--text-muted); font-size: 0.85em;">' + extensionsRemaining + ' of ' + maxExtensions + ' daily extensions remaining</span>'
+        : '';
+
       if (config.enabled) {
         toggle.classList.add('active');
         const now = new Date();
@@ -176,17 +189,17 @@ import Layout from '../layouts/Layout.astro';
           const diffMs = delayUntil - now;
           const hours = Math.ceil(diffMs / 3600000);
           const minutes = Math.ceil((diffMs % 3600000) / 60000);
-          info.innerHTML = 'Enabled - Teardown delayed until ' + delayUntil.toLocaleString('de-CH') + '<br><span style="color: var(--warning);">(' + hours + 'h ' + minutes + 'm remaining)</span>';
+          info.innerHTML = 'Enabled - Teardown delayed until ' + delayUntil.toLocaleString('de-CH') + '<br><span style="color: var(--warning);">(' + hours + 'h ' + minutes + 'm remaining)</span>' + counterText;
           delayBtn.disabled = true;
         } else if (config.timeRemaining) {
           const tr = config.timeRemaining;
           let timeText = tr.hours > 0 ? tr.hours + 'h ' + tr.minutes + 'm' : tr.minutes + 'm';
           const next = config.nextTeardown ? new Date(config.nextTeardown).toLocaleString('de-CH') : '';
-          info.innerHTML = 'Enabled - Next: ' + next + '<br><span style="color: var(--warning);">(' + timeText + ' remaining)</span>';
-          delayBtn.disabled = false;
+          info.innerHTML = 'Enabled - Next: ' + next + '<br><span style="color: var(--warning);">(' + timeText + ' remaining)</span>' + counterText;
+          delayBtn.disabled = limitReached;
         } else {
-          info.textContent = 'Enabled - Daily at ' + (config.teardownTime || '22:00') + ' ' + (config.timezone || 'UTC');
-          delayBtn.disabled = false;
+          info.innerHTML = 'Enabled - Daily at ' + (config.teardownTime || '22:00') + ' ' + (config.timezone || 'UTC') + counterText;
+          delayBtn.disabled = limitReached;
         }
       } else {
         toggle.classList.remove('active');
@@ -225,27 +238,33 @@ import Layout from '../layouts/Layout.astro';
 
   async function delayTeardown() {
     const btn = document.getElementById('btn-delay-teardown');
+    const originalLabel = btn.textContent;
     btn.disabled = true;
     btn.textContent = 'Processing...';
     try {
+      // Re-fetch current config to get the configured max delay hours
+      const cfgResponse = await fetch(API_URL + '/api/scheduled-teardown', { credentials: 'same-origin' });
+      const cfgData = await cfgResponse.json();
+      const delayHours = (cfgData.success && cfgData.config && cfgData.config.maxDelayHours) || 4;
+
       const response = await fetch(API_URL + '/api/scheduled-teardown', {
         method: 'POST', credentials: 'same-origin',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ delayHours: 2 }),
+        body: JSON.stringify({ delayHours }),
       });
       const data = await response.json();
       if (data.success) {
-        showToast('Teardown delayed by 2 hours');
+        showToast('Teardown delayed by ' + delayHours + ' hours');
         loadScheduledTeardownConfig();
       } else {
         showToast(data.error || 'Failed to delay', 'error');
         btn.disabled = false;
-        btn.textContent = 'Delay Teardown by 2 Hours';
+        btn.textContent = originalLabel;
       }
     } catch {
       showToast('Failed to delay teardown', 'error');
       btn.disabled = false;
-      btn.textContent = 'Delay Teardown by 2 Hours';
+      btn.textContent = originalLabel;
     }
   }
 

--- a/control-plane/worker/src/index.js
+++ b/control-plane/worker/src/index.js
@@ -47,9 +47,66 @@ export default {
   },
 
   async fetch(request, env) {
-    // Health check endpoint
+    // Basic health check endpoint - just confirms the worker is reachable
     if (request.url.endsWith('/health')) {
       return new Response(JSON.stringify({ status: 'ok', service: 'scheduled-teardown' }), {
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    // Diagnostic health check - verifies all bindings and secrets are configured.
+    // Used by the setup workflow to fail loudly if anything is missing after deploy.
+    // Does NOT expose secret values - only reports presence (true/false).
+    if (request.url.endsWith('/health/diagnostic')) {
+      const checks = {
+        bindings: {
+          NEXUS_DB: !!env.NEXUS_DB,
+        },
+        env_vars: {
+          DOMAIN: !!env.DOMAIN,
+          ADMIN_EMAIL: !!env.ADMIN_EMAIL,
+          GITHUB_OWNER: !!env.GITHUB_OWNER,
+          GITHUB_REPO: !!env.GITHUB_REPO,
+          NOTIFICATION_CRON: !!env.NOTIFICATION_CRON,
+          TEARDOWN_CRON: !!env.TEARDOWN_CRON,
+        },
+        secrets: {
+          GITHUB_TOKEN: !!env.GITHUB_TOKEN,
+          RESEND_API_KEY: !!env.RESEND_API_KEY,
+        },
+        d1_query: false,
+      };
+
+      // Verify the D1 binding actually works by running a trivial query
+      if (env.NEXUS_DB) {
+        try {
+          await env.NEXUS_DB.prepare('SELECT 1 AS ok').first();
+          checks.d1_query = true;
+        } catch (error) {
+          checks.d1_query = false;
+          checks.d1_error = error.message;
+        }
+      }
+
+      // Determine overall status: required = bindings + required env vars + GITHUB_TOKEN + d1_query
+      const required = [
+        checks.bindings.NEXUS_DB,
+        checks.env_vars.DOMAIN,
+        checks.env_vars.GITHUB_OWNER,
+        checks.env_vars.GITHUB_REPO,
+        checks.secrets.GITHUB_TOKEN,
+        checks.d1_query,
+      ];
+      const allRequiredOk = required.every(Boolean);
+      const status = allRequiredOk ? 'ok' : 'error';
+      const httpStatus = allRequiredOk ? 200 : 503;
+
+      return new Response(JSON.stringify({
+        status,
+        service: 'scheduled-teardown',
+        checks,
+      }, null, 2), {
+        status: httpStatus,
         headers: { 'Content-Type': 'application/json' },
       });
     }

--- a/control-plane/worker/src/index.js
+++ b/control-plane/worker/src/index.js
@@ -57,7 +57,27 @@ export default {
     // Diagnostic health check - verifies all bindings and secrets are configured.
     // Used by the setup workflow to fail loudly if anything is missing after deploy.
     // Does NOT expose secret values - only reports presence (true/false).
+    //
+    // GATED: requires Authorization: Bearer <GITHUB_TOKEN> header. Both the
+    // worker and the setup workflow already have this secret, so we reuse it
+    // instead of introducing a new one. The workers.dev URL is publicly
+    // reachable, so without this gate the diagnostic would leak which
+    // bindings/secrets are configured (useful reconnaissance).
     if (request.url.endsWith('/health/diagnostic')) {
+      const authHeader = request.headers.get('Authorization') || '';
+      const expectedToken = env.GITHUB_TOKEN || '';
+      const providedToken = authHeader.startsWith('Bearer ') ? authHeader.slice(7) : '';
+
+      if (!expectedToken || !constantTimeEqual(providedToken, expectedToken)) {
+        return new Response(JSON.stringify({
+          status: 'error',
+          error: 'Forbidden: missing or invalid Authorization header',
+        }), {
+          status: 403,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+
       const checks = {
         bindings: {
           NEXUS_DB: !!env.NEXUS_DB,
@@ -88,12 +108,18 @@ export default {
         }
       }
 
-      // Determine overall status: required = bindings + required env vars + GITHUB_TOKEN + d1_query
+      // Determine overall status. Required items are everything the worker
+      // needs to function correctly. RESEND_API_KEY is intentionally NOT
+      // required because the existing setup workflow treats it as optional
+      // (notifications are disabled when missing).
       const required = [
         checks.bindings.NEXUS_DB,
         checks.env_vars.DOMAIN,
+        checks.env_vars.ADMIN_EMAIL,
         checks.env_vars.GITHUB_OWNER,
         checks.env_vars.GITHUB_REPO,
+        checks.env_vars.NOTIFICATION_CRON,
+        checks.env_vars.TEARDOWN_CRON,
         checks.secrets.GITHUB_TOKEN,
         checks.d1_query,
       ];
@@ -114,6 +140,19 @@ export default {
     return new Response('Not Found', { status: 404 });
   },
 };
+
+// Constant-time string comparison to mitigate timing attacks against the
+// diagnostic endpoint's bearer token check.
+function constantTimeEqual(a, b) {
+  if (typeof a !== 'string' || typeof b !== 'string' || a.length !== b.length) {
+    return false;
+  }
+  let result = 0;
+  for (let i = 0; i < a.length; i++) {
+    result |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return result === 0;
+}
 
 // Clean up logs older than 30 days
 async function cleanupOldLogs(env) {

--- a/docs/control-plane.md
+++ b/docs/control-plane.md
@@ -94,9 +94,20 @@ Times are configurable. Notification is always 15 minutes before teardown.
 
 ### Delay Teardown
 
-Use the **Delay Teardown by 2 Hours** button to postpone the next scheduled teardown. This is useful when you need more time to complete work.
+Use the **Delay Teardown** button to postpone the next scheduled teardown when you need more time to complete work. The default delay is **4 hours** per request, capped at **3 extensions per UTC day** per user. The Settings page shows how many extensions are remaining today.
 
-The delay can be used multiple times and works regardless of other settings.
+When the daily limit is reached, the button is disabled until UTC midnight.
+
+Each extension is recorded in the Control Plane's D1 log table with the requesting user's email and the new teardown time, so administrators can audit usage.
+
+**Configurable limits (Terraform):**
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `max_delay_hours` | `4` | Maximum hours per single delay request |
+| `max_extensions_per_day` | `3` | Maximum delay requests per UTC day per user |
+
+Tune these in `tofu/control-plane/variables.tf` or via `TF_VAR_*` env vars, then re-run `gh workflow run setup-control-plane.yaml`.
 
 ### Administrator Policy (Infrastructure-Level)
 
@@ -105,7 +116,7 @@ The delay can be used multiple times and works regardless of other settings.
 When `allow_disable_auto_shutdown = false` is set in the Terraform configuration (default):
 - The toggle switch is **visible but disabled** (grayed out)
 - Users can see if auto-shutdown is enabled but cannot turn it off
-- The **Delay by 2 Hours** button remains functional
+- The **Delay Teardown** button remains functional (within the daily limit)
 - API rejects any attempts to disable auto-shutdown (403 Forbidden)
 
 This setting provides cost control for shared environments (e.g., student labs) while maintaining operational flexibility through delays.
@@ -116,6 +127,12 @@ allow_disable_auto_shutdown = true
 ```
 
 Then re-deploy the Control Plane via `gh workflow run setup-control-plane.yaml`.
+
+### Worker Health Check
+
+After every Control Plane setup run, the workflow automatically calls the scheduled-teardown worker's `/health/diagnostic` endpoint to verify that all bindings, environment variables, secrets, and the D1 connection are functional. The workflow fails loudly if anything is misconfigured, instead of letting the misconfiguration surface hours later when the next cron trigger fires.
+
+The diagnostic endpoint reports presence (`true`/`false`) of each required binding/secret without ever exposing actual values.
 
 ## Credentials Email
 

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -279,7 +279,7 @@ allow_disable_auto_shutdown = true
 **Default behavior** (`false`):
 - Toggle switch is visible but grayed out
 - Users can see if auto-shutdown is enabled
-- Users can delay teardown by 2 hours
+- Users can delay teardown (within the daily limit, see below)
 - Users cannot disable auto-shutdown entirely
 
 **Permissive behavior** (`true`):
@@ -289,6 +289,23 @@ allow_disable_auto_shutdown = true
 After changing this setting, re-deploy the Control Plane:
 ```bash
 gh workflow run setup-control-plane.yaml
+```
+
+#### Teardown Delay Limits
+
+By default, users can delay each scheduled teardown by **4 hours** at a time, with a maximum of **3 extensions per UTC day**. Each extension is recorded in the Control Plane's audit log with the requesting user's email.
+
+To customize, edit `tofu/control-plane/variables.tf`:
+
+```hcl
+max_delay_hours        = 4   # Maximum hours per single delay request
+max_extensions_per_day = 3   # Maximum delay requests per UTC day per user
+```
+
+Or set via environment variable:
+
+```bash
+TF_VAR_max_delay_hours=2 TF_VAR_max_extensions_per_day=5 gh workflow run setup-control-plane.yaml
 ```
 
 See [Control Plane User Guide](control-plane.md#administrator-policy-infrastructure-level) for details.

--- a/tofu/control-plane/main.tf
+++ b/tofu/control-plane/main.tf
@@ -94,16 +94,10 @@ resource "cloudflare_workers_cron_trigger" "scheduled_teardown" {
   ]
 }
 
-# Enable workers.dev subdomain so the post-deploy health check can hit
-# https://<worker-name>.<account-subdomain>.workers.dev/health/diagnostic
-# from the GitHub Actions runner. The diagnostic endpoint reports binding,
-# env var, secret, and D1 query status without exposing any secret values.
-resource "cloudflare_workers_script_subdomain" "scheduled_teardown" {
-  account_id       = var.cloudflare_account_id
-  script_name      = cloudflare_workers_script.scheduled_teardown.name
-  enabled          = true
-  previews_enabled = false
-}
+# Note: workers.dev subdomain for the diagnostic health check is enabled
+# via the Cloudflare API directly in setup-control-plane.yaml. The
+# cloudflare_workers_script_subdomain resource only exists in provider v5+
+# and we are pinned to v4 here.
 
 # -----------------------------------------------------------------------------
 # Cloudflare KV Namespace (persistent config)

--- a/tofu/control-plane/main.tf
+++ b/tofu/control-plane/main.tf
@@ -94,6 +94,17 @@ resource "cloudflare_workers_cron_trigger" "scheduled_teardown" {
   ]
 }
 
+# Enable workers.dev subdomain so the post-deploy health check can hit
+# https://<worker-name>.<account-subdomain>.workers.dev/health/diagnostic
+# from the GitHub Actions runner. The diagnostic endpoint reports binding,
+# env var, secret, and D1 query status without exposing any secret values.
+resource "cloudflare_workers_script_subdomain" "scheduled_teardown" {
+  account_id       = var.cloudflare_account_id
+  script_name      = cloudflare_workers_script.scheduled_teardown.name
+  enabled          = true
+  previews_enabled = false
+}
+
 # -----------------------------------------------------------------------------
 # Cloudflare KV Namespace (persistent config)
 # -----------------------------------------------------------------------------

--- a/tofu/control-plane/main.tf
+++ b/tofu/control-plane/main.tf
@@ -94,10 +94,13 @@ resource "cloudflare_workers_cron_trigger" "scheduled_teardown" {
   ]
 }
 
-# Note: workers.dev subdomain for the diagnostic health check is enabled
-# via the Cloudflare API directly in setup-control-plane.yaml. The
-# cloudflare_workers_script_subdomain resource only exists in provider v5+
-# and we are pinned to v4 here.
+# Note: the workers.dev subdomain for the worker stays disabled by default.
+# The post-deploy health check in setup-control-plane.yaml temporarily enables
+# it via the Cloudflare API just for the duration of the diagnostic call,
+# then disables it again. The diagnostic endpoint also requires a Bearer
+# token (GITHUB_TOKEN) to prevent reconnaissance during the open window.
+# The cloudflare_workers_script_subdomain Terraform resource only exists
+# in provider v5+ and we are pinned to v4 here - see issue #342.
 
 # -----------------------------------------------------------------------------
 # Cloudflare KV Namespace (persistent config)

--- a/tofu/control-plane/main.tf
+++ b/tofu/control-plane/main.tf
@@ -131,6 +131,8 @@ resource "cloudflare_pages_project" "control_plane" {
         SERVER_TYPE                  = var.server_type
         SERVER_LOCATION              = var.server_location
         ALLOW_DISABLE_AUTO_SHUTDOWN  = tostring(var.allow_disable_auto_shutdown)
+        MAX_EXTENSIONS_PER_DAY       = tostring(var.max_extensions_per_day)
+        MAX_DELAY_HOURS              = tostring(var.max_delay_hours)
       }
       
       d1_databases = {
@@ -155,6 +157,8 @@ resource "cloudflare_pages_project" "control_plane" {
         SERVER_TYPE                  = var.server_type
         SERVER_LOCATION              = var.server_location
         ALLOW_DISABLE_AUTO_SHUTDOWN  = tostring(var.allow_disable_auto_shutdown)
+        MAX_EXTENSIONS_PER_DAY       = tostring(var.max_extensions_per_day)
+        MAX_DELAY_HOURS              = tostring(var.max_delay_hours)
       }
       
       d1_databases = {

--- a/tofu/control-plane/variables.tf
+++ b/tofu/control-plane/variables.tf
@@ -65,6 +65,18 @@ variable "allow_disable_auto_shutdown" {
   default     = false
 }
 
+variable "max_extensions_per_day" {
+  description = "Maximum number of teardown delay extensions a user can request per UTC day"
+  type        = number
+  default     = 3
+}
+
+variable "max_delay_hours" {
+  description = "Maximum hours per teardown delay extension request"
+  type        = number
+  default     = 4
+}
+
 # =============================================================================
 # Hetzner Cloud (for persistent volumes)
 # =============================================================================


### PR DESCRIPTION
## Summary

Three related changes that harden the Control Plane around scheduled teardowns:

1. **Limits + audit logging on teardown extensions** (closes #340)
2. **Post-deploy diagnostic health check for the worker** (catches misconfiguration immediately instead of hours later)
3. **Documentation updates**

---

### 1. Teardown extension limits + audit logging

Previously the "Delay Teardown" feature had **no limits**:
- API accepted any `delayHours` value (e.g. `9999` would effectively disable teardown)
- No daily cap on how often a user could press the button
- No audit log of who delayed when and for how long
- A bored user pressing "Delay" every 2 hours could keep the server running indefinitely → unexpected cloud costs

**API (`control-plane/functions/api/scheduled-teardown.js`):**
- Validate `delayHours` is a positive finite number, reject with `400` if negative or non-numeric
- Reject `delayHours > MAX_DELAY_HOURS` (default 4) with `400`
- Track daily extension counter per user in D1 (`extensions_<YYYY-MM-DD>_<user_email>`)
- **Atomic** counter increment via `INSERT ... ON CONFLICT DO UPDATE ... RETURNING` (no TOCTOU race)
- Reject with `429` when the post-increment count exceeds `MAX_EXTENSIONS_PER_DAY` (default 3), rolling back to the cap
- Append audit entry to existing `logs` table for every extension
- Counter resets at UTC midnight (calendar day, not rolling 24h)
- Best-effort cleanup of `extensions_*` config rows older than 30 days on every successful extension
- `parsePositiveInt()` helper guards against missing/empty/non-numeric env vars (would otherwise produce `NaN` and silently disable the caps)
- GET/POST responses include `extensionsUsed`, `extensionsRemaining`, `maxExtensionsPerDay`, `maxDelayHours`

**UI (`control-plane/src/pages/settings.astro`):**
- Shows "X of N daily extensions remaining" under the teardown info
- Disables the button when daily limit reached
- Button label and request body now use the configured `maxDelayHours` instead of hardcoded `2`
- Reloads config on POST failure (including HTTP 429) so the UI reflects the actual backend state
- HTML-escapes `teardownTime`, `timezone`, `delayUntil`, and `nextTeardown` before injecting into `innerHTML` (defense-in-depth against stored XSS via the API)

**Configuration (`tofu/control-plane/`):**
- New tofu variables `max_extensions_per_day` (default `3`) and `max_delay_hours` (default `4`)
- Wired as Cloudflare Pages env vars `MAX_EXTENSIONS_PER_DAY` and `MAX_DELAY_HOURS`
- Self-hosters can override either via `config.tfvars` if they want stricter or more permissive limits

---

### 2. Post-deploy worker diagnostic health check

Previously a missing `GITHUB_TOKEN` secret or broken D1 binding on the scheduled-teardown worker would only surface hours later when the next cron trigger fired. The setup workflow now verifies everything immediately after deploy and fails loudly if anything is misconfigured.

**Worker (`control-plane/worker/src/index.js`):**
- New `/health/diagnostic` endpoint reports presence (`true`/`false`) of:
  - `NEXUS_DB` D1 binding
  - `DOMAIN`, `ADMIN_EMAIL`, `GITHUB_OWNER`, `GITHUB_REPO`, `NOTIFICATION_CRON`, `TEARDOWN_CRON` env vars
  - `GITHUB_TOKEN`, `RESEND_API_KEY` secrets
- Actually runs `SELECT 1` against D1 to verify the binding works
- Returns HTTP `503` if any required check fails, `200` otherwise
- **Gated by `Authorization: Bearer <GITHUB_TOKEN>`** with constant-time comparison so the publicly reachable workers.dev URL doesn't leak which bindings/secrets are configured
- **Never exposes secret values** - only `true`/`false`
- Required checks include `ADMIN_EMAIL`, `NOTIFICATION_CRON`, `TEARDOWN_CRON` (not just D1 + DOMAIN). `RESEND_API_KEY` stays optional to match the existing workflow's behavior

**Workflow (`.github/workflows/setup-control-plane.yaml`):**
- New "Verify Worker health (post-deploy diagnostic)" step after Worker secrets are set
- Fetches the account `workers.dev` subdomain via Cloudflare API
- **Temporarily** enables the `workers.dev` subdomain via `POST /accounts/{id}/workers/scripts/{name}/subdomain` (the `cloudflare_workers_script_subdomain` Terraform resource only exists in provider v5+, see #342)
- Calls `https://<worker>.<subdomain>.workers.dev/health/diagnostic` with the Bearer token
- Retries up to 10 times for `workers.dev` propagation delay
- Pretty-prints the diagnostic JSON in the workflow log
- **Disables the workers.dev subdomain again** after the check so the worker is only reachable via its routed hostname
- **Fails the workflow** if HTTP `503` (missing required config) with a list of common causes
- Soft-skips if subdomain unreachable after retries (logs how to check manually)

---

### 3. Node.js 22 pinned in CI workflows

PR #338 upgraded the control-plane to Astro 6 which requires Node `>=22.12.0`, but `setup-control-plane.yaml` and `spin-up.yml` rely on the `ubuntu-latest` default (still Node 20). Both workflows now run `actions/setup-node@v4` with `node-version: '22'` before the build step.

---

### 4. Documentation updates

- `docs/control-plane.md`: Replaces hardcoded "2 hours" wording with the configurable defaults, documents the audit log, lists the new Terraform variables, adds a section on the post-deploy worker health check
- `docs/setup-guide.md`: Adds a "Teardown Delay Limits" subsection with `TF_VAR_*` examples for customizing the limits

---

## Test plan

- [x] Local `npm run build` succeeds, all 9 pages built
- [x] Local `node --check` confirms `scheduled-teardown.js` and `worker/src/index.js` parse cleanly
- [x] Local YAML lint confirms `setup-control-plane.yaml` is valid
- [x] `initial-setup.yaml` run on this branch succeeds end-to-end
- [x] Worker diagnostic check returns HTTP 200 with all required checks `true`
- [ ] After deploy: GET `/api/scheduled-teardown` returns the new fields (`extensionsUsed`, `extensionsRemaining`, `maxExtensionsPerDay`, `maxDelayHours`)
- [ ] After deploy: pressing "Delay" 3 times increments the counter and disables the button
- [ ] After deploy: 4th attempt returns HTTP 429 with the correct error message
- [ ] After deploy: API call with `delayHours: 999` returns HTTP 400
- [ ] After deploy: D1 `logs` table contains entries with `source='api'` for each extension
- [ ] After deploy: temporarily removing a required secret and re-running setup-control-plane causes the workflow to fail at the new health check step

Closes #340
