### PR TITLE
feat(stacks): Add Appsmith low-code platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,10 +66,11 @@ After deployment you'll have:
 
 ![Quick Start Flow](docs/images/architecture-quickstart.svg)
 
-## Available Stacks (61)
+## Available Stacks (62)
 
 ![AKHQ](https://img.shields.io/badge/AKHQ-000000?logo=apachekafka&logoColor=white)
 ![Adminer](https://img.shields.io/badge/Adminer-34567C?logo=adminer&logoColor=white)
+![Appsmith](https://img.shields.io/badge/Appsmith-F86A2E?logo=appsmith&logoColor=white)
 ![Budibase](https://img.shields.io/badge/Budibase-9981F5?logo=budibase&logoColor=white)
 ![CloudBeaver](https://img.shields.io/badge/CloudBeaver-3776AB?logo=dbeaver&logoColor=white)
 ![ClickHouse](https://img.shields.io/badge/ClickHouse-FFCC00?logo=clickhouse&logoColor=black)
@@ -134,6 +135,7 @@ After deployment you'll have:
 |-------|-------------|--------|
 | **AKHQ** | Kafka/Redpanda management GUI for topics, consumer groups, schema registry, and Kafka Connect | [akhq.io](https://akhq.io) |
 | **Adminer** | Lightweight database management tool (supports PostgreSQL, MySQL, SQLite, etc.) | [adminer.org](https://www.adminer.org) |
+| **Appsmith** | Open-source low-code platform for building admin panels, dashboards, and internal tools | [appsmith.com](https://appsmith.com) |
 | **Budibase** | Open-source low-code platform for building internal tools and dashboards | [budibase.com](https://budibase.com) |
 | **CloudBeaver** | Web-based database management tool | [dbeaver.com/cloudbeaver](https://dbeaver.com/cloudbeaver/) |
 | **ClickHouse** | Fast columnar database for real-time analytics and OLAP queries | [clickhouse.com](https://clickhouse.com) |

--- a/docs/stacks/README.md
+++ b/docs/stacks/README.md
@@ -10,6 +10,7 @@ Images are pinned to **major versions** where supported for automatic security p
 |---------|-------|-----|----------|
 | AKHQ | `tchiotludo/akhq` | `0.27.0` | Exact ¹ |
 | Adminer | `adminer` | `latest` | Latest ² |
+| Appsmith | `appsmith/appsmith-ce` | `v1.98` | Minor |
 | Budibase | `budibase/budibase` | `latest` | Latest ² |
 | CloudBeaver | `dbeaver/cloudbeaver` | `24` | Major |
 | ClickHouse | `clickhouse/clickhouse-server` | `25.8.16.34` | Exact ¹ |
@@ -118,6 +119,7 @@ Images are pinned to **major versions** where supported for automatic security p
 | **AKHQ** | Kafka/Redpanda management GUI | [akhq.md](akhq.md) |
 | **Adminer** | Lightweight database management tool | [adminer.md](adminer.md) |
 | **Apache Spark** | Distributed data processing engine | [spark.md](spark.md) |
+| **Appsmith** | Low-code platform for admin panels and internal tools | [appsmith.md](appsmith.md) |
 | **Budibase** | Low-code platform for internal tools | [budibase.md](budibase.md) |
 | **CloudBeaver** | Web-based database management tool | [cloudbeaver.md](cloudbeaver.md) |
 | **ClickHouse** | Columnar database for real-time analytics | [clickhouse.md](clickhouse.md) |

--- a/docs/stacks/appsmith.md
+++ b/docs/stacks/appsmith.md
@@ -1,3 +1,7 @@
+---
+title: "Appsmith"
+---
+
 ## Appsmith
 
 ![Appsmith](https://img.shields.io/badge/Appsmith-F86A2E?logo=appsmith&logoColor=white)

--- a/docs/stacks/appsmith.md
+++ b/docs/stacks/appsmith.md
@@ -1,0 +1,53 @@
+## Appsmith
+
+![Appsmith](https://img.shields.io/badge/Appsmith-F86A2E?logo=appsmith&logoColor=white)
+
+**Open-source low-code platform for building admin panels, dashboards, and internal tools**
+
+Appsmith is an open-source framework for building internal tools and custom UIs. Features include:
+- Drag-and-drop widget library (tables, forms, charts, maps, and more)
+- 18+ native data source connectors (PostgreSQL, MySQL, MongoDB, REST APIs, GraphQL, S3, and more)
+- JavaScript editor for writing business logic directly in the UI
+- Git-based version control for application source
+- Role-based access control with granular permissions
+- All-in-one container with bundled MongoDB, PostgreSQL, and Redis
+
+| Setting | Value |
+|---------|-------|
+| Default Port | `8098` |
+| Suggested Subdomain | `appsmith` |
+| Public Access | No |
+| Website | [appsmith.com](https://appsmith.com) |
+| Source | [GitHub](https://github.com/appsmithorg/appsmith) |
+
+### First-Time Setup
+
+On first access, Appsmith shows a registration screen. The first user to register becomes the admin. Complete this setup before sharing access with others.
+
+### Admin Account
+
+On first access, Appsmith shows a registration screen to create the initial admin account. **The first user to register becomes the instance admin** — complete this before sharing the URL with others. There are no pre-configured credentials; the account you create here is stored in Appsmith's internal database. Keep the credentials safe as they are not managed by Infisical.
+
+### Connecting to the Nexus-Stack PostgreSQL Database
+
+Since Appsmith and the PostgreSQL stack share the same Docker network (`app-network`), you can connect directly using the internal container hostname.
+
+In Appsmith, go to **Datasources → New datasource → PostgreSQL** and enter:
+
+| Field | Value |
+|-------|-------|
+| Host | `postgres` |
+| Port | `5432` |
+| Database | `postgres` |
+| Username | `nexus-postgres` |
+| Password | From Infisical → `postgres` folder → `POSTGRES_PASSWORD` |
+
+No firewall rules or additional configuration are required.
+
+### Persistent Data
+
+All application data (apps, datasources, configurations) is stored in the `appsmith_data` Docker volume mounted at `/appsmith-stacks` inside the container. Data persists across container restarts.
+
+### Encryption Keys
+
+Appsmith uses `APPSMITH_ENCRYPTION_PASSWORD` and `APPSMITH_ENCRYPTION_SALT` to encrypt datasource credentials at rest. These are auto-generated during deployment and stored in Infisical. **Do not change these after the first run** — doing so will render all saved datasource credentials unreadable.

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -158,6 +158,8 @@ NOCODB_ADMIN_PASS=$(echo "$SECRETS_JSON" | jq -r '.nocodb_admin_password // empt
 NOCODB_DB_PASS=$(echo "$SECRETS_JSON" | jq -r '.nocodb_db_password // empty')
 NOCODB_JWT_SECRET=$(echo "$SECRETS_JSON" | jq -r '.nocodb_jwt_secret // empty')
 DINKY_ADMIN_PASS=$(echo "$SECRETS_JSON" | jq -r '.dinky_admin_password // empty')
+APPSMITH_ENCRYPTION_PASSWORD=$(echo "$SECRETS_JSON" | jq -r '.appsmith_encryption_password // empty')
+APPSMITH_ENCRYPTION_SALT=$(echo "$SECRETS_JSON" | jq -r '.appsmith_encryption_salt // empty')
 DIFY_ADMIN_PASS=$(echo "$SECRETS_JSON" | jq -r '.dify_admin_password // empty')
 DIFY_DB_PASS=$(echo "$SECRETS_JSON" | jq -r '.dify_db_password // empty')
 DIFY_REDIS_PASS=$(echo "$SECRETS_JSON" | jq -r '.dify_redis_password // empty')
@@ -1109,6 +1111,19 @@ EOF
     echo -e "${GREEN}  ✓ S3 Manager .env generated${NC}"
 fi
 
+# Appsmith
+if echo "$ENABLED_SERVICES" | grep -qw "appsmith" && [ -n "$APPSMITH_ENCRYPTION_PASSWORD" ] && [ -n "$APPSMITH_ENCRYPTION_SALT" ]; then
+    echo "  Generating Appsmith config from OpenTofu secrets..."
+    cat > "$STACKS_DIR/appsmith/.env" << EOF
+# Auto-generated from OpenTofu secrets - DO NOT COMMIT
+APPSMITH_ENCRYPTION_PASSWORD=${APPSMITH_ENCRYPTION_PASSWORD}
+APPSMITH_ENCRYPTION_SALT=${APPSMITH_ENCRYPTION_SALT}
+APPSMITH_DISABLE_TELEMETRY=true
+APPSMITH_CUSTOM_DOMAIN=https://appsmith.${DOMAIN}
+EOF
+    echo -e "${GREEN}  ✓ Appsmith .env generated${NC}"
+fi
+
 # NocoDB
 if echo "$ENABLED_SERVICES" | grep -qw "nocodb" && [ -n "$NOCODB_DB_PASS" ] && [ -n "$NOCODB_ADMIN_PASS" ] && [ -n "$NOCODB_JWT_SECRET" ]; then
     echo "  Generating NocoDB config from OpenTofu secrets..."
@@ -1913,6 +1928,10 @@ EOF
             "NOCODB_PASSWORD" "$NOCODB_ADMIN_PASS" \
             "NOCODB_DB_PASSWORD" "$NOCODB_DB_PASS" \
             "NOCODB_JWT_SECRET" "$NOCODB_JWT_SECRET"
+
+        build_folder "appsmith" \
+            "APPSMITH_ENCRYPTION_PASSWORD" "$APPSMITH_ENCRYPTION_PASSWORD" \
+            "APPSMITH_ENCRYPTION_SALT" "$APPSMITH_ENCRYPTION_SALT"
 
         build_folder "dinky" \
             "DINKY_USERNAME" "admin" \

--- a/services.yaml
+++ b/services.yaml
@@ -60,6 +60,16 @@ services:
     long_description: "Adminer is a full-featured, single-file database management tool written in PHP. It supports PostgreSQL, MySQL, MariaDB, SQLite, MS SQL, Oracle, and MongoDB. Run SQL queries, browse tables, import/export data, and manage database structure - all in a lightweight web interface."
     image: "adminer:latest"
 
+  appsmith:
+    subdomain: "appsmith"
+    port: 8098
+    public: false
+    category: "low-code"
+    website: "https://appsmith.com"
+    description: "Open-source low-code platform for building admin panels, dashboards, and internal tools."
+    long_description: "Appsmith is an open-source framework for building internal tools and custom UIs. Connect to 18+ data sources including PostgreSQL, MySQL, MongoDB, REST APIs, and GraphQL. Features drag-and-drop widgets, JavaScript business logic, Git-based version control, and granular access controls. All-in-one container with bundled MongoDB, PostgreSQL, and Redis."
+    image: "appsmith/appsmith-ce:v1.98"
+
   cloudbeaver:
     subdomain: "cloudbeaver"
     port: 8978

--- a/stacks/appsmith/docker-compose.yml
+++ b/stacks/appsmith/docker-compose.yml
@@ -22,11 +22,16 @@ services:
       - appsmith_data:/appsmith-stacks
     networks:
       - app-network
+    deploy:
+      resources:
+        limits:
+          memory: 2g
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:80"]
       interval: 30s
       timeout: 10s
       retries: 3
+      start_period: 60s
 
 volumes:
   appsmith_data:

--- a/stacks/appsmith/docker-compose.yml
+++ b/stacks/appsmith/docker-compose.yml
@@ -1,0 +1,36 @@
+# =============================================================================
+# Appsmith - Low-Code Platform for Internal Tools
+# =============================================================================
+# Open-source framework for building admin panels, dashboards, and internal
+# tools. Connect to databases and APIs, build UIs with drag-and-drop widgets,
+# and write JavaScript for business logic.
+#
+# Access: https://appsmith.<domain>
+# Docs: https://docs.appsmith.com/
+# =============================================================================
+
+services:
+  appsmith:
+    image: ${IMAGE_APPSMITH:-appsmith/appsmith-ce:v1.98}
+    container_name: appsmith
+    restart: unless-stopped
+    ports:
+      - "8098:80"
+    env_file:
+      - .env
+    volumes:
+      - appsmith_data:/appsmith-stacks
+    networks:
+      - app-network
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:80"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+volumes:
+  appsmith_data:
+
+networks:
+  app-network:
+    external: true

--- a/tofu/stack/main.tf
+++ b/tofu/stack/main.tf
@@ -406,6 +406,17 @@ resource "random_password" "dinky_admin" {
   special = false
 }
 
+# Appsmith encryption keys
+resource "random_password" "appsmith_encryption_password" {
+  length  = 32
+  special = false
+}
+
+resource "random_password" "appsmith_encryption_salt" {
+  length  = 32
+  special = false
+}
+
 # Note: Hetzner Object Storage bucket is created in control-plane/main.tf
 # to persist through teardown. The bucket name is passed via hetzner_s3_bucket variable.
 

--- a/tofu/stack/outputs.tf
+++ b/tofu/stack/outputs.tf
@@ -240,6 +240,10 @@ output "secrets" {
     nocodb_db_password    = random_password.nocodb_db.result
     nocodb_jwt_secret     = random_password.nocodb_jwt_secret.result
 
+    # Appsmith
+    appsmith_encryption_password = random_password.appsmith_encryption_password.result
+    appsmith_encryption_salt     = random_password.appsmith_encryption_salt.result
+
     # Dinky
     dinky_admin_password = random_password.dinky_admin.result
 


### PR DESCRIPTION
## Description
This time for real and tested.
Adds [Appsmith](https://appsmith.com) as a new stack — an open-source low-code platform for building internal tools, admin panels, and dashboards.

- New stack: `stacks/appsmith/docker-compose.yml` (port 8098, ARM64-compatible)
- Service registered in `services.yaml` under the `low-code` category
- Two encryption keys auto-generated via OpenTofu and stored in Infisical (`appsmith_encryption_password`, `appsmith_encryption_salt`)
- `.env` generated during deploy with encryption keys, telemetry disabled, and custom domain set
- Encryption keys pushed to Infisical via `build_folder`
- Stack documentation added at `docs/stacks/appsmith.md`
- README and `docs/stacks/README.md` updated

Closes #401

## Motivation and Context

Appsmith fills a gap in the low-code category alongside Budibase — it has a different approach with stronger support for connecting to existing databases and APIs, making it a good complement for users who want to build internal tooling on top of their data stack.

## How Has This Been Tested?

Deployed twice via `spin-up.yml` on the feature branch against a live Hetzner/Cloudflare environment.

- Appsmith started healthy and was accessible via Cloudflare Tunnel
- Completed first-time registration (first user becomes admin)
- Connected to the shared PostgreSQL stack using the internal `app-network` hostname (`postgres:5432`) — successfully wrote and read data
- Encryption keys were present in Infisical after deployment
- Service appeared correctly in the Control Plane under the Low-Code Platforms category

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
