### PR TITLE
fix(control-plane): Parse comma-separated USER_EMAIL for Resend

### DIFF
--- a/control-plane/functions/api/send-credentials.js
+++ b/control-plane/functions/api/send-credentials.js
@@ -9,6 +9,14 @@ import { fetchWithTimeout } from './_utils/fetch-with-timeout.js';
 import { logApiCall, logError } from './_utils/logger.js';
 import { safeHttpsUrl } from './_utils/url.js';
 
+// Resend-accepted email formats. Hoisted to module scope so the regex
+// objects are created once per Worker boot instead of once per request.
+//   plain:     `email@example.com` (no angle brackets)
+//   bracketed: `Name <email@example.com>` (non-empty display name + both brackets)
+const PLAIN_EMAIL_RE = /^[^\s@<>]+@[^\s@<>]+\.[^\s@<>]+$/;
+const BRACKETED_EMAIL_RE = /^\S[^<>]*<[^\s@<>]+@[^\s@<>]+\.[^\s@<>]+>$/;
+const isValidResendEmail = (e) => PLAIN_EMAIL_RE.test(e) || BRACKETED_EMAIL_RE.test(e);
+
 export async function onRequestPost(context) {
   const { env } = context;
 
@@ -48,14 +56,8 @@ export async function onRequestPost(context) {
 
     // USER_EMAIL may be a single address or a comma-separated list
     // (e.g. when multiple admin emails are piped through from the admin panel).
-    // Resend rejects a to[] entry that contains commas, so split + trim +
-    // validate. Two explicit alternatives cover Resend's accepted formats;
-    // half-bracketed / no-display-name variants are excluded.
-    //   plain:     `email@example.com`
-    //   bracketed: `Name <email@example.com>` (non-empty display name required)
-    const PLAIN_EMAIL_RE = /^[^\s@<>]+@[^\s@<>]+\.[^\s@<>]+$/;
-    const BRACKETED_EMAIL_RE = /^\S[^<>]*<[^\s@<>]+@[^\s@<>]+\.[^\s@<>]+>$/;
-    const isValidResendEmail = (e) => PLAIN_EMAIL_RE.test(e) || BRACKETED_EMAIL_RE.test(e);
+    // Split + trim + validate against the Resend-accepted email regex
+    // (hoisted to module scope above).
     const userEmails = (env.USER_EMAIL || '')
       .split(',')
       .map((e) => e.trim())

--- a/control-plane/functions/api/send-credentials.js
+++ b/control-plane/functions/api/send-credentials.js
@@ -49,15 +49,17 @@ export async function onRequestPost(context) {
     // USER_EMAIL may be a single address or a comma-separated list
     // (e.g. when multiple admin emails are piped through from the admin panel).
     // Resend rejects a to[] entry that contains commas, so split + trim +
-    // validate. The regex accepts both Resend-supported forms:
-    //   - plain:   email@example.com
-    //   - with display name: Name <email@example.com>
-    // and requires at least one dot in the domain (rejects `foo@`, `foo@bar`).
-    const RESEND_EMAIL_RE = /^(?:[^<]*<)?[^\s@<>]+@[^\s@<>]+\.[^\s@<>]+>?$/;
+    // validate. Two explicit alternatives cover Resend's accepted formats;
+    // half-bracketed / no-display-name variants are excluded.
+    //   plain:     `email@example.com`
+    //   bracketed: `Name <email@example.com>` (non-empty display name required)
+    const PLAIN_EMAIL_RE = /^[^\s@<>]+@[^\s@<>]+\.[^\s@<>]+$/;
+    const BRACKETED_EMAIL_RE = /^\S[^<>]*<[^\s@<>]+@[^\s@<>]+\.[^\s@<>]+>$/;
+    const isValidResendEmail = (e) => PLAIN_EMAIL_RE.test(e) || BRACKETED_EMAIL_RE.test(e);
     const userEmails = (env.USER_EMAIL || '')
       .split(',')
       .map((e) => e.trim())
-      .filter((e) => RESEND_EMAIL_RE.test(e));
+      .filter(isValidResendEmail);
     const primaryUserEmail = userEmails[0] || null;
     const extraUserEmails = userEmails.slice(1);
     // Back-compat: keep `userEmail` as the primary for downstream logic.

--- a/control-plane/functions/api/send-credentials.js
+++ b/control-plane/functions/api/send-credentials.js
@@ -45,7 +45,18 @@ export async function onRequestPost(context) {
     const credentials = JSON.parse(credentialsJson);
     const domain = env.DOMAIN;
     const adminEmail = env.ADMIN_EMAIL;
-    const userEmail = env.USER_EMAIL && env.USER_EMAIL.trim() !== '' ? env.USER_EMAIL : null;
+
+    // USER_EMAIL may be a single address or a comma-separated list
+    // (e.g. when multiple admin emails are piped through from the admin panel).
+    // Resend rejects a to[] entry that contains commas, so split + trim + filter.
+    const userEmails = (env.USER_EMAIL || '')
+      .split(',')
+      .map((e) => e.trim())
+      .filter((e) => e.length > 0 && e.includes('@'));
+    const primaryUserEmail = userEmails[0] || null;
+    const extraUserEmails = userEmails.slice(1);
+    // Back-compat: keep `userEmail` as the primary for downstream logic.
+    const userEmail = primaryUserEmail;
     const infisicalUrl = safeHttpsUrl(env.INFISICAL_URL, `https://infisical.${domain}`);
     const controlPlaneUrl = safeHttpsUrl(env.CONTROL_PLANE_URL, `https://control.${domain}`);
 
@@ -103,7 +114,7 @@ export async function onRequestPost(context) {
 </div>
     `;
 
-    // Send email via Resend (User as primary, Admin in CC)
+    // Send email via Resend (User as primary, Admin + extra users in CC)
     const emailPayload = {
       from: `Nexus-Stack <nexus@${domain}>`,
       to: userEmail ? [userEmail] : [adminEmail],
@@ -111,7 +122,7 @@ export async function onRequestPost(context) {
       html: emailHTML
     };
     if (userEmail) {
-      emailPayload.cc = [adminEmail];
+      emailPayload.cc = [adminEmail, ...extraUserEmails];
     }
 
     const resendResponse = await fetchWithTimeout('https://api.resend.com/emails', {

--- a/control-plane/functions/api/send-credentials.js
+++ b/control-plane/functions/api/send-credentials.js
@@ -141,7 +141,10 @@ export async function onRequestPost(context) {
 
     const emailResult = await resendResponse.json();
 
-    const recipientMsg = userEmail ? `${userEmail} (cc: ${adminEmail})` : adminEmail;
+    const ccList = emailPayload.cc || [];
+    const recipientMsg = userEmail
+      ? (ccList.length > 0 ? `${userEmail} (cc: ${ccList.join(', ')})` : userEmail)
+      : adminEmail;
     await logApiCall(env.NEXUS_DB, '/api/send-credentials', 'POST', {
       action: 'credentials_sent',
       recipient: recipientMsg,

--- a/control-plane/functions/api/send-credentials.js
+++ b/control-plane/functions/api/send-credentials.js
@@ -48,11 +48,16 @@ export async function onRequestPost(context) {
 
     // USER_EMAIL may be a single address or a comma-separated list
     // (e.g. when multiple admin emails are piped through from the admin panel).
-    // Resend rejects a to[] entry that contains commas, so split + trim + filter.
+    // Resend rejects a to[] entry that contains commas, so split + trim +
+    // validate. The regex accepts both Resend-supported forms:
+    //   - plain:   email@example.com
+    //   - with display name: Name <email@example.com>
+    // and requires at least one dot in the domain (rejects `foo@`, `foo@bar`).
+    const RESEND_EMAIL_RE = /^(?:[^<]*<)?[^\s@<>]+@[^\s@<>]+\.[^\s@<>]+>?$/;
     const userEmails = (env.USER_EMAIL || '')
       .split(',')
       .map((e) => e.trim())
-      .filter((e) => e.length > 0 && e.includes('@'));
+      .filter((e) => RESEND_EMAIL_RE.test(e));
     const primaryUserEmail = userEmails[0] || null;
     const extraUserEmails = userEmails.slice(1);
     // Back-compat: keep `userEmail` as the primary for downstream logic.

--- a/control-plane/worker/src/index.js
+++ b/control-plane/worker/src/index.js
@@ -15,6 +15,15 @@
 // Duplicates functions/api/_utils/url.js. The worker is deployed as a single
 // raw file via Terraform (tofu/control-plane/main.tf -> file(...)), so it cannot
 // import from the Pages Functions _utils/ tree without introducing a bundler.
+
+// Resend-accepted email formats. Hoisted to module scope so the regex
+// objects are created once per Worker boot instead of once per notification.
+//   plain:     `email@example.com` (no angle brackets)
+//   bracketed: `Name <email@example.com>` (non-empty display name + both brackets)
+const PLAIN_EMAIL_RE = /^[^\s@<>]+@[^\s@<>]+\.[^\s@<>]+$/;
+const BRACKETED_EMAIL_RE = /^\S[^<>]*<[^\s@<>]+@[^\s@<>]+\.[^\s@<>]+>$/;
+const isValidResendEmail = (e) => PLAIN_EMAIL_RE.test(e) || BRACKETED_EMAIL_RE.test(e);
+
 function validateHttpsOrigin(url) {
   if (!url) return null;
   try {
@@ -463,15 +472,8 @@ async function sendNotification(env, config) {
   }
 
   // Email recipients: User as primary, Admin + extra users in CC.
-  // USER_EMAIL may be comma-separated (e.g. admin panel sets multiple emails);
-  // Resend rejects a to[] entry that contains commas, so split + validate.
-  // Two explicit alternatives cover Resend's accepted formats; half-bracketed
-  // / no-display-name variants are excluded.
-  //   plain:     `email@example.com`
-  //   bracketed: `Name <email@example.com>` (non-empty display name required)
-  const PLAIN_EMAIL_RE = /^[^\s@<>]+@[^\s@<>]+\.[^\s@<>]+$/;
-  const BRACKETED_EMAIL_RE = /^\S[^<>]*<[^\s@<>]+@[^\s@<>]+\.[^\s@<>]+>$/;
-  const isValidResendEmail = (e) => PLAIN_EMAIL_RE.test(e) || BRACKETED_EMAIL_RE.test(e);
+  // USER_EMAIL may be comma-separated. Validation via the Resend-accepted
+  // email regex hoisted to module scope at the top of the file.
   const userEmails = (env.USER_EMAIL || '')
     .split(',')
     .map((e) => e.trim())

--- a/control-plane/worker/src/index.js
+++ b/control-plane/worker/src/index.js
@@ -462,8 +462,15 @@ async function sendNotification(env, config) {
     return;
   }
 
-  // Email recipients: User as primary, Admin in CC
-  const userEmail = env.USER_EMAIL && env.USER_EMAIL.trim() !== '' ? env.USER_EMAIL : null;
+  // Email recipients: User as primary, Admin + extra users in CC.
+  // USER_EMAIL may be comma-separated (e.g. admin panel sets multiple emails);
+  // Resend rejects a to[] entry that contains commas, so split + sanitize.
+  const userEmails = (env.USER_EMAIL || '')
+    .split(',')
+    .map((e) => e.trim())
+    .filter((e) => e.length > 0 && e.includes('@'));
+  const userEmail = userEmails[0] || null;
+  const extraUserEmails = userEmails.slice(1);
 
   try {
     const teardownTime = `${config.teardownTime} ${getTimezoneAbbr(config.timezone)}`;
@@ -504,7 +511,7 @@ async function sendNotification(env, config) {
       html: emailHtml,
     };
     if (userEmail) {
-      emailPayload.cc = [env.ADMIN_EMAIL];
+      emailPayload.cc = [env.ADMIN_EMAIL, ...extraUserEmails];
     }
 
     const response = await fetchWithTimeout('https://api.resend.com/emails', {

--- a/control-plane/worker/src/index.js
+++ b/control-plane/worker/src/index.js
@@ -465,14 +465,17 @@ async function sendNotification(env, config) {
   // Email recipients: User as primary, Admin + extra users in CC.
   // USER_EMAIL may be comma-separated (e.g. admin panel sets multiple emails);
   // Resend rejects a to[] entry that contains commas, so split + validate.
-  // Regex accepts both Resend formats: `email@example.com` and
-  // `Name <email@example.com>`; requires at least one dot in the domain so
-  // malformed entries like `foo@` or `foo@bar` are skipped.
-  const RESEND_EMAIL_RE = /^(?:[^<]*<)?[^\s@<>]+@[^\s@<>]+\.[^\s@<>]+>?$/;
+  // Two explicit alternatives cover Resend's accepted formats; half-bracketed
+  // / no-display-name variants are excluded.
+  //   plain:     `email@example.com`
+  //   bracketed: `Name <email@example.com>` (non-empty display name required)
+  const PLAIN_EMAIL_RE = /^[^\s@<>]+@[^\s@<>]+\.[^\s@<>]+$/;
+  const BRACKETED_EMAIL_RE = /^\S[^<>]*<[^\s@<>]+@[^\s@<>]+\.[^\s@<>]+>$/;
+  const isValidResendEmail = (e) => PLAIN_EMAIL_RE.test(e) || BRACKETED_EMAIL_RE.test(e);
   const userEmails = (env.USER_EMAIL || '')
     .split(',')
     .map((e) => e.trim())
-    .filter((e) => RESEND_EMAIL_RE.test(e));
+    .filter(isValidResendEmail);
   const userEmail = userEmails[0] || null;
   const extraUserEmails = userEmails.slice(1);
 

--- a/control-plane/worker/src/index.js
+++ b/control-plane/worker/src/index.js
@@ -524,7 +524,10 @@ async function sendNotification(env, config) {
     }, 15000);
 
     if (response.ok) {
-      const recipientMsg = userEmail ? `${userEmail} (cc: ${env.ADMIN_EMAIL})` : env.ADMIN_EMAIL;
+      const ccList = emailPayload.cc || [];
+      const recipientMsg = userEmail
+        ? (ccList.length > 0 ? `${userEmail} (cc: ${ccList.join(', ')})` : userEmail)
+        : env.ADMIN_EMAIL;
       const message = `Notification email sent to ${recipientMsg}`;
       console.log(`✅ ${message}`);
       await logToD1(env.NEXUS_DB, 'info', message);

--- a/control-plane/worker/src/index.js
+++ b/control-plane/worker/src/index.js
@@ -464,11 +464,15 @@ async function sendNotification(env, config) {
 
   // Email recipients: User as primary, Admin + extra users in CC.
   // USER_EMAIL may be comma-separated (e.g. admin panel sets multiple emails);
-  // Resend rejects a to[] entry that contains commas, so split + sanitize.
+  // Resend rejects a to[] entry that contains commas, so split + validate.
+  // Regex accepts both Resend formats: `email@example.com` and
+  // `Name <email@example.com>`; requires at least one dot in the domain so
+  // malformed entries like `foo@` or `foo@bar` are skipped.
+  const RESEND_EMAIL_RE = /^(?:[^<]*<)?[^\s@<>]+@[^\s@<>]+\.[^\s@<>]+>?$/;
   const userEmails = (env.USER_EMAIL || '')
     .split(',')
     .map((e) => e.trim())
-    .filter((e) => e.length > 0 && e.includes('@'));
+    .filter((e) => RESEND_EMAIL_RE.test(e));
   const userEmail = userEmails[0] || null;
   const extraUserEmails = userEmails.slice(1);
 


### PR DESCRIPTION
## Problem

Control Plane email senders fail with `Resend API error: Invalid \`to\` field` when `USER_EMAIL` contains multiple comma-separated addresses.

```
Failed to send email: Resend API error: Invalid `to` field.
The email address needs to follow the `email@example.com` or
`Name <email@example.com>` format.
```

Reproduces whenever a stack is set up via Nexus-Stack-for-Education (or any other caller that joins multiple admin emails into `USER_EMAIL` for Cloudflare Access). A value like `"stefan.koch@hslu.ch,sk@stefanko.ch"` gets handed to Resend as a single `to[0]` entry and the whole send is rejected.

## Root cause

Both email code paths do the same thing — pass `env.USER_EMAIL` straight into `to[]`:

- `control-plane/functions/api/send-credentials.js` — the **Send Credentials** button
- `control-plane/worker/src/index.js` — the **scheduled-teardown** notification cron

Resend requires each `to[]` entry to be exactly one RFC-5322 address; commas inside an entry fail validation.

## Fix

Split `USER_EMAIL` on comma at both call sites, keep the first valid address as the primary `to`, fold the rest alongside `ADMIN_EMAIL` into `cc`:

```js
const userEmails = (env.USER_EMAIL || '')
  .split(',')
  .map((e) => e.trim())
  .filter((e) => e.length > 0 && e.includes('@'));
const userEmail = userEmails[0] || null;
const extraUserEmails = userEmails.slice(1);
// ...
if (userEmail) {
  emailPayload.cc = [env.ADMIN_EMAIL, ...extraUserEmails];
}
```

Single-address `USER_EMAIL` produces a one-element array → behaviour unchanged for existing single-stack deployments.

## Scope

Admin-panel-side (`Nexus-Stack-for-Education`) intentionally keeps the comma-joined `TF_VAR_user_email` — Terraform consumes it for the Cloudflare Access allow-list where comma-separated is the expected format. The split belongs in the email senders.

## Test plan

- [ ] `USER_EMAIL` = single address → credentials arrive at user, CC admin (unchanged)
- [ ] `USER_EMAIL` = `"primary@x.com,admin@y.com"` → credentials arrive at primary, CC admin + `admin@y.com`, Resend accepts
- [ ] Scheduled-teardown notification cron succeeds in both cases
- [ ] `USER_EMAIL=""` → falls back to `ADMIN_EMAIL` (unchanged)
