### PR TITLE
feat(control-plane): Email Credentials on Secrets page + tofu init retry

### DIFF
--- a/.github/workflows/setup-control-plane.yaml
+++ b/.github/workflows/setup-control-plane.yaml
@@ -436,7 +436,23 @@ jobs:
           EOF
           sed -i 's/^          //' backend.hcl
 
-          tofu init -backend-config=backend.hcl
+          # Retry tofu init a few times: the OpenTofu provider registry
+          # occasionally returns a transient failure fetching authentication
+          # checksums ("could not query provider registry ... failed to retrieve
+          # authentication checksums"), and a single retry after a short pause
+          # almost always succeeds.
+          for ATTEMPT in 1 2 3; do
+            if tofu init -backend-config=backend.hcl; then
+              break
+            fi
+            if [ "$ATTEMPT" -lt 3 ]; then
+              echo "⚠️  tofu init failed on attempt $ATTEMPT — retrying in 15s..."
+              sleep 15
+            else
+              echo "❌ tofu init failed after 3 attempts"
+              exit 1
+            fi
+          done
 
       - name: Clean up orphaned Hetzner Object Storage buckets
         run: |

--- a/control-plane/src/pages/index.astro
+++ b/control-plane/src/pages/index.astro
@@ -14,10 +14,6 @@ import Layout from '../layouts/Layout.astro';
 
   <!-- Action Buttons -->
   <div class="actions">
-    <button class="action-btn email-credentials" id="btn-email-credentials" disabled>
-      <span class="icon">&#x1F4E7;</span>
-      Email Credentials
-    </button>
     <button class="action-btn spin-up" id="btn-spin-up" disabled>
       <span class="icon">&#x26A1;</span>
       Spin Up
@@ -202,11 +198,6 @@ import Layout from '../layouts/Layout.astro';
     display: block;
     font-size: 2rem;
     margin-bottom: 0.5rem;
-  }
-
-  .action-btn.email-credentials {
-    border-color: rgba(168, 85, 247, 0.6);
-    color: #a855f7;
   }
 
   .action-btn.spin-up {
@@ -519,12 +510,10 @@ import Layout from '../layouts/Layout.astro';
   }
 
   function updateButtons(data) {
-    const btnEmail = document.getElementById('btn-email-credentials');
     const btnSpinUp = document.getElementById('btn-spin-up');
     const btnTeardown = document.getElementById('btn-teardown');
 
     if (data.inProgress) {
-      btnEmail.disabled = true;
       btnSpinUp.disabled = true;
       btnTeardown.disabled = true;
       btnSpinUp.innerHTML = '<span class="spinner"></span>Working...';
@@ -532,7 +521,6 @@ import Layout from '../layouts/Layout.astro';
       return;
     }
 
-    btnEmail.innerHTML = '<span class="icon">&#x1F4E7;</span>Email Credentials';
     if (pendingChangesCount > 0) {
       btnSpinUp.innerHTML = '<span class="icon">&#x26A1;</span>Deploy Changes (' + pendingChangesCount + ')';
     } else {
@@ -542,45 +530,20 @@ import Layout from '../layouts/Layout.astro';
 
     switch (data.infraState) {
       case 'deployed':
-        btnEmail.disabled = false;
         btnSpinUp.disabled = pendingChangesCount === 0;
         btnTeardown.disabled = false;
         break;
       case 'torn-down':
-        btnEmail.disabled = true;
         btnSpinUp.disabled = false;
         btnTeardown.disabled = true;
         break;
       case 'destroyed':
-        btnEmail.disabled = true;
         btnSpinUp.disabled = false;
         btnTeardown.disabled = true;
         break;
       default:
-        btnEmail.disabled = true;
         btnSpinUp.disabled = false;
         btnTeardown.disabled = false;
-    }
-  }
-
-  // Email Credentials
-  async function emailCredentials() {
-    const btn = document.getElementById('btn-email-credentials');
-    const originalHTML = btn.innerHTML;
-    btn.disabled = true;
-    btn.innerHTML = '<span class="spinner"></span>Sending...';
-    try {
-      const response = await fetch(`${API_URL}/api/send-credentials`, {
-        method: 'POST', credentials: 'same-origin',
-        headers: { 'Content-Type': 'application/json' }
-      });
-      const data = await response.json();
-      showToast(data.success ? 'Credentials email sent!' : (data.error || 'Failed to send email'), data.success ? 'success' : 'error');
-    } catch {
-      showToast('Failed to send email', 'error');
-    } finally {
-      btn.disabled = false;
-      btn.innerHTML = originalHTML;
     }
   }
 
@@ -668,7 +631,7 @@ import Layout from '../layouts/Layout.astro';
       }
       const data = await response.json();
       if (data.success) {
-        const labels = { 'spin-up': 'Spin Up', 'teardown': 'Teardown', 'email-credentials': 'Email Credentials' };
+        const labels = { 'spin-up': 'Spin Up', 'teardown': 'Teardown' };
         showToast((labels[action] || action) + ' triggered!');
         setTimeout(fetchStatus, 2000);
       } else {
@@ -697,7 +660,6 @@ import Layout from '../layouts/Layout.astro';
   }
 
   // Event listeners
-  document.getElementById('btn-email-credentials').addEventListener('click', () => emailCredentials());
   document.getElementById('btn-spin-up').addEventListener('click', () => triggerAction('spin-up'));
   document.getElementById('btn-teardown').addEventListener('click', () => showConfirmModal('teardown'));
   document.getElementById('modal-cancel').addEventListener('click', hideModal);

--- a/control-plane/src/pages/secrets.astro
+++ b/control-plane/src/pages/secrets.astro
@@ -378,7 +378,11 @@ import Layout from '../layouts/Layout.astro';
 
   loadSecrets();
 
-  // Email Credentials button — POST /api/send-credentials
+  // Email Credentials button — POST /api/send-credentials.
+  // Mirrors the content-type handling used in loadSecrets() above so a
+  // non-JSON response (Cloudflare Access HTML login page, proxy error,
+  // etc.) surfaces an actionable "session expired" toast instead of
+  // being swallowed by the generic catch.
   async function emailCredentials() {
     const btn = document.getElementById('btn-email-credentials');
     if (!btn) return;
@@ -391,18 +395,18 @@ import Layout from '../layouts/Layout.astro';
         credentials: 'same-origin',
         headers: { 'Content-Type': 'application/json' }
       });
-      const data = await response.json();
-      if (typeof showToast === 'function') {
-        showToast(
-          data.success ? 'Credentials email sent!' : (data.error || 'Failed to send email'),
-          data.success ? 'success' : 'error'
-        );
-      } else {
-        alert(data.success ? 'Credentials email sent!' : (data.error || 'Failed to send email'));
+      const ct = response.headers.get('content-type') || '';
+      if (!ct.includes('application/json')) {
+        showToast('Session expired — please refresh the page', 'error');
+        return;
       }
+      const data = await response.json();
+      showToast(
+        data.success ? 'Credentials email sent!' : (data.error || 'Failed to send email'),
+        data.success ? 'success' : 'error'
+      );
     } catch (e) {
-      if (typeof showToast === 'function') showToast('Failed to send email', 'error');
-      else alert('Failed to send email');
+      showToast('Failed to send email', 'error');
     } finally {
       btn.disabled = false;
       btn.innerHTML = originalHTML;

--- a/control-plane/src/pages/secrets.astro
+++ b/control-plane/src/pages/secrets.astro
@@ -8,6 +8,17 @@ import Layout from '../layouts/Layout.astro';
     <p class="hint">Hover to reveal &middot; Click to copy</p>
   </div>
 
+  <div class="email-credentials-panel">
+    <div class="email-credentials-text">
+      <strong>Email Credentials</strong>
+      <p>Sends an email with the <strong>Infisical admin URL, email, and password</strong> to the stack owner. All other service credentials live inside Infisical itself — log in there to view them.</p>
+    </div>
+    <button class="email-credentials-btn" id="btn-email-credentials">
+      <span class="icon">&#x1F4E7;</span>
+      <span class="label">Send Email</span>
+    </button>
+  </div>
+
   <div class="search-bar">
     <input type="text" id="secret-search" placeholder="Filter secrets..." autocomplete="off">
   </div>
@@ -36,6 +47,65 @@ import Layout from '../layouts/Layout.astro';
     font-size: 0.75rem;
     color: var(--text-muted);
     margin-top: 0.3rem;
+  }
+
+  /* Email Credentials panel (above the search bar) */
+  .email-credentials-panel {
+    display: flex;
+    align-items: center;
+    gap: 1.5rem;
+    background: rgba(168, 85, 247, 0.05);
+    border: 1px solid rgba(168, 85, 247, 0.3);
+    padding: 1rem 1.5rem;
+    margin-bottom: 1.5rem;
+  }
+
+  .email-credentials-text {
+    flex: 1;
+    font-size: 0.85rem;
+    line-height: 1.6;
+    color: var(--text-secondary);
+  }
+
+  .email-credentials-text strong {
+    color: #a855f7;
+  }
+
+  .email-credentials-text p {
+    margin-top: 0.3rem;
+  }
+
+  .email-credentials-btn {
+    flex-shrink: 0;
+    background: rgba(168, 85, 247, 0.1);
+    border: 1px solid rgba(168, 85, 247, 0.5);
+    color: #a855f7;
+    font-family: 'Orbitron', sans-serif;
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    padding: 0.7rem 1.2rem;
+    cursor: pointer;
+    transition: all 0.3s ease;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .email-credentials-btn:hover {
+    background: rgba(168, 85, 247, 0.2);
+    border-color: #a855f7;
+    box-shadow: 0 0 20px rgba(168, 85, 247, 0.3);
+  }
+
+  .email-credentials-btn:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+    pointer-events: none;
+  }
+
+  .email-credentials-btn .icon {
+    font-size: 1.1rem;
   }
 
   .search-bar {
@@ -307,4 +377,38 @@ import Layout from '../layouts/Layout.astro';
   });
 
   loadSecrets();
+
+  // Email Credentials button — POST /api/send-credentials
+  async function emailCredentials() {
+    const btn = document.getElementById('btn-email-credentials');
+    if (!btn) return;
+    const originalHTML = btn.innerHTML;
+    btn.disabled = true;
+    btn.innerHTML = '<span class="spinner"></span><span class="label">Sending&hellip;</span>';
+    try {
+      const response = await fetch('/api/send-credentials', {
+        method: 'POST',
+        credentials: 'same-origin',
+        headers: { 'Content-Type': 'application/json' }
+      });
+      const data = await response.json();
+      if (typeof showToast === 'function') {
+        showToast(
+          data.success ? 'Credentials email sent!' : (data.error || 'Failed to send email'),
+          data.success ? 'success' : 'error'
+        );
+      } else {
+        alert(data.success ? 'Credentials email sent!' : (data.error || 'Failed to send email'));
+      }
+    } catch (e) {
+      if (typeof showToast === 'function') showToast('Failed to send email', 'error');
+      else alert('Failed to send email');
+    } finally {
+      btn.disabled = false;
+      btn.innerHTML = originalHTML;
+    }
+  }
+
+  const emailBtn = document.getElementById('btn-email-credentials');
+  if (emailBtn) emailBtn.addEventListener('click', emailCredentials);
 </script>


### PR DESCRIPTION
## Summary

Two changes bundled here:

**1. UX** — Move **Email Credentials** from the Dashboard to the Secrets page, where it thematically belongs. The Dashboard's three buttons (Email Credentials · Spin Up · Teardown) mixed two concerns; Spin Up and Teardown control infrastructure state, Email Credentials delivers secrets.

**2. CI reliability** — Retry `tofu init` in `setup-control-plane.yaml` on OpenTofu provider-registry transient failures.

## Changes

### `control-plane/src/pages/index.astro` (Dashboard)
- Remove the Email Credentials button, its CSS rule, its event listener, and the `emailCredentials()` handler.
- `updateButtons()` no longer touches `btn-email-credentials`; per-state logic is simpler (Spin Up + Teardown only).

### `control-plane/src/pages/secrets.astro` (Secrets)
- New **Email Credentials panel** above the search bar with:
  - Short description: *"Sends an email with the Infisical admin URL, email, and password to the stack owner. All other service credentials live inside Infisical itself."*
  - **Send Email** button (purple accent to distinguish the action from the read-only secret listing below).
- Handler POSTs to the existing `/api/send-credentials` endpoint — no backend change.
- Content-type check before `response.json()` so a Cloudflare Access HTML response surfaces a *"Session expired — please refresh the page"* toast instead of the generic catch. Matches the pattern used in `loadSecrets()`.
- Uses the global `showToast` helper (guaranteed by `Layout.astro`'s Toast component), consistent with other call sites on this page.

### `.github/workflows/setup-control-plane.yaml`
- Wrap `tofu init` in a 3-attempt retry with a 15 s pause. The OpenTofu provider registry (`registry.opentofu.org`) occasionally fails the provider checksum fetch (observed in today's Initial Setup run with errors like *"could not query provider registry … failed to retrieve authentication checksums: request failed after 2"* for both `cloudflare/cloudflare v4.52.7` and `hetznercloud/hcloud v1.60.1`). A short retry covers these blips so a single transient CDN hiccup doesn't fail an entire setup.

## Test plan

- [x] `npm run build` in `control-plane/` passes (9 pages built)
- [ ] Dashboard: only Spin Up + Teardown visible, layout still looks right
- [ ] Secrets: new purple panel at the top with description + Send Email button
- [ ] Click Send Email → credentials email arrives; toast confirms
- [ ] Session expiry path: kill the Access session → click Send Email → toast says "Session expired"
- [ ] Run a Setup Control Plane workflow → `tofu init` either succeeds on attempt 1 or retries gracefully
