### PR TITLE
fix(ci): Add pre-apply reconciliation for orphaned KV namespace and volume

### DIFF
--- a/.github/workflows/setup-control-plane.yaml
+++ b/.github/workflows/setup-control-plane.yaml
@@ -699,6 +699,47 @@ jobs:
             export TF_VAR_hetzner_object_storage_secret_key=""
           fi
 
+          # =================================================================
+          # Pre-apply reconciliation: import orphaned resources
+          # Safety net for when earlier import steps were skipped due to
+          # failures (e.g., init-r2-state.sh failed, job aborted, but
+          # resources still exist in Cloudflare/Hetzner from a previous run)
+          # =================================================================
+          DOMAIN="${{ secrets.DOMAIN }}"
+          DOMAIN_SLUG="${DOMAIN//./-}"
+
+          # KV Namespace
+          if ! tofu state show cloudflare_workers_kv_namespace.config >/dev/null 2>&1; then
+            KV_TITLE="nexus-${DOMAIN_SLUG}-config"
+            echo "🔍 KV namespace not in state - checking Cloudflare for '${KV_TITLE}'..."
+            KV_ID=$(curl -sf "https://api.cloudflare.com/client/v4/accounts/${{ secrets.CLOUDFLARE_ACCOUNT_ID }}/storage/kv/namespaces" \
+              -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" | \
+              jq -r --arg title "$KV_TITLE" '.result[] | select(.title==$title) | .id // empty' 2>/dev/null || echo "")
+            if [ -n "$KV_ID" ]; then
+              echo "💾 Importing orphaned KV namespace (ID: $KV_ID)..."
+              tofu import -var-file=config.tfvars cloudflare_workers_kv_namespace.config "${{ secrets.CLOUDFLARE_ACCOUNT_ID }}/${KV_ID}" || \
+                echo "⚠️  KV import failed (non-fatal, tofu apply will attempt create)"
+            else
+              echo "ℹ️  No existing KV namespace found - will create new one"
+            fi
+          fi
+
+          # Persistent Volume
+          if ! tofu state show hcloud_volume.persistent >/dev/null 2>&1; then
+            VOL_NAME="nexus-${DOMAIN_SLUG}-data"
+            echo "🔍 Persistent volume not in state - checking Hetzner for '${VOL_NAME}'..."
+            VOL_ID=$(curl -sf "https://api.hetzner.cloud/v1/volumes?name=${VOL_NAME}" \
+              -H "Authorization: Bearer ${{ secrets.HCLOUD_TOKEN }}" | \
+              jq -r '.volumes[0].id // empty' 2>/dev/null || echo "")
+            if [ -n "$VOL_ID" ] && [ "$VOL_ID" != "null" ]; then
+              echo "💾 Importing orphaned persistent volume (ID: $VOL_ID)..."
+              tofu import -var-file=config.tfvars hcloud_volume.persistent "$VOL_ID" || \
+                echo "⚠️  Volume import failed (non-fatal, tofu apply will attempt create)"
+            else
+              echo "ℹ️  No existing persistent volume found - will create new one"
+            fi
+          fi
+
           echo "🏗️  Deploying Control Plane infrastructure (Cloudflare Pages + Worker)..."
           tofu apply -var-file=config.tfvars -auto-approve
 

--- a/.github/workflows/setup-control-plane.yaml
+++ b/.github/workflows/setup-control-plane.yaml
@@ -712,9 +712,9 @@ jobs:
           if ! tofu state show cloudflare_workers_kv_namespace.config >/dev/null 2>&1; then
             KV_TITLE="nexus-${DOMAIN_SLUG}-config"
             echo "🔍 KV namespace not in state - checking Cloudflare for '${KV_TITLE}'..."
-            KV_ID=$(curl -sf "https://api.cloudflare.com/client/v4/accounts/${{ secrets.CLOUDFLARE_ACCOUNT_ID }}/storage/kv/namespaces" \
+            KV_ID=$(curl -sf "https://api.cloudflare.com/client/v4/accounts/${{ secrets.CLOUDFLARE_ACCOUNT_ID }}/storage/kv/namespaces?per_page=100" \
               -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" | \
-              jq -r --arg title "$KV_TITLE" '.result[] | select(.title==$title) | .id // empty' 2>/dev/null || echo "")
+              jq -r --arg title "$KV_TITLE" '.result[] | select(.title==$title) | .id // empty' 2>/dev/null | head -1 || echo "")
             if [ -n "$KV_ID" ]; then
               echo "💾 Importing orphaned KV namespace (ID: $KV_ID)..."
               tofu import -var-file=config.tfvars cloudflare_workers_kv_namespace.config "${{ secrets.CLOUDFLARE_ACCOUNT_ID }}/${KV_ID}" || \


### PR DESCRIPTION
## Summary

When `init-r2-state.sh` fails during `initial-setup`, the job aborts and the standalone import steps for KV namespace and persistent volume never run. On the next setup attempt, `tofu apply` fails with "already exists" because the resources exist in Cloudflare/Hetzner but are not in the Terraform state.

- Adds a pre-apply reconciliation block directly before `tofu apply` that checks for orphaned resources (KV namespace, persistent volume) and imports them
- Idempotent: if the standalone import steps already ran, the state check finds the resource and skips
- Observed in Education student deployments

## Test plan

- [ ] Normal deploy: standalone import steps run as before, pre-apply checks find resources in state, skip (no-op)
- [ ] After destroy + redeploy: KV namespace and volume are imported correctly (either by standalone steps or pre-apply reconciliation)
- [ ] Verify KV namespace data (Databricks config) is preserved across destroy/redeploy cycles
