### PR TITLE
fix(scripts): Strip comma-suffix from USER_EMAIL for Gitea user create

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -61,14 +61,29 @@ DOMAIN=$(grep -E '^domain\s*=' "$TOFU_DIR/config.tfvars" 2>/dev/null | sed 's/.*
 ADMIN_EMAIL=$(grep -E '^admin_email\s*=' "$TOFU_DIR/config.tfvars" 2>/dev/null | sed 's/.*"\(.*\)"/\1/' || echo "")
 USER_EMAIL=$(grep -E '^user_email\s*=' "$TOFU_DIR/config.tfvars" 2>/dev/null | sed 's/.*"\(.*\)"/\1/' || echo "")
 
-# ADMIN_EMAIL must be distinct from USER_EMAIL: Gitea enforces uniqueness on
-# user.email, so if both rows are created with the same address the second
+# Gitea needs a single address for the user.email column; USER_EMAIL may
+# be a comma-separated list (student + teacher admins, so tofu/stack can
+# build the Cloudflare Access allow-list from every entry). Strip to the
+# first entry here — Gitea's validator rejects commas with "e-mail address
+# contains unsupported character" and the raw list would otherwise reach
+# `gitea admin user create --email`. Downstream derivations in this script
+# (workspace-config block ~line 1193, user-create block ~line 3000,
+# workspace-repo block ~line 3071) all reuse GITEA_USER_EMAIL for the same
+# single-value semantics. Derived BEFORE the ADMIN_EMAIL collision check
+# below so that check compares single-vs-single (not admin-single-vs-
+# user-list, which would never match and silently skip the remap).
+GITEA_USER_EMAIL="${USER_EMAIL%%,*}"
+GITEA_USER_USERNAME="${GITEA_USER_EMAIL%%@*}"
+
+# ADMIN_EMAIL must be distinct from GITEA_USER_EMAIL: Gitea enforces uniqueness
+# on user.email, so if both rows are created with the same address the second
 # create fails with "e-mail already in use". The admin-panel caller
-# (Nexus-Stack-for-Education) passes both values from the same field today,
-# and self-provisioned tfvars can omit admin_email entirely. In either case
-# fall back to a synthetic gitea-admin@${DOMAIN} that's guaranteed distinct
-# from any normal human USER_EMAIL.
-if [ -z "$ADMIN_EMAIL" ] || [ "$ADMIN_EMAIL" = "$USER_EMAIL" ]; then
+# (Nexus-Stack-for-Education) passes both values from the same source field
+# today (admin_email = first entry of user_email list), and self-provisioned
+# tfvars can omit admin_email entirely. In either case fall back to a
+# synthetic gitea-admin@${DOMAIN} that's guaranteed distinct from any real
+# human email.
+if [ -z "$ADMIN_EMAIL" ] || [ "$ADMIN_EMAIL" = "$GITEA_USER_EMAIL" ]; then
     # Use a local-part that no human-email scheme would produce. `admin@${DOMAIN}`
     # is also safe for the stack-scoped student domains (e.g. <user>.nona.company),
     # but `gitea-admin` narrows the probability of collision with a real USER_EMAIL
@@ -81,17 +96,6 @@ OM_PRINCIPAL_DOMAIN=$(echo "$ADMIN_EMAIL" | cut -d'@' -f2)
 # uniqueness collision. The Gitea user-create block below is already gated
 # by `[ -n "$USER_EMAIL" ]`, so an unset USER_EMAIL skips user creation
 # cleanly instead of colliding with the admin row.
-# Gitea needs a single address for the user.email column; USER_EMAIL may
-# be a comma-separated list (student + teacher admins, so tofu/stack can
-# build the Cloudflare Access allow-list from every entry). Strip to the
-# first entry here — Gitea's validator rejects commas with "e-mail address
-# contains unsupported character" and the raw list would otherwise reach
-# `gitea admin user create --email`. Downstream derivations in this script
-# (workspace-config block ~line 1193, user-create block ~line 3000,
-# workspace-repo block ~line 3071) all reuse GITEA_USER_EMAIL for the same
-# single-value semantics.
-GITEA_USER_EMAIL="${USER_EMAIL%%,*}"
-GITEA_USER_USERNAME="${GITEA_USER_EMAIL%%@*}"
 SSH_HOST="ssh.${DOMAIN}"
 
 if [ -z "$DOMAIN" ]; then
@@ -1242,7 +1246,10 @@ if echo "$ENABLED_SERVICES" | grep -qw "gitea" && [ -n "$GITEA_ADMIN_PASS" ]; th
         GITEA_GIT_USER="${GITEA_USER_USERNAME}"
         GITEA_GIT_PASS="${GITEA_USER_PASS}"
         GIT_AUTHOR="${GITEA_USER_USERNAME}"
-        GIT_EMAIL="${USER_EMAIL}"
+        # Single-address: GIT_EMAIL is written to service .env files and used
+        # as git author/committer email. USER_EMAIL may be a comma-list;
+        # use GITEA_USER_EMAIL so commit metadata is well-formed.
+        GIT_EMAIL="${GITEA_USER_EMAIL}"
     else
         # Fallback to admin if no user identity/password available
         GITEA_GIT_USER="${ADMIN_USERNAME}"
@@ -1978,7 +1985,7 @@ EOF
             "CLOUDBEAVER_PASSWORD" "$CLOUDBEAVER_PASS"
 
         build_folder "mage" \
-            "MAGE_USERNAME" "${USER_EMAIL:-$ADMIN_EMAIL}" \
+            "MAGE_USERNAME" "${GITEA_USER_EMAIL:-$ADMIN_EMAIL}" \
             "MAGE_PASSWORD" "$MAGE_PASS"
 
         build_folder "minio" \
@@ -2082,7 +2089,7 @@ EOF
             "CLICKHOUSE_PASSWORD" "$CLICKHOUSE_ADMIN_PASS"
 
         build_folder "wikijs" \
-            "WIKIJS_USERNAME" "${USER_EMAIL:-$ADMIN_EMAIL}" \
+            "WIKIJS_USERNAME" "${GITEA_USER_EMAIL:-$ADMIN_EMAIL}" \
             "WIKIJS_PASSWORD" "$WIKIJS_ADMIN_PASS" \
             "WIKIJS_DB_PASSWORD" "$WIKIJS_DB_PASS"
 
@@ -2748,9 +2755,11 @@ if echo "$ENABLED_SERVICES" | grep -qw "windmill" && [ -n "$WINDMILL_ADMIN_PASS"
             echo -e "${YELLOW}  ⚠ Windmill admin creation: ${WINDMILL_CREATE_RESULT:-no response}${NC}"
         fi
 
-        # --- Step 2: Create regular user for USER_EMAIL (if different from ADMIN_EMAIL) ---
-        if [ -n "$USER_EMAIL" ] && [ "$USER_EMAIL" != "$ADMIN_EMAIL" ]; then
-            WINDMILL_USER_JSON=$(jq -n --arg email "$USER_EMAIL" --arg password "$WINDMILL_ADMIN_PASS" \
+        # --- Step 2: Create regular user for GITEA_USER_EMAIL (if different from ADMIN_EMAIL) ---
+        # Use GITEA_USER_EMAIL (single address) not USER_EMAIL (may be comma list).
+        # Windmill's email field has the same single-value semantics as Gitea's.
+        if [ -n "$GITEA_USER_EMAIL" ] && [ "$GITEA_USER_EMAIL" != "$ADMIN_EMAIL" ]; then
+            WINDMILL_USER_JSON=$(jq -n --arg email "$GITEA_USER_EMAIL" --arg password "$WINDMILL_ADMIN_PASS" \
                 '{email: $email, password: $password, super_admin: false, name: "User"}')
             WINDMILL_USER_RESULT=$(printf '%s' "$WINDMILL_USER_JSON" | ssh nexus "curl -s -X POST '$WM_URL/users/create' \
                 -H '$WM_AUTH' \
@@ -2758,7 +2767,7 @@ if echo "$ENABLED_SERVICES" | grep -qw "windmill" && [ -n "$WINDMILL_ADMIN_PASS"
                 -d @-" 2>/dev/null || echo "")
 
             if echo "$WINDMILL_USER_RESULT" | grep -q '"email"' 2>/dev/null; then
-                echo -e "${GREEN}  ✓ Windmill user created (user: $USER_EMAIL)${NC}"
+                echo -e "${GREEN}  ✓ Windmill user created (user: $GITEA_USER_EMAIL)${NC}"
             elif echo "$WINDMILL_USER_RESULT" | grep -qi 'already exists' 2>/dev/null; then
                 echo -e "${YELLOW}  ⚠ Windmill user already exists${NC}"
             fi
@@ -2952,9 +2961,14 @@ if echo "$ENABLED_SERVICES" | grep -qw "gitea" && [ -n "$GITEA_ADMIN_PASS" ]; th
         # The PATCH body requires source_id and login_name even for an
         # email-only update — Gitea's admin-users schema rejects partial
         # bodies without them. source_id:0 = local auth provider.
-        if [ "$ADMIN_EXISTS" -gt 0 ] && [ -n "$USER_EMAIL" ]; then
+        if [ "$ADMIN_EXISTS" -gt 0 ] && [ -n "$GITEA_USER_EMAIL" ]; then
             CURRENT_ADMIN_EMAIL=$(printf '%s\n' "$ADMIN_LIST" | awk -v name="$ADMIN_USERNAME" 'NR>1 && $2==name {print $3; exit}')
-            if [ "$CURRENT_ADMIN_EMAIL" = "$USER_EMAIL" ]; then
+            # Compare against GITEA_USER_EMAIL (single address). The admin
+            # row's email column is always a single address; if USER_EMAIL
+            # is a comma-list, a raw equality check would never match and
+            # this remap (Stage 3, v0.51.9) would silently not fire for
+            # upgraded stacks, leaving the legacy collision in place.
+            if [ "$CURRENT_ADMIN_EMAIL" = "$GITEA_USER_EMAIL" ]; then
                 echo "  Admin has legacy email conflicting with user — remapping to $ADMIN_EMAIL..."
                 # --fail-with-body so curl exits non-zero on HTTP 4xx/5xx while
                 # still printing the response body — without it, a Gitea
@@ -3440,7 +3454,7 @@ fi
 if echo "$ENABLED_SERVICES" | grep -qw "wikijs" && [ -n "$WIKIJS_ADMIN_PASS" ]; then
     (
         echo "  Configuring Wiki.js admin..."
-        WIKIJS_EMAIL="${USER_EMAIL:-$ADMIN_EMAIL}"
+        WIKIJS_EMAIL="${GITEA_USER_EMAIL:-$ADMIN_EMAIL}"
         for i in $(seq 1 30); do
             if ssh nexus "curl -fsS --connect-timeout 2 'http://localhost:3005/healthz'" 2>/dev/null | grep -qi 'ok'; then
                 break

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -72,7 +72,13 @@ USER_EMAIL=$(grep -E '^user_email\s*=' "$TOFU_DIR/config.tfvars" 2>/dev/null | s
 # single-value semantics. Derived BEFORE the ADMIN_EMAIL collision check
 # below so that check compares single-vs-single (not admin-single-vs-
 # user-list, which would never match and silently skip the remap).
-GITEA_USER_EMAIL="${USER_EMAIL%%,*}"
+# Trim whitespace: upstream joins commonly emit ", " between entries
+# (`a@b.com, c@d.com`), and self-provisioned tfvars can have leading
+# spaces inside the quoted value. Gitea/Windmill/Wiki.js validators all
+# reject space-prefixed emails. ADMIN_EMAIL gets the same treatment so
+# the equality check below compares normalized single addresses.
+ADMIN_EMAIL=$(printf '%s' "$ADMIN_EMAIL" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')
+GITEA_USER_EMAIL=$(printf '%s' "${USER_EMAIL%%,*}" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')
 GITEA_USER_USERNAME="${GITEA_USER_EMAIL%%@*}"
 
 # ADMIN_EMAIL must be distinct from GITEA_USER_EMAIL: Gitea enforces uniqueness
@@ -93,9 +99,10 @@ fi
 OM_PRINCIPAL_DOMAIN=$(echo "$ADMIN_EMAIL" | cut -d'@' -f2)
 
 # No USER_EMAIL fallback to ADMIN_EMAIL — that was the root of the Gitea
-# uniqueness collision. The Gitea user-create block below is already gated
-# by `[ -n "$USER_EMAIL" ]`, so an unset USER_EMAIL skips user creation
-# cleanly instead of colliding with the admin row.
+# uniqueness collision. The Gitea user-create block below is gated on
+# `[ -n "$GITEA_USER_EMAIL" ]`, so an empty-after-trim GITEA_USER_EMAIL
+# (no USER_EMAIL set, or its first entry was whitespace-only) skips user
+# creation cleanly instead of colliding with the admin row.
 SSH_HOST="ssh.${DOMAIN}"
 
 if [ -z "$DOMAIN" ]; then
@@ -1194,15 +1201,20 @@ fi
 # Security: Credentials are passed via GITEA_USERNAME/GITEA_PASSWORD env vars and
 # injected into containers via .netrc at startup (not embedded in the repo URL).
 if echo "$ENABLED_SERVICES" | grep -qw "gitea" && [ -n "$GITEA_ADMIN_PASS" ]; then
-    # Workspace-config identity: when no separate USER_EMAIL is configured,
-    # fall back to the admin identity for repo URLs and service .env values.
+    # Workspace-config identity: when no separate single-address user is
+    # configured (GITEA_USER_EMAIL empty after trim+comma-split), fall back
+    # to the admin identity for repo URLs and service .env values.
     # Downstream service containers need a non-empty username + email for
     # git operations (empty values would produce invalid URLs like
     # http://gitea:3000//repo.git). This fallback is config-only and does
     # NOT reintroduce the email-uniqueness collision the parent PR fixed:
-    # the Gitea user-create block below stays gated on `[ -n "$USER_EMAIL" ]`
-    # and skips cleanly when USER_EMAIL is unset.
-    if [ -n "$USER_EMAIL" ]; then
+    # the Gitea user-create block below also gates on
+    # `[ -n "$GITEA_USER_EMAIL" ]` and skips cleanly when empty.
+    #
+    # Gate uses GITEA_USER_EMAIL (not raw USER_EMAIL) so a USER_EMAIL whose
+    # first entry is empty/whitespace (e.g. a leading `,` in the joined
+    # list) correctly routes to the admin fallback.
+    if [ -n "$GITEA_USER_EMAIL" ]; then
         # See top-of-script comment (~line 85) on GITEA_USER_EMAIL vs USER_EMAIL.
         GITEA_USER_USERNAME="${GITEA_USER_EMAIL%%@*}"
     else
@@ -1214,7 +1226,7 @@ if echo "$ENABLED_SERVICES" | grep -qw "gitea" && [ -n "$GITEA_ADMIN_PASS" ]; th
     #   later in the mirror block regardless of USER_EMAIL)
     # - no mirror → admin's default empty repo (created further below only when
     #   GH_MIRROR_REPOS is unset)
-    if [ -n "${GH_MIRROR_REPOS:-}" ] && [ -n "$USER_EMAIL" ]; then
+    if [ -n "${GH_MIRROR_REPOS:-}" ] && [ -n "$GITEA_USER_EMAIL" ]; then
         # Derive repo name from first mirror URL (e.g. https://github.com/user/Bsc_EDS_GIS_FS2026)
         FIRST_MIRROR=$(echo "$GH_MIRROR_REPOS" | cut -d',' -f1 | tr -d ' ')
         WORKSPACE_REPO_NAME=$(basename "$FIRST_MIRROR" .git)
@@ -1240,9 +1252,11 @@ if echo "$ENABLED_SERVICES" | grep -qw "gitea" && [ -n "$GITEA_ADMIN_PASS" ]; th
         GITEA_REPO_OWNER="${ADMIN_USERNAME}"
         GITEA_REPO_URL="http://gitea:3000/${GITEA_REPO_OWNER}/${REPO_NAME}.git"
     fi
-    # Require BOTH a user email and a user password to use user credentials
-    # for service Git integration. Either one missing → fall back to admin.
-    if [ -n "$USER_EMAIL" ] && [ -n "$GITEA_USER_PASS" ]; then
+    # Require BOTH a valid single user email and a user password to use user
+    # credentials for service Git integration. Either one missing → fall
+    # back to admin. Gate on GITEA_USER_EMAIL (not USER_EMAIL) so a list
+    # with empty first entry routes to the admin branch.
+    if [ -n "$GITEA_USER_EMAIL" ] && [ -n "$GITEA_USER_PASS" ]; then
         GITEA_GIT_USER="${GITEA_USER_USERNAME}"
         GITEA_GIT_PASS="${GITEA_USER_PASS}"
         GIT_AUTHOR="${GITEA_USER_USERNAME}"
@@ -3021,8 +3035,10 @@ if echo "$ENABLED_SERVICES" | grep -qw "gitea" && [ -n "$GITEA_ADMIN_PASS" ]; th
 
         # --- Create regular user account (for students/user_email) ---
         # Extract username from the single-address GITEA_USER_EMAIL (see ~line 85).
+        # Gate on GITEA_USER_EMAIL (not raw USER_EMAIL) — empty-after-trim
+        # means no valid single address, so CREATE/SYNC both skip cleanly.
         GITEA_USER_USERNAME="${GITEA_USER_EMAIL%%@*}"
-        if [ -n "$USER_EMAIL" ] && [ -n "$GITEA_USER_PASS" ]; then
+        if [ -n "$GITEA_USER_EMAIL" ] && [ -n "$GITEA_USER_PASS" ]; then
             # Same column-exact awk pattern as the admin block above, with the
             # same two-step fetch-then-parse structure. Note that the current
             # `|| echo ""` fallback collapses ssh/list failures into an empty

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -81,8 +81,17 @@ OM_PRINCIPAL_DOMAIN=$(echo "$ADMIN_EMAIL" | cut -d'@' -f2)
 # uniqueness collision. The Gitea user-create block below is already gated
 # by `[ -n "$USER_EMAIL" ]`, so an unset USER_EMAIL skips user creation
 # cleanly instead of colliding with the admin row.
-# Gitea user username derived from user_email (part before @)
-GITEA_USER_USERNAME="${USER_EMAIL%%@*}"
+# Gitea needs a single address for the user.email column; USER_EMAIL may
+# be a comma-separated list (student + teacher admins, so tofu/stack can
+# build the Cloudflare Access allow-list from every entry). Strip to the
+# first entry here — Gitea's validator rejects commas with "e-mail address
+# contains unsupported character" and the raw list would otherwise reach
+# `gitea admin user create --email`. Downstream derivations in this script
+# (workspace-config block ~line 1193, user-create block ~line 3000,
+# workspace-repo block ~line 3071) all reuse GITEA_USER_EMAIL for the same
+# single-value semantics.
+GITEA_USER_EMAIL="${USER_EMAIL%%,*}"
+GITEA_USER_USERNAME="${GITEA_USER_EMAIL%%@*}"
 SSH_HOST="ssh.${DOMAIN}"
 
 if [ -z "$DOMAIN" ]; then
@@ -1190,7 +1199,8 @@ if echo "$ENABLED_SERVICES" | grep -qw "gitea" && [ -n "$GITEA_ADMIN_PASS" ]; th
     # the Gitea user-create block below stays gated on `[ -n "$USER_EMAIL" ]`
     # and skips cleanly when USER_EMAIL is unset.
     if [ -n "$USER_EMAIL" ]; then
-        GITEA_USER_USERNAME="${USER_EMAIL%%@*}"
+        # See top-of-script comment (~line 85) on GITEA_USER_EMAIL vs USER_EMAIL.
+        GITEA_USER_USERNAME="${GITEA_USER_EMAIL%%@*}"
     else
         GITEA_USER_USERNAME="$ADMIN_USERNAME"
     fi
@@ -2996,8 +3006,8 @@ if echo "$ENABLED_SERVICES" | grep -qw "gitea" && [ -n "$GITEA_ADMIN_PASS" ]; th
         fi
 
         # --- Create regular user account (for students/user_email) ---
-        # Extract username from user_email (part before @)
-        GITEA_USER_USERNAME="${USER_EMAIL%%@*}"
+        # Extract username from the single-address GITEA_USER_EMAIL (see ~line 85).
+        GITEA_USER_USERNAME="${GITEA_USER_EMAIL%%@*}"
         if [ -n "$USER_EMAIL" ] && [ -n "$GITEA_USER_PASS" ]; then
             # Same column-exact awk pattern as the admin block above, with the
             # same two-step fetch-then-parse structure. Note that the current
@@ -3037,7 +3047,7 @@ if echo "$ENABLED_SERVICES" | grep -qw "gitea" && [ -n "$GITEA_ADMIN_PASS" ]; th
                 GITEA_USER_RESULT=$(ssh nexus "docker exec -u git gitea gitea admin user create \
                     --username '$GITEA_USER_USERNAME' \
                     --password '$GITEA_USER_PASS' \
-                    --email '$USER_EMAIL' \
+                    --email '$GITEA_USER_EMAIL' \
                     --must-change-password=false" 2>&1 || echo "")
 
                 if echo "$GITEA_USER_RESULT" | grep -qi "created\|success\|New user"; then
@@ -3068,7 +3078,7 @@ if echo "$ENABLED_SERVICES" | grep -qw "gitea" && [ -n "$GITEA_ADMIN_PASS" ]; th
         fi
 
         if [ -n "$GITEA_TOKEN" ]; then
-            GITEA_USER_USERNAME="${USER_EMAIL%%@*}"
+            GITEA_USER_USERNAME="${GITEA_USER_EMAIL%%@*}"
 
             if [ -z "${GH_MIRROR_REPOS:-}" ]; then
                 # --- Create default empty workspace repo ---

--- a/tofu/stack/main.tf
+++ b/tofu/stack/main.tf
@@ -21,7 +21,7 @@ locals {
 
 resource "hcloud_ssh_key" "main" {
   name       = "${local.resource_prefix}-key"
-  public_key = file(var.ssh_public_key_path)
+  public_key = trimspace(file(var.ssh_public_key_path))
 }
 
 # =============================================================================


### PR DESCRIPTION
## Summary

- Stage 4 of the Gitea bug chain. Stage 3 (#468, v0.51.9) unblocked the CREATE path on fresh stacks — which now hits Gitea's email validator rejecting commas in `user.email`.
- Primary fix is template-internal (`scripts/deploy.sh`). Also bundles an unrelated one-line `tofu/stack/main.tf` fix (see [Bundled tofu fix](#bundled-tofu-fix) below) — the spin-up started failing on an SSH-key inconsistency error and had to be unblocked before this PR could be end-to-end tested.

## Root cause

`USER_EMAIL` carries two value-types in the same script:

1. **Comma-separated list** — admin-panel joins the student's email + teacher-admin emails so that `tofu/stack/main.tf` can split on `,` and build the Cloudflare Access allow-list with every human.
2. **Single address** — `scripts/deploy.sh` handed the raw list to `gitea admin user create --email`, and Gitea's validator rejects:

```
CreateUser: e-mail address contains unsupported character [email: ***]
```

(`***` = GH-Actions-masked `stefan.koch@hslu.ch,sk@stefanko.ch`.)

Tofu handles the list correctly. `scripts/deploy.sh` didn't.

## What changed

Introduce `GITEA_USER_EMAIL` at the top of the script as the first entry of the comma list — guaranteed comma-free — and route all five single-value derivation sites through it.

| # | Line | Edit |
|---|---|---|
| 1 | 85 | New: `GITEA_USER_EMAIL="${USER_EMAIL%%,*}"` + derive `GITEA_USER_USERNAME` from it |
| 2 | 1193 | Workspace-config block: `GITEA_USER_USERNAME` from `GITEA_USER_EMAIL` |
| 3 | 3000 | User-create username: same |
| 4 | 3040 | `--email '$GITEA_USER_EMAIL'` — **the actual failing call** |
| 5 | 3071 | Workspace-repo block: same |

Edits 2/3/5 were already *accidentally correct* under the old `${USER_EMAIL%%@*}` pattern (strip at first `@` also discards the comma), but routing them through `GITEA_USER_EMAIL` makes the invariant explicit and prevents future edits from regressing.

## Invariant after this PR

- `USER_EMAIL` — comma-separated list of all humans for allow-lists (Cloudflare Access, service-level `.env`, SSH env export). Never used as a single-address value.
- `GITEA_USER_EMAIL` — first entry of `USER_EMAIL`, single-address. Used wherever Gitea (or any future single-value consumer) needs one email.

## Mental rehearsal

| `USER_EMAIL` | `GITEA_USER_EMAIL` | `GITEA_USER_USERNAME` | CF Access allow-list (tofu, unchanged) |
|---|---|---|---|
| `stefan.koch@hslu.ch,sk@stefanko.ch` | `stefan.koch@hslu.ch` | `stefan.koch` | admin + student + teacher (3 entries) |
| `stefan.koch@hslu.ch` (single) | `stefan.koch@hslu.ch` | `stefan.koch` | admin + student (2 entries) |
| `""` (empty) | `""` | `""` → falls through to admin-identity (Stage 3 gating) | admin only |

`bash -n scripts/deploy.sh` passes.

## What does NOT change

- `USER_EMAIL` export to the SSH env (~line 496) — downstream consumes the full list.
- Service `.env` writes embedding `USER_EMAIL` — app-level allow-lists still need the full list.
- `tofu/stack/main.tf` — the comma-split logic for the CF Access allow-list is already correct and stays untouched. The only tofu edit in this PR is the unrelated SSH-key trimspace one-liner described below.
- `config.tfvars` format — stays comma-separated.

## Bundled tofu fix

A second, unrelated failure surfaced while trying to spin up a fresh stack to test this PR: OpenTofu aborted with

```
Error: Provider produced inconsistent result after apply
  hcloud_ssh_key.main: .public_key: was "ssh-ed25519 AAAA… nexus-stack\n",
                                  but now "ssh-ed25519 AAAA… nexus-stack".
```

Root cause: [tofu/stack/main.tf:24](../blob/fix/gitea-user-email-comma-strip/tofu/stack/main.tf#L24) read the SSH public key via `file(var.ssh_public_key_path)`, which preserves the trailing `\n`. The Hetzner API strips it on read-back, so OpenTofu saw an "inconsistent" apply result and failed the workflow — blocking end-to-end verification of the Gitea fix.

Fix is a one-line `trimspace()` wrap:

```hcl
public_key = trimspace(file(var.ssh_public_key_path))
```

Bundled here rather than split into a separate PR because (a) this PR can't be end-to-end tested without it, and (b) the user explicitly asked not to merge a Gitea fix that hasn't been verified against a working spin-up. Release notes will land under "Bug Fixes" regardless since both commits use `fix(scope):` titles.

## Bug chain

- #462 (v0.51.7) — Redpanda SASL escape
- #464 (v0.51.7) — Gitea `change-password` stderr capture
- #466 (v0.51.8) — USER_EXISTS awk column match
- #468 (v0.51.9) — admin/user email collision
- **this PR** — comma-rejected `USER_EMAIL` for Gitea user-create (+ the tofu SSH-key trimspace unblocker)

## Test plan

- [ ] Merge, release-please cuts v0.51.10
- [ ] Full teardown + cleanup of stefan-hslu
- [ ] Fresh Setup + Deploy via admin-panel — verifies the `hcloud_ssh_key` trimspace fix lets the spin-up complete
- [ ] `Deploy stacks` log shows `✓ Gitea user created (user: stefan.koch)` — **not** the `⚠ needs manual configuration` warning
- [ ] `ssh stefan-hslu docker exec -u git gitea gitea admin user list` shows two rows with distinct single-address emails (no comma in the student row)
- [ ] Login to Gitea as `stefan.koch` with `GITEA_USER_PASSWORD` from Infisical
- [ ] Cloudflare Access policy for the Gitea app still shows **all three humans** in the allow-list (admin + student + teacher) — confirms tofu allow-list path is untouched
- [ ] code-server restart → `git clone` of the workspace fork succeeds → `/home/coder/` shows the repo

## Regression floor

- Template (`nexus-stack.ch`): single-entry `USER_EMAIL` → `GITEA_USER_EMAIL == USER_EMAIL`, identical behaviour to pre-fix.
- Legacy student stacks with user already created → SYNC path (`change-password`), `--email` isn't passed, no behaviour change.
- `hcloud_ssh_key` trimspace: idempotent on existing stacks — next plan will show an in-place update of `.public_key` removing the trailing `\n`, no key rotation, no server recreate.

## Not in scope

- Early-script sanity guard (`case "$GITEA_USER_EMAIL" in *,*)`) — redundant since `%%,*` mathematically cannot produce a string containing a comma.
- Renaming `USER_EMAIL` → `USER_EMAIL_LIST` — larger refactor with blast radius into `.env` files; separate PR if desired.
- `Nexus-Stack-for-Education` mirror change to stop comma-joining — independent task in the education repo.

Closes #470
