### PR TITLE
fix(ci): Upgrade setup-node v5, fix Hetzner Object Storage resilience

### DIFF
--- a/.github/workflows/destroy-all.yml
+++ b/.github/workflows/destroy-all.yml
@@ -227,10 +227,13 @@ jobs:
           echo "💾 Protecting KV namespace from destroy..."
           tofu state rm cloudflare_workers_kv_namespace.config 2>/dev/null || true
 
-          # Protect Hetzner S3 buckets from destruction (keeps student data)
+          # Protect ALL Hetzner S3 buckets from destruction (keeps student data)
+          # Uses dynamic discovery so new buckets are automatically covered
           echo "💾 Protecting Hetzner S3 buckets from destroy..."
-          tofu state rm 'minio_s3_bucket.lakefs[0]' 2>/dev/null || true
-          tofu state rm 'minio_s3_bucket.general[0]' 2>/dev/null || true
+          for RESOURCE in $(tofu state list 2>/dev/null | grep '^minio_s3_bucket\.' || true); do
+            echo "   Removing $RESOURCE from state..."
+            tofu state rm "$RESOURCE" 2>/dev/null || true
+          done
 
           echo "🗑️  Destroying Control Plane (Pages, Worker, DNS)..."
           if ! tofu destroy -var-file=config.tfvars -auto-approve; then

--- a/.github/workflows/setup-control-plane.yaml
+++ b/.github/workflows/setup-control-plane.yaml
@@ -73,7 +73,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
 

--- a/.github/workflows/setup-control-plane.yaml
+++ b/.github/workflows/setup-control-plane.yaml
@@ -596,9 +596,11 @@ jobs:
           fi
 
       - name: Pre-create Hetzner Object Storage buckets (avoids provider ACL issues)
+        id: hetzner_s3
         run: |
           if [ -z "${{ secrets.HETZNER_OBJECT_STORAGE_ACCESS_KEY }}" ]; then
             echo "ℹ️  Hetzner Object Storage not configured - skipping"
+            echo "available=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -618,6 +620,25 @@ jobs:
           export TF_VAR_hetzner_object_storage_region="${HZ_REGION}"
           HZ_AK="${{ secrets.HETZNER_OBJECT_STORAGE_ACCESS_KEY }}"
           HZ_SK="${{ secrets.HETZNER_OBJECT_STORAGE_SECRET_KEY }}"
+
+          # Health check: verify Hetzner Object Storage is reachable
+          if ! AWS_ACCESS_KEY_ID="$HZ_AK" AWS_SECRET_ACCESS_KEY="$HZ_SK" \
+               aws s3api list-buckets --endpoint-url "$HZ_ENDPOINT" --max-items 1 >/dev/null 2>&1; then
+            echo "⚠️  Hetzner Object Storage is unavailable - skipping bucket setup"
+            echo "   Buckets will be created/imported on next run when service is back"
+            echo "   Affected services: LakeFS, Filestash, pg_ducklake (no S3 backend)"
+            echo "available=false" >> "$GITHUB_OUTPUT"
+
+            # Remove any existing bucket resources from state so tofu apply doesn't
+            # try to refresh them against the unavailable service
+            for RESOURCE in $(tofu state list 2>/dev/null | grep '^minio_s3_bucket\.' || true); do
+              echo "   Removing $RESOURCE from state (will re-import later)..."
+              tofu state rm "$RESOURCE" 2>/dev/null || true
+            done
+            exit 0
+          fi
+
+          echo "available=true" >> "$GITHUB_OUTPUT"
 
           # All Hetzner S3 buckets: name -> Terraform resource mapping
           declare -A BUCKET_MAP=(
@@ -669,6 +690,14 @@ jobs:
           source ../.r2-credentials
           export AWS_ACCESS_KEY_ID="$R2_ACCESS_KEY_ID"
           export AWS_SECRET_ACCESS_KEY="$R2_SECRET_ACCESS_KEY"
+
+          # If Hetzner Object Storage is unavailable, clear credentials so MinIO
+          # provider resources get count=0 and tofu doesn't try to reach the service
+          if [ "${{ steps.hetzner_s3.outputs.available }}" != "true" ]; then
+            echo "⚠️  Hetzner Object Storage unavailable - deploying without S3 buckets"
+            export TF_VAR_hetzner_object_storage_access_key=""
+            export TF_VAR_hetzner_object_storage_secret_key=""
+          fi
 
           echo "🏗️  Deploying Control Plane infrastructure (Cloudflare Pages + Worker)..."
           tofu apply -var-file=config.tfvars -auto-approve

--- a/.github/workflows/setup-control-plane.yaml
+++ b/.github/workflows/setup-control-plane.yaml
@@ -619,9 +619,18 @@ jobs:
           HZ_AK="${{ secrets.HETZNER_OBJECT_STORAGE_ACCESS_KEY }}"
           HZ_SK="${{ secrets.HETZNER_OBJECT_STORAGE_SECRET_KEY }}"
 
-          for BUCKET in "${RESOURCE_PREFIX}-lakefs" "${RESOURCE_PREFIX}"; do
+          # All Hetzner S3 buckets: name -> Terraform resource mapping
+          declare -A BUCKET_MAP=(
+            ["${RESOURCE_PREFIX}-lakefs"]="lakefs[0]"
+            ["${RESOURCE_PREFIX}"]="general[0]"
+            ["${RESOURCE_PREFIX}-pgducklake"]="pgducklake[0]"
+          )
+
+          for BUCKET in "${!BUCKET_MAP[@]}"; do
+            RES_NAME="${BUCKET_MAP[$BUCKET]}"
+            RESOURCE_NAME="minio_s3_bucket.${RES_NAME}"
+
             # Skip if already in state
-            RESOURCE_NAME="minio_s3_bucket.$([ "$BUCKET" = "${RESOURCE_PREFIX}-lakefs" ] && echo 'lakefs[0]' || echo 'general[0]')"
             if tofu state show "$RESOURCE_NAME" >/dev/null 2>&1; then
               echo "✅ $BUCKET already in state"
               continue
@@ -647,8 +656,7 @@ jobs:
             fi
 
             # Import into state so tofu apply doesn't try to create (and fail on ACL)
-            IMPORT_RESOURCE="minio_s3_bucket.$([ "$BUCKET" = "${RESOURCE_PREFIX}-lakefs" ] && echo 'lakefs[0]' || echo 'general[0]')"
-            if tofu import -var-file=config.tfvars "$IMPORT_RESOURCE" "$BUCKET" 2>/dev/null; then
+            if tofu import -var-file=config.tfvars "$RESOURCE_NAME" "$BUCKET" 2>/dev/null; then
               echo "✅ $BUCKET imported into state"
             else
               echo "⚠️  Import failed for $BUCKET - tofu apply will handle it"

--- a/.github/workflows/setup-control-plane.yaml
+++ b/.github/workflows/setup-control-plane.yaml
@@ -623,7 +623,7 @@ jobs:
 
           # Health check: verify Hetzner Object Storage is reachable
           if ! AWS_ACCESS_KEY_ID="$HZ_AK" AWS_SECRET_ACCESS_KEY="$HZ_SK" \
-               aws s3api list-buckets --endpoint-url "$HZ_ENDPOINT" --max-items 1 >/dev/null 2>&1; then
+               aws s3api list-buckets --region "$HZ_REGION" --endpoint-url "$HZ_ENDPOINT" --max-items 1 >/dev/null 2>&1; then
             echo "⚠️  Hetzner Object Storage is unavailable - skipping bucket setup"
             echo "   Buckets will be created/imported on next run when service is back"
             echo "   Affected services: LakeFS, Filestash, pg_ducklake (no S3 backend)"
@@ -659,13 +659,13 @@ jobs:
 
             # Create bucket via AWS CLI (no ACL/policy issues)
             if AWS_ACCESS_KEY_ID="$HZ_AK" AWS_SECRET_ACCESS_KEY="$HZ_SK" \
-               aws s3api head-bucket --bucket "$BUCKET" --endpoint-url "$HZ_ENDPOINT" 2>/dev/null; then
+               aws s3api head-bucket --bucket "$BUCKET" --region "$HZ_REGION" --endpoint-url "$HZ_ENDPOINT" 2>/dev/null; then
               echo "✅ $BUCKET already exists in Hetzner"
             else
               echo "🪣 Creating $BUCKET (endpoint: $HZ_ENDPOINT)..."
               CREATE_RC=0
               CREATE_OUTPUT=$(AWS_ACCESS_KEY_ID="$HZ_AK" AWS_SECRET_ACCESS_KEY="$HZ_SK" \
-                 aws s3api create-bucket --bucket "$BUCKET" --endpoint-url "$HZ_ENDPOINT" 2>&1) || CREATE_RC=$?
+                 aws s3api create-bucket --bucket "$BUCKET" --region "$HZ_REGION" --endpoint-url "$HZ_ENDPOINT" 2>&1) || CREATE_RC=$?
               if [ "$CREATE_RC" -eq 0 ]; then
                 echo "✅ $BUCKET created"
               elif echo "$CREATE_OUTPUT" | grep -q "BucketAlreadyOwnedByYou\|BucketAlreadyExists"; then

--- a/.github/workflows/spin-up.yml
+++ b/.github/workflows/spin-up.yml
@@ -103,7 +103,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
 


### PR DESCRIPTION
## Summary

- Upgrade `actions/setup-node` from v4 to v5 (Node.js 20 EOL April 2026, forced Node.js 24 from June 2026)
- Fix missing `pgducklake` bucket in `destroy-all.yml` and `setup-control-plane.yaml` workflows — this caused both workflows to fail when Hetzner Object Storage was unavailable
- Make Hetzner Object Storage non-blocking in setup workflow: if the service is unreachable, core infrastructure (server, tunnel, DNS, Control Plane) deploys normally; S3 buckets are created on next run

## Changes

### `setup-control-plane.yaml`
- `actions/setup-node` v4 -> v5
- Add health check for Hetzner Object Storage before bucket operations
- If unavailable: remove bucket resources from state, clear credentials so `count=0`, deploy without S3
- Add `pgducklake` to bucket pre-creation/import loop using associative array

### `destroy-all.yml`
- Replace hardcoded bucket list (`lakefs`, `general`) with dynamic discovery via `tofu state list | grep minio_s3_bucket` — automatically covers future buckets

### `spin-up.yml`
- `actions/setup-node` v4 -> v5

## Test plan

- [x] Initial Setup with Hetzner Object Storage outage: deploys successfully, skips buckets
- [ ] Initial Setup with Hetzner Object Storage available: creates/imports all 3 buckets
- [ ] Destroy All: dynamically removes all bucket resources from state before destroy
