### PR TITLE
fix(control-plane): Wire subdomain_separator through Terraform and workflows

### DIFF
--- a/.github/workflows/destroy-all.yml
+++ b/.github/workflows/destroy-all.yml
@@ -127,13 +127,14 @@ jobs:
           
           # Control Plane config
           cat > tofu/control-plane/config.tfvars << EOF
-          server_type     = "cax31"
-          server_location = "${{ vars.SERVER_LOCATION || 'fsn1' }}"
-          domain          = "${{ secrets.DOMAIN }}"
-          admin_email     = "${{ secrets.TF_VAR_admin_email }}"
-          user_email      = "${{ secrets.TF_VAR_user_email }}"
-          github_owner    = "${{ github.repository_owner }}"
-          github_repo     = "${{ github.event.repository.name }}"
+          server_type         = "cax31"
+          server_location     = "${{ vars.SERVER_LOCATION || 'fsn1' }}"
+          domain              = "${{ secrets.DOMAIN }}"
+          subdomain_separator = "${{ secrets.SUBDOMAIN_SEPARATOR || '.' }}"
+          admin_email         = "${{ secrets.TF_VAR_admin_email }}"
+          user_email          = "${{ secrets.TF_VAR_user_email }}"
+          github_owner        = "${{ github.repository_owner }}"
+          github_repo         = "${{ github.event.repository.name }}"
           EOF
 
       - name: Initialize OpenTofu for both states

--- a/.github/workflows/setup-control-plane.yaml
+++ b/.github/workflows/setup-control-plane.yaml
@@ -163,13 +163,14 @@ jobs:
         run: |
           # Control Plane config (emails from secrets)
           cat > tofu/control-plane/config.tfvars << EOF
-          server_type     = "cax31"
-          server_location = "${{ vars.SERVER_LOCATION || 'fsn1' }}"
-          domain          = "${{ secrets.DOMAIN }}"
-          admin_email     = "${{ secrets.TF_VAR_admin_email }}"
-          user_email      = "${{ secrets.TF_VAR_user_email }}"
-          github_owner    = "${{ github.repository_owner }}"
-          github_repo     = "${{ github.event.repository.name }}"
+          server_type         = "cax31"
+          server_location     = "${{ vars.SERVER_LOCATION || 'fsn1' }}"
+          domain              = "${{ secrets.DOMAIN }}"
+          subdomain_separator = "${{ secrets.SUBDOMAIN_SEPARATOR || '.' }}"
+          admin_email         = "${{ secrets.TF_VAR_admin_email }}"
+          user_email          = "${{ secrets.TF_VAR_user_email }}"
+          github_owner        = "${{ github.repository_owner }}"
+          github_repo         = "${{ github.event.repository.name }}"
           EOF
           sed -i 's/^          //' tofu/control-plane/config.tfvars
 

--- a/tofu/control-plane/main.tf
+++ b/tofu/control-plane/main.tf
@@ -21,9 +21,11 @@ locals {
 
   # Control Plane URLs. Built from the base domain and the subdomain separator
   # so flat-subdomain deployments (e.g. infisical-tenant.example.com) work
-  # without code changes. Consumed by Pages Functions and the teardown Worker.
-  infisical_url     = "https://infisical${var.subdomain_separator}${var.domain}"
-  control_plane_url = "https://control${var.subdomain_separator}${var.domain}"
+  # without code changes. Consumed by Pages Functions, the teardown Worker,
+  # and the DNS / Pages domain / Access app / CORS resources below.
+  control_plane_hostname = "control${var.subdomain_separator}${var.domain}"
+  infisical_url          = "https://infisical${var.subdomain_separator}${var.domain}"
+  control_plane_url      = "https://${local.control_plane_hostname}"
 }
 
 # -----------------------------------------------------------------------------
@@ -207,7 +209,7 @@ resource "cloudflare_pages_project" "control_plane" {
 
 resource "cloudflare_record" "control_plane" {
   zone_id = var.cloudflare_zone_id
-  name    = "control"
+  name    = local.control_plane_hostname
   content = "${cloudflare_pages_project.control_plane.name}.pages.dev"
   type    = "CNAME"
   proxied = true
@@ -217,7 +219,7 @@ resource "cloudflare_record" "control_plane" {
 resource "cloudflare_pages_domain" "control_plane" {
   account_id   = var.cloudflare_account_id
   project_name = cloudflare_pages_project.control_plane.name
-  domain       = "control.${var.domain}"
+  domain       = local.control_plane_hostname
 
   depends_on = [cloudflare_record.control_plane]
 }
@@ -229,7 +231,7 @@ resource "cloudflare_pages_domain" "control_plane" {
 resource "cloudflare_zero_trust_access_application" "control_plane" {
   zone_id          = var.cloudflare_zone_id
   name             = "${local.resource_prefix} Control Plane"
-  domain           = "control.${var.domain}"
+  domain           = local.control_plane_hostname
   type             = "self_hosted"
   session_duration = "24h"
 
@@ -240,7 +242,7 @@ resource "cloudflare_zero_trust_access_application" "control_plane" {
   same_site_cookie_attribute = "lax"
 
   cors_headers {
-    allowed_origins   = ["https://control.${var.domain}"]
+    allowed_origins   = [local.control_plane_url]
     allowed_methods   = ["GET", "POST", "OPTIONS"]
     allow_credentials = true
   }

--- a/tofu/control-plane/main.tf
+++ b/tofu/control-plane/main.tf
@@ -18,6 +18,12 @@ locals {
     [trimspace(var.admin_email)],
     [for email in split(",", var.user_email) : trimspace(email)]
   )))
+
+  # Control Plane URLs. Built from the base domain and the subdomain separator
+  # so flat-subdomain deployments (e.g. infisical-tenant.example.com) work
+  # without code changes. Consumed by Pages Functions and the teardown Worker.
+  infisical_url     = "https://infisical${var.subdomain_separator}${var.domain}"
+  control_plane_url = "https://control${var.subdomain_separator}${var.domain}"
 }
 
 # -----------------------------------------------------------------------------
@@ -51,6 +57,11 @@ resource "cloudflare_workers_script" "scheduled_teardown" {
   plain_text_binding {
     name = "DOMAIN"
     text = var.domain
+  }
+
+  plain_text_binding {
+    name = "CONTROL_PLANE_URL"
+    text = local.control_plane_url
   }
 
   plain_text_binding {
@@ -125,28 +136,31 @@ resource "cloudflare_pages_project" "control_plane" {
   account_id        = var.cloudflare_account_id
   name              = "${local.resource_prefix}-control"
   production_branch = "main"
-  
+
   build_config {
     build_command   = ""
     destination_dir = "pages"
     root_dir        = "control-plane"
   }
-  
+
   deployment_configs {
     production {
       environment_variables = {
-        GITHUB_OWNER                 = var.github_owner
-        GITHUB_REPO                  = var.github_repo
-        DOMAIN                       = var.domain
-        ADMIN_EMAIL                  = var.admin_email
-        USER_EMAIL                   = var.user_email
-        SERVER_TYPE                  = var.server_type
-        SERVER_LOCATION              = var.server_location
-        ALLOW_DISABLE_AUTO_SHUTDOWN  = tostring(var.allow_disable_auto_shutdown)
-        MAX_EXTENSIONS_PER_DAY       = tostring(var.max_extensions_per_day)
-        MAX_DELAY_HOURS              = tostring(var.max_delay_hours)
+        GITHUB_OWNER                = var.github_owner
+        GITHUB_REPO                 = var.github_repo
+        DOMAIN                      = var.domain
+        SUBDOMAIN_SEPARATOR         = var.subdomain_separator
+        INFISICAL_URL               = local.infisical_url
+        CONTROL_PLANE_URL           = local.control_plane_url
+        ADMIN_EMAIL                 = var.admin_email
+        USER_EMAIL                  = var.user_email
+        SERVER_TYPE                 = var.server_type
+        SERVER_LOCATION             = var.server_location
+        ALLOW_DISABLE_AUTO_SHUTDOWN = tostring(var.allow_disable_auto_shutdown)
+        MAX_EXTENSIONS_PER_DAY      = tostring(var.max_extensions_per_day)
+        MAX_DELAY_HOURS             = tostring(var.max_delay_hours)
       }
-      
+
       d1_databases = {
         NEXUS_DB = cloudflare_d1_database.nexus.id
       }
@@ -161,18 +175,21 @@ resource "cloudflare_pages_project" "control_plane" {
 
     preview {
       environment_variables = {
-        GITHUB_OWNER                 = var.github_owner
-        GITHUB_REPO                  = var.github_repo
-        DOMAIN                       = var.domain
-        ADMIN_EMAIL                  = var.admin_email
-        USER_EMAIL                   = var.user_email
-        SERVER_TYPE                  = var.server_type
-        SERVER_LOCATION              = var.server_location
-        ALLOW_DISABLE_AUTO_SHUTDOWN  = tostring(var.allow_disable_auto_shutdown)
-        MAX_EXTENSIONS_PER_DAY       = tostring(var.max_extensions_per_day)
-        MAX_DELAY_HOURS              = tostring(var.max_delay_hours)
+        GITHUB_OWNER                = var.github_owner
+        GITHUB_REPO                 = var.github_repo
+        DOMAIN                      = var.domain
+        SUBDOMAIN_SEPARATOR         = var.subdomain_separator
+        INFISICAL_URL               = local.infisical_url
+        CONTROL_PLANE_URL           = local.control_plane_url
+        ADMIN_EMAIL                 = var.admin_email
+        USER_EMAIL                  = var.user_email
+        SERVER_TYPE                 = var.server_type
+        SERVER_LOCATION             = var.server_location
+        ALLOW_DISABLE_AUTO_SHUTDOWN = tostring(var.allow_disable_auto_shutdown)
+        MAX_EXTENSIONS_PER_DAY      = tostring(var.max_extensions_per_day)
+        MAX_DELAY_HOURS             = tostring(var.max_delay_hours)
       }
-      
+
       d1_databases = {
         NEXUS_DB = cloudflare_d1_database.nexus.id
       }
@@ -201,7 +218,7 @@ resource "cloudflare_pages_domain" "control_plane" {
   account_id   = var.cloudflare_account_id
   project_name = cloudflare_pages_project.control_plane.name
   domain       = "control.${var.domain}"
-  
+
   depends_on = [cloudflare_record.control_plane]
 }
 
@@ -221,7 +238,7 @@ resource "cloudflare_zero_trust_access_application" "control_plane" {
 
   http_only_cookie_attribute = true
   same_site_cookie_attribute = "lax"
-  
+
   cors_headers {
     allowed_origins   = ["https://control.${var.domain}"]
     allowed_methods   = ["GET", "POST", "OPTIONS"]

--- a/tofu/control-plane/variables.tf
+++ b/tofu/control-plane/variables.tf
@@ -25,6 +25,16 @@ variable "domain" {
   type        = string
 }
 
+variable "subdomain_separator" {
+  description = "Separator between service subdomain and base domain. '.' for standard dot-subdomains (default, requires wildcard cert at 3rd level), '-' for flat subdomains used when provisioning tenants under a shared base domain."
+  type        = string
+  default     = "."
+  validation {
+    condition     = contains([".", "-"], var.subdomain_separator)
+    error_message = "subdomain_separator must be '.' or '-'."
+  }
+}
+
 variable "admin_email" {
   description = "Admin email for Cloudflare Access (full access including SSH)"
   type        = string


### PR DESCRIPTION
## Summary

Wires the `subdomain_separator` flag through the Control Plane infrastructure so flat-subdomain deployments (e.g. `infisical-tenant.example.com`) can opt in without code changes. Follow-up to PR #432, which added the env-var reads in code but left nothing setting the values.

## Background

PR #432 made the Control Plane code read `INFISICAL_URL`, `CONTROL_PLANE_URL`, and `SUBDOMAIN_SEPARATOR` from the environment, falling back to `https://infisical.${domain}` / `https://control.${domain}` / `.`. The template's own deployment (`nexus-stack.ch`) stayed functional because the fallbacks match dot-subdomain hosts. User forks deployed by the admin panel (Nexus-Stack-for-Education) use flat subdomains like `infisical-tenant.example.com`, so the fallback URLs point to hosts that don't exist. Nothing was setting the env vars, so the Secrets page, stack links in the UI, and links in the credentials/teardown emails were broken on user forks.

## Changes

**`tofu/control-plane/variables.tf`** — new `subdomain_separator` variable (default `.`, validated to `.` or `-`).

**`tofu/control-plane/main.tf`**
- Locals for `infisical_url` / `control_plane_url` built from `var.domain` + `var.subdomain_separator`.
- Worker gets a `CONTROL_PLANE_URL` `plain_text_binding` (used by the teardown reminder email).
- Pages `production` + `preview` `environment_variables` include `INFISICAL_URL`, `CONTROL_PLANE_URL`, and `SUBDOMAIN_SEPARATOR`.
- `tofu fmt` also trimmed pre-existing trailing whitespace on a few unrelated blank lines.

**`.github/workflows/setup-control-plane.yaml`** + **`.github/workflows/destroy-all.yml`** — add `subdomain_separator = "${{ secrets.SUBDOMAIN_SEPARATOR || '.' }}"` to the generated `tofu/control-plane/config.tfvars`.

## Backward compatibility

Default `subdomain_separator = "."` keeps every derived value identical to today:
- `INFISICAL_URL = https://infisical.${domain}` (same as old fallback)
- `CONTROL_PLANE_URL = https://control.${domain}` (same as old fallback)
- `SUBDOMAIN_SEPARATOR = .` (same as old default in info.js)

Template deployment (`nexus-stack.ch`) is unaffected.

## Admin panel integration (Nexus-Stack-for-Education)

One additional secret push alongside the existing `DOMAIN` secret during user fork provisioning:

```bash
gh secret set SUBDOMAIN_SEPARATOR --repo "$USER_FORK" --body "-"
```

The workflows pick it up from `secrets.SUBDOMAIN_SEPARATOR` and inject it into Terraform automatically.

## Test plan

- [ ] `tofu validate` in `tofu/control-plane/` passes.
- [ ] Template regression: `gh workflow run setup-control-plane.yaml` on this repo (no `SUBDOMAIN_SEPARATOR` secret set). Cloudflare Pages env vars show `.` separator and dot-subdomain URLs. https://control.nexus-stack.ch/secrets still loads, stack links still use dot format, teardown email link unchanged.
- [ ] Flat-subdomain: on a test user fork with `gh secret set SUBDOMAIN_SEPARATOR --body "-"`, run `setup-control-plane.yaml`. Cloudflare Pages env vars show `-` separator, `INFISICAL_URL=https://infisical-<fork>.<base>`. Open `https://control-<fork>.<base>/secrets` — loads without the "unexpected response" error. Stack links point to `<subdomain>-<fork>.<base>`. Trigger a teardown-notification test; email links to the flat-subdomain Control Plane URL.
