### PR TITLE
feat(control-plane): Stacks UX overhaul — list view, tri-state status, keyboard, pending bar

### DIFF
--- a/control-plane/src/components/PendingBar.astro
+++ b/control-plane/src/components/PendingBar.astro
@@ -7,8 +7,8 @@
 //   - 'stacks:updated' event dispatched by toggleService()
 ---
 
-<div id="pending-bar" class="pending-bar" hidden>
-  <span class="pending-bar-dot">◐</span>
+<div id="pending-bar" class="pending-bar" role="status" aria-live="polite" hidden>
+  <span class="pending-bar-dot" aria-hidden="true">◐</span>
   <span id="pending-bar-text" class="pending-bar-text">Loading...</span>
   <a id="pending-bar-view" class="pending-bar-action" href="/stacks?filter=pending">View</a>
   <a class="pending-bar-action primary" href="/?action=spin-up">Spin Up</a>

--- a/control-plane/src/components/PendingBar.astro
+++ b/control-plane/src/components/PendingBar.astro
@@ -67,30 +67,20 @@
     const text = document.getElementById('pending-bar-text');
     if (!bar || !text) return;
 
-    let inflight = null;
-
     async function refresh() {
-      if (inflight) return inflight;
-      inflight = (async () => {
-        try {
-          const res = await fetch('/api/services', { credentials: 'same-origin' });
-          if (!res.ok) return;
-          const data = await res.json();
-          const count = (data && data.success && typeof data.pendingChangesCount === 'number')
-            ? data.pendingChangesCount : 0;
-          if (count > 0) {
-            text.textContent = count + ' change' + (count === 1 ? '' : 's') + ' pending. Spin Up to deploy.';
-            bar.hidden = false;
-          } else {
-            bar.hidden = true;
-          }
-        } catch {
-          // Silent — don't spam toasts for a background poll.
-        } finally {
-          inflight = null;
-        }
-      })();
-      return inflight;
+      // Shared cache in window.NS — if a stacks page also requested
+      // /api/services on the same tick, we reuse its response instead of
+      // firing a duplicate request.
+      const data = await window.NS.getServices();
+      if (!data) return; // Silent on failure — don't spam toasts for a background poll
+      const count = (data.success && typeof data.pendingChangesCount === 'number')
+        ? data.pendingChangesCount : 0;
+      if (count > 0) {
+        text.textContent = count + ' change' + (count === 1 ? '' : 's') + ' pending. Spin Up to deploy.';
+        bar.hidden = false;
+      } else {
+        bar.hidden = true;
+      }
     }
 
     refresh();

--- a/control-plane/src/components/PendingBar.astro
+++ b/control-plane/src/components/PendingBar.astro
@@ -11,7 +11,7 @@
   <span class="pending-bar-dot" aria-hidden="true">◐</span>
   <span id="pending-bar-text" class="pending-bar-text">Loading...</span>
   <a id="pending-bar-view" class="pending-bar-action" href="/stacks?filter=pending">View</a>
-  <a class="pending-bar-action primary" href="/?action=spin-up">Spin Up</a>
+  <a class="pending-bar-action primary" href="/" title="Open the Dashboard and click Spin Up to deploy">Open Dashboard</a>
 </div>
 
 <style>

--- a/control-plane/src/components/PendingBar.astro
+++ b/control-plane/src/components/PendingBar.astro
@@ -1,0 +1,102 @@
+---
+// Persistent pending-changes indicator. Visible on every page once mounted.
+// Shows nothing until /api/services reports pendingChangesCount > 0.
+// Re-fetches on:
+//   - initial mount
+//   - page becoming visible again (visibilitychange)
+//   - 'stacks:updated' event dispatched by toggleService()
+---
+
+<div id="pending-bar" class="pending-bar" hidden>
+  <span class="pending-bar-dot">◐</span>
+  <span id="pending-bar-text" class="pending-bar-text">Loading...</span>
+  <a id="pending-bar-view" class="pending-bar-action" href="/stacks?filter=pending">View</a>
+  <a class="pending-bar-action primary" href="/?action=spin-up">Spin Up</a>
+</div>
+
+<style>
+  .pending-bar {
+    display: flex;
+    align-items: center;
+    gap: 0.8rem;
+    background: rgba(255, 170, 0, 0.08);
+    border: 1px solid rgba(255, 170, 0, 0.3);
+    border-left-width: 3px;
+    color: var(--warning);
+    padding: 0.6rem 1rem;
+    margin: 0 0 1.5rem 0;
+    font-size: 0.85rem;
+    border-radius: 3px;
+  }
+
+  .pending-bar[hidden] { display: none; }
+
+  .pending-bar-dot {
+    font-family: 'JetBrains Mono', monospace;
+    animation: pulse 2s infinite;
+  }
+
+  .pending-bar-text { flex: 1; }
+
+  .pending-bar-action {
+    color: var(--accent);
+    text-decoration: none;
+    padding: 0.2rem 0.6rem;
+    border: 1px solid rgba(0, 255, 136, 0.3);
+    border-radius: 3px;
+    font-size: 0.78rem;
+    white-space: nowrap;
+  }
+
+  .pending-bar-action:hover {
+    background: rgba(0, 255, 136, 0.1);
+  }
+
+  .pending-bar-action.primary {
+    background: rgba(0, 255, 136, 0.1);
+  }
+
+  .pending-bar-action.primary:hover {
+    background: rgba(0, 255, 136, 0.2);
+  }
+</style>
+
+<script is:inline>
+  (function() {
+    const bar = document.getElementById('pending-bar');
+    const text = document.getElementById('pending-bar-text');
+    if (!bar || !text) return;
+
+    let inflight = null;
+
+    async function refresh() {
+      if (inflight) return inflight;
+      inflight = (async () => {
+        try {
+          const res = await fetch('/api/services', { credentials: 'same-origin' });
+          if (!res.ok) return;
+          const data = await res.json();
+          const count = (data && data.success && typeof data.pendingChangesCount === 'number')
+            ? data.pendingChangesCount : 0;
+          if (count > 0) {
+            text.textContent = count + ' change' + (count === 1 ? '' : 's') + ' pending. Spin Up to deploy.';
+            bar.hidden = false;
+          } else {
+            bar.hidden = true;
+          }
+        } catch {
+          // Silent — don't spam toasts for a background poll.
+        } finally {
+          inflight = null;
+        }
+      })();
+      return inflight;
+    }
+
+    refresh();
+    document.addEventListener('visibilitychange', function() {
+      if (!document.hidden) refresh();
+    });
+    window.addEventListener('stacks:updated', refresh);
+  })();
+</script>

--- a/control-plane/src/components/ShortcutsHelp.astro
+++ b/control-plane/src/components/ShortcutsHelp.astro
@@ -1,0 +1,119 @@
+---
+// Keyboard shortcut overlay. Toggled by `?` via window.NS.registerKeyboard.
+// Lives as a native <dialog> so Escape closes it for free.
+---
+
+<dialog id="shortcuts-help" class="shortcuts-help">
+  <div class="shortcuts-help-body">
+    <div class="shortcuts-help-header">
+      <h3>Keyboard shortcuts</h3>
+      <button id="shortcuts-help-close" aria-label="Close">×</button>
+    </div>
+    <table>
+      <tbody>
+        <tr><td><kbd>/</kbd></td><td>Focus search</td></tr>
+        <tr><td><kbd>?</kbd></td><td>Toggle this help</td></tr>
+        <tr><td><kbd>Esc</kbd></td><td>Close overlay / blur search</td></tr>
+        <tr><td><kbd>g</kbd> <kbd>d</kbd></td><td>Go to Dashboard</td></tr>
+        <tr><td><kbd>g</kbd> <kbd>s</kbd></td><td>Go to Stacks</td></tr>
+        <tr><td colspan="2" class="group">In list view</td></tr>
+        <tr><td><kbd>j</kbd> <kbd>↓</kbd></td><td>Next row</td></tr>
+        <tr><td><kbd>k</kbd> <kbd>↑</kbd></td><td>Previous row</td></tr>
+        <tr><td><kbd>Enter</kbd></td><td>Open stack URL</td></tr>
+        <tr><td><kbd>e</kbd> <kbd>Space</kbd></td><td>Toggle enabled</td></tr>
+        <tr><td><kbd>c</kbd></td><td>Open category page</td></tr>
+      </tbody>
+    </table>
+  </div>
+</dialog>
+
+<style>
+  .shortcuts-help {
+    background: var(--bg-card);
+    color: var(--text);
+    border: 1px solid rgba(0, 255, 136, 0.3);
+    border-radius: 4px;
+    padding: 0;
+    max-width: 420px;
+    width: calc(100% - 2rem);
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.6);
+  }
+
+  .shortcuts-help::backdrop {
+    background: rgba(0, 0, 0, 0.6);
+  }
+
+  .shortcuts-help-body { padding: 1rem 1.2rem; }
+
+  .shortcuts-help-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 0.8rem;
+  }
+
+  .shortcuts-help-header h3 {
+    color: var(--accent);
+    margin: 0;
+    font-size: 1rem;
+  }
+
+  #shortcuts-help-close {
+    background: transparent;
+    border: none;
+    color: var(--text-muted);
+    font-size: 1.4rem;
+    cursor: pointer;
+    padding: 0 0.4rem;
+    line-height: 1;
+  }
+
+  #shortcuts-help-close:hover { color: var(--accent); }
+
+  .shortcuts-help table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.82rem;
+  }
+
+  .shortcuts-help td {
+    padding: 0.3rem 0.2rem;
+    vertical-align: middle;
+  }
+
+  .shortcuts-help td:first-child { white-space: nowrap; width: 45%; }
+
+  .shortcuts-help td.group {
+    color: var(--text-muted);
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    padding-top: 0.9rem;
+    border-top: 1px solid rgba(42, 42, 62, 0.5);
+  }
+
+  .shortcuts-help kbd {
+    background: rgba(0, 255, 136, 0.08);
+    border: 1px solid rgba(0, 255, 136, 0.25);
+    border-radius: 3px;
+    padding: 0.1rem 0.4rem;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.78rem;
+    color: var(--accent);
+    margin-right: 0.2rem;
+  }
+</style>
+
+<script is:inline>
+  (function() {
+    const dlg = document.getElementById('shortcuts-help');
+    const closeBtn = document.getElementById('shortcuts-help-close');
+    if (!dlg || !closeBtn) return;
+    closeBtn.addEventListener('click', function() { dlg.close(); });
+    // Click-outside-to-close — native <dialog> emits click on the dialog element
+    // when you click the backdrop.
+    dlg.addEventListener('click', function(e) {
+      if (e.target === dlg) dlg.close();
+    });
+  })();
+</script>

--- a/control-plane/src/components/StackTable.astro
+++ b/control-plane/src/components/StackTable.astro
@@ -154,7 +154,6 @@
         tr.dataset.index = String(idx);
         if (idx === state.focusIndex) tr.className = 'focused';
 
-        const badge = window.NS.statusBadge(window.NS.resolveStatus(service));
         const url = window.NS.stackUrl(service);
         const catMeta = window.NS.CATEGORIES[service.category];
         const catName = catMeta ? catMeta.name : service.category;

--- a/control-plane/src/components/StackTable.astro
+++ b/control-plane/src/components/StackTable.astro
@@ -1,0 +1,243 @@
+---
+// Flat table view of all stacks. Rendered client-side from the services
+// array that each hosting page passes via window.NS.renderTable(...).
+// Density-oriented: one row per stack with status dot, name, category,
+// URL, toggle. Supports keyboard navigation via window.NS.registerKeyboard.
+---
+
+<table class="stack-table" id="stack-table">
+  <thead>
+    <tr>
+      <th class="col-status" aria-label="Status"></th>
+      <th class="col-name">Name</th>
+      <th class="col-category">Category</th>
+      <th class="col-url">URL</th>
+      <th class="col-toggle" aria-label="Enabled"></th>
+    </tr>
+  </thead>
+  <tbody id="stack-table-body"></tbody>
+</table>
+<p id="stack-table-empty" class="stack-table-empty" hidden>No stacks match the current filter.</p>
+
+<style>
+  .stack-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.82rem;
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+  }
+
+  .stack-table thead th {
+    text-align: left;
+    padding: 0.5rem 0.8rem;
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: var(--text-muted);
+    border-bottom: 1px solid var(--border);
+    background: rgba(0, 0, 0, 0.3);
+    font-weight: 400;
+  }
+
+  .stack-table .col-status  { width: 2.2rem; text-align: center; }
+  .stack-table .col-toggle  { width: 3.5rem; text-align: right; }
+  .stack-table .col-category{ width: 20%; }
+  .stack-table .col-url     { width: 28%; }
+
+  .stack-table tbody tr {
+    border-bottom: 1px solid rgba(42, 42, 62, 0.5);
+    transition: background 0.12s;
+  }
+
+  .stack-table tbody tr:last-child { border-bottom: none; }
+
+  .stack-table tbody tr:hover,
+  .stack-table tbody tr.focused {
+    background: rgba(0, 255, 136, 0.06);
+  }
+
+  .stack-table tbody tr.focused {
+    outline: 1px solid rgba(0, 255, 136, 0.4);
+    outline-offset: -1px;
+  }
+
+  .stack-table td {
+    padding: 0.45rem 0.8rem;
+    vertical-align: middle;
+  }
+
+  .stack-table td.col-status { text-align: center; font-size: 1rem; line-height: 1; }
+
+  .stack-row-name {
+    color: var(--accent);
+    font-weight: 700;
+  }
+
+  .stack-row-url {
+    color: var(--text-muted);
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.75rem;
+    text-decoration: none;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    display: inline-block;
+    max-width: 100%;
+  }
+
+  .stack-row-url:hover { color: var(--accent); }
+
+  .stack-row-url.no-url { color: var(--text-muted); opacity: 0.5; }
+
+  .stack-row-category {
+    color: var(--text-secondary);
+    font-size: 0.78rem;
+  }
+
+  .stack-row-badges {
+    display: inline-flex;
+    gap: 0.3rem;
+    margin-left: 0.4rem;
+    flex-wrap: wrap;
+  }
+
+  .stack-table .toggle-switch {
+    margin-left: auto;
+  }
+
+  .stack-table-empty {
+    color: var(--text-muted);
+    text-align: center;
+    padding: 2rem;
+    font-size: 0.85rem;
+  }
+
+  @media (max-width: 768px) {
+    .stack-table .col-category,
+    .stack-table .col-url,
+    .stack-table .col-toggle { display: none; }
+    .stack-table td { padding: 0.5rem 0.6rem; }
+  }
+</style>
+
+<script is:inline>
+  (function() {
+    const tbody = document.getElementById('stack-table-body');
+    const emptyEl = document.getElementById('stack-table-empty');
+    if (!tbody || !emptyEl) return;
+
+    const state = {
+      services: [],
+      focusIndex: -1,
+    };
+
+    window.NS.renderTable = function(services) {
+      state.services = services || [];
+      state.focusIndex = state.services.length > 0 ? 0 : -1;
+      renderRows();
+    };
+
+    window.NS.getTableState = function() { return state; };
+
+    function renderRows() {
+      tbody.innerHTML = '';
+      if (state.services.length === 0) {
+        emptyEl.hidden = false;
+        return;
+      }
+      emptyEl.hidden = true;
+
+      state.services.forEach(function(service, idx) {
+        const tr = document.createElement('tr');
+        tr.dataset.serviceName = service.name;
+        tr.dataset.index = String(idx);
+        if (idx === state.focusIndex) tr.className = 'focused';
+
+        const badge = window.NS.statusBadge(window.NS.resolveStatus(service));
+        const url = window.NS.stackUrl(service);
+        const catMeta = window.NS.CATEGORIES[service.category];
+        const catName = catMeta ? catMeta.name : service.category;
+
+        let badges = '';
+        if (service.core) badges += '<span class="badge badge-core">core</span>';
+        if (service.admin_only) badges += '<span class="badge badge-admin">admin</span>';
+        if (!service.subdomain) badges += '<span class="badge badge-internal">internal</span>';
+        if (service.pending) {
+          badges += '<span class="badge badge-pending">' + (service.enabled ? 'will enable' : 'will disable') + '</span>';
+        }
+
+        const isDisabled = service.core || service.admin_only;
+        const toggleClass = 'toggle-switch' + (service.enabled ? ' active' : '') + (isDisabled ? ' disabled' : '');
+        const toggleTitle = service.core ? 'Core service - cannot be disabled' :
+                           service.admin_only ? 'Admin-only - managed via GitHub Actions' : '';
+
+        const urlHtml = url && service.deployed
+          ? '<a class="stack-row-url" href="' + url + '" target="_blank" rel="noopener">' + escapeHtml(url.replace(/^https:\/\//, '')) + '</a>'
+          : '<span class="stack-row-url no-url">—</span>';
+
+        tr.innerHTML =
+          '<td class="col-status"><span class="status-dot ' + badge.className + '" title="' + badge.label + '">' + badge.glyph + '</span></td>' +
+          '<td class="col-name"><a class="stack-row-name" href="/category?cat=' + encodeURIComponent(service.category) + '#' + escapeHtml(service.name) + '">' + escapeHtml(service.name) + '</a><span class="stack-row-badges">' + badges + '</span></td>' +
+          '<td class="col-category"><a class="stack-row-category" href="/category?cat=' + encodeURIComponent(service.category) + '">' + escapeHtml(catName) + '</a></td>' +
+          '<td class="col-url">' + urlHtml + '</td>' +
+          '<td class="col-toggle"><div class="' + toggleClass + '" data-service="' + escapeHtml(service.name) + '" data-target="' + (!service.enabled) + '" title="' + escapeHtml(toggleTitle) + '"></div></td>';
+
+        tr.querySelector('.toggle-switch').addEventListener('click', function(e) {
+          e.stopPropagation();
+          handleToggle(this);
+        });
+        tr.addEventListener('click', function() {
+          state.focusIndex = idx;
+          applyFocusClass();
+        });
+
+        tbody.appendChild(tr);
+      });
+    }
+
+    function applyFocusClass() {
+      Array.prototype.forEach.call(tbody.querySelectorAll('tr'), function(tr, idx) {
+        tr.classList.toggle('focused', idx === state.focusIndex);
+        if (idx === state.focusIndex) {
+          tr.scrollIntoView({ block: 'nearest' });
+        }
+      });
+    }
+
+    async function handleToggle(toggleEl) {
+      if (toggleEl.classList.contains('disabled')) return;
+      const name = toggleEl.dataset.service;
+      const target = toggleEl.dataset.target === 'true';
+      toggleEl.classList.add('disabled');
+      const result = await window.NS.toggleService(name, target);
+      if (result.success) {
+        // Let the host page re-fetch and re-render.
+        window.dispatchEvent(new Event('stacks:reload'));
+      } else {
+        toggleEl.classList.remove('disabled');
+      }
+    }
+
+    // Expose focus/apply so the page's keyboard registration can drive it.
+    window.NS.tableController = {
+      get focus() { return state.focusIndex; },
+      set focus(v) { state.focusIndex = v; applyFocusClass(); },
+      get items() { return state.services; },
+      render: applyFocusClass,
+      onOpen: function(service) {
+        const url = window.NS.stackUrl(service);
+        if (url && service.deployed) window.open(url, '_blank', 'noopener');
+      },
+      onToggle: function(service) {
+        const tr = tbody.querySelector('tr[data-service-name="' + (window.CSS && CSS.escape ? CSS.escape(service.name) : service.name) + '"]');
+        if (!tr) return;
+        const toggleEl = tr.querySelector('.toggle-switch');
+        if (toggleEl) handleToggle(toggleEl);
+      },
+      onCategory: function(service) {
+        window.location.href = '/category?cat=' + encodeURIComponent(service.category) + '#' + service.name;
+      },
+    };
+  })();
+</script>

--- a/control-plane/src/components/StackTable.astro
+++ b/control-plane/src/components/StackTable.astro
@@ -175,10 +175,13 @@
           ? '<a class="stack-row-url" href="' + url + '" target="_blank" rel="noopener">' + escapeHtml(url.replace(/^https:\/\//, '')) + '</a>'
           : '<span class="stack-row-url no-url">—</span>';
 
+        const categoryHref = '/category?cat=' + encodeURIComponent(service.category);
+        const serviceAnchor = '#' + encodeURIComponent(service.name);
+
         tr.innerHTML =
           '<td class="col-status">' + window.NS.renderStatusDot(service) + '</td>' +
-          '<td class="col-name"><a class="stack-row-name" href="/category?cat=' + encodeURIComponent(service.category) + '#' + escapeHtml(service.name) + '">' + escapeHtml(service.name) + '</a><span class="stack-row-badges">' + badges + '</span></td>' +
-          '<td class="col-category"><a class="stack-row-category" href="/category?cat=' + encodeURIComponent(service.category) + '">' + escapeHtml(catName) + '</a></td>' +
+          '<td class="col-name"><a class="stack-row-name" href="' + categoryHref + serviceAnchor + '">' + escapeHtml(service.name) + '</a><span class="stack-row-badges">' + badges + '</span></td>' +
+          '<td class="col-category"><a class="stack-row-category" href="' + categoryHref + '">' + escapeHtml(catName) + '</a></td>' +
           '<td class="col-url">' + urlHtml + '</td>' +
           '<td class="col-toggle"><div class="' + toggleClass + '" data-service="' + escapeHtml(service.name) + '" data-target="' + (!service.enabled) + '" title="' + escapeHtml(toggleTitle) + '"></div></td>';
 
@@ -234,7 +237,7 @@
         if (toggleEl) handleToggle(toggleEl);
       },
       onCategory: function(service) {
-        window.location.href = '/category?cat=' + encodeURIComponent(service.category) + '#' + service.name;
+        window.location.href = '/category?cat=' + encodeURIComponent(service.category) + '#' + encodeURIComponent(service.name);
       },
     };
   })();

--- a/control-plane/src/components/StackTable.astro
+++ b/control-plane/src/components/StackTable.astro
@@ -177,7 +177,7 @@
           : '<span class="stack-row-url no-url">—</span>';
 
         tr.innerHTML =
-          '<td class="col-status"><span class="status-dot ' + badge.className + '" title="' + badge.label + '">' + badge.glyph + '</span></td>' +
+          '<td class="col-status">' + window.NS.renderStatusDot(service) + '</td>' +
           '<td class="col-name"><a class="stack-row-name" href="/category?cat=' + encodeURIComponent(service.category) + '#' + escapeHtml(service.name) + '">' + escapeHtml(service.name) + '</a><span class="stack-row-badges">' + badges + '</span></td>' +
           '<td class="col-category"><a class="stack-row-category" href="/category?cat=' + encodeURIComponent(service.category) + '">' + escapeHtml(catName) + '</a></td>' +
           '<td class="col-url">' + urlHtml + '</td>' +
@@ -211,10 +211,9 @@
       const target = toggleEl.dataset.target === 'true';
       toggleEl.classList.add('disabled');
       const result = await window.NS.toggleService(name, target);
-      if (result.success) {
-        // Let the host page re-fetch and re-render.
-        window.dispatchEvent(new Event('stacks:reload'));
-      } else {
+      // toggleService already dispatches 'stacks:updated' on success; the
+      // host page listens and re-fetches. Only restore UI on failure.
+      if (!result.success) {
         toggleEl.classList.remove('disabled');
       }
     }

--- a/control-plane/src/components/StackTable.astro
+++ b/control-plane/src/components/StackTable.astro
@@ -137,8 +137,22 @@
     // consistent with each other ("loading..." / "failed to load" / "run
     // spin up" / "no match").
     window.NS.renderTable = function(services, emptyText) {
+      // Preserve focus by service name across re-renders (toggle, refresh,
+      // filter change). Falls back to the same index, then to 0 if the old
+      // focused row disappeared entirely, then to -1 if the list is empty.
+      const priorServices = state.services;
+      const priorName = (state.focusIndex >= 0 && priorServices[state.focusIndex])
+        ? priorServices[state.focusIndex].name : null;
       state.services = services || [];
-      state.focusIndex = state.services.length > 0 ? 0 : -1;
+      if (state.services.length === 0) {
+        state.focusIndex = -1;
+      } else if (priorName) {
+        const matched = state.services.findIndex(function(s) { return s.name === priorName; });
+        state.focusIndex = matched !== -1 ? matched : Math.min(state.focusIndex, state.services.length - 1);
+        if (state.focusIndex < 0) state.focusIndex = 0;
+      } else {
+        state.focusIndex = 0;
+      }
       if (typeof emptyText === 'string') state.emptyText = emptyText;
       renderRows();
     };
@@ -178,7 +192,7 @@
                            service.admin_only ? 'Admin-only - managed via GitHub Actions' : '';
 
         const urlHtml = url && service.deployed
-          ? '<a class="stack-row-url" href="' + url + '" target="_blank" rel="noopener">' + escapeHtml(url.replace(/^https:\/\//, '')) + '</a>'
+          ? '<a class="stack-row-url" href="' + escapeAttr(url) + '" target="_blank" rel="noopener">' + escapeHtml(url.replace(/^https:\/\//, '')) + '</a>'
           : '<span class="stack-row-url no-url">—</span>';
 
         const categoryHref = '/category?cat=' + encodeURIComponent(service.category);
@@ -186,10 +200,10 @@
 
         tr.innerHTML =
           '<td class="col-status">' + window.NS.renderStatusDot(service) + '</td>' +
-          '<td class="col-name"><a class="stack-row-name" href="' + categoryHref + serviceAnchor + '">' + escapeHtml(service.name) + '</a><span class="stack-row-badges">' + badges + '</span></td>' +
-          '<td class="col-category"><a class="stack-row-category" href="' + categoryHref + '">' + escapeHtml(catName) + '</a></td>' +
+          '<td class="col-name"><a class="stack-row-name" href="' + escapeAttr(categoryHref + serviceAnchor) + '">' + escapeHtml(service.name) + '</a><span class="stack-row-badges">' + badges + '</span></td>' +
+          '<td class="col-category"><a class="stack-row-category" href="' + escapeAttr(categoryHref) + '">' + escapeHtml(catName) + '</a></td>' +
           '<td class="col-url">' + urlHtml + '</td>' +
-          '<td class="col-toggle"><div class="' + toggleClass + '" data-service="' + escapeHtml(service.name) + '" data-target="' + (!service.enabled) + '" title="' + escapeHtml(toggleTitle) + '"></div></td>';
+          '<td class="col-toggle"><div class="' + toggleClass + '" data-service="' + escapeAttr(service.name) + '" data-target="' + (!service.enabled) + '" title="' + escapeAttr(toggleTitle) + '"></div></td>';
 
         tr.querySelector('.toggle-switch').addEventListener('click', function(e) {
           e.stopPropagation();

--- a/control-plane/src/components/StackTable.astro
+++ b/control-plane/src/components/StackTable.astro
@@ -17,7 +17,7 @@
   </thead>
   <tbody id="stack-table-body"></tbody>
 </table>
-<p id="stack-table-empty" class="stack-table-empty" hidden>No stacks match the current filter.</p>
+<p id="stack-table-empty" class="stack-table-empty" hidden></p>
 
 <style>
   .stack-table {
@@ -130,11 +130,16 @@
     const state = {
       services: [],
       focusIndex: -1,
+      emptyText: 'No stacks match the current filter.',
     };
 
-    window.NS.renderTable = function(services) {
+    // host may pass a custom empty message so list and grid views stay
+    // consistent with each other ("loading..." / "failed to load" / "run
+    // spin up" / "no match").
+    window.NS.renderTable = function(services, emptyText) {
       state.services = services || [];
       state.focusIndex = state.services.length > 0 ? 0 : -1;
+      if (typeof emptyText === 'string') state.emptyText = emptyText;
       renderRows();
     };
 
@@ -143,6 +148,7 @@
     function renderRows() {
       tbody.innerHTML = '';
       if (state.services.length === 0) {
+        emptyEl.textContent = state.emptyText;
         emptyEl.hidden = false;
         return;
       }

--- a/control-plane/src/components/StacksShared.astro
+++ b/control-plane/src/components/StacksShared.astro
@@ -111,7 +111,7 @@ import { CATEGORIES, CATEGORY_ORDER } from '../lib/categories.ts';
 
   window.NS.renderStatusDot = function(service) {
     const b = window.NS.statusBadge(window.NS.resolveStatus(service));
-    return '<span class="status-dot ' + b.className + '" role="img" aria-label="' + b.label + '" title="' + b.label + '">' +
+    return '<span class="stack-status-dot ' + b.className + '" role="img" aria-label="' + b.label + '" title="' + b.label + '">' +
       '<span aria-hidden="true">' + b.glyph + '</span>' +
     '</span>';
   };

--- a/control-plane/src/components/StacksShared.astro
+++ b/control-plane/src/components/StacksShared.astro
@@ -161,9 +161,15 @@ import { CATEGORIES, CATEGORY_ORDER } from '../lib/categories.ts';
     let pendingG = false;
     let gTimer = null;
 
+    // Tags where keystrokes have their own meaning (Space clicks a button,
+    // Enter submits a form, j/k types into a field, etc.). Shortcuts must
+    // not fire over these, or they override expected browser behaviour.
+    const INTERACTIVE_TAGS = ['INPUT', 'TEXTAREA', 'SELECT', 'BUTTON', 'A'];
+
     function handler(e) {
-      if (e.target && ['INPUT', 'TEXTAREA'].indexOf(e.target.tagName) !== -1) {
-        if (e.key === 'Escape') e.target.blur();
+      const t = e.target;
+      if (t && (INTERACTIVE_TAGS.indexOf(t.tagName) !== -1 || t.isContentEditable)) {
+        if (e.key === 'Escape' && (t.tagName === 'INPUT' || t.tagName === 'TEXTAREA')) t.blur();
         return;
       }
       // When a modal dialog is open, suppress all shortcuts (even our own)

--- a/control-plane/src/components/StacksShared.astro
+++ b/control-plane/src/components/StacksShared.astro
@@ -12,7 +12,10 @@ import { CATEGORIES, CATEGORY_ORDER } from '../lib/categories.ts';
 
   // ---- Domain & URL -------------------------------------------------------
 
-  let cachedDomain = null;
+  // Seed from URL so stackUrl() works even if /api/info hasn't resolved yet
+  // (or fails permanently). The old control.foo / control-foo pages did this
+  // before the refactor — preserve the fallback.
+  let cachedDomain = window.location.hostname.replace(/^control[.-]/, '');
   let cachedSeparator = '.';
   let domainFetch = null;
 
@@ -27,7 +30,11 @@ import { CATEGORIES, CATEGORY_ORDER } from '../lib/categories.ts';
         }
         return { domain: cachedDomain, separator: cachedSeparator };
       })
-      .catch(function() { return { domain: cachedDomain, separator: cachedSeparator }; });
+      .catch(function() {
+        // Clear the memo so the next call can retry once connectivity returns.
+        domainFetch = null;
+        return { domain: cachedDomain, separator: cachedSeparator };
+      });
     return domainFetch;
   };
 
@@ -60,7 +67,9 @@ import { CATEGORIES, CATEGORY_ORDER } from '../lib/categories.ts';
 
   window.NS.renderStatusDot = function(service) {
     const b = window.NS.statusBadge(window.NS.resolveStatus(service));
-    return '<span class="status-dot ' + b.className + '" title="' + b.label + '">' + b.glyph + '</span>';
+    return '<span class="status-dot ' + b.className + '" role="img" aria-label="' + b.label + '" title="' + b.label + '">' +
+      '<span aria-hidden="true">' + b.glyph + '</span>' +
+    '</span>';
   };
 
   // ---- Service toggle -----------------------------------------------------
@@ -109,10 +118,14 @@ import { CATEGORIES, CATEGORY_ORDER } from '../lib/categories.ts';
         if (e.key === 'Escape') e.target.blur();
         return;
       }
+      // When a modal dialog is open, suppress all shortcuts (even our own)
+      // so background navigation/toggles don't fire "through" the overlay.
       const openDialog = document.querySelector('dialog[open]');
-      if (openDialog && e.key === 'Escape') {
-        openDialog.close();
-        e.preventDefault();
+      if (openDialog) {
+        if (e.key === 'Escape') {
+          openDialog.close();
+          e.preventDefault();
+        }
         return;
       }
 

--- a/control-plane/src/components/StacksShared.astro
+++ b/control-plane/src/components/StacksShared.astro
@@ -22,7 +22,15 @@ import { CATEGORIES, CATEGORY_ORDER } from '../lib/categories.ts';
   window.NS.fetchDomain = function() {
     if (domainFetch) return domainFetch;
     domainFetch = fetch('/api/info', { credentials: 'same-origin' })
-      .then(function(r) { return r.ok ? r.json() : null; })
+      .then(function(r) {
+        if (!r.ok) {
+          // Non-2xx: clear the memo so a later call can retry once the
+          // server recovers, and fall back to the URL-derived domain.
+          domainFetch = null;
+          return null;
+        }
+        return r.json();
+      })
       .then(function(d) {
         if (d && d.success && d.info && d.info.server) {
           if (d.info.server.domain) cachedDomain = d.info.server.domain;
@@ -31,7 +39,7 @@ import { CATEGORIES, CATEGORY_ORDER } from '../lib/categories.ts';
         return { domain: cachedDomain, separator: cachedSeparator };
       })
       .catch(function() {
-        // Clear the memo so the next call can retry once connectivity returns.
+        // Network/parse error — same retry treatment.
         domainFetch = null;
         return { domain: cachedDomain, separator: cachedSeparator };
       });

--- a/control-plane/src/components/StacksShared.astro
+++ b/control-plane/src/components/StacksShared.astro
@@ -1,0 +1,169 @@
+---
+// Shared client-side helpers for the stacks-related pages.
+// Attaches constants and helpers to `window.NS` so the per-page
+// <script is:inline> blocks can consume them without duplicating code.
+import { CATEGORIES, CATEGORY_ORDER } from '../lib/categories.ts';
+---
+
+<script is:inline define:vars={{ CATEGORIES, CATEGORY_ORDER }}>
+  window.NS = window.NS || {};
+  window.NS.CATEGORIES = CATEGORIES;
+  window.NS.CATEGORY_ORDER = CATEGORY_ORDER;
+
+  // ---- Domain & URL -------------------------------------------------------
+
+  let cachedDomain = null;
+  let cachedSeparator = '.';
+  let domainFetch = null;
+
+  window.NS.fetchDomain = function() {
+    if (domainFetch) return domainFetch;
+    domainFetch = fetch('/api/info', { credentials: 'same-origin' })
+      .then(function(r) { return r.ok ? r.json() : null; })
+      .then(function(d) {
+        if (d && d.success && d.info && d.info.server) {
+          if (d.info.server.domain) cachedDomain = d.info.server.domain;
+          if (d.info.server.subdomainSeparator) cachedSeparator = d.info.server.subdomainSeparator;
+        }
+        return { domain: cachedDomain, separator: cachedSeparator };
+      })
+      .catch(function() { return { domain: cachedDomain, separator: cachedSeparator }; });
+    return domainFetch;
+  };
+
+  window.NS.stackUrl = function(service) {
+    if (!service || !service.subdomain || !cachedDomain) return '';
+    return 'https://' + service.subdomain + cachedSeparator + cachedDomain;
+  };
+
+  // ---- Tri-state status ---------------------------------------------------
+  // enabled + deployed -> running
+  // enabled + !deployed -> pending-enable
+  // !enabled + deployed -> pending-disable
+  // !enabled + !deployed -> disabled
+
+  window.NS.resolveStatus = function(service) {
+    if (service.enabled && service.deployed) return 'running';
+    if (service.enabled && !service.deployed) return 'pending-enable';
+    if (!service.enabled && service.deployed) return 'pending-disable';
+    return 'disabled';
+  };
+
+  window.NS.statusBadge = function(status) {
+    switch (status) {
+      case 'running':        return { glyph: '●', label: 'running',        className: 'status-running' };
+      case 'pending-enable': return { glyph: '◐', label: 'pending enable', className: 'status-pending' };
+      case 'pending-disable':return { glyph: '◐', label: 'pending disable',className: 'status-pending' };
+      default:               return { glyph: '○', label: 'disabled',       className: 'status-disabled' };
+    }
+  };
+
+  window.NS.renderStatusDot = function(service) {
+    const b = window.NS.statusBadge(window.NS.resolveStatus(service));
+    return '<span class="status-dot ' + b.className + '" title="' + b.label + '">' + b.glyph + '</span>';
+  };
+
+  // ---- Service toggle -----------------------------------------------------
+
+  window.NS.toggleService = async function(name, enabled) {
+    try {
+      const response = await fetch('/api/services', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'same-origin',
+        body: JSON.stringify({ service: name, enabled: enabled }),
+      });
+      let data = null;
+      try { data = await response.json(); } catch {}
+      if (!response.ok || !data || !data.success) {
+        const msg = (data && data.error) || ('HTTP ' + response.status);
+        if (typeof showToast === 'function') showToast(msg, 'error');
+        return { success: false, error: msg };
+      }
+      if (typeof showToast === 'function') {
+        showToast(name + ' ' + (enabled ? 'enabled' : 'disabled') + '. Go to Dashboard to Spin Up.');
+      }
+      window.dispatchEvent(new Event('stacks:updated'));
+      return { success: true };
+    } catch (err) {
+      const msg = err && err.message ? err.message : 'Network error';
+      if (typeof showToast === 'function') showToast(msg, 'error');
+      return { success: false, error: msg };
+    }
+  };
+
+  // ---- Keyboard bindings --------------------------------------------------
+  // Registers global shortcuts (/ ? g d g s Esc) plus list-specific nav
+  // (j/k Enter e c) if the page passes a list controller.
+
+  window.NS.registerKeyboard = function(opts) {
+    opts = opts || {};
+    const searchInputId = opts.searchInputId || null;
+    const list = opts.list || null;   // { items: [], getEl: i => element, onOpen, onToggle, onCategory }
+
+    let pendingG = false;
+    let gTimer = null;
+
+    function handler(e) {
+      if (e.target && ['INPUT', 'TEXTAREA'].indexOf(e.target.tagName) !== -1) {
+        if (e.key === 'Escape') e.target.blur();
+        return;
+      }
+      const openDialog = document.querySelector('dialog[open]');
+      if (openDialog && e.key === 'Escape') {
+        openDialog.close();
+        e.preventDefault();
+        return;
+      }
+
+      if (e.key === '/') {
+        if (searchInputId) {
+          const input = document.getElementById(searchInputId);
+          if (input) { input.focus(); input.select && input.select(); e.preventDefault(); return; }
+        }
+      }
+
+      if (e.key === '?') {
+        const help = document.getElementById('shortcuts-help');
+        if (help) { help.open ? help.close() : help.showModal(); e.preventDefault(); return; }
+      }
+
+      if (pendingG) {
+        pendingG = false;
+        clearTimeout(gTimer);
+        if (e.key === 'd') { window.location.href = '/'; e.preventDefault(); return; }
+        if (e.key === 's') { window.location.href = '/stacks'; e.preventDefault(); return; }
+        return;
+      }
+      if (e.key === 'g') {
+        pendingG = true;
+        gTimer = setTimeout(function() { pendingG = false; }, 1000);
+        return;
+      }
+
+      if (list && list.items && list.items.length > 0) {
+        if (e.key === 'j' || e.key === 'ArrowDown') {
+          list.focus = Math.min((list.focus ?? -1) + 1, list.items.length - 1);
+          list.render && list.render();
+          e.preventDefault();
+          return;
+        }
+        if (e.key === 'k' || e.key === 'ArrowUp') {
+          list.focus = Math.max((list.focus ?? 0) - 1, 0);
+          list.render && list.render();
+          e.preventDefault();
+          return;
+        }
+        if (list.focus != null && list.focus >= 0 && list.focus < list.items.length) {
+          const item = list.items[list.focus];
+          if (e.key === 'Enter' && list.onOpen) { list.onOpen(item); e.preventDefault(); return; }
+          if ((e.key === 'e' || e.key === ' ') && list.onToggle) { list.onToggle(item); e.preventDefault(); return; }
+          if (e.key === 'c' && list.onCategory) { list.onCategory(item); e.preventDefault(); return; }
+        }
+      }
+    }
+
+    document.addEventListener('keydown', handler);
+    return function teardown() { document.removeEventListener('keydown', handler); };
+  };
+</script>

--- a/control-plane/src/components/StacksShared.astro
+++ b/control-plane/src/components/StacksShared.astro
@@ -43,6 +43,42 @@ import { CATEGORIES, CATEGORY_ORDER } from '../lib/categories.ts';
     return 'https://' + service.subdomain + cachedSeparator + cachedDomain;
   };
 
+  // ---- Services fetch cache -----------------------------------------------
+  // PendingBar (mounted globally in Layout) and the stacks pages both need
+  // /api/services. Share a single in-flight request and a short-lived cache
+  // so a page load doesn't double-fetch. Invalidated by toggleService().
+
+  const SERVICES_TTL_MS = 1000;
+  let servicesInflight = null;
+  let servicesCache = null;
+  let servicesCacheTime = 0;
+
+  window.NS.getServices = function() {
+    const now = Date.now();
+    if (servicesCache && (now - servicesCacheTime) < SERVICES_TTL_MS) {
+      return Promise.resolve(servicesCache);
+    }
+    if (servicesInflight) return servicesInflight;
+    servicesInflight = fetch('/api/services', { credentials: 'same-origin' })
+      .then(function(r) { return r.ok ? r.json() : null; })
+      .then(function(data) {
+        servicesCache = data;
+        servicesCacheTime = Date.now();
+        servicesInflight = null;
+        return data;
+      })
+      .catch(function() {
+        servicesInflight = null;
+        return null;
+      });
+    return servicesInflight;
+  };
+
+  window.NS.invalidateServices = function() {
+    servicesCache = null;
+    servicesCacheTime = 0;
+  };
+
   // ---- Tri-state status ---------------------------------------------------
   // enabled + deployed -> running
   // enabled + !deployed -> pending-enable
@@ -75,6 +111,7 @@ import { CATEGORIES, CATEGORY_ORDER } from '../lib/categories.ts';
   // ---- Service toggle -----------------------------------------------------
 
   window.NS.toggleService = async function(name, enabled) {
+    const action = enabled ? 'enable' : 'disable';
     try {
       const response = await fetch('/api/services', {
         method: 'POST',
@@ -85,17 +122,20 @@ import { CATEGORIES, CATEGORY_ORDER } from '../lib/categories.ts';
       let data = null;
       try { data = await response.json(); } catch {}
       if (!response.ok || !data || !data.success) {
-        const msg = (data && data.error) || ('HTTP ' + response.status);
+        const detail = (data && data.error) || ('HTTP ' + response.status);
+        const msg = 'Failed to ' + action + ' ' + name + ': ' + detail;
         if (typeof showToast === 'function') showToast(msg, 'error');
         return { success: false, error: msg };
       }
       if (typeof showToast === 'function') {
         showToast(name + ' ' + (enabled ? 'enabled' : 'disabled') + '. Go to Dashboard to Spin Up.');
       }
+      window.NS.invalidateServices();
       window.dispatchEvent(new Event('stacks:updated'));
       return { success: true };
     } catch (err) {
-      const msg = err && err.message ? err.message : 'Network error';
+      const detail = err && err.message ? err.message : 'network error';
+      const msg = 'Failed to ' + action + ' ' + name + ': ' + detail;
       if (typeof showToast === 'function') showToast(msg, 'error');
       return { success: false, error: msg };
     }

--- a/control-plane/src/components/Toast.astro
+++ b/control-plane/src/components/Toast.astro
@@ -16,4 +16,16 @@
     div.textContent = text;
     return div.innerHTML;
   }
+
+  // Escapes a value for safe insertion into an HTML attribute.
+  // escapeHtml() alone is insufficient — text-node escaping doesn't cover
+  // ", ', which can still break attribute quoting.
+  function escapeAttr(text) {
+    return String(text)
+      .replace(/&/g, '&amp;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;');
+  }
 </script>

--- a/control-plane/src/layouts/Layout.astro
+++ b/control-plane/src/layouts/Layout.astro
@@ -1,6 +1,7 @@
 ---
 import Header from '../components/Header.astro';
 import Toast from '../components/Toast.astro';
+import StacksShared from '../components/StacksShared.astro';
 import '../styles/global.css';
 
 interface Props {
@@ -30,5 +31,6 @@ const { title, activeNav = '', narrow = false } = Astro.props;
     </footer>
   </div>
   <Toast />
+  <StacksShared />
 </body>
 </html>

--- a/control-plane/src/layouts/Layout.astro
+++ b/control-plane/src/layouts/Layout.astro
@@ -2,6 +2,8 @@
 import Header from '../components/Header.astro';
 import Toast from '../components/Toast.astro';
 import StacksShared from '../components/StacksShared.astro';
+import PendingBar from '../components/PendingBar.astro';
+import ShortcutsHelp from '../components/ShortcutsHelp.astro';
 import '../styles/global.css';
 
 interface Props {
@@ -22,15 +24,18 @@ const { title, activeNav = '', narrow = false } = Astro.props;
   <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;700&family=Orbitron:wght@700&display=swap" rel="stylesheet">
 </head>
 <body>
+  <!-- Shared helpers load first so page scripts can call window.NS.* / showToast during init -->
+  <Toast />
+  <StacksShared />
   <div class={narrow ? 'container-narrow' : 'container'}>
     <Header activeNav={activeNav} />
+    <PendingBar />
     <slot />
     <footer>
       <p>Built with lots of coffee by <a href="https://github.com/stefanko-ch" target="_blank" rel="noopener noreferrer">Stefan</a></p>
       <p>Powered by <a href="https://github.com/stefanko-ch/Nexus-Stack" target="_blank" rel="noopener noreferrer">Nexus-Stack</a></p>
     </footer>
   </div>
-  <Toast />
-  <StacksShared />
+  <ShortcutsHelp />
 </body>
 </html>

--- a/control-plane/src/pages/category.astro
+++ b/control-plane/src/pages/category.astro
@@ -127,21 +127,21 @@ import Layout from '../layouts/Layout.astro';
       let openHtml = '';
       const url = window.NS.stackUrl(service);
       if (url && service.deployed) {
-        openHtml = '<a href="' + url + '" target="_blank" rel="noopener" class="card-open-link">Open &#8599;</a>';
+        openHtml = '<a href="' + escapeAttr(url) + '" target="_blank" rel="noopener" class="card-open-link">Open &#8599;</a>';
       }
 
       let websiteHtml = '';
       if (service.website) {
         try {
           const wDomain = new URL(service.website).hostname.replace('www.', '');
-          websiteHtml = '<a href="' + escapeHtml(service.website) + '" target="_blank" rel="noopener" class="card-project-link">' + escapeHtml(wDomain) + '</a>';
+          websiteHtml = '<a href="' + escapeAttr(service.website) + '" target="_blank" rel="noopener" class="card-project-link">' + escapeHtml(wDomain) + '</a>';
         } catch {}
       }
 
       card.innerHTML =
         '<div class="card-header">' +
           '<div class="card-name-section"><div class="card-name">' + statusDotHtml + ' ' + escapeHtml(service.name) + ' ' + badges + '</div></div>' +
-          '<div class="' + toggleClass + '" id="toggle-' + service.name + '" title="' + escapeHtml(toggleTitle) + '" data-service="' + escapeHtml(service.name) + '" data-target="' + (!service.enabled) + '"></div>' +
+          '<div class="' + toggleClass + '" id="toggle-' + escapeAttr(service.name) + '" title="' + escapeAttr(toggleTitle) + '" data-service="' + escapeAttr(service.name) + '" data-target="' + (!service.enabled) + '"></div>' +
         '</div>' +
         '<div class="card-description">' + escapeHtml(desc) + '</div>' +
         '<div class="card-footer"><div class="card-meta">' + websiteHtml + '</div>' + openHtml + '</div>';

--- a/control-plane/src/pages/category.astro
+++ b/control-plane/src/pages/category.astro
@@ -69,12 +69,19 @@ import Layout from '../layouts/Layout.astro';
   async function loadServices() {
     try {
       const response = await fetch('/api/services?category=' + encodeURIComponent(categorySlug), { credentials: 'same-origin' });
-      if (!response.ok) return;
+      if (!response.ok) {
+        document.getElementById('services-grid').innerHTML = '<div class="empty-state">Failed to load services (HTTP ' + response.status + '). Refresh the page to retry.</div>';
+        return;
+      }
       const data = await response.json();
-      if (data.success) renderServices(data.services || []);
+      if (data.success) {
+        renderServices(data.services || []);
+      } else {
+        document.getElementById('services-grid').innerHTML = '<div class="empty-state">Failed to load services. Refresh the page to retry.</div>';
+      }
     } catch (error) {
       console.error('Failed to load services:', error);
-      document.getElementById('services-grid').innerHTML = '<div class="empty-state">Failed to load services.</div>';
+      document.getElementById('services-grid').innerHTML = '<div class="empty-state">Failed to load services. Refresh the page to retry.</div>';
     }
   }
 

--- a/control-plane/src/pages/category.astro
+++ b/control-plane/src/pages/category.astro
@@ -9,10 +9,6 @@ import Layout from '../layouts/Layout.astro';
     <div id="category-stats" class="category-stats"></div>
   </div>
 
-  <div id="pending-banner" class="pending-banner">
-    Pending changes in this category. <a href="/">Go to Dashboard</a> to deploy.
-  </div>
-
   <div id="services-grid" class="services-grid">
     <div class="loading">Loading services...</div>
   </div>
@@ -37,29 +33,8 @@ import Layout from '../layouts/Layout.astro';
   }
 
   .category-stats :global(span) { color: var(--text-muted); }
-  .category-stats :global(.count-enabled) { color: var(--accent); }
+  .category-stats :global(.count-running) { color: var(--accent); }
   .category-stats :global(.count-pending) { color: var(--warning); }
-
-  .pending-banner {
-    background: rgba(255, 170, 0, 0.1);
-    border: 1px solid rgba(255, 170, 0, 0.3);
-    padding: 0.8rem 1.2rem;
-    margin-bottom: 1.5rem;
-    display: none;
-    align-items: center;
-    gap: 0.8rem;
-    font-size: 0.85rem;
-    color: var(--warning);
-  }
-
-  .pending-banner.visible { display: flex; }
-
-  .pending-banner a {
-    color: var(--accent);
-    text-decoration: none;
-  }
-
-  .pending-banner a:hover { text-decoration: underline; }
 
   .card-name-section { flex: 1; }
 
@@ -75,44 +50,11 @@ import Layout from '../layouts/Layout.astro';
 </style>
 
 <script is:inline>
-  const CATEGORIES = {
-    'core': { name: 'Core Infrastructure', description: 'Essential services that keep your Nexus Stack running. These cannot be disabled.' },
-    'databases': { name: 'Databases', description: 'Relational and analytical database engines for storing and querying structured data.' },
-    'storage': { name: 'Object Storage', description: 'S3-compatible object storage systems for data lakes, backups, and file management.' },
-    'db-management': { name: 'Database Management', description: 'Web-based tools for administering, browsing, and managing your databases and object storage.' },
-    'orchestration': { name: 'Data Orchestration', description: 'Platforms for building, scheduling, and monitoring data pipelines and ETL/ELT workflows.' },
-    'streaming': { name: 'Stream Processing', description: 'Engines and frameworks for real-time data processing, CDC, and streaming pipelines.' },
-    'messaging': { name: 'Message Brokers', description: 'Event streaming platforms and management UIs for Kafka/Redpanda message brokers.' },
-    'analytics': { name: 'Analytics & BI', description: 'Business intelligence, search engines, metadata management, and distributed query engines.' },
-    'data-quality': { name: 'Data Quality', description: 'Tools for testing, validating, and monitoring the quality of your data.' },
-    'ai-ml': { name: 'AI & Machine Learning', description: 'LLM inference, AI workflow builders, and machine learning platforms.' },
-    'dev-tools': { name: 'Development Tools', description: 'IDEs, notebooks, API testing platforms, and developer utilities.' },
-    'ci-cd': { name: 'CI/CD & Automation', description: 'Continuous integration, deployment pipelines, and workflow automation tools.' },
-    'low-code': { name: 'Low-Code Platforms', description: 'Build internal tools, CRUD apps, and spreadsheet interfaces without extensive coding.' },
-    'observability': { name: 'Observability', description: 'Monitoring agents, log pipelines, and uptime tracking for your infrastructure.' },
-    'knowledge': { name: 'Knowledge & Docs', description: 'Wiki platforms, knowledge bases, and email testing tools.' },
-    'visual-tools': { name: 'Visual Tools', description: 'Diagramming, whiteboard, and visual collaboration tools.' },
-    'files': { name: 'File Management', description: 'Web-based file managers for browsing and managing files across storage backends.' },
-    'server-access': { name: 'Server Access', description: 'Tools for accessing your server via browser-based terminals and Git proxies.' },
-  };
-
-  const API_URL = window.location.origin;
   const params = new URLSearchParams(window.location.search);
   const categorySlug = params.get('cat');
-  let stackDomain = window.location.hostname.replace(/^control[.-]/, '');
-  let subdomainSeparator = '.';
-
-  async function fetchDomain() {
-    try {
-      const res = await fetch(API_URL + '/api/info', { credentials: 'same-origin' });
-      const data = await res.json();
-      if (data.success && data.info?.server?.domain) stackDomain = data.info.server.domain;
-      if (data.success && data.info?.server?.subdomainSeparator) subdomainSeparator = data.info.server.subdomainSeparator;
-    } catch {}
-  }
 
   function initPage() {
-    const cat = CATEGORIES[categorySlug];
+    const cat = window.NS.CATEGORIES[categorySlug];
     if (!cat) {
       document.getElementById('page-title').textContent = 'Unknown Category';
       document.getElementById('services-grid').innerHTML = '<div class="empty-state">Category not found. <a href="/stacks" style="color: var(--accent);">Back to Stacks</a></div>';
@@ -121,12 +63,12 @@ import Layout from '../layouts/Layout.astro';
     document.title = cat.name + ' - Nexus Control Plane';
     document.getElementById('page-title').textContent = cat.name;
     document.getElementById('category-description').textContent = cat.description;
-    fetchDomain().then(function() { loadServices(); });
+    window.NS.fetchDomain().then(function() { loadServices(); });
   }
 
   async function loadServices() {
     try {
-      const response = await fetch(API_URL + '/api/services?category=' + encodeURIComponent(categorySlug), { credentials: 'same-origin' });
+      const response = await fetch('/api/services?category=' + encodeURIComponent(categorySlug), { credentials: 'same-origin' });
       if (!response.ok) return;
       const data = await response.json();
       if (data.success) renderServices(data.services || []);
@@ -146,19 +88,19 @@ import Layout from '../layouts/Layout.astro';
     }
 
     const total = services.length;
-    const enabled = services.filter(function(s) { return s.enabled; }).length;
+    const running = services.filter(function(s) { return s.enabled && s.deployed; }).length;
     const pending = services.filter(function(s) { return s.pending; }).length;
 
     document.getElementById('category-stats').innerHTML =
-      '<span class="count-enabled">' + enabled + ' / ' + total + ' enabled</span>' +
+      '<span class="count-running">' + running + ' / ' + total + ' running</span>' +
       (pending > 0 ? '<span class="count-pending">' + pending + ' pending</span>' : '');
-
-    if (pending > 0) document.getElementById('pending-banner').classList.add('visible');
 
     services.forEach(function(service) {
       const card = document.createElement('div');
       card.className = 'service-card' + (service.pending ? ' pending' : '');
       card.id = 'service-' + service.name;
+
+      const statusDotHtml = window.NS.renderStatusDot(service);
 
       let badges = '';
       if (service.core) badges += '<span class="badge badge-core">core</span>';
@@ -176,8 +118,9 @@ import Layout from '../layouts/Layout.astro';
       const desc = service.long_description || service.description || '';
 
       let openHtml = '';
-      if (service.subdomain && service.deployed) {
-        openHtml = '<a href="https://' + service.subdomain + subdomainSeparator + stackDomain + '" target="_blank" rel="noopener" class="card-open-link">Open &#8599;</a>';
+      const url = window.NS.stackUrl(service);
+      if (url && service.deployed) {
+        openHtml = '<a href="' + url + '" target="_blank" rel="noopener" class="card-open-link">Open &#8599;</a>';
       }
 
       let websiteHtml = '';
@@ -190,11 +133,14 @@ import Layout from '../layouts/Layout.astro';
 
       card.innerHTML =
         '<div class="card-header">' +
-          '<div class="card-name-section"><div class="card-name">' + escapeHtml(service.name) + ' ' + badges + '</div></div>' +
-          '<div class="' + toggleClass + '" id="toggle-' + service.name + '" title="' + escapeHtml(toggleTitle) + '" onclick="handleToggle(\'' + service.name + '\', ' + !service.enabled + ', this)"></div>' +
+          '<div class="card-name-section"><div class="card-name">' + statusDotHtml + ' ' + escapeHtml(service.name) + ' ' + badges + '</div></div>' +
+          '<div class="' + toggleClass + '" id="toggle-' + service.name + '" title="' + escapeHtml(toggleTitle) + '" data-service="' + escapeHtml(service.name) + '" data-target="' + (!service.enabled) + '"></div>' +
         '</div>' +
         '<div class="card-description">' + escapeHtml(desc) + '</div>' +
         '<div class="card-footer"><div class="card-meta">' + websiteHtml + '</div>' + openHtml + '</div>';
+
+      const toggleEl = card.querySelector('.toggle-switch');
+      toggleEl.addEventListener('click', function() { handleToggle(this); });
 
       grid.appendChild(card);
     });
@@ -209,29 +155,20 @@ import Layout from '../layouts/Layout.astro';
     }
   }
 
-  async function handleToggle(serviceName, enabled, toggleEl) {
+  async function handleToggle(toggleEl) {
     if (toggleEl.classList.contains('disabled')) return;
+    const name = toggleEl.dataset.service;
+    const target = toggleEl.dataset.target === 'true';
     toggleEl.classList.add('disabled');
-    try {
-      const response = await fetch(API_URL + '/api/services', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'same-origin',
-        body: JSON.stringify({ service: serviceName, enabled: enabled }),
-      });
-      const data = await response.json();
-      if (data.success) {
-        showToast(serviceName + ' ' + (enabled ? 'enabled' : 'disabled') + '. Deploy from Dashboard.');
-        loadServices();
-      } else {
-        showToast(data.error || 'Failed to update service', 'error');
-        toggleEl.classList.remove('disabled');
-      }
-    } catch {
-      showToast('Failed to update service', 'error');
+    const result = await window.NS.toggleService(name, target);
+    if (result.success) {
+      loadServices();
+    } else {
       toggleEl.classList.remove('disabled');
     }
   }
+
+  window.NS.registerKeyboard({ searchInputId: null });
 
   initPage();
 </script>

--- a/control-plane/src/pages/category.astro
+++ b/control-plane/src/pages/category.astro
@@ -146,7 +146,8 @@ import Layout from '../layouts/Layout.astro';
     });
 
     if (window.location.hash) {
-      const el = document.getElementById('service-' + window.location.hash.slice(1));
+      const anchor = decodeURIComponent(window.location.hash.slice(1));
+      const el = document.getElementById('service-' + anchor);
       if (el) {
         el.scrollIntoView({ behavior: 'smooth', block: 'center' });
         el.style.boxShadow = '0 0 20px rgba(0, 255, 136, 0.4)';

--- a/control-plane/src/pages/search.astro
+++ b/control-plane/src/pages/search.astro
@@ -125,21 +125,21 @@ import Layout from '../layouts/Layout.astro';
       let openHtml = '';
       const url = window.NS.stackUrl(service);
       if (url && service.deployed) {
-        openHtml = '<a href="' + url + '" target="_blank" rel="noopener" class="card-open-link">Open &#8599;</a>';
+        openHtml = '<a href="' + escapeAttr(url) + '" target="_blank" rel="noopener" class="card-open-link">Open &#8599;</a>';
       }
 
       let websiteHtml = '';
       if (service.website) {
         try {
           const wDomain = new URL(service.website).hostname.replace('www.', '');
-          websiteHtml = '<a href="' + escapeHtml(service.website) + '" target="_blank" rel="noopener" class="card-project-link">' + escapeHtml(wDomain) + '</a>';
+          websiteHtml = '<a href="' + escapeAttr(service.website) + '" target="_blank" rel="noopener" class="card-project-link">' + escapeHtml(wDomain) + '</a>';
         } catch {}
       }
 
       card.innerHTML =
         '<div class="card-header">' +
           '<div><div class="card-name">' + statusDotHtml + ' ' + escapeHtml(service.name) + ' ' + badges + '</div></div>' +
-          '<div class="' + toggleClass + '" data-service="' + escapeHtml(service.name) + '" data-target="' + (!service.enabled) + '" title="' + escapeHtml(toggleTitle) + '"></div>' +
+          '<div class="' + toggleClass + '" data-service="' + escapeAttr(service.name) + '" data-target="' + (!service.enabled) + '" title="' + escapeAttr(toggleTitle) + '"></div>' +
         '</div>' +
         '<div class="card-description">' + escapeHtml(desc) + '</div>' +
         '<div class="card-footer"><div class="card-meta">' + websiteHtml + '</div>' + openHtml + '</div>';

--- a/control-plane/src/pages/search.astro
+++ b/control-plane/src/pages/search.astro
@@ -49,10 +49,8 @@ import Layout from '../layouts/Layout.astro';
   async function loadAllServices() {
     try {
       await window.NS.fetchDomain();
-      const response = await fetch('/api/services', { credentials: 'same-origin' });
-      if (!response.ok) return;
-      const data = await response.json();
-      if (data.success) {
+      const data = await window.NS.getServices();
+      if (data && data.success) {
         allServices = data.services || [];
         const params = new URLSearchParams(window.location.search);
         const q = params.get('q') || '';

--- a/control-plane/src/pages/search.astro
+++ b/control-plane/src/pages/search.astro
@@ -46,18 +46,25 @@ import Layout from '../layouts/Layout.astro';
 <script is:inline>
   let allServices = [];
 
+  let firstLoad = true;
+
   async function loadAllServices() {
     try {
       await window.NS.fetchDomain();
       const data = await window.NS.getServices();
       if (data && data.success) {
         allServices = data.services || [];
-        const params = new URLSearchParams(window.location.search);
-        const q = params.get('q') || '';
-        if (q) {
-          document.getElementById('search-input').value = q;
+        const input = document.getElementById('search-input');
+        // First load: seed from URL (deep-link support). Subsequent loads
+        // (e.g. after a toggle re-fetch): trust the live input value, since
+        // the URL is debounced 200ms and may be stale mid-typing.
+        if (firstLoad) {
+          const params = new URLSearchParams(window.location.search);
+          const q = params.get('q') || '';
+          if (q) input.value = q;
+          firstLoad = false;
         }
-        filterAndRender(q);
+        filterAndRender(input.value);
       }
     } catch (error) {
       console.error('Failed to load services:', error);

--- a/control-plane/src/pages/search.astro
+++ b/control-plane/src/pages/search.astro
@@ -44,45 +44,12 @@ import Layout from '../layouts/Layout.astro';
 </style>
 
 <script is:inline>
-  const CATEGORIES = {
-    'core': { name: 'Core Infrastructure' },
-    'databases': { name: 'Databases' },
-    'storage': { name: 'Object Storage' },
-    'db-management': { name: 'Database Management' },
-    'orchestration': { name: 'Data Orchestration' },
-    'streaming': { name: 'Stream Processing' },
-    'messaging': { name: 'Message Brokers' },
-    'analytics': { name: 'Analytics & BI' },
-    'data-quality': { name: 'Data Quality' },
-    'ai-ml': { name: 'AI & Machine Learning' },
-    'dev-tools': { name: 'Development Tools' },
-    'ci-cd': { name: 'CI/CD & Automation' },
-    'low-code': { name: 'Low-Code Platforms' },
-    'observability': { name: 'Observability' },
-    'knowledge': { name: 'Knowledge & Docs' },
-    'visual-tools': { name: 'Visual Tools' },
-    'files': { name: 'File Management' },
-    'server-access': { name: 'Server Access' },
-  };
-
-  const API_URL = window.location.origin;
   let allServices = [];
-  let stackDomain = window.location.hostname.replace(/^control[.-]/, '');
-  let subdomainSeparator = '.';
-
-  async function fetchDomain() {
-    try {
-      const res = await fetch(API_URL + '/api/info', { credentials: 'same-origin' });
-      const data = await res.json();
-      if (data.success && data.info?.server?.domain) stackDomain = data.info.server.domain;
-      if (data.success && data.info?.server?.subdomainSeparator) subdomainSeparator = data.info.server.subdomainSeparator;
-    } catch {}
-  }
 
   async function loadAllServices() {
     try {
-      await fetchDomain();
-      const response = await fetch(API_URL + '/api/services', { credentials: 'same-origin' });
+      await window.NS.fetchDomain();
+      const response = await fetch('/api/services', { credentials: 'same-origin' });
       if (!response.ok) return;
       const data = await response.json();
       if (data.success) {
@@ -91,8 +58,8 @@ import Layout from '../layouts/Layout.astro';
         const q = params.get('q') || '';
         if (q) {
           document.getElementById('search-input').value = q;
-          filterAndRender(q);
         }
+        filterAndRender(q);
       }
     } catch (error) {
       console.error('Failed to load services:', error);
@@ -112,10 +79,11 @@ import Layout from '../layouts/Layout.astro';
 
     const q = query.toLowerCase();
     const matches = allServices.filter(function(s) {
+      const catName = window.NS.CATEGORIES[s.category] ? window.NS.CATEGORIES[s.category].name.toLowerCase() : '';
       return s.name.toLowerCase().includes(q) ||
         s.description.toLowerCase().includes(q) ||
         (s.long_description && s.long_description.toLowerCase().includes(q)) ||
-        (s.category && CATEGORIES[s.category] && CATEGORIES[s.category].name.toLowerCase().includes(q));
+        catName.includes(q);
     });
 
     if (matches.length === 0) {
@@ -135,6 +103,8 @@ import Layout from '../layouts/Layout.astro';
       const card = document.createElement('div');
       card.className = 'service-card' + (service.pending ? ' pending' : '');
 
+      const statusDotHtml = window.NS.renderStatusDot(service);
+
       let badges = '';
       if (service.core) badges += '<span class="badge badge-core">core</span>';
       if (service.admin_only) badges += '<span class="badge badge-admin">admin</span>';
@@ -144,7 +114,8 @@ import Layout from '../layouts/Layout.astro';
         badges += '<span class="badge badge-pending">' + (service.enabled ? 'will enable' : 'will disable') + '</span>';
       }
 
-      const catName = CATEGORIES[service.category] ? CATEGORIES[service.category].name : service.category;
+      const catMeta = window.NS.CATEGORIES[service.category];
+      const catName = catMeta ? catMeta.name : service.category;
       badges += '<span class="badge badge-category">' + escapeHtml(catName) + '</span>';
 
       const isDisabled = service.core || service.admin_only;
@@ -154,8 +125,9 @@ import Layout from '../layouts/Layout.astro';
       const desc = service.long_description || service.description || '';
 
       let openHtml = '';
-      if (service.subdomain && service.deployed) {
-        openHtml = '<a href="https://' + service.subdomain + subdomainSeparator + stackDomain + '" target="_blank" rel="noopener" class="card-open-link">Open &#8599;</a>';
+      const url = window.NS.stackUrl(service);
+      if (url && service.deployed) {
+        openHtml = '<a href="' + url + '" target="_blank" rel="noopener" class="card-open-link">Open &#8599;</a>';
       }
 
       let websiteHtml = '';
@@ -168,38 +140,27 @@ import Layout from '../layouts/Layout.astro';
 
       card.innerHTML =
         '<div class="card-header">' +
-          '<div><div class="card-name">' + escapeHtml(service.name) + ' ' + badges + '</div></div>' +
-          '<div class="' + toggleClass + '" title="' + escapeHtml(toggleTitle) + '" onclick="handleToggle(\'' + service.name + '\', ' + !service.enabled + ', this)"></div>' +
+          '<div><div class="card-name">' + statusDotHtml + ' ' + escapeHtml(service.name) + ' ' + badges + '</div></div>' +
+          '<div class="' + toggleClass + '" data-service="' + escapeHtml(service.name) + '" data-target="' + (!service.enabled) + '" title="' + escapeHtml(toggleTitle) + '"></div>' +
         '</div>' +
         '<div class="card-description">' + escapeHtml(desc) + '</div>' +
         '<div class="card-footer"><div class="card-meta">' + websiteHtml + '</div>' + openHtml + '</div>';
+
+      card.querySelector('.toggle-switch').addEventListener('click', function() { handleToggle(this); });
 
       grid.appendChild(card);
     });
   }
 
-  async function handleToggle(serviceName, enabled, toggleEl) {
+  async function handleToggle(toggleEl) {
     if (toggleEl.classList.contains('disabled')) return;
+    const name = toggleEl.dataset.service;
+    const target = toggleEl.dataset.target === 'true';
     toggleEl.classList.add('disabled');
-    try {
-      const response = await fetch(API_URL + '/api/services', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'same-origin',
-        body: JSON.stringify({ service: serviceName, enabled: enabled }),
-      });
-      const data = await response.json();
-      if (data.success) {
-        showToast(serviceName + ' ' + (enabled ? 'enabled' : 'disabled') + '. Deploy from Dashboard.');
-        await loadAllServices();
-        const query = document.getElementById('search-input').value;
-        filterAndRender(query);
-      } else {
-        showToast(data.error || 'Failed to update service', 'error');
-        toggleEl.classList.remove('disabled');
-      }
-    } catch {
-      showToast('Failed to update service', 'error');
+    const result = await window.NS.toggleService(name, target);
+    if (result.success) {
+      await loadAllServices();
+    } else {
       toggleEl.classList.remove('disabled');
     }
   }
@@ -215,6 +176,8 @@ import Layout from '../layouts/Layout.astro';
       history.replaceState(null, '', url);
     }, 200);
   });
+
+  window.NS.registerKeyboard({ searchInputId: 'search-input' });
 
   loadAllServices();
 </script>

--- a/control-plane/src/pages/stacks.astro
+++ b/control-plane/src/pages/stacks.astro
@@ -1,24 +1,49 @@
 ---
 import Layout from '../layouts/Layout.astro';
+import StackTable from '../components/StackTable.astro';
 ---
 
 <Layout title="Stack Management" activeNav="stacks">
   <div class="services-panel">
-    <h2>Stack Management</h2>
-    <div class="search-panel">
-      <input type="text" id="global-search" class="search-input" placeholder="Search stacks..." autocomplete="off">
-      <div id="search-results" class="search-dropdown"></div>
+    <div class="panel-header">
+      <h2>Stack Management</h2>
+      <div class="panel-controls">
+        <div class="view-toggle" role="group" aria-label="View">
+          <button id="view-grid" aria-pressed="true">Grid</button>
+          <button id="view-list" aria-pressed="false">List</button>
+        </div>
+      </div>
     </div>
-    <div class="categories-grid" id="categories-grid">
-      <p class="loading-text">Loading categories...</p>
+
+    <div class="search-panel">
+      <input type="text" id="stacks-search" class="search-input" placeholder='Search stacks... (press "/" to focus, Enter for full search)' autocomplete="off">
+    </div>
+
+    <div id="grid-view" class="view">
+      <div class="categories-grid" id="categories-grid">
+        <p class="loading-text">Loading categories...</p>
+      </div>
+    </div>
+
+    <div id="list-view" class="view" hidden>
+      <StackTable />
     </div>
   </div>
 </Layout>
 
 <style>
-  .services-panel {
-    margin-bottom: 2rem;
+  .services-panel { margin-bottom: 2rem; }
+
+  .panel-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-bottom: 1rem;
   }
+
+  .panel-header h2 { margin: 0; }
 
   .search-panel {
     position: relative;
@@ -44,93 +69,6 @@ import Layout from '../layouts/Layout.astro';
   }
 
   .search-input::placeholder { color: #607080; }
-
-  .search-dropdown {
-    display: none;
-    position: absolute;
-    top: 100%;
-    left: 0;
-    right: 0;
-    background: var(--bg-card);
-    border: 1px solid rgba(0, 255, 136, 0.2);
-    border-top: none;
-    border-radius: 0 0 4px 4px;
-    z-index: 50;
-    max-height: 420px;
-    overflow-y: auto;
-    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
-  }
-
-  .search-dropdown.visible { display: block; }
-
-  :global(.search-result-item) {
-    display: flex;
-    align-items: center;
-    gap: 1rem;
-    padding: 0.75rem 1rem;
-    border-bottom: 1px solid rgba(42, 42, 62, 0.5);
-    text-decoration: none;
-    color: inherit;
-    transition: background 0.2s;
-  }
-
-  :global(.search-result-item:last-of-type) {
-    border-bottom: none;
-  }
-
-  :global(.search-result-item:hover) {
-    background: rgba(0, 255, 136, 0.06);
-  }
-
-  :global(.search-result-name) {
-    color: var(--accent);
-    font-weight: 700;
-    font-size: 0.85rem;
-  }
-
-  :global(.search-result-desc) {
-    color: var(--text-secondary);
-    font-size: 0.75rem;
-    margin-top: 0.15rem;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  :global(.search-result-badge) {
-    font-size: 0.65rem;
-    color: var(--accent);
-    border: 1px solid rgba(0, 255, 136, 0.25);
-    background: rgba(0, 255, 136, 0.08);
-    padding: 0.2rem 0.5rem;
-    border-radius: 3px;
-    margin-left: auto;
-    flex-shrink: 0;
-    white-space: nowrap;
-  }
-
-  :global(.search-all-link) {
-    display: block;
-    padding: 0.7rem 1rem;
-    color: var(--accent);
-    font-size: 0.8rem;
-    text-decoration: none;
-    text-align: center;
-    border-top: 1px solid rgba(0, 255, 136, 0.15);
-    background: rgba(0, 255, 136, 0.03);
-    transition: background 0.2s;
-  }
-
-  :global(.search-all-link:hover) {
-    background: rgba(0, 255, 136, 0.08);
-  }
-
-  :global(.search-no-results) {
-    padding: 1.2rem 1rem;
-    color: var(--text-muted);
-    font-size: 0.8rem;
-    text-align: center;
-  }
 
   .categories-grid {
     display: grid;
@@ -173,162 +111,175 @@ import Layout from '../layouts/Layout.astro';
     margin-top: 0.5rem;
     font-size: 0.75rem;
     display: flex;
-    gap: 1rem;
+    gap: 0.9rem;
+    flex-wrap: wrap;
   }
 
-  :global(.category-card-stats .enabled) { color: var(--accent); }
-  :global(.category-card-stats .pending) { color: var(--warning); }
+  :global(.category-card-stats .running)  { color: var(--accent); }
+  :global(.category-card-stats .pending)  { color: var(--warning); }
+  :global(.category-card-stats .disabled) { color: var(--text-muted); }
+  :global(.category-card-stats.empty)     { color: var(--text-muted); }
 </style>
 
 <script is:inline>
-  const CATEGORIES = {
-    'core': { name: 'Core Infrastructure' },
-    'databases': { name: 'Databases' },
-    'storage': { name: 'Object Storage' },
-    'db-management': { name: 'Database Management' },
-    'orchestration': { name: 'Data Orchestration' },
-    'streaming': { name: 'Stream Processing' },
-    'messaging': { name: 'Message Brokers' },
-    'analytics': { name: 'Analytics & BI' },
-    'data-quality': { name: 'Data Quality' },
-    'ai-ml': { name: 'AI & Machine Learning' },
-    'dev-tools': { name: 'Development Tools' },
-    'ci-cd': { name: 'CI/CD & Automation' },
-    'low-code': { name: 'Low-Code Platforms' },
-    'observability': { name: 'Observability' },
-    'knowledge': { name: 'Knowledge & Docs' },
-    'visual-tools': { name: 'Visual Tools' },
-    'files': { name: 'File Management' },
-    'server-access': { name: 'Server Access' },
-  };
-
-  const CATEGORY_ORDER = [
-    'core', 'databases', 'storage', 'db-management', 'orchestration', 'streaming',
-    'messaging', 'analytics', 'data-quality', 'ai-ml', 'dev-tools',
-    'ci-cd', 'low-code', 'observability', 'knowledge', 'visual-tools',
-    'files', 'server-access'
-  ];
+  const VIEW_KEY = 'stacksView';
 
   let allServices = [];
+  let currentView = (localStorage.getItem(VIEW_KEY) === 'list') ? 'list' : 'grid';
+  let currentQuery = '';
+  let currentFilter = null; // 'pending' from ?filter=pending query param
+
+  function setView(view) {
+    currentView = view;
+    localStorage.setItem(VIEW_KEY, view);
+    document.getElementById('view-grid').setAttribute('aria-pressed', view === 'grid');
+    document.getElementById('view-list').setAttribute('aria-pressed', view === 'list');
+    document.getElementById('grid-view').hidden = view !== 'grid';
+    document.getElementById('list-view').hidden = view !== 'list';
+    applyFilterAndRender();
+  }
 
   async function loadServices() {
     try {
+      await window.NS.fetchDomain();
       const response = await fetch('/api/services', { credentials: 'same-origin' });
       if (!response.ok) return;
       const data = await response.json();
       if (data.success) {
         allServices = data.services || [];
-        renderCategoryGrid(data.categoryCounts || {});
+        applyFilterAndRender();
       }
     } catch (error) {
       console.error('Failed to load services:', error);
     }
   }
 
-  function renderCategoryGrid(categoryCounts) {
+  function filteredServices() {
+    let services = allServices.slice();
+    if (currentFilter === 'pending') {
+      services = services.filter(function(s) { return s.pending; });
+    }
+    if (currentQuery) {
+      const q = currentQuery.toLowerCase();
+      services = services.filter(function(s) {
+        const cat = window.NS.CATEGORIES[s.category];
+        const catName = cat ? cat.name.toLowerCase() : '';
+        return s.name.toLowerCase().includes(q) ||
+          s.description.toLowerCase().includes(q) ||
+          (s.long_description && s.long_description.toLowerCase().includes(q)) ||
+          catName.includes(q);
+      });
+    }
+    return services;
+  }
+
+  function applyFilterAndRender() {
+    const services = filteredServices();
+    if (currentView === 'list') {
+      window.NS.renderTable(services);
+    } else {
+      renderGrid(services);
+    }
+  }
+
+  function renderGrid(services) {
     const grid = document.getElementById('categories-grid');
     grid.innerHTML = '';
 
-    if (Object.keys(categoryCounts).length === 0) {
+    if (allServices.length === 0) {
       grid.innerHTML = '<p class="loading-text">No services found. Run Spin Up to initialize.</p>';
       return;
     }
 
-    CATEGORY_ORDER.forEach(slug => {
-      const stats = categoryCounts[slug];
+    // Aggregate by category.
+    const counts = {};
+    services.forEach(function(s) {
+      if (!s.category) return;
+      if (!counts[s.category]) counts[s.category] = { total: 0, running: 0, pending: 0, disabled: 0 };
+      counts[s.category].total++;
+      const status = window.NS.resolveStatus(s);
+      if (status === 'running') counts[s.category].running++;
+      else if (status === 'pending-enable' || status === 'pending-disable') counts[s.category].pending++;
+      else counts[s.category].disabled++;
+    });
+
+    let rendered = 0;
+    window.NS.CATEGORY_ORDER.forEach(function(slug) {
+      const stats = counts[slug];
       if (!stats) return;
-      const cat = CATEGORIES[slug];
+      const cat = window.NS.CATEGORIES[slug];
       if (!cat) return;
 
       const card = document.createElement('a');
       card.className = 'category-card';
       card.href = '/category?cat=' + slug;
 
-      let statsHtml = '<span class="enabled">' + stats.enabled + ' / ' + stats.total + ' enabled</span>';
-      if (stats.pending > 0) {
-        statsHtml += '<span class="pending">' + stats.pending + ' pending</span>';
-      }
+      let statsHtml = '';
+      if (stats.running > 0)  statsHtml += '<span class="running">● ' + stats.running + ' running</span>';
+      if (stats.pending > 0)  statsHtml += '<span class="pending">◐ ' + stats.pending + ' pending</span>';
+      if (stats.disabled > 0) statsHtml += '<span class="disabled">○ ' + stats.disabled + ' disabled</span>';
+      if (!statsHtml) statsHtml = '<span>—</span>';
 
       card.innerHTML =
         '<div style="display: flex; justify-content: space-between; align-items: flex-start;">' +
-          '<div class="category-card-name">' + cat.name + '</div>' +
+          '<div class="category-card-name">' + escapeHtml(cat.name) + '</div>' +
           '<div class="category-card-count">' + stats.total + '</div>' +
         '</div>' +
         '<div class="category-card-stats">' + statsHtml + '</div>';
 
       grid.appendChild(card);
+      rendered++;
     });
+
+    if (rendered === 0) {
+      grid.innerHTML = '<p class="loading-text">No stacks match the current filter.</p>';
+    }
   }
 
-  // Search
-  let searchTimeout;
-  function handleSearch(query) {
-    clearTimeout(searchTimeout);
-    const dropdown = document.getElementById('search-results');
+  // Init from URL + localStorage
+  const urlParams = new URLSearchParams(window.location.search);
+  if (urlParams.get('filter') === 'pending') {
+    currentFilter = 'pending';
+    // Pending filter is most useful in list view — auto-switch.
+    currentView = 'list';
+    localStorage.setItem(VIEW_KEY, 'list');
+  }
+  const initialQuery = urlParams.get('q') || '';
+  if (initialQuery) currentQuery = initialQuery;
 
-    if (!query || query.length < 2) {
-      dropdown.classList.remove('visible');
-      dropdown.innerHTML = '';
-      return;
-    }
+  setView(currentView);
+  if (initialQuery) document.getElementById('stacks-search').value = initialQuery;
 
-    searchTimeout = setTimeout(() => {
-      const q = query.toLowerCase();
-      const matches = allServices.filter(s =>
-        s.name.toLowerCase().includes(q) ||
-        s.description.toLowerCase().includes(q) ||
-        (s.long_description && s.long_description.toLowerCase().includes(q)) ||
-        (s.category && CATEGORIES[s.category] && CATEGORIES[s.category].name.toLowerCase().includes(q))
-      ).slice(0, 8);
+  // Event wiring
+  document.getElementById('view-grid').addEventListener('click', function() { setView('grid'); });
+  document.getElementById('view-list').addEventListener('click', function() { setView('list'); });
 
-      dropdown.innerHTML = '';
-
-      if (matches.length === 0) {
-        dropdown.innerHTML = '<div class="search-no-results">No stacks found</div>';
-        dropdown.classList.add('visible');
-        return;
-      }
-
-      matches.forEach(s => {
-        const item = document.createElement('a');
-        item.className = 'search-result-item';
-        item.href = '/category?cat=' + s.category + '#' + s.name;
-        item.style.textDecoration = 'none';
-        item.style.color = 'inherit';
-
-        const catName = CATEGORIES[s.category] ? CATEGORIES[s.category].name : s.category;
-        item.innerHTML =
-          '<div style="flex: 1; min-width: 0;">' +
-            '<div class="search-result-name">' + escapeHtml(s.name) + '</div>' +
-            '<div class="search-result-desc">' + escapeHtml(s.description) + '</div>' +
-          '</div>' +
-          '<span class="search-result-badge">' + escapeHtml(catName) + '</span>';
-        dropdown.appendChild(item);
-      });
-
-      const allLink = document.createElement('a');
-      allLink.className = 'search-all-link';
-      allLink.href = '/search?q=' + encodeURIComponent(query);
-      allLink.textContent = 'View all results for "' + query + '"';
-      dropdown.appendChild(allLink);
-
-      dropdown.classList.add('visible');
+  let searchTimer;
+  const searchInput = document.getElementById('stacks-search');
+  searchInput.addEventListener('input', function(e) {
+    clearTimeout(searchTimer);
+    searchTimer = setTimeout(function() {
+      currentQuery = e.target.value;
+      applyFilterAndRender();
     }, 150);
-  }
-
-  // Event listeners
-  document.getElementById('global-search').addEventListener('input', function() {
-    handleSearch(this.value);
   });
-
-  document.addEventListener('click', (e) => {
-    const dropdown = document.getElementById('search-results');
-    const input = document.getElementById('global-search');
-    if (!dropdown.contains(e.target) && e.target !== input) {
-      dropdown.classList.remove('visible');
+  searchInput.addEventListener('keydown', function(e) {
+    if (e.key === 'Enter' && searchInput.value.trim()) {
+      window.location.href = '/search?q=' + encodeURIComponent(searchInput.value.trim());
     }
   });
 
-  // Init
+  // Keyboard
+  window.NS.registerKeyboard({
+    searchInputId: 'stacks-search',
+    list: window.NS.tableController,
+  });
+
+  // Reload after a toggle from the table component
+  window.addEventListener('stacks:reload', loadServices);
+  // Reload when any page updates stacks (e.g. toggle on category.astro keeps
+  // this tab's state fresh via visibilitychange -> PendingBar already does this).
+  window.addEventListener('stacks:updated', loadServices);
+
   loadServices();
 </script>

--- a/control-plane/src/pages/stacks.astro
+++ b/control-plane/src/pages/stacks.astro
@@ -143,10 +143,8 @@ import StackTable from '../components/StackTable.astro';
   async function loadServices() {
     try {
       await window.NS.fetchDomain();
-      const response = await fetch('/api/services', { credentials: 'same-origin' });
-      if (!response.ok) return;
-      const data = await response.json();
-      if (data.success) {
+      const data = await window.NS.getServices();
+      if (data && data.success) {
         allServices = data.services || [];
         loading = false;
         applyFilterAndRender();

--- a/control-plane/src/pages/stacks.astro
+++ b/control-plane/src/pages/stacks.astro
@@ -125,6 +125,7 @@ import StackTable from '../components/StackTable.astro';
   const VIEW_KEY = 'stacksView';
 
   let allServices = [];
+  let loading = true;
   let currentView = (localStorage.getItem(VIEW_KEY) === 'list') ? 'list' : 'grid';
   let currentQuery = '';
   let currentFilter = null; // 'pending' from ?filter=pending query param
@@ -147,6 +148,7 @@ import StackTable from '../components/StackTable.astro';
       const data = await response.json();
       if (data.success) {
         allServices = data.services || [];
+        loading = false;
         applyFilterAndRender();
       }
     } catch (error) {
@@ -174,6 +176,9 @@ import StackTable from '../components/StackTable.astro';
   }
 
   function applyFilterAndRender() {
+    // Skip until first fetch resolves so the initial "Loading..." placeholder
+    // isn't replaced with a misleading "No services found" empty state.
+    if (loading) return;
     const services = filteredServices();
     if (currentView === 'list') {
       window.NS.renderTable(services);
@@ -215,9 +220,9 @@ import StackTable from '../components/StackTable.astro';
       card.href = '/category?cat=' + slug;
 
       let statsHtml = '';
-      if (stats.running > 0)  statsHtml += '<span class="running">● ' + stats.running + ' running</span>';
-      if (stats.pending > 0)  statsHtml += '<span class="pending">◐ ' + stats.pending + ' pending</span>';
-      if (stats.disabled > 0) statsHtml += '<span class="disabled">○ ' + stats.disabled + ' disabled</span>';
+      if (stats.running > 0)  statsHtml += '<span class="running"><span aria-hidden="true">●</span> ' + stats.running + ' running</span>';
+      if (stats.pending > 0)  statsHtml += '<span class="pending"><span aria-hidden="true">◐</span> ' + stats.pending + ' pending</span>';
+      if (stats.disabled > 0) statsHtml += '<span class="disabled"><span aria-hidden="true">○</span> ' + stats.disabled + ' disabled</span>';
       if (!statsHtml) statsHtml = '<span>—</span>';
 
       card.innerHTML =
@@ -275,10 +280,7 @@ import StackTable from '../components/StackTable.astro';
     list: window.NS.tableController,
   });
 
-  // Reload after a toggle from the table component
-  window.addEventListener('stacks:reload', loadServices);
-  // Reload when any page updates stacks (e.g. toggle on category.astro keeps
-  // this tab's state fresh via visibilitychange -> PendingBar already does this).
+  // Reload whenever a toggle succeeds anywhere (fired by window.NS.toggleService).
   window.addEventListener('stacks:updated', loadServices);
 
   loadServices();

--- a/control-plane/src/pages/stacks.astro
+++ b/control-plane/src/pages/stacks.astro
@@ -118,7 +118,6 @@ import StackTable from '../components/StackTable.astro';
   :global(.category-card-stats .running)  { color: var(--accent); }
   :global(.category-card-stats .pending)  { color: var(--warning); }
   :global(.category-card-stats .disabled) { color: var(--text-muted); }
-  :global(.category-card-stats.empty)     { color: var(--text-muted); }
 </style>
 
 <script is:inline>
@@ -126,6 +125,7 @@ import StackTable from '../components/StackTable.astro';
 
   let allServices = [];
   let loading = true;
+  let loadError = null;
   let currentView = (localStorage.getItem(VIEW_KEY) === 'list') ? 'list' : 'grid';
   let currentQuery = '';
   let currentFilter = null; // 'pending' from ?filter=pending query param
@@ -146,11 +146,20 @@ import StackTable from '../components/StackTable.astro';
       const data = await window.NS.getServices();
       if (data && data.success) {
         allServices = data.services || [];
-        loading = false;
-        applyFilterAndRender();
+        loadError = null;
+      } else {
+        allServices = [];
+        loadError = 'Failed to load stacks. Refresh the page to retry.';
       }
     } catch (error) {
       console.error('Failed to load services:', error);
+      allServices = [];
+      loadError = 'Failed to load stacks. Refresh the page to retry.';
+    } finally {
+      // Always clear loading — leaving it set on failure strands the page on
+      // the "Loading..." placeholder forever.
+      loading = false;
+      applyFilterAndRender();
     }
   }
 
@@ -188,6 +197,11 @@ import StackTable from '../components/StackTable.astro';
   function renderGrid(services) {
     const grid = document.getElementById('categories-grid');
     grid.innerHTML = '';
+
+    if (loadError) {
+      grid.innerHTML = '<p class="loading-text">' + escapeHtml(loadError) + '</p>';
+      return;
+    }
 
     if (allServices.length === 0) {
       grid.innerHTML = '<p class="loading-text">No services found. Run Spin Up to initialize.</p>';

--- a/control-plane/src/pages/stacks.astro
+++ b/control-plane/src/pages/stacks.astro
@@ -188,10 +188,16 @@ import StackTable from '../components/StackTable.astro';
     if (loading) return;
     const services = filteredServices();
     if (currentView === 'list') {
-      window.NS.renderTable(services);
+      window.NS.renderTable(services, currentEmptyMessage());
     } else {
       renderGrid(services);
     }
+  }
+
+  function currentEmptyMessage() {
+    if (loadError) return loadError;
+    if (allServices.length === 0) return 'No services found. Run Spin Up to initialize.';
+    return 'No stacks match the current filter.';
   }
 
   function renderGrid(services) {
@@ -286,10 +292,21 @@ import StackTable from '../components/StackTable.astro';
     }
   });
 
-  // Keyboard
+  // Keyboard — wrap the table controller so list-only shortcuts (j/k/Enter/e/c)
+  // are suppressed while the grid is active. The controller retains focus/items
+  // across view switches, so we gate via a live proxy instead of re-registering.
+  const gatedList = {
+    get items() { return currentView === 'list' ? window.NS.tableController.items : []; },
+    get focus() { return window.NS.tableController.focus; },
+    set focus(v) { window.NS.tableController.focus = v; },
+    render: function() { window.NS.tableController.render(); },
+    onOpen: function(s) { window.NS.tableController.onOpen(s); },
+    onToggle: function(s) { window.NS.tableController.onToggle(s); },
+    onCategory: function(s) { window.NS.tableController.onCategory(s); },
+  };
   window.NS.registerKeyboard({
     searchInputId: 'stacks-search',
-    list: window.NS.tableController,
+    list: gatedList,
   });
 
   // Reload whenever a toggle succeeds anywhere (fired by window.NS.toggleService).

--- a/control-plane/src/styles/global.css
+++ b/control-plane/src/styles/global.css
@@ -160,6 +160,40 @@ h2 {
 .status-dot.status-disabled { color: var(--text-muted); opacity: 0.6; }
 
 /* =============================================================================
+   View toggle (grid / list)
+   ============================================================================= */
+.view-toggle {
+  display: inline-flex;
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.view-toggle button {
+  background: transparent;
+  border: none;
+  color: var(--text-muted);
+  padding: 0.4rem 0.8rem;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.78rem;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+
+.view-toggle button:not(:last-child) {
+  border-right: 1px solid var(--border);
+}
+
+.view-toggle button:hover {
+  color: var(--accent);
+}
+
+.view-toggle button[aria-pressed="true"] {
+  background: rgba(0, 255, 136, 0.1);
+  color: var(--accent);
+}
+
+/* =============================================================================
    Service Cards
    ============================================================================= */
 .services-grid {

--- a/control-plane/src/styles/global.css
+++ b/control-plane/src/styles/global.css
@@ -143,6 +143,23 @@ h2 {
 @keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.6; } }
 
 /* =============================================================================
+   Status dots (tri-state: disabled / pending / running)
+   ============================================================================= */
+.status-dot {
+  display: inline-block;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.95rem;
+  width: 1em;
+  text-align: center;
+  vertical-align: baseline;
+  line-height: 1;
+}
+
+.status-dot.status-running  { color: var(--accent); text-shadow: 0 0 6px rgba(0, 255, 136, 0.5); }
+.status-dot.status-pending  { color: var(--warning); animation: pulse 2s infinite; }
+.status-dot.status-disabled { color: var(--text-muted); opacity: 0.6; }
+
+/* =============================================================================
    Service Cards
    ============================================================================= */
 .services-grid {

--- a/control-plane/src/styles/global.css
+++ b/control-plane/src/styles/global.css
@@ -143,9 +143,11 @@ h2 {
 @keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.6; } }
 
 /* =============================================================================
-   Status dots (tri-state: disabled / pending / running)
+   Stack status dots (tri-state: disabled / pending / running)
+   Namespaced as .stack-status-dot to avoid colliding with the solid-circle
+   .status-dot used in pages/index.astro (Dashboard infrastructure state).
    ============================================================================= */
-.status-dot {
+.stack-status-dot {
   display: inline-block;
   font-family: 'JetBrains Mono', monospace;
   font-size: 0.95rem;
@@ -155,9 +157,9 @@ h2 {
   line-height: 1;
 }
 
-.status-dot.status-running  { color: var(--accent); text-shadow: 0 0 6px rgba(0, 255, 136, 0.5); }
-.status-dot.status-pending  { color: var(--warning); animation: pulse 2s infinite; }
-.status-dot.status-disabled { color: var(--text-muted); opacity: 0.6; }
+.stack-status-dot.status-running  { color: var(--accent); text-shadow: 0 0 6px rgba(0, 255, 136, 0.5); }
+.stack-status-dot.status-pending  { color: var(--warning); animation: pulse 2s infinite; }
+.stack-status-dot.status-disabled { color: var(--text-muted); opacity: 0.6; }
 
 /* =============================================================================
    View toggle (grid / list)


### PR DESCRIPTION
## Summary

UX overhaul of the Control Plane Stacks surface area, applying eight improvements in one pass. Keeps the category grid as the default (zero disruption for existing users) and adds a denser, keyboard-first flat list view, a tri-state status indicator, and a persistent pending-changes bar. No API changes — `functions/api/services.js` already exposes `enabled` / `deployed` / `pending` / `pendingChangesCount`.

## Motivation

The current Stacks page forces two clicks to reach any individual stack (category tile → drill-down), shows only `X / Y enabled` per category with no running-state signal, and duplicates an inline search dropdown that also exists as a full `/search` page. Pending changes are buried inside per-category banners, keyboard accessibility is missing on toggles, category metadata is hardcoded twice, and toggle errors get silently swallowed.

## Changes

### New behaviour

- **Grid / List toggle** on `/stacks`. Preference persists in `localStorage.stacksView`.
- **Flat list view** via `StackTable.astro` — one row per stack with status dot, name + badges, category, URL, toggle.
- **Tri-state status** everywhere a stack is rendered: `○ disabled`, `◐ pending`, `● running` (derived from `enabled` + `deployed`).
- **Persistent `PendingBar`** below the nav. Hidden while `pendingChangesCount == 0`; shows `[View] [Spin Up]` when changes are pending. Auto-refreshes on visibilitychange and on `stacks:updated`.
- **Keyboard shortcuts** (`/` to focus search, `?` for help overlay, `Esc` to close, `g d` → Dashboard, `g s` → Stacks; in list view: `j/k` navigate, `Enter` open, `e`/`Space` toggle, `c` open category).
- **Deep-links**: `/stacks?filter=pending` auto-switches to list view and filters; `?q=` preserves search.

### Cleanups

- **Single source of truth** for CATEGORIES: `lib/categories.ts` is now actually imported (via `StacksShared.astro` with `define:vars`), replacing three inlined duplicates.
- **Dropped the inline search dropdown** on `/stacks` — consolidated on `/search`; the top-of-page input filters the current view, `Enter` jumps to full search.
- **Terminology** consistent: `"Go to Dashboard to Spin Up"` matches the actual button label.
- **Toggle error handling**: `window.NS.toggleService()` now surfaces HTTP/server errors in the toast and restores the toggle UI on failure.
- **Shared helpers** (`window.NS.fetchDomain / stackUrl / resolveStatus / statusBadge / toggleService / registerKeyboard`) extracted into `StacksShared.astro` so the three stacks pages no longer duplicate fetch/toggle/URL logic.

## Files

**New:** `components/StacksShared.astro`, `components/PendingBar.astro`, `components/ShortcutsHelp.astro`, `components/StackTable.astro`.
**Modified:** `layouts/Layout.astro` (mounts the new globals, Toast+StacksShared moved to top of body so `window.NS` is available before page scripts init), `pages/stacks.astro` (rewritten), `pages/category.astro` + `pages/search.astro` (use shared helpers, render status dots), `styles/global.css` (status-dot + view-toggle classes).

## Test plan

- [x] `cd control-plane && npx astro build` — all 9 pages compile cleanly across both commits.
- [ ] `npx astro dev`, verify on `/stacks`:
  - Toggle Grid ↔ List; reload → view preference persisted.
  - Enable a disabled stack → toast appears, tri-state dot moves `○ → ◐`, PendingBar shows `1 change pending`.
  - Click `[View]` in PendingBar → `/stacks?filter=pending` opens in list view filtered to pending rows.
  - Press `/` — search input focuses; type, `Enter` → `/search?q=...`.
  - Press `?` — shortcut overlay opens; `Esc` closes.
  - In list view: `j`/`k` move focus ring; `Enter` opens URL in new tab (if deployed); `e` toggles enabled; `c` jumps to category page.
- [ ] Visit `/category?cat=databases` → status dots next to each name; toggle → toast + PendingBar updates (same event).
- [ ] Visit `/search?q=grafana` → status dots + shared toggle path.
- [ ] Disable network in DevTools, toggle a stack → error toast, toggle UI restores.
- [ ] Shrink viewport to 375 px → grid collapses to single column; table collapses to 2 columns (status + name).
- [ ] Fresh incognito → grid view renders identically to today for users who never discover the toggle.
