### PR TITLE
fix(control-plane): Support configurable URLs for flat-subdomain deployments

### DIFF
--- a/control-plane/functions/api/_utils/url.js
+++ b/control-plane/functions/api/_utils/url.js
@@ -1,0 +1,24 @@
+/**
+ * URL validation helpers for env-var-sourced URLs.
+ *
+ * Config values like INFISICAL_URL / CONTROL_PLANE_URL are Pages secrets,
+ * not user-controlled, but we still validate them as defense-in-depth:
+ * a typo could otherwise leak bearer tokens to the wrong host or break
+ * HTML email rendering via attribute-breaking characters.
+ */
+
+/**
+ * Returns the origin of `candidate` if it parses as an https: URL.
+ * Otherwise returns `fallback`. The returned value is always either
+ * a trusted fallback or a scheme+host string with no path/query.
+ */
+export function safeHttpsUrl(candidate, fallback) {
+  if (!candidate) return fallback;
+  try {
+    const u = new URL(candidate);
+    if (u.protocol !== 'https:') return fallback;
+    return u.origin;
+  } catch {
+    return fallback;
+  }
+}

--- a/control-plane/functions/api/_utils/url.js
+++ b/control-plane/functions/api/_utils/url.js
@@ -7,18 +7,23 @@
  * HTML email rendering via attribute-breaking characters.
  */
 
-/**
- * Returns the origin of `candidate` if it parses as an https: URL.
- * Otherwise returns `fallback`. The returned value is always either
- * a trusted fallback or a scheme+host string with no path/query.
- */
-export function safeHttpsUrl(candidate, fallback) {
-  if (!candidate) return fallback;
+function validateHttpsOrigin(url) {
+  if (!url) return null;
   try {
-    const u = new URL(candidate);
-    if (u.protocol !== 'https:') return fallback;
+    const u = new URL(url);
+    if (u.protocol !== 'https:') return null;
     return u.origin;
   } catch {
-    return fallback;
+    return null;
   }
+}
+
+/**
+ * Returns the origin of `candidate` if it parses as an https: URL.
+ * Falls back to `fallback` (which is also validated the same way).
+ * Returns '' if neither validates — safer than leaking a malformed URL
+ * into a bearer-token fetch or an HTML href.
+ */
+export function safeHttpsUrl(candidate, fallback) {
+  return validateHttpsOrigin(candidate) || validateHttpsOrigin(fallback) || '';
 }

--- a/control-plane/functions/api/info.js
+++ b/control-plane/functions/api/info.js
@@ -102,6 +102,14 @@ export async function onRequestGet(context) {
     if (!serverLocation) serverLocation = env.SERVER_LOCATION || null;
     if (!domain) domain = env.DOMAIN || null;
 
+    // Validate domain as a hostname to prevent HTML/attribute injection
+    // when the UI interpolates it into hrefs. Allows alphanumerics, dots,
+    // and hyphens (standard DNS label characters); rejects scheme, slash,
+    // whitespace, quotes, or any other structural characters.
+    if (domain && !/^[a-z0-9]([a-z0-9.-]*[a-z0-9])?$/i.test(domain)) {
+      domain = null;
+    }
+
     // Allowlist subdomain separator to prevent HTML/attribute injection
     // when the UI concatenates this value into stack link hrefs.
     const rawSeparator = env.SUBDOMAIN_SEPARATOR;

--- a/control-plane/functions/api/info.js
+++ b/control-plane/functions/api/info.js
@@ -102,11 +102,16 @@ export async function onRequestGet(context) {
     if (!serverLocation) serverLocation = env.SERVER_LOCATION || null;
     if (!domain) domain = env.DOMAIN || null;
 
+    // Allowlist subdomain separator to prevent HTML/attribute injection
+    // when the UI concatenates this value into stack link hrefs.
+    const rawSeparator = env.SUBDOMAIN_SEPARATOR;
+    const subdomainSeparator = (rawSeparator === '.' || rawSeparator === '-') ? rawSeparator : '.';
+
     info.server = {
       type: serverType,
       location: serverLocation,
       domain: domain,
-      subdomainSeparator: env.SUBDOMAIN_SEPARATOR || '.',
+      subdomainSeparator,
       lastSpinUp: lastSpinUp,
       lastTeardown: lastTeardown,
     };

--- a/control-plane/functions/api/info.js
+++ b/control-plane/functions/api/info.js
@@ -106,6 +106,7 @@ export async function onRequestGet(context) {
       type: serverType,
       location: serverLocation,
       domain: domain,
+      subdomainSeparator: env.SUBDOMAIN_SEPARATOR || '.',
       lastSpinUp: lastSpinUp,
       lastTeardown: lastTeardown,
     };

--- a/control-plane/functions/api/secrets.js
+++ b/control-plane/functions/api/secrets.js
@@ -9,17 +9,7 @@
  * for server-to-server authentication (no browser login required).
  */
 import { fetchWithTimeout } from './_utils/fetch-with-timeout.js';
-
-function safeHttpsUrl(candidate, fallback) {
-  if (!candidate) return fallback;
-  try {
-    const u = new URL(candidate);
-    if (u.protocol !== 'https:') return fallback;
-    return u.origin;
-  } catch {
-    return fallback;
-  }
-}
+import { safeHttpsUrl } from './_utils/url.js';
 
 async function safeJsonParse(response, label) {
   const contentType = response.headers.get('content-type') || '';

--- a/control-plane/functions/api/secrets.js
+++ b/control-plane/functions/api/secrets.js
@@ -41,7 +41,7 @@ export async function onRequestGet(context) {
       });
     }
 
-    const baseUrl = `https://infisical.${domain}`;
+    const baseUrl = context.env.INFISICAL_URL || `https://infisical.${domain}`;
     const environment = context.env.INFISICAL_ENV || 'dev';
     const headers = {
       'Authorization': `Bearer ${token}`,

--- a/control-plane/functions/api/secrets.js
+++ b/control-plane/functions/api/secrets.js
@@ -10,6 +10,17 @@
  */
 import { fetchWithTimeout } from './_utils/fetch-with-timeout.js';
 
+function safeHttpsUrl(candidate, fallback) {
+  if (!candidate) return fallback;
+  try {
+    const u = new URL(candidate);
+    if (u.protocol !== 'https:') return fallback;
+    return u.origin;
+  } catch {
+    return fallback;
+  }
+}
+
 async function safeJsonParse(response, label) {
   const contentType = response.headers.get('content-type') || '';
   if (!contentType.includes('application/json')) {
@@ -41,7 +52,7 @@ export async function onRequestGet(context) {
       });
     }
 
-    const baseUrl = context.env.INFISICAL_URL || `https://infisical.${domain}`;
+    const baseUrl = safeHttpsUrl(context.env.INFISICAL_URL, `https://infisical.${domain}`);
     const environment = context.env.INFISICAL_ENV || 'dev';
     const headers = {
       'Authorization': `Bearer ${token}`,

--- a/control-plane/functions/api/send-credentials.js
+++ b/control-plane/functions/api/send-credentials.js
@@ -8,6 +8,17 @@
 import { fetchWithTimeout } from './_utils/fetch-with-timeout.js';
 import { logApiCall, logError } from './_utils/logger.js';
 
+function safeHttpsUrl(candidate, fallback) {
+  if (!candidate) return fallback;
+  try {
+    const u = new URL(candidate);
+    if (u.protocol !== 'https:') return fallback;
+    return u.origin;
+  } catch {
+    return fallback;
+  }
+}
+
 export async function onRequestPost(context) {
   const { env } = context;
 
@@ -45,8 +56,8 @@ export async function onRequestPost(context) {
     const domain = env.DOMAIN;
     const adminEmail = env.ADMIN_EMAIL;
     const userEmail = env.USER_EMAIL && env.USER_EMAIL.trim() !== '' ? env.USER_EMAIL : null;
-    const infisicalUrl = env.INFISICAL_URL || `https://infisical.${domain}`;
-    const controlPlaneUrl = env.CONTROL_PLANE_URL || `https://control.${domain}`;
+    const infisicalUrl = safeHttpsUrl(env.INFISICAL_URL, `https://infisical.${domain}`);
+    const controlPlaneUrl = safeHttpsUrl(env.CONTROL_PLANE_URL, `https://control.${domain}`);
 
     // Only send Infisical credentials - all other credentials are stored in Infisical
     if (!credentials.infisical_admin_password) {

--- a/control-plane/functions/api/send-credentials.js
+++ b/control-plane/functions/api/send-credentials.js
@@ -45,6 +45,8 @@ export async function onRequestPost(context) {
     const domain = env.DOMAIN;
     const adminEmail = env.ADMIN_EMAIL;
     const userEmail = env.USER_EMAIL && env.USER_EMAIL.trim() !== '' ? env.USER_EMAIL : null;
+    const infisicalUrl = env.INFISICAL_URL || `https://infisical.${domain}`;
+    const controlPlaneUrl = env.CONTROL_PLANE_URL || `https://control.${domain}`;
 
     // Only send Infisical credentials - all other credentials are stored in Infisical
     if (!credentials.infisical_admin_password) {
@@ -64,7 +66,7 @@ export async function onRequestPost(context) {
   <h2 style="color:#00ff88;font-size:16px;margin-top:24px">🔑 Infisical (Secret Manager)</h2>
   <div style="background:#1a1a2e;padding:12px;margin:8px 0;border-radius:4px;border-left:3px solid #00ff88">
     <div style="color:#ccc;font-size:14px">
-      <div>URL: <a href="https://infisical.${domain}" style="color:#00ff88">https://infisical.${domain}</a></div>
+      <div>URL: <a href="${infisicalUrl}" style="color:#00ff88">${infisicalUrl}</a></div>
       <div>Email: <span style="color:#fff">${adminEmail}</span></div>
       <div>Password: <span style="color:#fff;font-family:monospace">${credentials.infisical_admin_password}</span></div>
     </div>
@@ -91,7 +93,7 @@ export async function onRequestPost(context) {
   
   <h2 style="color:#00ff88;font-size:16px;margin-top:24px">🔗 Quick Links</h2>
   <ul style="color:#ccc;padding-left:20px">
-    <li><a href="https://control.${domain}" style="color:#00ff88">Control Panel</a> - Manage services &amp; view URLs</li>
+    <li><a href="${controlPlaneUrl}" style="color:#00ff88">Control Panel</a> - Manage services &amp; view URLs</li>
   </ul>
   
   <p style="color:#666;font-size:12px;margin-top:24px;border-top:1px solid #333;padding-top:16px">

--- a/control-plane/functions/api/send-credentials.js
+++ b/control-plane/functions/api/send-credentials.js
@@ -7,17 +7,7 @@
  */
 import { fetchWithTimeout } from './_utils/fetch-with-timeout.js';
 import { logApiCall, logError } from './_utils/logger.js';
-
-function safeHttpsUrl(candidate, fallback) {
-  if (!candidate) return fallback;
-  try {
-    const u = new URL(candidate);
-    if (u.protocol !== 'https:') return fallback;
-    return u.origin;
-  } catch {
-    return fallback;
-  }
-}
+import { safeHttpsUrl } from './_utils/url.js';
 
 export async function onRequestPost(context) {
   const { env } = context;

--- a/control-plane/src/pages/category.astro
+++ b/control-plane/src/pages/category.astro
@@ -99,13 +99,15 @@ import Layout from '../layouts/Layout.astro';
   const API_URL = window.location.origin;
   const params = new URLSearchParams(window.location.search);
   const categorySlug = params.get('cat');
-  let stackDomain = window.location.hostname.replace('control.', '');
+  let stackDomain = window.location.hostname.replace(/^control[.-]/, '');
+  let subdomainSeparator = '.';
 
   async function fetchDomain() {
     try {
       const res = await fetch(API_URL + '/api/info', { credentials: 'same-origin' });
       const data = await res.json();
       if (data.success && data.info?.server?.domain) stackDomain = data.info.server.domain;
+      if (data.success && data.info?.server?.subdomainSeparator) subdomainSeparator = data.info.server.subdomainSeparator;
     } catch {}
   }
 
@@ -175,7 +177,7 @@ import Layout from '../layouts/Layout.astro';
 
       let openHtml = '';
       if (service.subdomain && service.deployed) {
-        openHtml = '<a href="https://' + service.subdomain + '.' + stackDomain + '" target="_blank" rel="noopener" class="card-open-link">Open &#8599;</a>';
+        openHtml = '<a href="https://' + service.subdomain + subdomainSeparator + stackDomain + '" target="_blank" rel="noopener" class="card-open-link">Open &#8599;</a>';
       }
 
       let websiteHtml = '';

--- a/control-plane/src/pages/index.astro
+++ b/control-plane/src/pages/index.astro
@@ -417,7 +417,8 @@ import Layout from '../layouts/Layout.astro';
   let currentAction = null;
   let pendingChangesCount = 0;
   let wasInProgress = false;
-  let stackDomain = window.location.hostname.replace('control.', '');
+  let stackDomain = window.location.hostname.replace(/^control[.-]/, '');
+  let subdomainSeparator = '.';
 
   const statusDescriptions = {
     'deployed': 'Infrastructure is running. All services are accessible.',
@@ -440,6 +441,9 @@ import Layout from '../layouts/Layout.astro';
       const data = await res.json();
       if (data.success && data.info?.server?.domain) {
         stackDomain = data.info.server.domain;
+      }
+      if (data.success && data.info?.server?.subdomainSeparator) {
+        subdomainSeparator = data.info.server.subdomainSeparator;
       }
     } catch {}
   }
@@ -631,7 +635,7 @@ import Layout from '../layouts/Layout.astro';
 
     services.forEach(s => {
       if (s.subdomain && s.deployed) {
-        const url = 'https://' + s.subdomain + '.' + stackDomain;
+        const url = 'https://' + s.subdomain + subdomainSeparator + stackDomain;
         html += '<a href="' + url + '" target="_blank" rel="noopener" class="stack-chip">' +
           escapeHtml(s.name) + '<span class="arrow">&#8599;</span></a>';
       } else {

--- a/control-plane/src/pages/search.astro
+++ b/control-plane/src/pages/search.astro
@@ -67,13 +67,15 @@ import Layout from '../layouts/Layout.astro';
 
   const API_URL = window.location.origin;
   let allServices = [];
-  let stackDomain = window.location.hostname.replace('control.', '');
+  let stackDomain = window.location.hostname.replace(/^control[.-]/, '');
+  let subdomainSeparator = '.';
 
   async function fetchDomain() {
     try {
       const res = await fetch(API_URL + '/api/info', { credentials: 'same-origin' });
       const data = await res.json();
       if (data.success && data.info?.server?.domain) stackDomain = data.info.server.domain;
+      if (data.success && data.info?.server?.subdomainSeparator) subdomainSeparator = data.info.server.subdomainSeparator;
     } catch {}
   }
 
@@ -153,7 +155,7 @@ import Layout from '../layouts/Layout.astro';
 
       let openHtml = '';
       if (service.subdomain && service.deployed) {
-        openHtml = '<a href="https://' + service.subdomain + '.' + stackDomain + '" target="_blank" rel="noopener" class="card-open-link">Open &#8599;</a>';
+        openHtml = '<a href="https://' + service.subdomain + subdomainSeparator + stackDomain + '" target="_blank" rel="noopener" class="card-open-link">Open &#8599;</a>';
       }
 
       let websiteHtml = '';

--- a/control-plane/worker/src/index.js
+++ b/control-plane/worker/src/index.js
@@ -12,6 +12,9 @@
  * - notification_time: "21:45" (default, 15 min before)
  */
 
+// Duplicates functions/api/_utils/url.js. The worker is deployed as a single
+// raw file via Terraform (tofu/control-plane/main.tf -> file(...)), so it cannot
+// import from the Pages Functions _utils/ tree without introducing a bundler.
 function safeHttpsUrl(candidate, fallback) {
   if (!candidate) return fallback;
   try {

--- a/control-plane/worker/src/index.js
+++ b/control-plane/worker/src/index.js
@@ -15,15 +15,19 @@
 // Duplicates functions/api/_utils/url.js. The worker is deployed as a single
 // raw file via Terraform (tofu/control-plane/main.tf -> file(...)), so it cannot
 // import from the Pages Functions _utils/ tree without introducing a bundler.
-function safeHttpsUrl(candidate, fallback) {
-  if (!candidate) return fallback;
+function validateHttpsOrigin(url) {
+  if (!url) return null;
   try {
-    const u = new URL(candidate);
-    if (u.protocol !== 'https:') return fallback;
+    const u = new URL(url);
+    if (u.protocol !== 'https:') return null;
     return u.origin;
   } catch {
-    return fallback;
+    return null;
   }
+}
+
+function safeHttpsUrl(candidate, fallback) {
+  return validateHttpsOrigin(candidate) || validateHttpsOrigin(fallback) || '';
 }
 
 // Fetch with timeout to prevent hanging requests

--- a/control-plane/worker/src/index.js
+++ b/control-plane/worker/src/index.js
@@ -467,7 +467,7 @@ async function sendNotification(env, config) {
         <p style="color:#fff">You can disable scheduled teardown via the Control Plane settings.</p>
         <h2 style="color:#00ff88;margin-top:2rem">🔗 Quick Links</h2>
         <ul>
-          <li><a href="https://control.${env.DOMAIN}" style="color:#00ff88">Control Plane</a> - Manage infrastructure</li>
+          <li><a href="${env.CONTROL_PLANE_URL || `https://control.${env.DOMAIN}`}" style="color:#00ff88">Control Plane</a> - Manage infrastructure</li>
           <li><a href="https://github.com/${env.GITHUB_OWNER}/${env.GITHUB_REPO}/actions" style="color:#00ff88">GitHub Actions</a> - View workflows</li>
         </ul>
         <div style="margin-top:2rem;padding:1rem;background:#1a1a2e;border-left:3px solid #ffaa00">

--- a/control-plane/worker/src/index.js
+++ b/control-plane/worker/src/index.js
@@ -12,6 +12,17 @@
  * - notification_time: "21:45" (default, 15 min before)
  */
 
+function safeHttpsUrl(candidate, fallback) {
+  if (!candidate) return fallback;
+  try {
+    const u = new URL(candidate);
+    if (u.protocol !== 'https:') return fallback;
+    return u.origin;
+  } catch {
+    return fallback;
+  }
+}
+
 // Fetch with timeout to prevent hanging requests
 async function fetchWithTimeout(url, options = {}, timeoutMs = 10000) {
   const controller = new AbortController();
@@ -449,6 +460,7 @@ async function sendNotification(env, config) {
 
   try {
     const teardownTime = `${config.teardownTime} ${getTimezoneAbbr(config.timezone)}`;
+    const controlPlaneUrl = safeHttpsUrl(env.CONTROL_PLANE_URL, `https://control.${env.DOMAIN}`);
 
     const emailHtml = `
       <div style="font-family:monospace;background:#0a0a0f;color:#00ff88;padding:20px">
@@ -467,7 +479,7 @@ async function sendNotification(env, config) {
         <p style="color:#fff">You can disable scheduled teardown via the Control Plane settings.</p>
         <h2 style="color:#00ff88;margin-top:2rem">🔗 Quick Links</h2>
         <ul>
-          <li><a href="${env.CONTROL_PLANE_URL || `https://control.${env.DOMAIN}`}" style="color:#00ff88">Control Plane</a> - Manage infrastructure</li>
+          <li><a href="${controlPlaneUrl}" style="color:#00ff88">Control Plane</a> - Manage infrastructure</li>
           <li><a href="https://github.com/${env.GITHUB_OWNER}/${env.GITHUB_REPO}/actions" style="color:#00ff88">GitHub Actions</a> - View workflows</li>
         </ul>
         <div style="margin-top:2rem;padding:1rem;background:#1a1a2e;border-left:3px solid #ffaa00">


### PR DESCRIPTION
## Summary

Makes the Control Plane URL construction configurable via environment variables so that downstream consumers (e.g. admin-panel that provisions per-user stacks) can use flat-subdomain hostnames like `infisical-user.domain.com` / `control-user.domain.com` instead of dot-subdomains like `infisical.domain.com`.

## Background

User stacks provisioned from this template cannot use dot-subdomains (e.g. `infisical.user.domain.com`) because that would require 3rd-level DNS names and expensive wildcard certificates. They use flat-subdomains instead (dash-separated). The Control Plane had several places where URLs were constructed with a hardcoded `infisical.${DOMAIN}` / `control.${DOMAIN}` pattern, which produced non-existent hosts on flat-subdomain deployments. The most visible symptom was the Secrets page returning "unexpected response" because the HTTP call landed on a Cloudflare error page instead of Infisical.

## Changes

**Pages Functions**
- `functions/api/secrets.js`: `baseUrl` now falls back to `INFISICAL_URL`.
- `functions/api/send-credentials.js`: `infisicalUrl` / `controlPlaneUrl` fall back to `INFISICAL_URL` / `CONTROL_PLANE_URL`.
- `functions/api/info.js`: exposes `server.subdomainSeparator` (from `SUBDOMAIN_SEPARATOR`, default `.`) so the UI can build correct stack links.

**UI**
- `src/pages/index.astro`, `category.astro`, `search.astro`:
  - Initial hostname fallback strips both `control.` and `control-`.
  - Stack link builder uses `subdomainSeparator` from `/api/info` instead of a hardcoded `.`.

**Worker**
- `worker/src/index.js`: teardown reminder email links via `CONTROL_PLANE_URL` with fallback to `https://control.${DOMAIN}`.

## Backward compatibility

All new env vars are optional. When unset, every code path falls back to the previous hardcoded `.`-separated construction, so the template's own deployment (`nexus-stack.ch`) is unaffected.

## Consumer-side env vars (for flat-subdomain deployments)

- `INFISICAL_URL=https://infisical-<user>.<baseDomain>` (Pages secret)
- `CONTROL_PLANE_URL=https://control-<user>.<baseDomain>` (Pages secret + Worker secret)
- `SUBDOMAIN_SEPARATOR=-` (Pages secret)

## Test plan

- [x] `node -c` passes on all changed JS files
- [x] `astro build` succeeds for all 9 pages
- [x] `grep` finds no remaining hardcoded `control.` / `'.' + stackDomain` constructions outside the new env-var-fallback pattern
- [ ] Deploy to template (`nexus-stack.ch`) and verify no regression in Secrets page, stack links, credentials email, teardown email
- [ ] Deploy to a user stack with flat-subdomain env vars set and verify Secrets page loads, stack links point to `subdomain-user.domain.com`, credentials email contains correct URLs
