### PR TITLE
fix(control-plane): Use BASE_DOMAIN as Resend sender domain

### DIFF
--- a/.github/workflows/setup-control-plane.yaml
+++ b/.github/workflows/setup-control-plane.yaml
@@ -52,6 +52,7 @@ jobs:
       TF_VAR_cloudflare_zone_id: ${{ secrets.CLOUDFLARE_ZONE_ID }}
       TF_VAR_hcloud_token: ${{ secrets.HCLOUD_TOKEN }}
       TF_VAR_domain: ${{ secrets.DOMAIN }}
+      TF_VAR_base_domain: ${{ secrets.BASE_DOMAIN }}
       TF_VAR_access_emails: ${{ secrets.ACCESS_EMAILS }}
       TF_VAR_infisical_token: ${{ secrets.INFISICAL_TOKEN }}
       TF_VAR_dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -1010,6 +1011,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_SECRETS_TOKEN }}
           RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
           DOMAIN: ${{ secrets.DOMAIN }}
+          BASE_DOMAIN: ${{ secrets.BASE_DOMAIN }}
           SUBDOMAIN_SEPARATOR: ${{ secrets.SUBDOMAIN_SEPARATOR || '.' }}
           ADMIN_EMAIL: ${{ secrets.TF_VAR_admin_email }}
           USER_EMAIL: ${{ secrets.TF_VAR_user_email }}
@@ -1054,6 +1056,17 @@ jobs:
             if ! echo "$DOMAIN" | npx wrangler@4 pages secret put DOMAIN \
               --project-name="$PROJECT_NAME" 2>&1; then
               echo "⚠️  Failed to set DOMAIN"
+            fi
+          fi
+
+          # BASE_DOMAIN is the Resend-verified parent used as the email
+          # sender. On single-stack installs BASE_DOMAIN is typically empty
+          # and the Functions code falls back to DOMAIN at runtime.
+          if [ -n "$BASE_DOMAIN" ]; then
+            echo "  Setting BASE_DOMAIN secret..."
+            if ! echo "$BASE_DOMAIN" | npx wrangler@4 pages secret put BASE_DOMAIN \
+              --project-name="$PROJECT_NAME" 2>&1; then
+              echo "⚠️  Failed to set BASE_DOMAIN"
             fi
           fi
 

--- a/.github/workflows/setup-control-plane.yaml
+++ b/.github/workflows/setup-control-plane.yaml
@@ -1062,12 +1062,23 @@ jobs:
           # BASE_DOMAIN is the Resend-verified parent used as the email
           # sender. On single-stack installs BASE_DOMAIN is typically empty
           # and the Functions code falls back to DOMAIN at runtime.
+          #
+          # Reconcile in BOTH directions: when non-empty, upsert; when empty,
+          # delete any previously-set Pages secret so a lingering value
+          # can't keep overriding DOMAIN after the operator unset it.
           if [ -n "$BASE_DOMAIN" ]; then
             echo "  Setting BASE_DOMAIN secret..."
             if ! echo "$BASE_DOMAIN" | npx wrangler@4 pages secret put BASE_DOMAIN \
               --project-name="$PROJECT_NAME" 2>&1; then
               echo "⚠️  Failed to set BASE_DOMAIN"
             fi
+          else
+            echo "  BASE_DOMAIN is empty; removing any stale Pages secret so runtime falls back to DOMAIN..."
+            # `secret delete` is interactive by default and fails loudly if the
+            # secret doesn't exist. Pipe 'y' to auto-confirm, swallow output,
+            # and don't fail the step when the secret wasn't there to begin with.
+            echo y | npx wrangler@4 pages secret delete BASE_DOMAIN \
+              --project-name="$PROJECT_NAME" >/dev/null 2>&1 || true
           fi
 
           # SUBDOMAIN_SEPARATOR + derived URLs. These MUST be secrets (not Terraform

--- a/control-plane/functions/api/send-credentials.js
+++ b/control-plane/functions/api/send-credentials.js
@@ -57,7 +57,7 @@ export async function onRequestPost(context) {
     // subdomain that isn't registered with Resend, but BASE_DOMAIN is the
     // shared parent that IS verified. Fall back to DOMAIN for single-stack
     // installs where BASE_DOMAIN isn't set.
-    const fromDomain = env.BASE_DOMAIN || env.DOMAIN;
+    const fromDomain = env.BASE_DOMAIN || domain;
     const adminEmail = env.ADMIN_EMAIL;
 
     // USER_EMAIL may be a single address or a comma-separated list

--- a/control-plane/functions/api/send-credentials.js
+++ b/control-plane/functions/api/send-credentials.js
@@ -52,6 +52,12 @@ export async function onRequestPost(context) {
 
     const credentials = JSON.parse(credentialsJson);
     const domain = env.DOMAIN;
+    // Resend requires the sender domain to be verified. On multi-tenant
+    // deployments (e.g. Nexus-Stack-for-Education) DOMAIN is a per-user
+    // subdomain that isn't registered with Resend, but BASE_DOMAIN is the
+    // shared parent that IS verified. Fall back to DOMAIN for single-stack
+    // installs where BASE_DOMAIN isn't set.
+    const fromDomain = env.BASE_DOMAIN || env.DOMAIN;
     const adminEmail = env.ADMIN_EMAIL;
 
     // USER_EMAIL may be a single address or a comma-separated list
@@ -125,7 +131,7 @@ export async function onRequestPost(context) {
 
     // Send email via Resend (User as primary, Admin + extra users in CC)
     const emailPayload = {
-      from: `Nexus-Stack <nexus@${domain}>`,
+      from: `Nexus-Stack <nexus@${fromDomain}>`,
       to: userEmail ? [userEmail] : [adminEmail],
       subject: '🔐 Nexus-Stack Credentials',
       html: emailHTML

--- a/control-plane/worker/src/index.js
+++ b/control-plane/worker/src/index.js
@@ -513,8 +513,14 @@ async function sendNotification(env, config) {
       </div>
     `;
 
+    // Resend requires the sender domain to be verified. On multi-tenant
+    // deployments (e.g. Nexus-Stack-for-Education) DOMAIN is a per-user
+    // subdomain that isn't registered with Resend, but BASE_DOMAIN is the
+    // shared parent that IS verified. Fall back to DOMAIN for single-stack
+    // installs where BASE_DOMAIN isn't set.
+    const fromDomain = env.BASE_DOMAIN || env.DOMAIN;
     const emailPayload = {
-      from: `Nexus-Stack <nexus@${env.DOMAIN}>`,
+      from: `Nexus-Stack <nexus@${fromDomain}>`,
       to: userEmail ? [userEmail] : [env.ADMIN_EMAIL],
       subject: '⚠️ Scheduled Teardown in 15 Minutes',
       html: emailHtml,

--- a/tofu/control-plane/main.tf
+++ b/tofu/control-plane/main.tf
@@ -61,6 +61,15 @@ resource "cloudflare_workers_script" "scheduled_teardown" {
     text = var.domain
   }
 
+  # BASE_DOMAIN is the Resend-verified parent domain used as the email
+  # sender. Empty default falls back to `domain` at runtime in the worker
+  # code, so single-stack installs (where `domain` IS the verified
+  # Resend domain) don't need to set anything.
+  plain_text_binding {
+    name = "BASE_DOMAIN"
+    text = var.base_domain
+  }
+
   plain_text_binding {
     name = "CONTROL_PLANE_URL"
     text = local.control_plane_url

--- a/tofu/control-plane/main.tf
+++ b/tofu/control-plane/main.tf
@@ -65,6 +65,18 @@ resource "cloudflare_workers_script" "scheduled_teardown" {
   # sender. Empty default falls back to `domain` at runtime in the worker
   # code, so single-stack installs (where `domain` IS the verified
   # Resend domain) don't need to set anything.
+  #
+  # Note: the Cloudflare Pages project (Functions side) reads BASE_DOMAIN
+  # as a Pages SECRET, not as a Terraform env var. Same pattern as DOMAIN
+  # / SUBDOMAIN_SEPARATOR / INFISICAL_URL / CONTROL_PLANE_URL — `wrangler
+  # pages deploy` later in the setup-control-plane workflow wipes any
+  # Terraform-managed environment_variables that aren't in wrangler.toml,
+  # but it preserves secrets. That's why these values are kept out of the
+  # Pages `environment_variables` map below and pushed via
+  # `wrangler pages secret put BASE_DOMAIN` in the workflow instead.
+  # Terraform and the Pages secret step must therefore run together — a
+  # bare `tofu apply` without the workflow will leave the Pages Function
+  # without BASE_DOMAIN; the Function falls back to DOMAIN in that case.
   plain_text_binding {
     name = "BASE_DOMAIN"
     text = var.base_domain

--- a/tofu/control-plane/variables.tf
+++ b/tofu/control-plane/variables.tf
@@ -25,6 +25,12 @@ variable "domain" {
   type        = string
 }
 
+variable "base_domain" {
+  description = "Parent domain used as the Resend sender domain. For single-stack installs this is the same as `domain`. For multi-tenant deployments where `domain` is a per-user subdomain (e.g. `user.base.com`), set this to the verified parent (`base.com`) so outgoing emails don't fail with 'domain not verified'. Defaults to an empty string, which falls back to `domain`."
+  type        = string
+  default     = ""
+}
+
 variable "subdomain_separator" {
   description = "Separator between service subdomain and base domain. '.' for standard dot-subdomains (default, requires wildcard cert at 3rd level), '-' for flat subdomains used when provisioning tenants under a shared base domain."
   type        = string

--- a/tofu/control-plane/variables.tf
+++ b/tofu/control-plane/variables.tf
@@ -29,6 +29,14 @@ variable "base_domain" {
   description = "Parent domain used as the Resend sender domain. For single-stack installs this is the same as `domain`. For multi-tenant deployments where `domain` is a per-user subdomain (e.g. `user.base.com`), set this to the verified parent (`base.com`) so outgoing emails don't fail with 'domain not verified'. Defaults to an empty string, which falls back to `domain`."
   type        = string
   default     = ""
+
+  validation {
+    condition = (
+      var.base_domain == "" ||
+      can(regex("^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$", var.base_domain))
+    )
+    error_message = "base_domain must be empty or a valid domain name (e.g., example.com)."
+  }
 }
 
 variable "subdomain_separator" {


### PR DESCRIPTION
## Problem

Resend rejects sends whose sender domain isn't verified:

```
Resend API error: The stefan-hslu.nona.company domain is not verified.
Please, add and verify your domain on https://resend.com/domains
```

On multi-tenant deployments (Nexus-Stack-for-Education) `DOMAIN` is a per-user subdomain (`stefan-hslu.nona.company`) and the Resend account is verified only against the shared parent (`nona.company`). The email senders picked the wrong one.

## Fix

Introduce an optional `BASE_DOMAIN` that identifies the Resend-verified parent. Both email senders use `env.BASE_DOMAIN || env.DOMAIN`. Single-stack installs leave it unset and fall back to `DOMAIN` → fully backward compatible.

## Changes

| File | What changes |
|---|---|
| `control-plane/functions/api/send-credentials.js` | `from: nexus@${BASE_DOMAIN || DOMAIN}` |
| `control-plane/worker/src/index.js` | Same, for the scheduled-teardown notification |
| `tofu/control-plane/variables.tf` | New optional `base_domain` variable (default `""`) |
| `tofu/control-plane/main.tf` | `plain_text_binding { name = "BASE_DOMAIN" }` on the worker |
| `.github/workflows/setup-control-plane.yaml` | `TF_VAR_base_domain` from the `BASE_DOMAIN` secret; `wrangler pages secret put BASE_DOMAIN` so the Pages Function sees the same value (Pages env vars get wiped by `wrangler deploy`, secrets survive — same pattern already in use for `DOMAIN` and `SUBDOMAIN_SEPARATOR`) |

## Test plan

- [x] `tofu validate` on `tofu/control-plane/` (syntax only; full `init` requires provider network)
- [x] Astro build passes
- [ ] Single-stack deployment (no `BASE_DOMAIN`) → email still sends, `from: nexus@<DOMAIN>`, no regression
- [ ] Multi-tenant deployment with `BASE_DOMAIN=nona.company`, `DOMAIN=stefan-hslu.nona.company` → email sends, `from: nexus@nona.company`, Resend accepts

## Follow-up (Education admin panel)

The Education `setup.ts` already sets `BASE_DOMAIN` as a repo secret on user forks. After this template release + Upgrade on each user, the Pages/Worker read it automatically. No Education-side change needed.
