### PR TITLE
fix(scripts): Surface Gitea change-password stderr for diagnosis (Stage 1)

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -2853,14 +2853,18 @@ if echo "$ENABLED_SERVICES" | grep -qw "gitea" && [ -n "$GITEA_ADMIN_PASS" ]; th
         ADMIN_EXISTS=$(ssh nexus "docker exec -u git gitea gitea admin user list --admin 2>/dev/null | grep -c '$ADMIN_USERNAME'" || echo "0")
 
         if [ "$ADMIN_EXISTS" -gt 0 ]; then
-            # Sync password to match current OpenTofu state (persistent volume may have old password)
+            # Sync password to match current OpenTofu state (persistent volume may have old password).
+            # Capture stderr so when the sync fails we see WHY. Previously this block
+            # used `>/dev/null 2>&1` and silently discarded the error, making diagnosis
+            # impossible (see the dotted-username failure class, issue #NNN). Matches
+            # the 2>&1 → RESULT var pattern the CREATE path below already uses.
             echo "  Syncing Gitea admin password..."
-            ssh nexus "docker exec -u git gitea gitea admin user change-password \
+            CHANGE_OUTPUT=$(ssh nexus "docker exec -u git gitea gitea admin user change-password \
                 --username '$ADMIN_USERNAME' \
                 --password '$GITEA_ADMIN_PASS' \
-                --must-change-password=false" >/dev/null 2>&1 \
+                --must-change-password=false" 2>&1) \
                 && echo -e "${GREEN}  ✓ Gitea admin password synced${NC}" \
-                || echo -e "${YELLOW}  ⚠ Could not sync Gitea admin password${NC}"
+                || echo -e "${YELLOW}  ⚠ Could not sync Gitea admin password: ${CHANGE_OUTPUT}${NC}"
         else
             # Create admin user via CLI
             GITEA_RESULT=$(ssh nexus "docker exec -u git gitea gitea admin user create \
@@ -2885,14 +2889,20 @@ if echo "$ENABLED_SERVICES" | grep -qw "gitea" && [ -n "$GITEA_ADMIN_PASS" ]; th
             USER_EXISTS=$(ssh nexus "docker exec -u git gitea gitea admin user list 2>/dev/null | grep -c '$GITEA_USER_USERNAME'" || echo "0")
 
             if [ "$USER_EXISTS" -gt 0 ]; then
-                # Sync password to match current OpenTofu state (persistent volume may have old password)
+                # Sync password to match current OpenTofu state (persistent volume may have old password).
+                # Capture stderr — see admin block above for rationale. Currently chasing
+                # a failure class where user stacks whose email prefix contains a dot
+                # (e.g. stefan.koch@hslu.ch → username stefan.koch) silently fail this
+                # sync on every second-or-later Spin Up. Template stack (sk@…) works.
+                # Without the output here we can't tell whether it's a CLI limitation,
+                # a sanitized-name mismatch, or something else — so make it vocal.
                 echo "  Syncing Gitea user password..."
-                ssh nexus "docker exec -u git gitea gitea admin user change-password \
+                CHANGE_OUTPUT=$(ssh nexus "docker exec -u git gitea gitea admin user change-password \
                     --username '$GITEA_USER_USERNAME' \
                     --password '$GITEA_USER_PASS' \
-                    --must-change-password=false" >/dev/null 2>&1 \
+                    --must-change-password=false" 2>&1) \
                     && echo -e "${GREEN}  ✓ Gitea user password synced${NC}" \
-                    || echo -e "${YELLOW}  ⚠ Could not sync Gitea user password${NC}"
+                    || echo -e "${YELLOW}  ⚠ Could not sync Gitea user password: ${CHANGE_OUTPUT}${NC}"
             else
                 GITEA_USER_RESULT=$(ssh nexus "docker exec -u git gitea gitea admin user create \
                     --username '$GITEA_USER_USERNAME' \

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -2856,15 +2856,18 @@ if echo "$ENABLED_SERVICES" | grep -qw "gitea" && [ -n "$GITEA_ADMIN_PASS" ]; th
             # Sync password to match current OpenTofu state (persistent volume may have old password).
             # Capture stderr so when the sync fails we see WHY. Previously this block
             # used `>/dev/null 2>&1` and silently discarded the error, making diagnosis
-            # impossible (see the dotted-username failure class, issue #NNN). Matches
+            # impossible for the dotted-username and similar failure classes. Matches
             # the 2>&1 → RESULT var pattern the CREATE path below already uses.
+            # The failure branch uses printf so CHANGE_OUTPUT is printed verbatim —
+            # echo -e would interpret backslash sequences in the captured stderr
+            # (e.g. Gitea errors mentioning `\w+` or embedded escape codes).
             echo "  Syncing Gitea admin password..."
             CHANGE_OUTPUT=$(ssh nexus "docker exec -u git gitea gitea admin user change-password \
                 --username '$ADMIN_USERNAME' \
                 --password '$GITEA_ADMIN_PASS' \
                 --must-change-password=false" 2>&1) \
                 && echo -e "${GREEN}  ✓ Gitea admin password synced${NC}" \
-                || echo -e "${YELLOW}  ⚠ Could not sync Gitea admin password: ${CHANGE_OUTPUT}${NC}"
+                || printf "${YELLOW}  ⚠ Could not sync Gitea admin password: %s${NC}\n" "$CHANGE_OUTPUT"
         else
             # Create admin user via CLI
             GITEA_RESULT=$(ssh nexus "docker exec -u git gitea gitea admin user create \
@@ -2896,13 +2899,15 @@ if echo "$ENABLED_SERVICES" | grep -qw "gitea" && [ -n "$GITEA_ADMIN_PASS" ]; th
                 # sync on every second-or-later Spin Up. Template stack (sk@…) works.
                 # Without the output here we can't tell whether it's a CLI limitation,
                 # a sanitized-name mismatch, or something else — so make it vocal.
+                # Failure branch uses printf (not echo -e) so CHANGE_OUTPUT is printed
+                # verbatim — see admin block above.
                 echo "  Syncing Gitea user password..."
                 CHANGE_OUTPUT=$(ssh nexus "docker exec -u git gitea gitea admin user change-password \
                     --username '$GITEA_USER_USERNAME' \
                     --password '$GITEA_USER_PASS' \
                     --must-change-password=false" 2>&1) \
                     && echo -e "${GREEN}  ✓ Gitea user password synced${NC}" \
-                    || echo -e "${YELLOW}  ⚠ Could not sync Gitea user password: ${CHANGE_OUTPUT}${NC}"
+                    || printf "${YELLOW}  ⚠ Could not sync Gitea user password: %s${NC}\n" "$CHANGE_OUTPUT"
             else
                 GITEA_USER_RESULT=$(ssh nexus "docker exec -u git gitea gitea admin user create \
                     --username '$GITEA_USER_USERNAME' \


### PR DESCRIPTION
## Summary

Stage 1 of a two-stage fix for silent `⚠ Could not sync Gitea user password` failures in Spin Up. This PR adds **no behaviour change** — it makes the failure vocal so Stage 2 can apply a targeted fix based on what Gitea actually says.

## Symptom

Every user stack whose email prefix contains a dot (e.g. `stefan.koch@hslu.ch` → username `stefan.koch`) hits on every second-or-later Spin Up:

```
Syncing Gitea user password...
⚠ Could not sync Gitea user password
```

Follow-on breakage: the user can't log into Gitea with their Infisical-stored `GITEA_USER_PASSWORD`, and every service that mounts `.netrc` with that password (code-server, jupyter, marimo, meltano, prefect) fails to `git clone` the workspace repo. End result: `/home/coder/` in code-server is empty.

All 10 users in the bsc_eds_gis_fs26 class have dotted usernames → all 10 are affected. Template stack (`sk@stefanko.ch`, no dot) syncs cleanly on the same code path.

## Why Stage 1 only

`scripts/deploy.sh` currently muffles the sync call with `>/dev/null 2>&1`:

```bash
ssh nexus "docker exec -u git gitea gitea admin user change-password \
    --username '$GITEA_USER_USERNAME' \
    --password '$GITEA_USER_PASS' \
    --must-change-password=false" >/dev/null 2>&1 \
    && echo "✓ synced" \
    || echo "⚠ Could not sync"
```

The real Gitea-side error is discarded. Without it every theory (CLI rejects dots / internal username sanitization / escape issue / race condition) is speculation. So: first make the failure talk.

## Change

Capture stderr into a variable and print it in the warning line. Same edit applied to both admin-sync and user-sync blocks for consistency (if admin-sync is secretly also failing somewhere, Stage 1 will surface it).

```diff
-            ssh nexus "docker exec -u git gitea gitea admin user change-password \
+            CHANGE_OUTPUT=$(ssh nexus "docker exec -u git gitea gitea admin user change-password \
                 --username '$USERNAME' \
                 --password '$PASS' \
-                --must-change-password=false" >/dev/null 2>&1 \
+                --must-change-password=false" 2>&1) \
                 && echo -e "${GREEN}  ✓ … password synced${NC}" \
-                || echo -e "${YELLOW}  ⚠ Could not sync …${NC}"
+                || echo -e "${YELLOW}  ⚠ Could not sync …: ${CHANGE_OUTPUT}${NC}"
```

Also added a short comment block above each explaining WHY we capture stderr, so the next person doesn't revert it back to the muffled form thinking it's noise.

## Existing precedent

The CREATE path in the same file already uses exactly this `2>&1 → RESULT var → inspect` pattern:
- Admin create: lines 2872-2876 (was 2868-2872 before this PR's expansion)
- User create: lines 2902-2906 (was 2898-2902)

This PR just brings the SYNC path in line with what the CREATE path already does. No new abstraction.

## Security

`gitea admin user change-password` on Gitea 1.23.x emits user-existence / connection errors on stderr — not the password. Checked empirically. Safe to display in workflow logs (which are private to the user-fork repo anyway). If a future Gitea version starts echoing sensitive bits we can filter in Stage 2.

## Verification

### Local rehearsal (pre-commit)

Mock ssh that returns a simulated Gitea error, confirm it surfaces:

```bash
ssh() {
  echo "user does not exist [name: stefan.koch]: user does not exist" >&2
  return 1
}
# ... the captured block ...
```

Actual output:
```
⚠ Could not sync Gitea user password: user does not exist [name: stefan.koch]: user does not exist
```

Success-path test (`ssh() { return 0; }`):
```
✓ Gitea user password synced
```

Success case is unchanged — zero regression on the template stack and anyone else currently succeeding.

### End-to-end (the actual diagnostic payoff)

- [ ] Release-please cuts the next release (expected v0.51.7)
- [ ] `nexus-admin` → Upgrade `stefan-hslu` to pull new `deploy.sh`
- [ ] Trigger Spin Up
- [ ] Read the `Deploy stacks` step — the `⚠ Could not sync Gitea user password:` line now shows the actual Gitea error message

That error becomes the input to the Stage 2 PR.

## Not in scope

- **The actual fix (Stage 2).** Will plan based on Stage 1's observed stderr. Likely candidate: switch the sync path to Gitea's HTTP API (line 2966 already uses `curl -X PUT /api/v1/repos/…/collaborators/$GITEA_USER_USERNAME` successfully with the same dotted username — so the API demonstrably handles dots). But decision waits on the real error.
- **Race-condition hardening.** The existing `GITEA_READY` gate above this block already retries up to ~60s. If the real error turns out to be timing, Stage 2 handles it.
- **CREATE-path changes.** Already use the stderr-capture pattern. Not touched.
