### PR TITLE
fix(version): Show per-fork deployed template version (no more 'DEV' on forks)

### DIFF
--- a/.github/workflows/setup-control-plane.yaml
+++ b/.github/workflows/setup-control-plane.yaml
@@ -1092,7 +1092,7 @@ jobs:
             TEMPLATE_VERSION=$(tr -d '[:space:]' < .template-version)
           fi
           if [ -n "$TEMPLATE_VERSION" ]; then
-            echo "  Setting TEMPLATE_VERSION secret to $TEMPLATE_VERSION..."
+            echo "  Setting TEMPLATE_VERSION secret..."
             if ! echo "$TEMPLATE_VERSION" | npx wrangler@4 pages secret put TEMPLATE_VERSION \
               --project-name="$PROJECT_NAME" 2>&1; then
               echo "⚠️  Failed to set TEMPLATE_VERSION"

--- a/.github/workflows/setup-control-plane.yaml
+++ b/.github/workflows/setup-control-plane.yaml
@@ -1098,7 +1098,7 @@ jobs:
               echo "⚠️  Failed to set TEMPLATE_VERSION"
             fi
           else
-            echo "  No .template-version file found; removing any stale Pages secret so runtime falls back to the GitHub API / 'dev'..."
+            echo "  .template-version missing or empty; removing any stale Pages secret so runtime falls back to the GitHub API / 'dev'..."
             echo y | npx wrangler@4 pages secret delete TEMPLATE_VERSION \
               --project-name="$PROJECT_NAME" >/dev/null 2>&1 || true
           fi

--- a/.github/workflows/setup-control-plane.yaml
+++ b/.github/workflows/setup-control-plane.yaml
@@ -1081,6 +1081,28 @@ jobs:
               --project-name="$PROJECT_NAME" >/dev/null 2>&1 || true
           fi
 
+          # TEMPLATE_VERSION — the release tag of the template code currently
+          # deployed in this fork. Read from a `.template-version` file at the
+          # repo root, which the admin panel writes on every Setup / Upgrade.
+          # /api/version reads this so the header shows the actual deployed
+          # release per user instead of the 'dev' fallback triggered by a
+          # 404 on the fork's non-existent releases.
+          TEMPLATE_VERSION=""
+          if [ -f .template-version ]; then
+            TEMPLATE_VERSION=$(tr -d '[:space:]' < .template-version)
+          fi
+          if [ -n "$TEMPLATE_VERSION" ]; then
+            echo "  Setting TEMPLATE_VERSION secret to $TEMPLATE_VERSION..."
+            if ! echo "$TEMPLATE_VERSION" | npx wrangler@4 pages secret put TEMPLATE_VERSION \
+              --project-name="$PROJECT_NAME" 2>&1; then
+              echo "⚠️  Failed to set TEMPLATE_VERSION"
+            fi
+          else
+            echo "  No .template-version file found; removing any stale Pages secret so runtime falls back to the GitHub API / 'dev'..."
+            echo y | npx wrangler@4 pages secret delete TEMPLATE_VERSION \
+              --project-name="$PROJECT_NAME" >/dev/null 2>&1 || true
+          fi
+
           # SUBDOMAIN_SEPARATOR + derived URLs. These MUST be secrets (not Terraform
           # environment_variables) because `wrangler pages deploy` later in this
           # workflow wipes env_vars that aren't listed in wrangler.toml. Secrets

--- a/control-plane/functions/api/version.js
+++ b/control-plane/functions/api/version.js
@@ -8,17 +8,42 @@ import { fetchWithTimeout } from './_utils/fetch-with-timeout.js';
 
 export async function onRequestGet(context) {
   const { env } = context;
-  
+
+  // Prefer the explicit deployed-version env var if it's set. This is the
+  // authoritative source for user-fork deployments: the admin panel writes
+  // the template release tag (e.g. `v0.51.1`) into the fork on every
+  // Setup / Upgrade, and the setup-control-plane workflow pushes it into
+  // the Pages project as the TEMPLATE_VERSION secret. GitHub's
+  // releases-latest endpoint on a fork returns 404 (forks don't inherit
+  // releases), which used to leave the UI labelled "dev" for every
+  // multi-tenant user regardless of which version they were actually on.
+  if (env.TEMPLATE_VERSION && env.TEMPLATE_VERSION.trim()) {
+    const tag = env.TEMPLATE_VERSION.trim();
+    return new Response(JSON.stringify({
+      success: true,
+      version: tag,
+      name: tag,
+      url: `https://github.com/stefanko-ch/Nexus-Stack/releases/tag/${tag}`,
+      publishedAt: null,
+      source: 'env',
+    }), {
+      headers: {
+        'Content-Type': 'application/json',
+        'Cache-Control': 'public, max-age=300',
+      },
+    });
+  }
+
   // Validate environment variables
   const missing = [];
   if (!env.GITHUB_TOKEN) missing.push('GITHUB_TOKEN');
   if (!env.GITHUB_OWNER) missing.push('GITHUB_OWNER');
   if (!env.GITHUB_REPO) missing.push('GITHUB_REPO');
-  
+
   if (missing.length > 0) {
-    return new Response(JSON.stringify({ 
-      success: false, 
-      error: `Missing required environment variables: ${missing.join(', ')}` 
+    return new Response(JSON.stringify({
+      success: false,
+      error: `Missing required environment variables: ${missing.join(', ')}`
     }), {
       status: 500,
       headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Problem

Control Plane header shows **"DEV"** for every multi-tenant user regardless of which Nexus-Stack release they're actually on:

![Control Panel showing DEV](https://i.imgur.com/placeholder.png)

Root cause: forks don't inherit GitHub releases, so `/api/version` hits the fork's `releases/latest` endpoint, gets `404`, and falls back to `'dev'`.

Showing the upstream's latest release instead would be wrong — students on an older Nexus-Stack release shouldn't see the newest tag as if it were their deployed code. Authoritative source is the release tag that was actually copied into the fork at last Setup / Upgrade.

## Fix (two parts, both in this PR)

### Template / workflow

`setup-control-plane.yaml`: after setting `DOMAIN` / `BASE_DOMAIN` / `SUBDOMAIN_SEPARATOR` as Pages secrets, look for `.template-version` at the repo root. If present, push its content (e.g. `v0.51.1`) as Pages secret `TEMPLATE_VERSION`. If absent, delete any stale secret — fallback path returns.

### Template / Pages Function

`control-plane/functions/api/version.js`: prefer `env.TEMPLATE_VERSION` when set; otherwise keep today's GitHub-releases-latest lookup and the `'dev'` last-resort fallback. Backward compatible for single-stack / canonical-template deployments.

## Admin-panel side (separate PR, follows)

The Nexus-Stack-for-Education admin panel needs to write `.template-version` into the user fork on every Setup and Upgrade. That PR will go on `stefanko-ch/Nexus-Stack-for-Education` — doesn't block this one.

Until the Education PR lands, users stay on `'dev'` (same as today) — no regression.

## Test plan

- [x] Build passes in `control-plane/`
- [ ] Single-stack: template's own deployment at `control.nexus-stack.ch` — `.template-version` absent, `/api/version` still returns latest release from stefanko-ch/Nexus-Stack (unchanged)
- [ ] After Education PR merges + admin panel redeploy: trigger Upgrade on stefan-hslu → `.template-version` contains `v0.51.2` → `setup-control-plane.yaml` pushes TEMPLATE_VERSION secret → Control Plane header shows `v0.51.2` instead of `DEV`
