### PR TITLE
fix(tutorials): Put each category's landing page first in its sidebar group

### DIFF
--- a/docs/tutorials/code-server/index.md
+++ b/docs/tutorials/code-server/index.md
@@ -1,8 +1,7 @@
 ---
 title: "Code-Server"
 description: "Terminal and Python setup inside the browser-based VS Code that ships with Nexus-Stack"
-sidebar:
-  order: 1
+order: 0
 ---
 
 # Code-Server tutorials

--- a/docs/tutorials/flink/index.md
+++ b/docs/tutorials/flink/index.md
@@ -1,8 +1,7 @@
 ---
 title: "Flink"
 description: "Stream processing with Flink SQL via the Dinky web IDE"
-sidebar:
-  order: 4
+order: 0
 ---
 
 # Flink tutorials

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Tutorials"
 description: "Bite-sized how-tos for the most common Nexus-Stack workflows — each 5-15 min, no framework assumed"
+order: 0
 ---
 
 # Tutorials

--- a/docs/tutorials/redpanda-connect/index.md
+++ b/docs/tutorials/redpanda-connect/index.md
@@ -1,8 +1,7 @@
 ---
 title: "Redpanda Connect"
 description: "YAML-driven data pipelines — ingest external streams into Redpanda with zero code"
-sidebar:
-  order: 3
+order: 0
 ---
 
 # Redpanda Connect tutorials

--- a/docs/tutorials/redpanda/index.md
+++ b/docs/tutorials/redpanda/index.md
@@ -1,8 +1,7 @@
 ---
 title: "Redpanda"
 description: "Kafka-compatible event streaming — topics, producers, consumers, partitions, consumer groups"
-sidebar:
-  order: 2
+order: 0
 ---
 
 # Redpanda tutorials

--- a/docs/tutorials/spark/index.md
+++ b/docs/tutorials/spark/index.md
@@ -1,8 +1,7 @@
 ---
 title: "Spark Structured Streaming"
 description: "Read Redpanda from Databricks Spark, parse JSON, land a Bronze Delta table"
-sidebar:
-  order: 5
+order: 0
 ---
 
 # Spark Structured Streaming tutorials


### PR DESCRIPTION
## Summary

Each tutorial category's landing page (`index.md`) was rendering at the **bottom** of its sidebar group instead of the top. Top-level "Tutorials" landing was appearing after all five subgroups too. Verified both in the live site's sidebar HTML.

## Root cause (verified by code-reading)

`nexus-stack.ch/scripts/fetch-docs.mjs` uses a flat line-by-line regex parser for frontmatter:

```js
/^(\w+):\s*"?(.+?)"?\s*$/
```

It requires (a) no indentation on the key, and (b) a non-empty value after the colon.

My index.md files used **nested** YAML:

```yaml
---
title: "..."
sidebar:
  order: 1
---
```

- Line `sidebar:` — empty value after colon, fails the regex. Dropped.
- Line `  order: 1` — leading whitespace, `\w+` at start fails. Dropped.

Both lines silently ignored. `toStarlightFrontmatter` only emits `sidebar.order` when it sees a flat `fm.order`, so the synced output had no ordering info at all for the indexes. Starlight fell back to alphabetical sort, and since every tutorial had a valid `sidebar.order >= 1` (via flat `order: N` that parses cleanly), indexes sorted after all ordered items.

## Fix

Switch all 6 index.md files from nested `sidebar: { order: N }` to flat `order: 0`. Flat `order` IS parsed cleanly, and `toStarlightFrontmatter` converts it to `sidebar.order: 0` on the synced side — putting the index first (since tutorials have `sidebar.order >= 1`).

Files changed:

- `docs/tutorials/index.md` — top-level overview (`order: 0`)
- `docs/tutorials/code-server/index.md`
- `docs/tutorials/redpanda/index.md`
- `docs/tutorials/redpanda-connect/index.md`
- `docs/tutorials/flink/index.md`
- `docs/tutorials/spark/index.md`

## Not addressed here

The category subgroups themselves (code-server, redpanda, redpanda-connect, flink, spark) currently sort alphabetically at the Tutorials root. The original PR intent was pedagogical (code-server → redpanda → redpanda-connect → flink → spark). Fixing that requires either:

1. Upgrading `parseFrontmatter` on nexus-stack.ch to preserve nested YAML (so `sidebar.order` on each category index can set the subgroup's parent-level position), OR
2. Replacing the autogenerate sidebar config in `astro.config.mjs` with an explicit list.

The user flagged only the index-last issue, so that's what this PR fixes. Category-order is a follow-up if wanted.

## Test plan

- [ ] After merge + Cloudflare rebuild, `/docs/tutorials/` renders with "Tutorials" appearing at the top of its sidebar group
- [ ] Each category's landing page (Code-Server, Redpanda, etc.) appears FIRST inside its subgroup, before the individual tutorials
- [ ] Categories still alphabetical at the Tutorials root (expected — separate PR for pedagogical ordering)
