### PR TITLE
fix(tofu): Split comma-separated user_email in allowed_emails

### DIFF
--- a/tofu/control-plane/main.tf
+++ b/tofu/control-plane/main.tf
@@ -13,7 +13,11 @@ locals {
   resource_prefix = "nexus-${replace(var.domain, ".", "-")}"
 
   # List of emails allowed to access control plane (admin + optional user)
-  allowed_emails = compact([var.admin_email, var.user_email])
+  # user_email may be comma-separated, so split it into individual entries
+  allowed_emails = distinct(compact(concat(
+    [var.admin_email],
+    split(",", var.user_email)
+  )))
 }
 
 # -----------------------------------------------------------------------------

--- a/tofu/control-plane/main.tf
+++ b/tofu/control-plane/main.tf
@@ -13,10 +13,10 @@ locals {
   resource_prefix = "nexus-${replace(var.domain, ".", "-")}"
 
   # List of emails allowed to access control plane (admin + optional user)
-  # user_email may be comma-separated, so split it into individual entries
+  # user_email may be comma-separated, so split and trim into individual entries
   allowed_emails = distinct(compact(concat(
-    [var.admin_email],
-    split(",", var.user_email)
+    [trimspace(var.admin_email)],
+    [for email in split(",", var.user_email) : trimspace(email)]
   )))
 }
 

--- a/tofu/stack/main.tf
+++ b/tofu/stack/main.tf
@@ -8,10 +8,10 @@ locals {
   resource_prefix = "nexus-${replace(var.domain, ".", "-")}"
 
   # List of emails allowed to access services (admin + optional user)
-  # user_email may be comma-separated, so split it into individual entries
+  # user_email may be comma-separated, so split and trim into individual entries
   allowed_emails = distinct(compact(concat(
-    [var.admin_email],
-    split(",", var.user_email)
+    [trimspace(var.admin_email)],
+    [for email in split(",", var.user_email) : trimspace(email)]
   )))
 }
 

--- a/tofu/stack/main.tf
+++ b/tofu/stack/main.tf
@@ -8,8 +8,11 @@ locals {
   resource_prefix = "nexus-${replace(var.domain, ".", "-")}"
 
   # List of emails allowed to access services (admin + optional user)
-  # Filter out empty strings
-  allowed_emails = compact([var.admin_email, var.user_email])
+  # user_email may be comma-separated, so split it into individual entries
+  allowed_emails = distinct(compact(concat(
+    [var.admin_email],
+    split(",", var.user_email)
+  )))
 }
 
 # =============================================================================


### PR DESCRIPTION
## Summary

- Fix `allowed_emails` not splitting comma-separated `user_email` values
- `var.user_email` can be `"user1@example.com,user2@example.com"` but `compact()` treated this as a single entry, passing an invalid email to Cloudflare Access policies
- Fix uses `split(",", var.user_email)` + `concat` + `compact` + `distinct`
- Applied to both `tofu/control-plane/main.tf` and `tofu/stack/main.tf`

## Test plan

- [ ] `tofu plan` in both states shows `allowed_emails` as separate entries
- [ ] Run Initial Setup or Spin-Up, verify Cloudflare Access policies list individual emails
