### PR TITLE
fix(scripts): Match Gitea username by exact column, not line substring (Stage 2)

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -2849,8 +2849,18 @@ if echo "$ENABLED_SERVICES" | grep -qw "gitea" && [ -n "$GITEA_ADMIN_PASS" ]; th
     done
 
     if [ "$GITEA_READY" = "true" ]; then
-        # Check if admin user already exists
-        ADMIN_EXISTS=$(ssh nexus "docker exec -u git gitea gitea admin user list --admin 2>/dev/null | grep -c '$ADMIN_USERNAME'" || echo "0")
+        # Check if admin user already exists.
+        # awk-column-exact on the Username column (\$2), NOT grep-substring on
+        # the whole line. grep -c '$NAME' falsely matches when the name appears
+        # anywhere in the output — e.g. as a substring of another user's email
+        # address. For the admin block this is only latent (the admin almost
+        # always exists, so a true or false positive both route to the SYNC
+        # branch which was going to run anyway), but the same pattern on the
+        # USER_EXISTS check below is a confirmed bug (see v0.51.7 stderr: on
+        # stacks where the admin email contains the user's username substring,
+        # USER_EXISTS=1 wrongly, CREATE is skipped, the user never exists,
+        # SYNC then fails). Fix the detection in both places for consistency.
+        ADMIN_EXISTS=$(ssh nexus "docker exec -u git gitea gitea admin user list --admin 2>/dev/null | awk -v name='$ADMIN_USERNAME' 'NR>1 && \$2==name {c++} END{print c+0}'" || echo "0")
 
         if [ "$ADMIN_EXISTS" -gt 0 ]; then
             # Sync password to match current OpenTofu state (persistent volume may have old password).
@@ -2889,7 +2899,15 @@ if echo "$ENABLED_SERVICES" | grep -qw "gitea" && [ -n "$GITEA_ADMIN_PASS" ]; th
         # Extract username from user_email (part before @)
         GITEA_USER_USERNAME="${USER_EMAIL%%@*}"
         if [ -n "$USER_EMAIL" ] && [ -n "$GITEA_USER_PASS" ]; then
-            USER_EXISTS=$(ssh nexus "docker exec -u git gitea gitea admin user list 2>/dev/null | grep -c '$GITEA_USER_USERNAME'" || echo "0")
+            # Same column-exact awk pattern as the admin block above. This is
+            # the block where the grep-substring form actively broke things:
+            # GITEA_USER_USERNAME is derived from USER_EMAIL prefix (e.g.
+            # stefan.koch from stefan.koch@hslu.ch). If ADMIN_EMAIL also ends
+            # in @hslu.ch (or otherwise contains the user's username as a
+            # substring), `grep -c 'stefan.koch'` matches the admin's email
+            # column — USER_EXISTS=1, CREATE never runs, user is never
+            # created, subsequent SYNC fails because the target doesn't exist.
+            USER_EXISTS=$(ssh nexus "docker exec -u git gitea gitea admin user list 2>/dev/null | awk -v name='$GITEA_USER_USERNAME' 'NR>1 && \$2==name {c++} END{print c+0}'" || echo "0")
 
             if [ "$USER_EXISTS" -gt 0 ]; then
                 # Sync password to match current OpenTofu state (persistent volume may have old password).

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -2850,7 +2850,7 @@ if echo "$ENABLED_SERVICES" | grep -qw "gitea" && [ -n "$GITEA_ADMIN_PASS" ]; th
 
     if [ "$GITEA_READY" = "true" ]; then
         # Check if admin user already exists.
-        # awk-column-exact on the Username column (\$2), NOT grep-substring on
+        # awk-column-exact on the Username column ($2), NOT grep-substring on
         # the whole line. grep -c '$NAME' falsely matches when the name appears
         # anywhere in the output — e.g. as a substring of another user's email
         # address. For the admin block this is only latent (the admin almost
@@ -2860,7 +2860,16 @@ if echo "$ENABLED_SERVICES" | grep -qw "gitea" && [ -n "$GITEA_ADMIN_PASS" ]; th
         # stacks where the admin email contains the user's username substring,
         # USER_EXISTS=1 wrongly, CREATE is skipped, the user never exists,
         # SYNC then fails). Fix the detection in both places for consistency.
-        ADMIN_EXISTS=$(ssh nexus "docker exec -u git gitea gitea admin user list --admin 2>/dev/null | awk -v name='$ADMIN_USERNAME' 'NR>1 && \$2==name {c++} END{print c+0}'" || echo "0")
+        #
+        # Two-step form (fetch → parse) instead of one-line remote pipeline so
+        # an ssh/docker failure is distinguishable from "no match": the ssh
+        # call's || echo "" gives an empty list on failure → awk prints 0
+        # → CREATE path. Bundling awk into the remote pipeline would make the
+        # awk's END{print 0} exit 0 mask an upstream docker failure (the
+        # pipeline would look "successful" with count 0, which is misleading
+        # even if the downstream branch decision is the same).
+        ADMIN_LIST=$(ssh nexus "docker exec -u git gitea gitea admin user list --admin 2>/dev/null" || echo "")
+        ADMIN_EXISTS=$(echo "$ADMIN_LIST" | awk -v name="$ADMIN_USERNAME" 'NR>1 && $2==name {c++} END{print c+0}')
 
         if [ "$ADMIN_EXISTS" -gt 0 ]; then
             # Sync password to match current OpenTofu state (persistent volume may have old password).
@@ -2899,15 +2908,18 @@ if echo "$ENABLED_SERVICES" | grep -qw "gitea" && [ -n "$GITEA_ADMIN_PASS" ]; th
         # Extract username from user_email (part before @)
         GITEA_USER_USERNAME="${USER_EMAIL%%@*}"
         if [ -n "$USER_EMAIL" ] && [ -n "$GITEA_USER_PASS" ]; then
-            # Same column-exact awk pattern as the admin block above. This is
-            # the block where the grep-substring form actively broke things:
-            # GITEA_USER_USERNAME is derived from USER_EMAIL prefix (e.g.
-            # stefan.koch from stefan.koch@hslu.ch). If ADMIN_EMAIL also ends
-            # in @hslu.ch (or otherwise contains the user's username as a
-            # substring), `grep -c 'stefan.koch'` matches the admin's email
-            # column — USER_EXISTS=1, CREATE never runs, user is never
-            # created, subsequent SYNC fails because the target doesn't exist.
-            USER_EXISTS=$(ssh nexus "docker exec -u git gitea gitea admin user list 2>/dev/null | awk -v name='$GITEA_USER_USERNAME' 'NR>1 && \$2==name {c++} END{print c+0}'" || echo "0")
+            # Same column-exact awk pattern as the admin block above, same
+            # two-step fetch-then-parse to keep ssh failures distinguishable
+            # from the "no match" case. This is the block where the
+            # grep-substring form actively broke things: GITEA_USER_USERNAME
+            # is derived from USER_EMAIL prefix (e.g. stefan.koch from
+            # stefan.koch@hslu.ch). If ADMIN_EMAIL also ends in @hslu.ch (or
+            # otherwise contains the user's username as a substring),
+            # `grep -c 'stefan.koch'` matches the admin's email column —
+            # USER_EXISTS=1, CREATE never runs, user is never created,
+            # subsequent SYNC fails because the target doesn't exist.
+            USER_LIST=$(ssh nexus "docker exec -u git gitea gitea admin user list 2>/dev/null" || echo "")
+            USER_EXISTS=$(echo "$USER_LIST" | awk -v name="$GITEA_USER_USERNAME" 'NR>1 && $2==name {c++} END{print c+0}')
 
             if [ "$USER_EXISTS" -gt 0 ]; then
                 # Sync password to match current OpenTofu state (persistent volume may have old password).

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -2861,16 +2861,18 @@ if echo "$ENABLED_SERVICES" | grep -qw "gitea" && [ -n "$GITEA_ADMIN_PASS" ]; th
         # USER_EXISTS=1 wrongly, CREATE is skipped, the user never exists,
         # SYNC then fails). Fix the detection in both places for consistency.
         #
-        # Two-step form (fetch → parse) instead of one-line remote pipeline
-        # so bash's local set -o pipefail governs the ssh call independently
-        # of awk's always-zero exit. ssh/docker failures are folded into an
-        # empty list via || echo "" and the downstream awk then prints 0,
-        # routing to the CREATE branch (where PR #464's stderr capture will
-        # surface any genuine connectivity problem). That's the same soft
-        # fallback this section uses elsewhere for transient-Gitea resilience
-        # during deploy — not a crash-on-error design. If stricter failure
-        # handling is wanted later, upgrade here to capture ssh's exit status
-        # in a separate variable and warn explicitly.
+        # Two-step form (fetch → parse) instead of a one-line remote pipeline
+        # so the remote fetch isn't coupled to a downstream parser whose exit
+        # status could mask an upstream failure. The local code path here is
+        # a single command with an `||` fallback (not a pipeline), so
+        # set -o pipefail doesn't apply — ssh/docker failures are explicitly
+        # folded into an empty list via `|| echo ""` and the downstream awk
+        # then prints 0, routing to the CREATE branch (where PR #464's
+        # stderr capture surfaces any genuine connectivity problem). Same
+        # soft-fallback pattern this section uses elsewhere for transient-
+        # Gitea resilience during deploy — not a crash-on-error design.
+        # If stricter failure handling is wanted later, capture ssh's exit
+        # status in a separate variable and warn explicitly.
         #
         # printf '%s\n' instead of echo because bash's echo treats a leading
         # '-n'/'-e'/'-E' in $ADMIN_LIST as options (not data). Gitea's list
@@ -2916,9 +2918,12 @@ if echo "$ENABLED_SERVICES" | grep -qw "gitea" && [ -n "$GITEA_ADMIN_PASS" ]; th
         # Extract username from user_email (part before @)
         GITEA_USER_USERNAME="${USER_EMAIL%%@*}"
         if [ -n "$USER_EMAIL" ] && [ -n "$GITEA_USER_PASS" ]; then
-            # Same column-exact awk pattern as the admin block above, same
-            # two-step fetch-then-parse to keep ssh failures distinguishable
-            # from the "no match" case. This is the block where the
+            # Same column-exact awk pattern as the admin block above, with the
+            # same two-step fetch-then-parse structure. Note that the current
+            # `|| echo ""` fallback collapses ssh/list failures into an empty
+            # result, so failures are treated the same as the "no match" case
+            # (awk prints 0 → CREATE path fires, where PR #464's stderr capture
+            # surfaces the genuine error). This is the block where the
             # grep-substring form actively broke things: GITEA_USER_USERNAME
             # is derived from USER_EMAIL prefix (e.g. stefan.koch from
             # stefan.koch@hslu.ch). If ADMIN_EMAIL also ends in @hslu.ch (or

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -2861,15 +2861,23 @@ if echo "$ENABLED_SERVICES" | grep -qw "gitea" && [ -n "$GITEA_ADMIN_PASS" ]; th
         # USER_EXISTS=1 wrongly, CREATE is skipped, the user never exists,
         # SYNC then fails). Fix the detection in both places for consistency.
         #
-        # Two-step form (fetch → parse) instead of one-line remote pipeline so
-        # an ssh/docker failure is distinguishable from "no match": the ssh
-        # call's || echo "" gives an empty list on failure → awk prints 0
-        # → CREATE path. Bundling awk into the remote pipeline would make the
-        # awk's END{print 0} exit 0 mask an upstream docker failure (the
-        # pipeline would look "successful" with count 0, which is misleading
-        # even if the downstream branch decision is the same).
+        # Two-step form (fetch → parse) instead of one-line remote pipeline
+        # so bash's local set -o pipefail governs the ssh call independently
+        # of awk's always-zero exit. ssh/docker failures are folded into an
+        # empty list via || echo "" and the downstream awk then prints 0,
+        # routing to the CREATE branch (where PR #464's stderr capture will
+        # surface any genuine connectivity problem). That's the same soft
+        # fallback this section uses elsewhere for transient-Gitea resilience
+        # during deploy — not a crash-on-error design. If stricter failure
+        # handling is wanted later, upgrade here to capture ssh's exit status
+        # in a separate variable and warn explicitly.
+        #
+        # printf '%s\n' instead of echo because bash's echo treats a leading
+        # '-n'/'-e'/'-E' in $ADMIN_LIST as options (not data). Gitea's list
+        # starts with "ID  Username  Email ..." in practice so the collision
+        # doesn't happen today, but printf is the idiomatic safe form.
         ADMIN_LIST=$(ssh nexus "docker exec -u git gitea gitea admin user list --admin 2>/dev/null" || echo "")
-        ADMIN_EXISTS=$(echo "$ADMIN_LIST" | awk -v name="$ADMIN_USERNAME" 'NR>1 && $2==name {c++} END{print c+0}')
+        ADMIN_EXISTS=$(printf '%s\n' "$ADMIN_LIST" | awk -v name="$ADMIN_USERNAME" 'NR>1 && $2==name {c++} END{print c+0}')
 
         if [ "$ADMIN_EXISTS" -gt 0 ]; then
             # Sync password to match current OpenTofu state (persistent volume may have old password).
@@ -2918,8 +2926,9 @@ if echo "$ENABLED_SERVICES" | grep -qw "gitea" && [ -n "$GITEA_ADMIN_PASS" ]; th
             # `grep -c 'stefan.koch'` matches the admin's email column —
             # USER_EXISTS=1, CREATE never runs, user is never created,
             # subsequent SYNC fails because the target doesn't exist.
+            # printf '%s\n' instead of echo — see admin block above for rationale.
             USER_LIST=$(ssh nexus "docker exec -u git gitea gitea admin user list 2>/dev/null" || echo "")
-            USER_EXISTS=$(echo "$USER_LIST" | awk -v name="$GITEA_USER_USERNAME" 'NR>1 && $2==name {c++} END{print c+0}')
+            USER_EXISTS=$(printf '%s\n' "$USER_LIST" | awk -v name="$GITEA_USER_USERNAME" 'NR>1 && $2==name {c++} END{print c+0}')
 
             if [ "$USER_EXISTS" -gt 0 ]; then
                 # Sync password to match current OpenTofu state (persistent volume may have old password).


### PR DESCRIPTION
## Summary

Stage 2 of the Gitea user-creation fix. PR #464 (v0.51.7) surfaced the real error; this PR fixes the root cause.

## Symptom

On stefan-hslu's Spin Up (after v0.51.7 made the error vocal):

```
Syncing Gitea user password...
⚠ Could not sync Gitea user password: user does not exist [name: stefan.koch]
```

Gitea state on that stack was exactly one row:

```
ID   Username  Email                  IsActive  IsAdmin  2FA
1    admin     stefan.koch@hslu.ch    true      true     false
```

Only admin exists. No `stefan.koch` user was ever created.

## Root cause

`scripts/deploy.sh` line 2892 decided whether to CREATE or SYNC based on `grep -c`:

```bash
USER_EXISTS=$(ssh nexus "docker exec -u git gitea gitea admin user list 2>/dev/null | grep -c '$GITEA_USER_USERNAME'" || echo "0")
```

`grep -c` matches the username string **anywhere in the line**, including the Email column. For stefan-hslu, `GITEA_USER_USERNAME=stefan.koch` matches the admin row's email `stefan.koch@hslu.ch` → `USER_EXISTS=1` → SYNC branch → `change-password --username stefan.koch` → fails, the user was never actually created.

Consequence chain: user missing → `.netrc` in every service (code-server, jupyter, marimo, meltano, prefect) has the wrong password → every `git clone` returns 401 → `/home/coder/` empty, no repo in Explorer.

Same fragile pattern in the ADMIN_EXISTS check on line 2853. Latent there (the admin row usually self-matches, so a true-or-false-positive both route to SYNC which was going to run anyway), but fix both for consistency.

## Fix

Replace `grep -c` with awk column-exact match on the Username column (`$2`), skipping the header row:

```diff
-ADMIN_EXISTS=$(ssh nexus "docker exec -u git gitea gitea admin user list --admin 2>/dev/null | grep -c '$ADMIN_USERNAME'" || echo "0")
+ADMIN_EXISTS=$(ssh nexus "docker exec -u git gitea gitea admin user list --admin 2>/dev/null | awk -v name='$ADMIN_USERNAME' 'NR>1 && \$2==name {c++} END{print c+0}'" || echo "0")
```

```diff
-USER_EXISTS=$(ssh nexus "docker exec -u git gitea gitea admin user list 2>/dev/null | grep -c '$GITEA_USER_USERNAME'" || echo "0")
+USER_EXISTS=$(ssh nexus "docker exec -u git gitea gitea admin user list 2>/dev/null | awk -v name='$GITEA_USER_USERNAME' 'NR>1 && \$2==name {c++} END{print c+0}'" || echo "0")
```

### Semantics

- `NR>1` skips the `ID  Username  Email …` header row Gitea's CLI emits
- `$2==name` — **string equality** on the Username column, not substring, not regex (unlike grep, where `.` matched any char too)
- `{c++}` counts matching rows (Gitea enforces username uniqueness, always 0 or 1)
- `END{print c+0}` always emits a number, 0 even when no match
- `awk -v name='…'` passes the value safely without string-interpolating into the awk program
- `\$2` outer escape prevents bash from expanding `$2` as a positional parameter; the wire gets literal `$2`, awk interprets as second field. Verified empirically.
- `|| echo "0"` at the outer boundary is unchanged — still catches ssh/docker failures.

## Verification

### Local rehearsal (pre-commit)

Three synthetic cases against simulated `gitea admin user list` output:

```
Case 1 — admin-only with conflicting email (stefan-hslu's actual state):
  grep -c → 1  (bug: matches 'stefan.koch' in admin's email)
  awk     → 0  (correct: no user with username stefan.koch)

Case 2 — user genuinely exists in row 2:
  awk → 1

Case 3 — empty list (header only):
  awk → 0
```

Expected: `0, 1, 0`. Actual: `0, 1, 0`. Bonus: grep-c on Case 1 confirmed to return `1`, concretely demonstrating the bug being fixed.

### End-to-end (after v0.51.8 lands)

- [ ] Merge this PR. Release-please cuts v0.51.8 automatically.
- [ ] In nexus-admin: Upgrade `stefan-hslu` (pulls v0.51.8 deploy.sh).
- [ ] Trigger Spin Up for `stefan-hslu`.
- [ ] In the `Deploy stacks` step:
  - `⚠ Could not sync Gitea user password` should **no longer** appear
  - `USER_EXISTS=0` → CREATE path → `✓ Gitea user created (user: stefan.koch)` (or a visible CREATE stderr if the email-conflict edge case described below hits)
- [ ] `ssh nexus` → `docker exec -u git gitea gitea admin user list` should show both admin and `stefan.koch` rows.
- [ ] Log into Gitea UI with `stefan.koch` + the Infisical-stored `GITEA_USER_PASSWORD`.
- [ ] After service restart, `git clone` from code-server picks up the repo into `/home/coder/`.

## Regression floor

- **Template stack** (has historic user `sk`): awk finds `sk` via column match → SYNC branch, same as before. Unchanged behaviour.
- **Other student stacks**: if the user was correctly created historically, awk finds them → SYNC, unchanged. If they were NOT created (same stefan-hslu class bug), awk returns 0 → CREATE fires on next Spin Up → user appears. Self-healing across the class.
- **Stacks without Gitea enabled**: unreachable (guarded by outer `grep -qw "gitea"` at line 2829). No impact.

## Potential second-order issue (Stage 3, not in this PR)

For stefan-hslu specifically, the admin already has email `stefan.koch@hslu.ch`. The newly-triggered CREATE call on the user account will run:

```bash
gitea admin user create --username stefan.koch --email stefan.koch@hslu.ch ...
```

Gitea enforces email uniqueness. The CREATE may fail with "email already in use". PR #464's stderr capture in the CREATE path (`GITEA_USER_RESULT=$(… 2>&1 || echo "")` and inspect the output) will surface that if it happens.

For the other 9 bsc_eds_gis_fs26 class students, `ADMIN_EMAIL` (teacher) and `USER_EMAIL` (student) genuinely differ → no conflict. So this edge case is specific to stefan-hslu (where he's both teacher and test user). Stage 3 PR if and when it manifests.

## Clean-test strategy for the template

The template currently mirrors the stefan-hslu state (admin with email `stefan.koch@hslu.ch`, no user `stefan.koch`). Running this fix against it directly would also hit the email-conflict second-order case. For a **clean test of the USER_EXISTS fix in isolation**:

```bash
# Shift admin's email out of the way first (one-time cosmetic adjustment)
ssh nexus "docker exec -u git gitea gitea admin user edit \
  --username admin \
  --email 'admin-template@nexus-stack.ch'"
```

Then Spin Up the template. USER_EXISTS=0 cleanly, CREATE fires cleanly, user appears, no email-uniqueness complication. The admin stays admin with a different email. Deliberate, reversible, 5 seconds.

## Scope

- `scripts/deploy.sh` only, lines 2853 + 2892 plus explanatory comments. No other file.
- Builds on PR #464 (merged) — that one made the error visible, this one eliminates the cause. Together they fix the full failure mode.
