### PR TITLE
feat(firewall): Add RedPanda Admin API and Connect ports to firewall management

### DIFF
--- a/.github/scripts/sync-deployed-state.sh
+++ b/.github/scripts/sync-deployed-state.sh
@@ -321,7 +321,7 @@ cleanup_statements = []
 # DNS record mapping for known services
 dns_records = {
     'redpanda': {'kafka': 'redpanda-kafka', 'schema-registry': 'redpanda-schema-registry', 'admin': 'redpanda-admin'},
-    'redpanda-connect': {'api': 'redpanda-connect'},
+    'redpanda-connect': {'api': 'redpanda-connect-api'},
     'postgres': {'postgres': 'postgres'},
     'minio': {'s3-api': 's3'},
 }

--- a/.github/scripts/sync-deployed-state.sh
+++ b/.github/scripts/sync-deployed-state.sh
@@ -349,6 +349,8 @@ for name, config in services.items():
         safe_dns_record = dns_record.replace("'", "''")
         insert_sql = f"INSERT OR IGNORE INTO firewall_rules (service_name, port, protocol, label, enabled, deployed, source_ips, dns_record, updated_at) VALUES ('{safe_name}', {port}, 'tcp', '{safe_label}', 0, 0, '', '{safe_dns_record}', datetime('now'));"
         insert_statements.append(insert_sql)
+        update_sql = f"UPDATE firewall_rules SET label = '{safe_label}', dns_record = '{safe_dns_record}', updated_at = datetime('now') WHERE service_name = '{safe_name}' AND port = {port};"
+        insert_statements.append(update_sql)
 
     # Delete stale firewall rules whose port is no longer in services.yaml tcp_ports
     if valid_ports:

--- a/.github/scripts/sync-deployed-state.sh
+++ b/.github/scripts/sync-deployed-state.sh
@@ -320,7 +320,8 @@ cleanup_statements = []
 
 # DNS record mapping for known services
 dns_records = {
-    'redpanda': {'kafka': 'redpanda-kafka', 'schema-registry': 'redpanda-schema-registry'},
+    'redpanda': {'kafka': 'redpanda-kafka', 'schema-registry': 'redpanda-schema-registry', 'admin': 'redpanda-admin'},
+    'redpanda-connect': {'api': 'redpanda-connect'},
     'postgres': {'postgres': 'postgres'},
     'minio': {'s3-api': 's3'},
 }

--- a/.github/scripts/sync-deployed-state.sh
+++ b/.github/scripts/sync-deployed-state.sh
@@ -349,7 +349,10 @@ for name, config in services.items():
         safe_dns_record = dns_record.replace("'", "''")
         insert_sql = f"INSERT OR IGNORE INTO firewall_rules (service_name, port, protocol, label, enabled, deployed, source_ips, dns_record, updated_at) VALUES ('{safe_name}', {port}, 'tcp', '{safe_label}', 0, 0, '', '{safe_dns_record}', datetime('now'));"
         insert_statements.append(insert_sql)
-        update_sql = f"UPDATE firewall_rules SET label = '{safe_label}', dns_record = '{safe_dns_record}', updated_at = datetime('now') WHERE service_name = '{safe_name}' AND port = {port};"
+        if safe_dns_record:
+            update_sql = f"UPDATE firewall_rules SET label = '{safe_label}', dns_record = '{safe_dns_record}', updated_at = datetime('now') WHERE service_name = '{safe_name}' AND port = {port};"
+        else:
+            update_sql = f"UPDATE firewall_rules SET label = '{safe_label}', updated_at = datetime('now') WHERE service_name = '{safe_name}' AND port = {port};"
         insert_statements.append(update_sql)
 
     # Delete stale firewall rules whose port is no longer in services.yaml tcp_ports

--- a/.github/scripts/sync-firewall-rules.sh
+++ b/.github/scripts/sync-firewall-rules.sh
@@ -41,8 +41,8 @@ try:
     with open('services.yaml', 'r') as f:
         data = yaml.safe_load(f)
 except Exception as e:
-    print(f"  Warning: Error reading services.yaml: {e}")
-    sys.exit(0)
+    print(f"  Error reading services.yaml: {e}")
+    sys.exit(1)
 
 if not data or 'services' not in data:
     print("  No services found - skipping")

--- a/.github/scripts/sync-firewall-rules.sh
+++ b/.github/scripts/sync-firewall-rules.sh
@@ -77,7 +77,10 @@ for name, config in services.items():
         dns_record = dns_records.get(name, {}).get(label, '')
         safe_dns_record = dns_record.replace("'", "''")
         statements.append(f"INSERT OR IGNORE INTO firewall_rules (service_name, port, protocol, label, enabled, deployed, source_ips, dns_record, updated_at) VALUES ('{safe_name}', {port}, 'tcp', '{safe_label}', 0, 0, '', '{safe_dns_record}', datetime('now'));")
-        statements.append(f"UPDATE firewall_rules SET label = '{safe_label}', dns_record = '{safe_dns_record}', updated_at = datetime('now') WHERE service_name = '{safe_name}' AND port = {port};")
+        if safe_dns_record:
+            statements.append(f"UPDATE firewall_rules SET label = '{safe_label}', dns_record = '{safe_dns_record}', updated_at = datetime('now') WHERE service_name = '{safe_name}' AND port = {port};")
+        else:
+            statements.append(f"UPDATE firewall_rules SET label = '{safe_label}', updated_at = datetime('now') WHERE service_name = '{safe_name}' AND port = {port};")
 
     if valid_ports:
         ports_list = ', '.join(str(p) for p in valid_ports)
@@ -96,7 +99,7 @@ if [ -f /tmp/sync_firewall_rules.sql ] && [ -s /tmp/sync_firewall_rules.sql ]; t
   echo "  Executing $FW_COUNT statements..."
 
   set +e
-  FW_OUTPUT=$(npx wrangler@latest d1 execute "$D1_DATABASE_NAME" \
+  FW_OUTPUT=$(npx wrangler@4 d1 execute "$D1_DATABASE_NAME" \
     --remote --file /tmp/sync_firewall_rules.sql 2>&1)
   FW_EXIT=$?
   set -e
@@ -104,7 +107,9 @@ if [ -f /tmp/sync_firewall_rules.sql ] && [ -s /tmp/sync_firewall_rules.sql ]; t
   if [ $FW_EXIT -eq 0 ]; then
     echo "  ✅ Firewall rules synced"
   else
-    echo "  ⚠️ Firewall rules sync had issues" >&2
+    echo "  ❌ Firewall rules sync failed" >&2
+    rm -f /tmp/sync_firewall_rules.sql
+    exit 1
   fi
   rm -f /tmp/sync_firewall_rules.sql
 fi

--- a/.github/scripts/sync-firewall-rules.sh
+++ b/.github/scripts/sync-firewall-rules.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+# =============================================================================
+# Sync Firewall Rules from services.yaml to D1
+# =============================================================================
+# Runs BEFORE Tofu apply to ensure dns_record and label changes are in D1
+# before firewall rules are read for infrastructure provisioning.
+#
+# Environment variables required:
+#   CLOUDFLARE_API_TOKEN  - Cloudflare API token with D1 access
+#   CLOUDFLARE_ACCOUNT_ID - Cloudflare account ID
+#   DOMAIN                - Domain for database name derivation
+# =============================================================================
+
+set -euo pipefail
+
+if [ -z "${CLOUDFLARE_API_TOKEN:-}" ] || [ -z "${CLOUDFLARE_ACCOUNT_ID:-}" ] || [ -z "${DOMAIN:-}" ]; then
+  echo "  ⚠️ Missing required env vars for firewall sync - skipping"
+  exit 0
+fi
+
+D1_DATABASE_NAME="nexus-${DOMAIN//./-}-db"
+
+if [ ! -f "services.yaml" ]; then
+  echo "  ⚠️ services.yaml not found - skipping firewall sync"
+  exit 0
+fi
+
+python3 << 'PYEOF'
+import yaml
+import sys
+import re
+
+def validate_service_name(name):
+    if not isinstance(name, str):
+        return False
+    if len(name) == 0 or len(name) > 63:
+        return False
+    return bool(re.match(r'^[a-z0-9_-]+$', name))
+
+try:
+    with open('services.yaml', 'r') as f:
+        data = yaml.safe_load(f)
+except Exception as e:
+    print(f"  Warning: Error reading services.yaml: {e}")
+    sys.exit(0)
+
+if not data or 'services' not in data:
+    print("  No services found - skipping")
+    sys.exit(0)
+
+services = data['services']
+statements = []
+
+dns_records = {
+    'redpanda': {'kafka': 'redpanda-kafka', 'schema-registry': 'redpanda-schema-registry', 'admin': 'redpanda-admin'},
+    'redpanda-connect': {'api': 'redpanda-connect-api'},
+    'postgres': {'postgres': 'postgres'},
+    'minio': {'s3-api': 's3'},
+}
+
+for name, config in services.items():
+    if not validate_service_name(name):
+        continue
+    safe_name = name.replace("'", "''")
+    tcp_ports = config.get('tcp_ports', {})
+
+    if not tcp_ports:
+        statements.append(f"DELETE FROM firewall_rules WHERE service_name = '{safe_name}';")
+        continue
+
+    valid_ports = []
+    for label, port in tcp_ports.items():
+        if not isinstance(port, int) or port < 1 or port > 65535:
+            continue
+        valid_ports.append(port)
+        safe_label = label.replace("'", "''")
+        dns_record = dns_records.get(name, {}).get(label, '')
+        safe_dns_record = dns_record.replace("'", "''")
+        statements.append(f"INSERT OR IGNORE INTO firewall_rules (service_name, port, protocol, label, enabled, deployed, source_ips, dns_record, updated_at) VALUES ('{safe_name}', {port}, 'tcp', '{safe_label}', 0, 0, '', '{safe_dns_record}', datetime('now'));")
+        statements.append(f"UPDATE firewall_rules SET label = '{safe_label}', dns_record = '{safe_dns_record}', updated_at = datetime('now') WHERE service_name = '{safe_name}' AND port = {port};")
+
+    if valid_ports:
+        ports_list = ', '.join(str(p) for p in valid_ports)
+        statements.append(f"DELETE FROM firewall_rules WHERE service_name = '{safe_name}' AND port NOT IN ({ports_list});")
+
+with open('/tmp/sync_firewall_rules.sql', 'w') as f:
+    f.write('\n'.join(statements))
+    if statements:
+        f.write('\n')
+
+print(f"  Generated {len(statements)} firewall rule statements")
+PYEOF
+
+if [ -f /tmp/sync_firewall_rules.sql ] && [ -s /tmp/sync_firewall_rules.sql ]; then
+  FW_COUNT=$(wc -l < /tmp/sync_firewall_rules.sql | tr -d ' ')
+  echo "  Executing $FW_COUNT statements..."
+
+  set +e
+  FW_OUTPUT=$(npx wrangler@latest d1 execute "$D1_DATABASE_NAME" \
+    --remote --file /tmp/sync_firewall_rules.sql 2>&1)
+  FW_EXIT=$?
+  set -e
+
+  if [ $FW_EXIT -eq 0 ]; then
+    echo "  ✅ Firewall rules synced"
+  else
+    echo "  ⚠️ Firewall rules sync had issues" >&2
+  fi
+  rm -f /tmp/sync_firewall_rules.sql
+fi

--- a/.github/scripts/sync-firewall-rules.sh
+++ b/.github/scripts/sync-firewall-rules.sh
@@ -108,6 +108,7 @@ if [ -f /tmp/sync_firewall_rules.sql ] && [ -s /tmp/sync_firewall_rules.sql ]; t
     echo "  ✅ Firewall rules synced"
   else
     echo "  ❌ Firewall rules sync failed" >&2
+    echo "$FW_OUTPUT" >&2
     rm -f /tmp/sync_firewall_rules.sql
     exit 1
   fi

--- a/.github/workflows/spin-up.yml
+++ b/.github/workflows/spin-up.yml
@@ -335,8 +335,17 @@ jobs:
             fi
           fi
           
-          # Read enabled firewall rules from D1
+          # Sync firewall rules from services.yaml to D1 BEFORE reading them
+          # This ensures dns_record and label changes are applied before Tofu reads them
           D1_DATABASE_NAME="nexus-${DOMAIN//./-}-db"
+          echo "🔥 Syncing firewall rules from services.yaml to D1..."
+          chmod +x .github/scripts/sync-firewall-rules.sh
+          CLOUDFLARE_API_TOKEN="${{ secrets.CLOUDFLARE_API_TOKEN }}" \
+          CLOUDFLARE_ACCOUNT_ID="${{ secrets.CLOUDFLARE_ACCOUNT_ID }}" \
+          DOMAIN="${{ secrets.DOMAIN }}" \
+          bash .github/scripts/sync-firewall-rules.sh
+
+          # Read enabled firewall rules from D1
           echo "🔥 Reading firewall rules from D1..."
           FIREWALL_RULES=$(npx wrangler@4 d1 execute "$D1_DATABASE_NAME" --remote --json \
             --command "SELECT service_name, port, source_ips, dns_record FROM firewall_rules WHERE enabled = 1" 2>/dev/null \

--- a/.github/workflows/spin-up.yml
+++ b/.github/workflows/spin-up.yml
@@ -340,10 +340,13 @@ jobs:
           D1_DATABASE_NAME="nexus-${DOMAIN//./-}-db"
           echo "🔥 Syncing firewall rules from services.yaml to D1..."
           chmod +x .github/scripts/sync-firewall-rules.sh
-          CLOUDFLARE_API_TOKEN="${{ secrets.CLOUDFLARE_API_TOKEN }}" \
-          CLOUDFLARE_ACCOUNT_ID="${{ secrets.CLOUDFLARE_ACCOUNT_ID }}" \
-          DOMAIN="${{ secrets.DOMAIN }}" \
-          bash .github/scripts/sync-firewall-rules.sh
+          if ! CLOUDFLARE_API_TOKEN="${{ secrets.CLOUDFLARE_API_TOKEN }}" \
+            CLOUDFLARE_ACCOUNT_ID="${{ secrets.CLOUDFLARE_ACCOUNT_ID }}" \
+            DOMAIN="${{ secrets.DOMAIN }}" \
+            bash .github/scripts/sync-firewall-rules.sh; then
+            echo "❌ Firewall rule sync failed — aborting to avoid stale firewall metadata"
+            exit 1
+          fi
 
           # Read enabled firewall rules from D1
           echo "🔥 Reading firewall rules from D1..."

--- a/docs/stacks/README.md
+++ b/docs/stacks/README.md
@@ -207,7 +207,7 @@ OpenTofu creates inbound Hetzner firewall rules and DNS A records pointing direc
 | **LakeFS** (S3 Gateway) | 8000 | `s3.lakefs.<domain>` | S3/HTTP |
 | **MinIO** (S3 API) | 9000 | `s3.<domain>` | S3/HTTP |
 | **PostgreSQL** | 5432 | `postgres.<domain>` | PostgreSQL |
-| **RedPanda** (Kafka) | 9092 | `redpanda.<domain>` | Kafka |
+| **RedPanda** (Kafka) | 9092 | `redpanda-kafka.<domain>` | Kafka |
 | **RedPanda** (Schema Registry) | 18081 | `redpanda-schema-registry.<domain>` | HTTP |
 | **RedPanda** (Admin API) | 9644 | `redpanda-admin.<domain>` | HTTP |
 | **Redpanda Connect** (HTTP API) | 4195 | `redpanda-connect.<domain>` | HTTP |
@@ -219,7 +219,7 @@ OpenTofu creates inbound Hetzner firewall rules and DNS A records pointing direc
 
 ```bash
 # RedPanda Kafka (from Databricks or any Kafka client)
-redpanda.yourdomain.com:9092
+redpanda-kafka.yourdomain.com:9092
 
 # RedPanda Schema Registry
 curl http://redpanda-schema-registry.yourdomain.com:18081/subjects

--- a/docs/stacks/README.md
+++ b/docs/stacks/README.md
@@ -210,7 +210,7 @@ OpenTofu creates inbound Hetzner firewall rules and DNS A records pointing direc
 | **RedPanda** (Kafka) | 9092 | `redpanda-kafka.<domain>` | Kafka |
 | **RedPanda** (Schema Registry) | 18081 | `redpanda-schema-registry.<domain>` | HTTP |
 | **RedPanda** (Admin API) | 9644 | `redpanda-admin.<domain>` | HTTP |
-| **Redpanda Connect** (HTTP API) | 4195 | `redpanda-connect.<domain>` | HTTP |
+| **Redpanda Connect** (HTTP API) | 4195 | `redpanda-connect-api.<domain>` | HTTP |
 | **RustFS** (S3 API) | 9003 | `rustfs-s3.<domain>` | S3/HTTP |
 | **RisingWave** (PostgreSQL) | 4566 | `risingwave.<domain>` | PostgreSQL |
 | **SeaweedFS** (S3 API) | 8333 | `seaweedfs-s3.<domain>` | S3/HTTP |

--- a/docs/stacks/README.md
+++ b/docs/stacks/README.md
@@ -209,6 +209,8 @@ OpenTofu creates inbound Hetzner firewall rules and DNS A records pointing direc
 | **PostgreSQL** | 5432 | `postgres.<domain>` | PostgreSQL |
 | **RedPanda** (Kafka) | 9092 | `redpanda.<domain>` | Kafka |
 | **RedPanda** (Schema Registry) | 18081 | `redpanda-schema-registry.<domain>` | HTTP |
+| **RedPanda** (Admin API) | 9644 | `redpanda-admin.<domain>` | HTTP |
+| **Redpanda Connect** (HTTP API) | 4195 | `redpanda-connect.<domain>` | HTTP |
 | **RustFS** (S3 API) | 9003 | `rustfs-s3.<domain>` | S3/HTTP |
 | **RisingWave** (PostgreSQL) | 4566 | `risingwave.<domain>` | PostgreSQL |
 | **SeaweedFS** (S3 API) | 8333 | `seaweedfs-s3.<domain>` | S3/HTTP |
@@ -233,7 +235,10 @@ aws s3 ls --endpoint-url http://s3.yourdomain.com:9000
 
 - **Auto-Reset on Teardown:** All firewall rules are automatically reset (`enabled = 0`) when the infrastructure is torn down. Ports must be explicitly re-opened after each Spin Up.
 - **Source IP Restriction:** Each rule supports optional source IP/CIDR restriction. Open to all (`0.0.0.0/0`) if not specified.
-- **Service Authentication:** Most exposed services have their own auth (PostgreSQL passwords, Kafka SASL, MinIO access keys). **Exception:** RisingWave has no built-in authentication in single-node mode; restrict source IPs when opening port 4566.
+- **Service Authentication:** Most exposed services have their own auth (PostgreSQL passwords, Kafka SASL, MinIO access keys). Exceptions:
+  - **RisingWave** (4566): No built-in authentication in single-node mode — always restrict source IPs.
+  - **RedPanda Admin API** (9644): No authentication — grants full cluster control (user management, config changes, topic deletion). Only open temporarily for debugging and always restrict to your IP. Close immediately after use.
+  - **Redpanda Connect** (4195): No authentication on the HTTP API — allows pipeline management and data access. Restrict source IPs when opening.
 - **fail2ban:** Installed on the server, provides brute-force protection for opened ports.
 - **Pre-defined Ports Only:** Only ports defined in `services.yaml` under `tcp_ports` can be opened. No arbitrary port numbers.
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -2272,7 +2272,7 @@ if echo "$ENABLED_SERVICES" | grep -qw "filestash"; then
     CONFIG_JOBS+=($!)
 fi
 
-# Configure RedPanda SASL authentication (only when external TCP ports are exposed)
+# Configure RedPanda SASL authentication
 if echo "$ENABLED_SERVICES" | grep -qw "redpanda" && [ -n "$REDPANDA_ADMIN_PASS" ]; then
     (
         echo "  Configuring RedPanda SASL..."

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -2291,9 +2291,9 @@ if echo "$ENABLED_SERVICES" | grep -qw "redpanda" && [ -n "$REDPANDA_ADMIN_PASS"
             exit 0
         fi
 
-        # Create SASL user using rpk (password via stdin to avoid process list exposure)
-        USER_RESULT=$(ssh nexus "echo '$REDPANDA_ADMIN_PASS' | docker exec -i redpanda rpk acl user create nexus-redpanda \
-            --password-stdin \
+        # Create SASL user
+        USER_RESULT=$(ssh nexus "docker exec redpanda rpk acl user create nexus-redpanda \
+            --password '$REDPANDA_ADMIN_PASS' \
             --mechanism SCRAM-SHA-256 2>&1" || echo "")
         echo "  rpk user create result: $USER_RESULT"
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1977,7 +1977,9 @@ EOF
             "REDPANDA_SASL_USERNAME" "nexus-redpanda" \
             "REDPANDA_SASL_PASSWORD" "$REDPANDA_ADMIN_PASS" \
             "REDPANDA_KAFKA_PUBLIC_URL" "redpanda-kafka.${DOMAIN}:9092" \
-            "REDPANDA_SCHEMA_REGISTRY_PUBLIC_URL" "http://redpanda-schema-registry.${DOMAIN}:18081"
+            "REDPANDA_SCHEMA_REGISTRY_PUBLIC_URL" "redpanda-schema-registry.${DOMAIN}:18081" \
+            "REDPANDA_ADMIN_PUBLIC_URL" "redpanda-admin.${DOMAIN}:9644" \
+            "REDPANDA_CONNECT_PUBLIC_URL" "redpanda-connect-api.${DOMAIN}:4195"
 
         build_folder "meltano" \
             "MELTANO_DB_PASSWORD" "$MELTANO_DB_PASS"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -2291,10 +2291,9 @@ if echo "$ENABLED_SERVICES" | grep -qw "redpanda" && [ -n "$REDPANDA_ADMIN_PASS"
             exit 0
         fi
 
-        # Create SASL user
-        USER_RESULT=$(ssh nexus "docker exec redpanda rpk acl user create nexus-redpanda \
-            --password '$REDPANDA_ADMIN_PASS' \
-            --mechanism SCRAM-SHA-256 2>&1" || echo "")
+        # Create SASL user (password via env var to avoid process list exposure)
+        USER_RESULT=$(ssh nexus "docker exec -e RPK_PASS='$REDPANDA_ADMIN_PASS' redpanda \
+            sh -c 'rpk acl user create nexus-redpanda --password \"\\$RPK_PASS\" --mechanism SCRAM-SHA-256' 2>&1" || echo "")
         echo "  rpk user create result: $USER_RESULT"
 
         # Configure superuser (grants full permissions without ACLs)

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1463,7 +1463,7 @@ FWEOF
     # Special handling for RedPanda: Generate firewall-specific config
     # Instead of using docker-compose override with CLI flags, we generate
     # a firewall-specific redpanda.yaml with external advertised addresses
-    REDPANDA_PORTS=$(echo "$FIREWALL_JSON" | jq -r 'to_entries[] | select(.key | startswith("redpanda-")) | .value.port' 2>/dev/null | sort -n)
+    REDPANDA_PORTS=$(echo "$FIREWALL_JSON" | jq -r 'to_entries[] | select(.key | test("^redpanda-[0-9]+$")) | .value.port' 2>/dev/null | sort -n)
     if [ -n "$REDPANDA_PORTS" ]; then
         echo "  Configuring RedPanda for external TCP access (with SASL)..."
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -2273,7 +2273,7 @@ if echo "$ENABLED_SERVICES" | grep -qw "filestash"; then
 fi
 
 # Configure RedPanda SASL authentication (only when external TCP ports are exposed)
-if echo "$ENABLED_SERVICES" | grep -qw "redpanda" && [ -n "$REDPANDA_ADMIN_PASS" ] && [ -f "stacks/redpanda/docker-compose.firewall.yml" ]; then
+if echo "$ENABLED_SERVICES" | grep -qw "redpanda" && [ -n "$REDPANDA_ADMIN_PASS" ]; then
     (
         echo "  Configuring RedPanda SASL..."
         # Wait for RedPanda admin API to be ready

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -2276,20 +2276,26 @@ fi
 if echo "$ENABLED_SERVICES" | grep -qw "redpanda" && [ -n "$REDPANDA_ADMIN_PASS" ]; then
     (
         echo "  Configuring RedPanda SASL..."
-        # Wait for RedPanda admin API to be ready
-        for i in $(seq 1 10); do
+        # Wait for RedPanda admin API to be ready (up to 60s — cold start is slow)
+        REDPANDA_READY=false
+        for i in $(seq 1 30); do
             if ssh nexus "docker exec redpanda curl -s --connect-timeout 2 'http://localhost:9644/v1/status/ready'" >/dev/null 2>&1; then
+                REDPANDA_READY=true
                 break
             fi
             sleep 2
         done
 
-        # SASL is configured in redpanda.yaml - just create user and set superuser
+        if [ "$REDPANDA_READY" != "true" ]; then
+            echo -e "${YELLOW}  ⚠ RedPanda admin API not ready after 60s — skipping SASL setup${NC}"
+            exit 0
+        fi
 
         # Create SASL user using rpk (password via stdin to avoid process list exposure)
         USER_RESULT=$(ssh nexus "echo '$REDPANDA_ADMIN_PASS' | docker exec -i redpanda rpk acl user create nexus-redpanda \
             --password-stdin \
             --mechanism SCRAM-SHA-256 2>&1" || echo "")
+        echo "  rpk user create result: $USER_RESULT"
 
         # Configure superuser (grants full permissions without ACLs)
         ssh nexus "docker exec redpanda rpk cluster config set superusers '[\"nexus-redpanda\"]'" >/dev/null 2>&1

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1549,7 +1549,7 @@ if echo "$ENABLED_SERVICES" | grep -qw "redpanda"; then
         }
 
         # Check if firewall is enabled for RedPanda
-        REDPANDA_FIREWALL_ENABLED=$(echo "$FIREWALL_JSON" | jq -r 'to_entries[] | select(.key | startswith("redpanda-")) | .value.port' 2>/dev/null)
+        REDPANDA_FIREWALL_ENABLED=$(echo "$FIREWALL_JSON" | jq -r 'to_entries[] | select(.key | test("^redpanda-[0-9]+$")) | .value.port' 2>/dev/null)
 
         if [ -n "$REDPANDA_FIREWALL_ENABLED" ] && [ -f "stacks/redpanda/config/redpanda-firewall.yaml" ]; then
             # Firewall mode: Use the generated firewall-specific config

--- a/services.yaml
+++ b/services.yaml
@@ -584,6 +584,7 @@ services:
     tcp_ports:
       kafka: 9092
       schema-registry: 18081
+      admin: 9644
 
   seaweedfs:
     port: 8888
@@ -638,6 +639,8 @@ services:
     description: "Declarative data streaming framework for real-time pipelines."
     long_description: "Redpanda Connect (formerly Benthos) is a declarative stream processing framework. Define data pipelines in YAML to connect, transform, and route data between systems in real time. Supports 200+ connectors for databases, message brokers, cloud services, and more."
     image: "redpandadata/connect:4.43.0"
+    tcp_ports:
+      api: 4195
 
   redpanda-datagen:
     subdomain: "redpanda-datagen"


### PR DESCRIPTION
## Summary

- Add RedPanda Admin API (port 9644) and Redpanda Connect HTTP API (port 4195) to firewall management
- Add DNS record mappings for both ports
- Add security warnings: Admin API has no authentication, Connect API has no authentication — source IP restriction strongly recommended

## Security Notes

- **RedPanda Admin API (9644)**: No authentication — grants full cluster control. Should only be opened temporarily for debugging.
- **Redpanda Connect (4195)**: No authentication — allows pipeline management. Always restrict source IPs.

## Test Plan

- [ ] Run Spin Up → verify firewall rules for 9644 and 4195 appear in D1
- [ ] Open Firewall page → RedPanda card shows 3 ports, Redpanda Connect card shows 1 port
- [ ] Toggle ports → DNS records created after Spin Up

Closes #429
