### PR TITLE
fix(ci): Switch docs sync to Cloudflare Deploy Hook

### DIFF
--- a/.github/workflows/sync-docs-site.yml
+++ b/.github/workflows/sync-docs-site.yml
@@ -5,9 +5,8 @@
 # when documentation changes. The website fetches docs from this repo at build
 # time via a pre-build script (scripts/fetch-docs.mjs).
 #
-# Fork safety: This workflow only runs on the original repo (stefanko-ch/Nexus-Stack).
-# Forks don't have the WEBSITE_DEPLOY_HOOK secret and the repo check prevents
-# the workflow from even attempting to run.
+# Fork safety: The job-level `if` condition checks `github.repository` —
+# forks have a different repository name so the job is skipped entirely.
 #
 # Setup:
 # 1. Create a Deploy Hook in Cloudflare: Workers > nexus-stack-ch > Settings >

--- a/.github/workflows/sync-docs-site.yml
+++ b/.github/workflows/sync-docs-site.yml
@@ -1,12 +1,19 @@
 # =============================================================================
 # Sync Documentation to nexus-stack.ch Website
 # =============================================================================
-# Triggers a rebuild of the Astro website when documentation changes.
-# The website fetches docs from this repo at build time via Content Loaders.
+# Triggers a rebuild of the nexus-stack.ch website via Cloudflare Deploy Hook
+# when documentation changes. The website fetches docs from this repo at build
+# time via a pre-build script (scripts/fetch-docs.mjs).
 #
 # Fork safety: This workflow only runs on the original repo (stefanko-ch/Nexus-Stack).
-# Forks don't have the WEBSITE_DISPATCH_TOKEN secret and the repo check prevents
+# Forks don't have the WEBSITE_DEPLOY_HOOK secret and the repo check prevents
 # the workflow from even attempting to run.
+#
+# Setup:
+# 1. Create a Deploy Hook in Cloudflare: Workers > nexus-stack-ch > Settings >
+#    Builds > Deploy Hooks (name: "nexus-stack-docs-sync", branch: main)
+# 2. Store the hook URL as WEBSITE_DEPLOY_HOOK secret in this repo
+# 3. Set WEBSITE_SYNC_ENABLED repo variable to "true"
 # =============================================================================
 
 name: Sync docs to website
@@ -29,20 +36,21 @@ jobs:
     # Only run on the original repo and when website sync is enabled via repo variable
     if: github.repository == 'stefanko-ch/Nexus-Stack' && vars.WEBSITE_SYNC_ENABLED == 'true'
     runs-on: ubuntu-latest
-    env:
-      HAS_TOKEN: ${{ secrets.WEBSITE_DISPATCH_TOKEN != '' }}
     steps:
-      - name: Check dispatch token
-        if: env.HAS_TOKEN != 'true'
+      - name: Trigger Cloudflare Deploy Hook
+        env:
+          DEPLOY_HOOK: ${{ secrets.WEBSITE_DEPLOY_HOOK }}
         run: |
-          echo "⏭️ WEBSITE_DISPATCH_TOKEN not configured - skipping website sync"
-          echo "   See docs/docs-website-sync.md for setup instructions"
+          if [ -z "$DEPLOY_HOOK" ]; then
+            echo "⏭️ WEBSITE_DEPLOY_HOOK not configured - skipping website sync"
+            echo "   See docs/docs-website-sync.md for setup instructions"
+            exit 0
+          fi
 
-      - name: Trigger nexus-stack.ch rebuild
-        if: env.HAS_TOKEN == 'true'
-        uses: peter-evans/repository-dispatch@v3
-        with:
-          token: ${{ secrets.WEBSITE_DISPATCH_TOKEN }}
-          repository: stefanko-ch/nexus-stack.ch
-          event-type: docs-updated
-          client-payload: '{"sha": "${{ github.sha }}", "ref": "${{ github.ref }}"}'
+          echo "Triggering nexus-stack.ch rebuild..."
+          RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$DEPLOY_HOOK")
+          if [ "$RESPONSE" = "200" ] || [ "$RESPONSE" = "201" ]; then
+            echo "✓ Website rebuild triggered (HTTP $RESPONSE)"
+          else
+            echo "⚠️ Deploy hook returned HTTP $RESPONSE (non-fatal)"
+          fi

--- a/.github/workflows/sync-docs-site.yml
+++ b/.github/workflows/sync-docs-site.yml
@@ -42,9 +42,9 @@ jobs:
           DEPLOY_HOOK: ${{ secrets.WEBSITE_DEPLOY_HOOK }}
         run: |
           if [ -z "$DEPLOY_HOOK" ]; then
-            echo "⏭️ WEBSITE_DEPLOY_HOOK not configured - skipping website sync"
+            echo "❌ WEBSITE_DEPLOY_HOOK not configured but website sync is enabled"
             echo "   See docs/docs-website-sync.md for setup instructions"
-            exit 0
+            exit 1
           fi
 
           echo "Triggering nexus-stack.ch rebuild..."

--- a/.github/workflows/sync-docs-site.yml
+++ b/.github/workflows/sync-docs-site.yml
@@ -49,8 +49,9 @@ jobs:
 
           echo "Triggering nexus-stack.ch rebuild..."
           RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$DEPLOY_HOOK")
-          if [ "$RESPONSE" = "200" ] || [ "$RESPONSE" = "201" ]; then
+          if [ "$RESPONSE" -ge 200 ] && [ "$RESPONSE" -lt 300 ]; then
             echo "✓ Website rebuild triggered (HTTP $RESPONSE)"
           else
-            echo "⚠️ Deploy hook returned HTTP $RESPONSE (non-fatal)"
+            echo "❌ Deploy hook returned HTTP $RESPONSE"
+            exit 1
           fi

--- a/docs/docs-website-sync.md
+++ b/docs/docs-website-sync.md
@@ -27,7 +27,7 @@ Nexus-Stack repo                    Cloudflare Workers Builds
 
 1. A push to `main` that changes `docs/`, `services.yaml`, or `README.md` triggers the `sync-docs-site.yml` workflow
 2. The workflow calls the Cloudflare Deploy Hook via `curl -X POST`
-3. Cloudflare Workers Builds runs `fetch-docs.mjs` (fetches docs from GitHub) then `astro build`
+3. Cloudflare Workers Builds runs `scripts/fetch-docs.mjs` (fetches docs from GitHub) then `astro build`
 4. The updated site is deployed to the edge
 
 ## Content Mapping
@@ -117,12 +117,10 @@ The sync workflow is gated on this variable. If it is missing or set to any othe
 
 ## Fork Safety
 
-The sync workflow has three independent protection layers:
+The sync workflow is gated by three conditions that must all be true for it to run:
 
-| Layer | How it works |
-|-------|-------------|
-| Repo check | `if: github.repository == 'stefanko-ch/Nexus-Stack'` skips on any fork |
-| Missing variable | Forks don't have `WEBSITE_SYNC_ENABLED`, job is skipped |
-| Missing secret | Forks don't have `WEBSITE_DEPLOY_HOOK`, script exits cleanly |
+1. **Repository check** — `github.repository == 'stefanko-ch/Nexus-Stack'` in the job-level `if:`. This is the primary gate: forks have a different repository name, so the job is skipped entirely.
+2. **Sync enabled** — `vars.WEBSITE_SYNC_ENABLED == 'true'` must be set as a repository variable. Not configured by default.
+3. **Deploy hook configured** — `WEBSITE_DEPLOY_HOOK` secret must contain the Cloudflare Deploy Hook URL. The step fails if sync is enabled but the hook is missing.
 
-Forks can safely ignore the `sync-docs-site.yml` workflow. It will never run and never fail.
+Forks can safely ignore the `sync-docs-site.yml` workflow. The repository check alone prevents it from running.

--- a/docs/docs-website-sync.md
+++ b/docs/docs-website-sync.md
@@ -11,24 +11,24 @@ Documentation in this repo is the **single source of truth** for [nexus-stack.ch
 ## How It Works
 
 ```
-Nexus-Stack repo                    nexus-stack.ch repo
+Nexus-Stack repo                    Cloudflare Workers Builds
 ┌──────────────────┐                ┌──────────────────┐
-│ docs/stacks/*.md  │                │ Astro Content    │
-│ docs/*.md         │  ──push to──>  │ Loaders fetch    │
-│ docs/tutorials/*  │  ──main────>   │ from GitHub at   │
-│ services.yaml     │                │ build time       │
+│ docs/stacks/*.md  │                │ fetch-docs.mjs   │
+│ docs/*.md         │  ──push to──>  │ fetches docs     │
+│ docs/tutorials/*  │  ──main────>   │ from GitHub,     │
+│ services.yaml     │                │ then astro build │
 └──────────────────┘                └──────────────────┘
          │                                   │
          │ sync-docs-site.yml                │
-         │ (repository_dispatch)             │
+         │ (Cloudflare Deploy Hook)          │
          └──────────────────────────────────>┘
-                triggers rebuild
+              curl POST triggers rebuild
 ```
 
 1. A push to `main` that changes `docs/`, `services.yaml`, or `README.md` triggers the `sync-docs-site.yml` workflow
-2. The workflow sends a `repository_dispatch` event to the `stefanko-ch/nexus-stack.ch` repo
-3. The website repo rebuilds, fetching fresh content from `raw.githubusercontent.com`
-4. Cloudflare Pages deploys the updated site
+2. The workflow calls the Cloudflare Deploy Hook via `curl -X POST`
+3. Cloudflare Workers Builds runs `fetch-docs.mjs` (fetches docs from GitHub) then `astro build`
+4. The updated site is deployed to the edge
 
 ## Content Mapping
 

--- a/docs/docs-website-sync.md
+++ b/docs/docs-website-sync.md
@@ -91,20 +91,20 @@ order: 1
 
 This section is only relevant for the repository owner. Forks do not need this setup — the sync workflow is skipped automatically.
 
-### 1. Create a GitHub PAT
+### 1. Create a Cloudflare Deploy Hook
 
-1. Go to [GitHub Settings > Developer settings > Fine-grained tokens](https://github.com/settings/tokens?type=beta)
-2. Create a new token with:
-   - **Repository access**: Only `stefanko-ch/nexus-stack.ch`
-   - **Permissions**: Contents → Read and Write
-3. Copy the token
+1. Go to Cloudflare Dashboard > Workers & Pages > `nexus-stack-ch` > Settings > Builds > Deploy Hooks
+2. Create a hook:
+   - **Name**: `nexus-stack-docs-sync`
+   - **Branch**: `main`
+3. Copy the generated URL
 
 ### 2. Add the Secret
 
 1. Go to [Nexus-Stack repo settings > Secrets > Actions](https://github.com/stefanko-ch/Nexus-Stack/settings/secrets/actions)
 2. Add a new secret:
-   - **Name**: `WEBSITE_DISPATCH_TOKEN`
-   - **Value**: The PAT from step 1
+   - **Name**: `WEBSITE_DEPLOY_HOOK`
+   - **Value**: The Deploy Hook URL from step 1
 
 ### 3. Enable Website Sync
 
@@ -113,21 +113,7 @@ This section is only relevant for the repository owner. Forks do not need this s
    - **Name**: `WEBSITE_SYNC_ENABLED`
    - **Value**: `true`
 
-The sync workflow is gated on this variable. If it is missing or set to any other value, the job will be skipped even if `WEBSITE_DISPATCH_TOKEN` is configured.
-
-### 4. Website Repo Setup
-
-In the `nexus-stack.ch` repo, add a `repository_dispatch` trigger to the build workflow:
-
-```yaml
-on:
-  push:
-    branches: [main]
-  repository_dispatch:
-    types: [docs-updated]
-```
-
-The Astro Content Loaders in the website repo handle fetching and rendering the docs.
+The sync workflow is gated on this variable. If it is missing or set to any other value, the job will be skipped.
 
 ## Fork Safety
 
@@ -136,7 +122,7 @@ The sync workflow has three independent protection layers:
 | Layer | How it works |
 |-------|-------------|
 | Repo check | `if: github.repository == 'stefanko-ch/Nexus-Stack'` skips on any fork |
-| Missing secret | Forks don't have `WEBSITE_DISPATCH_TOKEN`, dispatch fails silently |
-| PAT scope | Token only has access to the specific target repo |
+| Missing variable | Forks don't have `WEBSITE_SYNC_ENABLED`, job is skipped |
+| Missing secret | Forks don't have `WEBSITE_DEPLOY_HOOK`, script exits cleanly |
 
 Forks can safely ignore the `sync-docs-site.yml` workflow. It will never run and never fail.

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -431,7 +431,7 @@ Docker Hub limits anonymous image pulls to **100 pulls per 6 hours per IP**. Add
 
 Documentation in `docs/` can be synced to [nexus-stack.ch](https://nexus-stack.ch) when changes are pushed to `main`. This is handled by the `sync-docs-site.yml` workflow and only runs on the original repository (not on forks).
 
-See [Website Sync Guide](docs-website-sync.md) for setup instructions. Sync requires adding the `WEBSITE_DISPATCH_TOKEN` secret and setting the `WEBSITE_SYNC_ENABLED` repository variable to `true`.
+See [Website Sync Guide](docs-website-sync.md) for setup instructions. Sync requires a Cloudflare Deploy Hook URL stored as `WEBSITE_DEPLOY_HOOK` secret and the `WEBSITE_SYNC_ENABLED` repository variable set to `true`.
 
 ## 📚 Next Steps
 


### PR DESCRIPTION
## Summary

- Switch docs sync from `repository_dispatch` (requires PAT + GitHub Action in target repo) to Cloudflare Workers Builds Deploy Hook (just a curl POST)
- No PAT needed, no GitHub Action in the website repo, no third-party Action dependency
- Deploy Hook has built-in deduplication (skips redundant builds)
- Update docs-website-sync.md and setup-guide.md with new setup steps

### Setup required after merge

1. Create Deploy Hook in Cloudflare: Workers > nexus-stack-ch > Settings > Builds > Deploy Hooks
2. Store the URL as `WEBSITE_DEPLOY_HOOK` secret in this repo
3. Set `WEBSITE_SYNC_ENABLED` repo variable to `true`

## Test plan

- [ ] Workflow passes validation (actionlint)
- [ ] After setup: push a docs change to main and verify website rebuild is triggered
- [ ] Without setup: workflow skips cleanly (no failure)
