### PR TITLE
fix(control-plane): Set SUBDOMAIN_SEPARATOR/INFISICAL_URL/CONTROL_PLANE_URL as Pages secrets

### DIFF
--- a/.github/workflows/setup-control-plane.yaml
+++ b/.github/workflows/setup-control-plane.yaml
@@ -994,6 +994,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_SECRETS_TOKEN }}
           RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
           DOMAIN: ${{ secrets.DOMAIN }}
+          SUBDOMAIN_SEPARATOR: ${{ secrets.SUBDOMAIN_SEPARATOR || '.' }}
           ADMIN_EMAIL: ${{ secrets.TF_VAR_admin_email }}
           USER_EMAIL: ${{ secrets.TF_VAR_user_email }}
         run: |
@@ -1038,6 +1039,27 @@ jobs:
               --project-name="$PROJECT_NAME" 2>&1; then
               echo "⚠️  Failed to set DOMAIN"
             fi
+          fi
+
+          # SUBDOMAIN_SEPARATOR + derived URLs. These MUST be secrets (not Terraform
+          # environment_variables) because `wrangler pages deploy` later in this
+          # workflow wipes env_vars that aren't listed in wrangler.toml. Secrets
+          # survive that wipe; that's how DOMAIN, GITHUB_TOKEN, etc. already work.
+          if [ -n "$DOMAIN" ] && [ -n "$SUBDOMAIN_SEPARATOR" ]; then
+            INFISICAL_URL="https://infisical${SUBDOMAIN_SEPARATOR}${DOMAIN}"
+            CONTROL_PLANE_URL="https://control${SUBDOMAIN_SEPARATOR}${DOMAIN}"
+
+            echo "  Setting SUBDOMAIN_SEPARATOR secret..."
+            echo "$SUBDOMAIN_SEPARATOR" | npx wrangler@4 pages secret put SUBDOMAIN_SEPARATOR \
+              --project-name="$PROJECT_NAME" 2>&1 || echo "⚠️  Failed to set SUBDOMAIN_SEPARATOR"
+
+            echo "  Setting INFISICAL_URL secret..."
+            echo "$INFISICAL_URL" | npx wrangler@4 pages secret put INFISICAL_URL \
+              --project-name="$PROJECT_NAME" 2>&1 || echo "⚠️  Failed to set INFISICAL_URL"
+
+            echo "  Setting CONTROL_PLANE_URL secret..."
+            echo "$CONTROL_PLANE_URL" | npx wrangler@4 pages secret put CONTROL_PLANE_URL \
+              --project-name="$PROJECT_NAME" 2>&1 || echo "⚠️  Failed to set CONTROL_PLANE_URL"
           fi
 
           if [ -n "$ADMIN_EMAIL" ]; then

--- a/.github/workflows/setup-control-plane.yaml
+++ b/.github/workflows/setup-control-plane.yaml
@@ -1045,21 +1045,33 @@ jobs:
           # environment_variables) because `wrangler pages deploy` later in this
           # workflow wipes env_vars that aren't listed in wrangler.toml. Secrets
           # survive that wipe; that's how DOMAIN, GITHUB_TOKEN, etc. already work.
+          # Failures here are fatal: without these the Control Plane Functions fall
+          # back to `https://infisical.${domain}` (dot form), which is wrong for any
+          # flat-subdomain deployment and silently breaks /secrets + stack links.
           if [ -n "$DOMAIN" ] && [ -n "$SUBDOMAIN_SEPARATOR" ]; then
             INFISICAL_URL="https://infisical${SUBDOMAIN_SEPARATOR}${DOMAIN}"
             CONTROL_PLANE_URL="https://control${SUBDOMAIN_SEPARATOR}${DOMAIN}"
 
             echo "  Setting SUBDOMAIN_SEPARATOR secret..."
-            echo "$SUBDOMAIN_SEPARATOR" | npx wrangler@4 pages secret put SUBDOMAIN_SEPARATOR \
-              --project-name="$PROJECT_NAME" 2>&1 || echo "⚠️  Failed to set SUBDOMAIN_SEPARATOR"
+            if ! echo "$SUBDOMAIN_SEPARATOR" | npx wrangler@4 pages secret put SUBDOMAIN_SEPARATOR \
+              --project-name="$PROJECT_NAME" 2>&1; then
+              echo "❌ Failed to set SUBDOMAIN_SEPARATOR - Control Plane will use wrong URLs"
+              exit 1
+            fi
 
             echo "  Setting INFISICAL_URL secret..."
-            echo "$INFISICAL_URL" | npx wrangler@4 pages secret put INFISICAL_URL \
-              --project-name="$PROJECT_NAME" 2>&1 || echo "⚠️  Failed to set INFISICAL_URL"
+            if ! echo "$INFISICAL_URL" | npx wrangler@4 pages secret put INFISICAL_URL \
+              --project-name="$PROJECT_NAME" 2>&1; then
+              echo "❌ Failed to set INFISICAL_URL - Secrets page will be broken"
+              exit 1
+            fi
 
             echo "  Setting CONTROL_PLANE_URL secret..."
-            echo "$CONTROL_PLANE_URL" | npx wrangler@4 pages secret put CONTROL_PLANE_URL \
-              --project-name="$PROJECT_NAME" 2>&1 || echo "⚠️  Failed to set CONTROL_PLANE_URL"
+            if ! echo "$CONTROL_PLANE_URL" | npx wrangler@4 pages secret put CONTROL_PLANE_URL \
+              --project-name="$PROJECT_NAME" 2>&1; then
+              echo "❌ Failed to set CONTROL_PLANE_URL - teardown emails will link to wrong host"
+              exit 1
+            fi
           fi
 
           if [ -n "$ADMIN_EMAIL" ]; then

--- a/tofu/control-plane/main.tf
+++ b/tofu/control-plane/main.tf
@@ -151,9 +151,6 @@ resource "cloudflare_pages_project" "control_plane" {
         GITHUB_OWNER                = var.github_owner
         GITHUB_REPO                 = var.github_repo
         DOMAIN                      = var.domain
-        SUBDOMAIN_SEPARATOR         = var.subdomain_separator
-        INFISICAL_URL               = local.infisical_url
-        CONTROL_PLANE_URL           = local.control_plane_url
         ADMIN_EMAIL                 = var.admin_email
         USER_EMAIL                  = var.user_email
         SERVER_TYPE                 = var.server_type
@@ -162,6 +159,9 @@ resource "cloudflare_pages_project" "control_plane" {
         MAX_EXTENSIONS_PER_DAY      = tostring(var.max_extensions_per_day)
         MAX_DELAY_HOURS             = tostring(var.max_delay_hours)
       }
+      # Note: SUBDOMAIN_SEPARATOR, INFISICAL_URL, CONTROL_PLANE_URL are set as Pages
+      # secrets (not environment_variables) in setup-control-plane.yaml's "Set Control
+      # Plane secrets" step — environment_variables get wiped by `wrangler pages deploy`.
 
       d1_databases = {
         NEXUS_DB = cloudflare_d1_database.nexus.id
@@ -180,9 +180,6 @@ resource "cloudflare_pages_project" "control_plane" {
         GITHUB_OWNER                = var.github_owner
         GITHUB_REPO                 = var.github_repo
         DOMAIN                      = var.domain
-        SUBDOMAIN_SEPARATOR         = var.subdomain_separator
-        INFISICAL_URL               = local.infisical_url
-        CONTROL_PLANE_URL           = local.control_plane_url
         ADMIN_EMAIL                 = var.admin_email
         USER_EMAIL                  = var.user_email
         SERVER_TYPE                 = var.server_type
@@ -191,6 +188,8 @@ resource "cloudflare_pages_project" "control_plane" {
         MAX_EXTENSIONS_PER_DAY      = tostring(var.max_extensions_per_day)
         MAX_DELAY_HOURS             = tostring(var.max_delay_hours)
       }
+      # Same note as production: SUBDOMAIN_SEPARATOR / INFISICAL_URL / CONTROL_PLANE_URL
+      # are Pages secrets, not env vars.
 
       d1_databases = {
         NEXUS_DB = cloudflare_d1_database.nexus.id


### PR DESCRIPTION
## Summary

Move `SUBDOMAIN_SEPARATOR`, `INFISICAL_URL`, `CONTROL_PLANE_URL` from Terraform `environment_variables` on the Pages project to Pages secrets set via `wrangler pages secret put`. Fixes the Control Plane Secrets page for flat-subdomain deployments.

## Root cause

PR #434 (v0.49.0) added these three values as Terraform `environment_variables` in [`tofu/control-plane/main.tf`](tofu/control-plane/main.tf) on both `production` and `preview` deployment configs. The assumption was they'd survive into the running Pages Functions runtime.

They don't. The existing comment block at [`setup-control-plane.yaml:1003-1007`](.github/workflows/setup-control-plane.yaml) already documents exactly why:

> Pages secrets survive wrangler pages deploy (unlike environment_variables which get wiped). Terraform sets environment_variables on the project, but wrangler pages deploy treats wrangler.toml as source of truth and deletes any env vars not in it. Secrets are NOT affected by this behavior. So we set all values the Functions need as secrets here.

The "Set Control Plane secrets" step (line 990) already runs `wrangler pages secret put` for `GITHUB_TOKEN`, `GITHUB_OWNER`, `GITHUB_REPO`, `DOMAIN`, `ADMIN_EMAIL`, `USER_EMAIL`, `SERVER_TYPE`, `SERVER_LOCATION`, `RESEND_API_KEY` — these are the values the template's own Functions read via `context.env.*`. The three v0.49.0 additions were never added to that list.

On default dot-subdomain deployments (e.g. `nexus-stack.ch`) the failure was invisible because `secrets.js`'s fallback URL `https://infisical.${domain}` happens to match the real host. On flat-subdomain deployments (user forks provisioned by `Nexus-Stack-for-Education`, e.g. `infisical-user.base.example`), the fallback points at a non-existent host and the Secrets page returns "unexpected response".

## Changes

**`tofu/control-plane/main.tf`**
- Drop `SUBDOMAIN_SEPARATOR` / `INFISICAL_URL` / `CONTROL_PLANE_URL` from both `deployment_configs.production.environment_variables` and `deployment_configs.preview.environment_variables`.
- Replace with a comment pointing to setup-control-plane.yaml.
- `locals.infisical_url` / `control_plane_url` / `control_plane_hostname` stay — still referenced by `cloudflare_record`, `cloudflare_pages_domain`, `cloudflare_zero_trust_access_application`, CORS `allowed_origins`.
- `var.subdomain_separator` stays in `variables.tf`.

**`.github/workflows/setup-control-plane.yaml`** (`Set Control Plane secrets` step)
- Add `SUBDOMAIN_SEPARATOR: ${{ secrets.SUBDOMAIN_SEPARATOR || '.' }}` to the step's `env:` block.
- Add three `wrangler pages secret put` calls that compute `INFISICAL_URL` / `CONTROL_PLANE_URL` from `$DOMAIN` + `$SUBDOMAIN_SEPARATOR` and push them as secrets alongside the existing DOMAIN block.

## Backward compatibility

- Default `SUBDOMAIN_SEPARATOR = '.'` when the secret is unset → the template's own deployment resolves to the same URLs as today (`https://infisical.${domain}` / `https://control.${domain}`) and keeps working unchanged.
- Consumers that already set `SUBDOMAIN_SEPARATOR=-` (admin-panel provisioning) now get the right flat-subdomain URLs wired through the whole stack instead of silently falling back.
- Existing deployments: next `setup-control-plane.yaml` run sets the three new secrets. `wrangler pages secret list` will confirm them. No other moving parts.

## Test plan

- [x] `tofu validate` in `tofu/control-plane/` → success (no non-provider errors).
- [x] YAML parse of `setup-control-plane.yaml` → valid.
- [ ] After merge + release: run `setup-control-plane.yaml` on a user fork with `SUBDOMAIN_SEPARATOR=-` in repo secrets. Verify:
  - `wrangler pages secret list` shows `SUBDOMAIN_SEPARATOR`, `INFISICAL_URL`, `CONTROL_PLANE_URL` as Encrypted.
  - `/api/debug` on the Control Plane shows `DOMAIN`, `GITHUB_TOKEN`, `INFISICAL_TOKEN`, `INFISICAL_PROJECT_ID` all set.
  - `/secrets` page renders Infisical secrets grouped by folder (no "unexpected response").
  - Stack links on `/stacks` use dash form.
- [ ] Template's own deployment (`nexus-stack.ch`, `SUBDOMAIN_SEPARATOR` unset) continues to work — default `.` separator keeps the same URLs.
