### PR TITLE
fix(docs): Make user-guide internal links resolve on the website

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -807,6 +807,20 @@ Why this matters — there is a concrete failure mode, not a style preference:
 3. **Do not use `style="width: N%"` or similar inline styles.** Starlight applies responsive image styling automatically. If you genuinely need a narrow image (icon, button), keep the source image itself small — do not rely on CSS width constraints.
 4. **Assets go in the guide's own `assets/` folder** (e.g. `docs/user-guides/assets/`, `docs/admin-guides/assets/`). The website's `fetch-docs.mjs` syncs these into the matching subfolder next to the markdown so relative `./assets/…` paths resolve at build time.
 
+## Documentation Internal Links
+
+**For relative links between markdown files in `docs/**/*.md`, always include the `.md` extension.** Use `[Monitoring](./monitoring.md)`, not `[Monitoring](./monitoring)`.
+
+Why this matters — same editor-vs-site mismatch as the image-syntax rule, different symptom:
+
+- Starlight renders each `.md` file as a directory with a trailing slash: `docs/user-guides/control-plane.md` → `/docs/guides/user-guides/control-plane/`.
+- A browser-side relative link `./monitoring` from that URL resolves to `/docs/guides/user-guides/control-plane/monitoring` — a child path that **does not exist**. The actual sibling page is at `/docs/guides/user-guides/monitoring/`.
+- Result: every extension-less `./foo` link between guides returns 404 on the website, while looking fine in the GitHub viewer (which resolves file-relative, not URL-relative). This is a silent drift — the broken links only show up when a user actually clicks through on the live site. Happened in [PR #452's companion fix](https://github.com/stefanko-ch/Nexus-Stack/pull/453).
+
+**Rule:** Write `[text](./sibling.md)`. Astro/Starlight strips the `.md` at build time and resolves against the source location, producing the correct URL. GitHub's markdown viewer also follows `.md` links correctly. Both renderers happy, one source of truth.
+
+This applies to **every** relative markdown-to-markdown link in `docs/`, not just user-guides.
+
 ## Closing Issues via PRs
 
 **When creating a Pull Request, always check if there is a corresponding Issue that should be closed by the PR.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -815,7 +815,7 @@ Why this matters — same editor-vs-site mismatch as the image-syntax rule, diff
 
 - Starlight renders each `.md` file as a directory with a trailing slash: `docs/user-guides/control-plane.md` → `/docs/guides/user-guides/control-plane/`.
 - A browser-side relative link `./monitoring` from that URL resolves to `/docs/guides/user-guides/control-plane/monitoring` — a child path that **does not exist**. The actual sibling page is at `/docs/guides/user-guides/monitoring/`.
-- Result: every extension-less `./foo` link between guides returns 404 on the website, while looking fine in the GitHub viewer (which resolves file-relative, not URL-relative). This is a silent drift — the broken links only show up when a user actually clicks through on the live site. Happened in [PR #452's companion fix](https://github.com/stefanko-ch/Nexus-Stack/pull/453).
+- Result: every extension-less `./foo` link between guides returns 404 on the website, while looking fine in the GitHub viewer (which resolves file-relative, not URL-relative). This is a silent drift — the broken links only show up when a user actually clicks through on the live site. Happened in [PR #454](https://github.com/stefanko-ch/Nexus-Stack/pull/454).
 
 **Rule:** Write `[text](./sibling.md)`. Astro/Starlight strips the `.md` at build time and resolves against the source location, producing the correct URL. GitHub's markdown viewer also follows `.md` links correctly. Both renderers happy, one source of truth.
 

--- a/docs/user-guides/control-plane.md
+++ b/docs/user-guides/control-plane.md
@@ -36,12 +36,12 @@ The top nav has seven sections:
 
 | Page | What you do there |
 |------|-------------------|
-| [Dashboard](./dashboard) | See infrastructure status, spin up / tear down the stack |
-| [Stacks](./stacks) | Enable, disable, and open individual Docker services |
-| [Monitoring](./monitoring) | Inspect workflow logs, config, and runtime state |
-| [Secrets](./secrets) | Read-only view of Infisical secrets |
-| [Firewall](./firewall) | Open TCP ports for services that need direct access |
-| [Settings](./settings) | Server info, teardown schedule, notifications |
-| [Integrations](./integrations) | Databricks sync and other third-party hookups |
+| [Dashboard](./dashboard.md) | See infrastructure status, spin up / tear down the stack |
+| [Stacks](./stacks.md) | Enable, disable, and open individual Docker services |
+| [Monitoring](./monitoring.md) | Inspect workflow logs, config, and runtime state |
+| [Secrets](./secrets.md) | Read-only view of Infisical secrets |
+| [Firewall](./firewall.md) | Open TCP ports for services that need direct access |
+| [Settings](./settings.md) | Server info, teardown schedule, notifications |
+| [Integrations](./integrations.md) | Databricks sync and other third-party hookups |
 
-Each page is covered in its own short guide — linked above. Start with the [Dashboard](./dashboard) guide if you're brand new.
+Each page is covered in its own short guide — linked above. Start with the [Dashboard](./dashboard.md) guide if you're brand new.

--- a/docs/user-guides/dashboard.md
+++ b/docs/user-guides/dashboard.md
@@ -26,7 +26,7 @@ The coloured indicator at the top reflects the current state of your Hetzner inf
 | Green — **Deployed** | Server is running, Docker services are up, domain resolves |
 | Amber — **Pending** | A workflow is in progress (spin-up, teardown, or initial setup) |
 | Orange — **Torn down** | No server exists; nothing is running, nothing is being billed |
-| Grey — **Unknown** | Status check failed; see [Monitoring](./monitoring) for details |
+| Grey — **Unknown** | Status check failed; see [Monitoring](./monitoring.md) for details |
 
 The panel re-polls automatically every few seconds, so you can keep it open while a workflow runs.
 
@@ -67,4 +67,4 @@ Below the action buttons the Dashboard lists which services are currently active
 
 ![Active Stacks list below the action buttons, showing the currently enabled and running services with a total count](./assets/dashboard-active-stacks.png)
 
-The count ("3 stacks active") reflects services enabled in [Stacks](./stacks). Click a service row to open the service directly in a new tab.
+The count ("3 stacks active") reflects services enabled in [Stacks](./stacks.md). Click a service row to open the service directly in a new tab.


### PR DESCRIPTION
## Summary

Fix 10 broken internal links in the user guides that 404 on nexus-stack.ch, and add a CLAUDE.md guardrail so the same trap doesn't recur.

`[Monitoring](./monitoring)` from `control-plane.md` resolves on GitHub to the sibling file `user-guides/monitoring.md` ✅. On the website, Starlight renders `control-plane.md` as `/docs/guides/user-guides/control-plane/` (trailing-slash directory), so the browser resolves `./monitoring` URL-relative — producing `/.../control-plane/monitoring` → 404 instead of the actual page at `/.../monitoring/`.

Appending the `.md` extension (`./monitoring.md`) makes Astro/Starlight resolve the link against the markdown's source location at build time (correct URL), while GitHub's markdown viewer still follows `.md` links as sibling files. Same source works in both renderers, no build-tool changes.

## Before / After

```
# before — 404 on website, works on GitHub
[Monitoring](./monitoring)
# → https://nexus-stack.ch/docs/guides/user-guides/control-plane/monitoring  (404)

# after — works in both
[Monitoring](./monitoring.md)
# → https://nexus-stack.ch/docs/guides/user-guides/monitoring/  (200)
```

## Changes

- `docs/user-guides/control-plane.md` — 7 nav-table rows + the final "Start with the Dashboard" link
- `docs/user-guides/dashboard.md` — `[Monitoring](./monitoring.md)` and `[Stacks](./stacks.md)`
- `CLAUDE.md` — new "Documentation Internal Links" guardrail explaining the editor-vs-site resolution mismatch and the `.md`-extension rule, mirroring the existing Documentation Image Syntax section

10 links total. Verified no admin-guide or stack-doc link uses the extension-less pattern.

## Test plan

- [ ] After merge, confirm `https://nexus-stack.ch/docs/guides/user-guides/control-plane/` renders the nav table with all 7 links pointing to the correct sibling pages (not 404 sub-paths).
- [ ] Click through each link from the live Control Plane page and verify each destination renders (Dashboard, Stacks, Monitoring, Secrets, Firewall, Settings, Integrations).
- [ ] Verify the Dashboard page's `[Monitoring]` and `[Stacks]` links also work.
- [ ] Spot-check that the links still render correctly in the GitHub preview of `control-plane.md` on the merged commit.
