### PR TITLE
fix(stacks): Prevent RedPanda OOM crash and add public URLs to Infisical

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1976,8 +1976,8 @@ EOF
         build_folder "redpanda" \
             "REDPANDA_SASL_USERNAME" "nexus-redpanda" \
             "REDPANDA_SASL_PASSWORD" "$REDPANDA_ADMIN_PASS" \
-            "REDPANDA_KAFKA_URL" "redpanda-kafka.${DOMAIN}:9092" \
-            "REDPANDA_SCHEMA_REGISTRY_URL" "redpanda-schema-registry.${DOMAIN}:18081"
+            "REDPANDA_KAFKA_PUBLIC_URL" "redpanda-kafka.${DOMAIN}:9092" \
+            "REDPANDA_SCHEMA_REGISTRY_PUBLIC_URL" "redpanda-schema-registry.${DOMAIN}:18081"
 
         build_folder "meltano" \
             "MELTANO_DB_PASSWORD" "$MELTANO_DB_PASS"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1975,7 +1975,9 @@ EOF
 
         build_folder "redpanda" \
             "REDPANDA_SASL_USERNAME" "nexus-redpanda" \
-            "REDPANDA_SASL_PASSWORD" "$REDPANDA_ADMIN_PASS"
+            "REDPANDA_SASL_PASSWORD" "$REDPANDA_ADMIN_PASS" \
+            "REDPANDA_KAFKA_URL" "redpanda-kafka.${DOMAIN}:9092" \
+            "REDPANDA_SCHEMA_REGISTRY_URL" "redpanda-schema-registry.${DOMAIN}:18081"
 
         build_folder "meltano" \
             "MELTANO_DB_PASSWORD" "$MELTANO_DB_PASS"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1977,7 +1977,7 @@ EOF
             "REDPANDA_SASL_USERNAME" "nexus-redpanda" \
             "REDPANDA_SASL_PASSWORD" "$REDPANDA_ADMIN_PASS" \
             "REDPANDA_KAFKA_PUBLIC_URL" "redpanda-kafka.${DOMAIN}:9092" \
-            "REDPANDA_SCHEMA_REGISTRY_PUBLIC_URL" "redpanda-schema-registry.${DOMAIN}:18081"
+            "REDPANDA_SCHEMA_REGISTRY_PUBLIC_URL" "http://redpanda-schema-registry.${DOMAIN}:18081"
 
         build_folder "meltano" \
             "MELTANO_DB_PASSWORD" "$MELTANO_DB_PASS"

--- a/stacks/redpanda/config/redpanda.yaml
+++ b/stacks/redpanda/config/redpanda.yaml
@@ -1,11 +1,13 @@
 # =============================================================================
 # RedPanda Production Configuration
 # =============================================================================
-# This configuration file contains ALL settings. No command-line flags are
-# used to prevent config file rewrites that strip authentication_method fields.
+# This configuration file contains ALL Redpanda settings. Seastar runtime
+# flags (--smp, --memory) are set in docker-compose.yml and do not trigger
+# config rewrites.
 #
-# IMPORTANT: Mixing CLI flags with mounted config files causes Redpanda to
-# rewrite this file, removing fields like authentication_method.
+# IMPORTANT: Do NOT add Redpanda-specific CLI flags (e.g. --kafka-addr) —
+# mixing them with this config file causes Redpanda to rewrite it, removing
+# fields like authentication_method.
 # See: https://github.com/redpanda-data/redpanda/issues/15902
 # =============================================================================
 

--- a/stacks/redpanda/docker-compose.yml
+++ b/stacks/redpanda/docker-compose.yml
@@ -13,9 +13,9 @@ services:
     command:
       - redpanda
       - start
+      # Seastar runtime flags — do not trigger Redpanda config rewrites
       - --smp=1
       - --memory=1536M
-      - --default-log-level=warn
     deploy:
       resources:
         limits:

--- a/stacks/redpanda/docker-compose.yml
+++ b/stacks/redpanda/docker-compose.yml
@@ -13,12 +13,13 @@ services:
     command:
       - redpanda
       - start
-      # All configuration is in /etc/redpanda/redpanda.yaml
-      # No CLI flags to prevent config file rewrites
+      - --smp=1
+      - --memory=1536M
+      - --default-log-level=warn
     deploy:
       resources:
         limits:
-          memory: 2g
+          memory: 4g
     volumes:
       - redpanda-data:/var/lib/redpanda/data
       - ./config:/etc/redpanda

--- a/tofu/stack/outputs.tf
+++ b/tofu/stack/outputs.tf
@@ -191,7 +191,9 @@ output "secrets" {
     pgadmin_password = random_password.pgadmin.result
 
     # RedPanda SASL (for external Kafka access)
-    redpanda_admin_password = random_password.redpanda_admin.result
+    redpanda_admin_password        = random_password.redpanda_admin.result
+    redpanda_kafka_public_url      = "redpanda-kafka.${var.domain}:9092"
+    redpanda_schema_registry_public_url = "http://redpanda-schema-registry.${var.domain}:18081"
 
     # RustFS
     rustfs_root_password = random_password.rustfs_root.result


### PR DESCRIPTION
## Summary

- Fix RedPanda OOM crash loop on multi-core servers by adding `--smp=1 --memory=1536M` flags and raising Docker memory limit to 4GB
- Add `REDPANDA_KAFKA_PUBLIC_URL` and `REDPANDA_SCHEMA_REGISTRY_PUBLIC_URL` to Infisical secrets for external client configuration

## Root Cause

RedPanda auto-detects all 8 host CPUs and allocates memory per-shard. With the 2GB Docker limit, only 464MB was available after 1.5GB reserved, causing `Failed to allocate 8877856 bytes` and exit code 133 crash loop. This made the SASL background config job fail, taking down the entire Spin Up workflow.

## Test Plan

- [ ] Run `gh workflow run spin-up.yml --ref fix/redpanda-oom`
- [ ] Verify RedPanda container is healthy: `ssh nexus "docker ps | grep redpanda"`
- [ ] Verify Infisical has new secrets in `redpanda` folder
- [ ] Verify Kafka connectivity via public URL
