### PR TITLE
fix(ci): Pin Node.js 22 in setup-control-plane and spin-up workflows

### DIFF
--- a/.github/workflows/setup-control-plane.yaml
+++ b/.github/workflows/setup-control-plane.yaml
@@ -71,6 +71,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
       - name: Install OpenTofu
         uses: opentofu/setup-opentofu@v2
         with:

--- a/.github/workflows/spin-up.yml
+++ b/.github/workflows/spin-up.yml
@@ -102,6 +102,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
       - name: Log workflow start
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}


### PR DESCRIPTION
## Summary

Hotfix for an Astro 6 / Node 20 mismatch introduced by PR #338.

PR #338 upgraded the control-plane to Astro 6 (which requires Node `>=22.12.0`) but neither `setup-control-plane.yaml` nor `spin-up.yml` pin a Node version. They rely on the `ubuntu-latest` default, which still ships Node 20.20.2. Astro 6 hard-fails:

```
Node.js v20.20.2 is not supported by Astro!
Please upgrade Node.js to a supported version: ">=22.12.0"
```

Both workflows now run `actions/setup-node@v4` with `node-version: '22'` right after `actions/checkout` and before any `npm` invocation. No other changes.

## Test plan

- [x] YAML lint passes for both workflows
- [ ] After merge: re-run `initial-setup.yaml` succeeds at the "Build Astro frontend" step
- [ ] After merge: `spin-up.yml` succeeds at its `npm run build` step

## Why a separate PR

This bug exists on `main` independently of PR #341 (which adds teardown extension limits + worker health check). Shipping the fix on its own makes it easy to back out if needed and unblocks anyone running setup workflows right now.
