### PR TITLE
docs(tutorials): Add Databricks ↔ R2 data-lake walkthrough

### DIFF
--- a/docs/tutorials/databricks/index.md
+++ b/docs/tutorials/databricks/index.md
@@ -1,0 +1,20 @@
+---
+title: "Databricks"
+description: "Connect Databricks to Nexus-Stack services — R2 data lake, Delta tables, external integrations"
+order: 0
+---
+
+# Databricks tutorials
+
+These tutorials cover the external side of Nexus-Stack — the workflows that run inside a Databricks workspace and talk back to services running on your Nexus server.
+
+Setup steps that belong on the Nexus side (saving the workspace host + token, syncing Infisical secrets to the `nexus` scope) live in the [Integrations user guide](/docs/guides/user-guides/integrations/). Everything here assumes that's already done.
+
+## Tutorials
+
+1. **[Read and write R2 from a Databricks notebook](./r2-datalake)** — connect to your Nexus R2 bucket from PySpark and boto3 using the synced `nexus` secret scope. First stop for any data-lake workflow.
+
+## What's not in this category
+
+- **Spark Structured Streaming from Redpanda → Delta** — lives in [Spark Structured Streaming](/docs/tutorials/spark/), because those tutorials are Spark-mechanics-first with Databricks as the execution environment. Come here for Databricks-specific connections; go there for Spark query patterns.
+- **Git access to Nexus Gitea from Databricks Repos** — see [stacks/git-proxy](/docs/stacks/git-proxy/) for the HTTPS proxy setup.

--- a/docs/tutorials/databricks/r2-datalake.md
+++ b/docs/tutorials/databricks/r2-datalake.md
@@ -61,10 +61,9 @@ ENDPOINT    = dbutils.secrets.get("nexus", "r2-datalake/R2_ENDPOINT")
 ACCESS_KEY  = dbutils.secrets.get("nexus", "r2-datalake/R2_ACCESS_KEY")
 SECRET_KEY  = dbutils.secrets.get("nexus", "r2-datalake/R2_SECRET_KEY")
 BUCKET      = dbutils.secrets.get("nexus", "r2-datalake/R2_BUCKET")
-
-# Values are never printed. Verify the bucket name only if you need to:
-print(f"Target bucket: {BUCKET}")
 ```
+
+Don't `print(...)` any of these values — Databricks redacts secret-scope results to `[REDACTED]` regardless of what's actually stored, so the print isn't a useful verification step and is a bad habit to build. If you need to confirm the bucket name, check the Control Plane Secrets page or the Cloudflare R2 dashboard, or just proceed with the write below and let a successful `list_objects` / `count()` be the confirmation.
 
 ### Configure Hadoop S3A
 
@@ -176,8 +175,8 @@ Just use `s3a://` directly. Everything you can do with a mount, you can do with 
 **`403 SignatureDoesNotMatch`**
 Either the wrong secret key (check you're reading `R2_SECRET_KEY`, not a raw Cloudflare token), or the Hadoop region isn't set — Spark silently fails signing when region is empty. Set `fs.s3a.region = auto`.
 
-**`NoSuchBucket: nexus-<domain>-data`**
-Bucket-name format uses dashes only — dots in the domain get replaced by dashes (`stefanko.ch` → `stefanko-ch`). Confirm the value from `dbutils.secrets.get("nexus", "r2-datalake/R2_BUCKET")` matches what exists in Cloudflare Dashboard → R2 → Buckets.
+**`NoSuchBucket: nexus-<domain-slug>-data`**
+Bucket-name format uses dashes only — dots in the domain get replaced by dashes (`stefanko.ch` → `stefanko-ch`). Confirm the value stored in the `R2_BUCKET` secret matches what exists in Cloudflare Dashboard → R2 → Buckets.
 
 **`SocketTimeoutException` or `connection refused`**
 Databricks Classic compute in some regions has egress restrictions to `*.r2.cloudflarestorage.com`. Switch to Serverless compute (default on Free Edition), or check your workspace's network policy.

--- a/docs/tutorials/databricks/r2-datalake.md
+++ b/docs/tutorials/databricks/r2-datalake.md
@@ -15,7 +15,7 @@ R2 is Nexus's **external-facing** S3 bridge. It's the one S3-compatible endpoint
 Internal Nexus services (Spark, Jupyter, LakeFS, Filestash, MinIO) do **not** use R2 — they write to Hetzner Object Storage over the Docker network, which is cheaper, faster, and stays inside the tunnel. So:
 
 - **You want Databricks to read Parquet files from your Nexus data lake → R2** (this tutorial).
-- **You want Jupyter-in-Nexus to write Parquet files for a Nexus-internal pipeline → use LakeFS or Hetzner Object Storage, not R2** (see [docs/stacks/lakefs.md](/docs/stacks/lakefs.md)).
+- **You want Jupyter-in-Nexus to write Parquet files for a Nexus-internal pipeline → use LakeFS or Hetzner Object Storage, not R2** (see [docs/stacks/lakefs](/docs/stacks/lakefs/)).
 
 The R2 bucket **persists across `destroy-all`** — Cloudflare side lives independently of the Hetzner server, and the teardown workflow explicitly preserves both the bucket and the API token. Your Parquet files survive a stack reset.
 

--- a/docs/tutorials/databricks/r2-datalake.md
+++ b/docs/tutorials/databricks/r2-datalake.md
@@ -1,0 +1,195 @@
+---
+title: "Read and write R2 from a Databricks notebook"
+description: "Use the synced Nexus-Stack R2 credentials from the nexus Databricks secret scope to read and write Parquet files"
+order: 1
+---
+
+# Read and write R2 from a Databricks notebook
+
+Nexus-Stack's external data-lake lives in Cloudflare R2. This tutorial shows how to read from and write to that bucket from a Databricks notebook, using the credentials that the Control Plane already mirrors into your `nexus` secret scope.
+
+## Where R2 fits in Nexus-Stack
+
+R2 is Nexus's **external-facing** S3 bridge. It's the one S3-compatible endpoint that is reachable from the public internet, which makes it the only Nexus storage that SaaS tools like Databricks can plug into directly.
+
+Internal Nexus services (Spark, Jupyter, LakeFS, Filestash, MinIO) do **not** use R2 — they write to Hetzner Object Storage over the Docker network, which is cheaper, faster, and stays inside the tunnel. So:
+
+- **You want Databricks to read Parquet files from your Nexus data lake → R2** (this tutorial).
+- **You want Jupyter-in-Nexus to write Parquet files for a Nexus-internal pipeline → use LakeFS or Hetzner Object Storage, not R2** (see [docs/stacks/lakefs.md](/docs/stacks/lakefs.md)).
+
+The R2 bucket **persists across `destroy-all`** — Cloudflare side lives independently of the Hetzner server, and the teardown workflow explicitly preserves both the bucket and the API token. Your Parquet files survive a stack reset.
+
+## Prerequisites
+
+- Nexus-Stack deployed (spin-up successful, Infisical running).
+- Databricks workspace connected on the Control Plane [Integrations page](/docs/guides/user-guides/integrations/) (host + personal access token saved).
+- **Sync Now** pressed on the [Secrets page](/docs/guides/user-guides/secrets/) at least once. After that, `dbutils.secrets.list("nexus")` from a Databricks notebook should include these four keys:
+  - `r2-datalake/R2_ENDPOINT`
+  - `r2-datalake/R2_ACCESS_KEY`
+  - `r2-datalake/R2_SECRET_KEY`
+  - `r2-datalake/R2_BUCKET`
+- A Databricks cluster (Free Edition works) attached to your notebook.
+
+If the four keys are missing, it's one of two things:
+1. **Spin-up didn't see R2 creds.** Check that `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, and `R2_DATA_BUCKET` exist in your GitHub repo's Actions Secrets. If not, re-run `gh workflow run setup-control-plane.yaml` with `GH_SECRETS_TOKEN` configured — it auto-populates them.
+2. **Sync Now wasn't pressed after the last spin-up.** Go to Secrets → Databricks panel → click the button.
+
+## What the four keys mean
+
+| Key | Example value | Purpose |
+|---|---|---|
+| `r2-datalake/R2_ENDPOINT` | `https://<account-id>.r2.cloudflarestorage.com` | S3-compatible API endpoint |
+| `r2-datalake/R2_ACCESS_KEY` | Token ID (long hex string) | `AWS_ACCESS_KEY_ID` / `fs.s3a.access.key` |
+| `r2-datalake/R2_SECRET_KEY` | SHA-256 of the raw Cloudflare token | `AWS_SECRET_ACCESS_KEY` / `fs.s3a.secret.key` |
+| `r2-datalake/R2_BUCKET` | `nexus-<domain-slug>-data` | Bucket name (no `s3://` prefix) |
+
+The `R2_SECRET_KEY` being a SHA-256 hash of the Cloudflare token (rather than the token itself) is [Cloudflare's documented convention](https://developers.cloudflare.com/r2/api/tokens/#get-s3-api-credentials-from-an-api-token) for S3-compatible auth. Any S3 client treats it as a normal secret access key; you never do the hashing yourself.
+
+## Path 1: PySpark via s3a:// (recommended)
+
+This is the workflow you want for anything Delta-table-shaped — Spark reads and writes `s3a://bucket/path` URIs natively, checkpoints work, and you can use the full DataFrame API.
+
+### Load credentials
+
+```python
+ENDPOINT    = dbutils.secrets.get("nexus", "r2-datalake/R2_ENDPOINT")
+ACCESS_KEY  = dbutils.secrets.get("nexus", "r2-datalake/R2_ACCESS_KEY")
+SECRET_KEY  = dbutils.secrets.get("nexus", "r2-datalake/R2_SECRET_KEY")
+BUCKET      = dbutils.secrets.get("nexus", "r2-datalake/R2_BUCKET")
+
+# Values are never printed. Verify the bucket name only if you need to:
+print(f"Target bucket: {BUCKET}")
+```
+
+### Configure Hadoop S3A
+
+```python
+hconf = spark._jsc.hadoopConfiguration()
+hconf.set("fs.s3a.endpoint",               ENDPOINT)
+hconf.set("fs.s3a.access.key",             ACCESS_KEY)
+hconf.set("fs.s3a.secret.key",             SECRET_KEY)
+hconf.set("fs.s3a.path.style.access",      "true")   # required for R2
+hconf.set("fs.s3a.region",                 "auto")   # R2 ignores region, but Hadoop wants one
+hconf.set("fs.s3a.aws.credentials.provider",
+          "org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider")
+```
+
+Three R2-specific points:
+
+- **`path.style.access = true` is not optional.** R2 does not support virtual-host-style addressing (`<bucket>.<account>.r2.cloudflarestorage.com`). You will get `UnknownHostException` without it.
+- **`region = auto`** — R2 is globally distributed, but Hadoop's AWS SDK refuses to start if no region is configured. `auto` is accepted by the SDK and ignored by R2, which is what you want.
+- **`SimpleAWSCredentialsProvider`** is the one provider that reads the access key / secret key from Hadoop config directly. The default chain walks AWS instance metadata and IAM roles, neither of which exist on a Databricks cluster reading R2.
+
+### Write and read a Parquet file
+
+```python
+path = f"s3a://{BUCKET}/tutorial/sample.parquet"
+
+# Write
+(spark.range(100)
+      .withColumnRenamed("id", "n")
+      .write.mode("overwrite")
+      .parquet(path))
+
+# Read back
+df = spark.read.parquet(path)
+print(f"Row count: {df.count()}")   # 100
+df.show(5)
+```
+
+Expected output:
+
+```
+Row count: 100
++---+
+|  n|
++---+
+|  0|
+|  1|
+|  2|
+|  3|
+|  4|
++---+
+```
+
+If you see `Row count: 100` and five rows, your Databricks cluster is successfully reading and writing R2 through the S3A connector. Everything else — Delta tables, partitioning, MERGE INTO, structured streaming sinks — works the same way from here; the `s3a://` URI is just a Hadoop path.
+
+## Path 2: boto3 (recommended for single-file operations)
+
+Good for quick uploads, bucket listings, or one-off object inspection. Uses the same credentials.
+
+```python
+import boto3
+
+s3 = boto3.client(
+    "s3",
+    endpoint_url          = dbutils.secrets.get("nexus", "r2-datalake/R2_ENDPOINT"),
+    aws_access_key_id     = dbutils.secrets.get("nexus", "r2-datalake/R2_ACCESS_KEY"),
+    aws_secret_access_key = dbutils.secrets.get("nexus", "r2-datalake/R2_SECRET_KEY"),
+    region_name           = "auto",
+)
+BUCKET = dbutils.secrets.get("nexus", "r2-datalake/R2_BUCKET")
+
+# Upload a small in-memory file
+s3.put_object(Bucket=BUCKET, Key="tutorial/hello.txt", Body=b"hello from databricks")
+
+# List what's in the tutorial/ prefix
+for obj in s3.list_objects_v2(Bucket=BUCKET, Prefix="tutorial/").get("Contents", []):
+    print(f"  {obj['Key']:<40} {obj['Size']:>8} bytes")
+
+# Read it back
+resp = s3.get_object(Bucket=BUCKET, Key="tutorial/hello.txt")
+print(resp["Body"].read().decode())   # "hello from databricks"
+```
+
+Expected output:
+
+```
+  tutorial/hello.txt                         22 bytes
+  tutorial/sample.parquet/_SUCCESS            0 bytes
+  tutorial/sample.parquet/part-00000-...    870 bytes
+  ...
+hello from databricks
+```
+
+You can see both the `boto3` upload and the Parquet parts from Path 1 sitting in the same prefix.
+
+## Path 3: dbutils.fs.mount — avoid
+
+Mounts technically work against R2 via `s3a://`, but Databricks has been moving away from them for years in favour of Unity Catalog External Locations. Two reasons to skip mounts:
+
+- They're cluster-scoped, not workspace-scoped; students on different clusters need to mount separately.
+- A mount stores the credentials in the cluster's internal state — rotating the R2 token requires unmounting and remounting everywhere.
+
+Just use `s3a://` directly. Everything you can do with a mount, you can do with the full URI.
+
+## Common errors
+
+**`UnknownHostException: <bucket>.<account-id>.r2.cloudflarestorage.com`**
+`fs.s3a.path.style.access` is not `true`. Fix the Hadoop config.
+
+**`403 SignatureDoesNotMatch`**
+Either the wrong secret key (check you're reading `R2_SECRET_KEY`, not a raw Cloudflare token), or the Hadoop region isn't set — Spark silently fails signing when region is empty. Set `fs.s3a.region = auto`.
+
+**`NoSuchBucket: nexus-<domain>-data`**
+Bucket-name format uses dashes only — dots in the domain get replaced by dashes (`stefanko.ch` → `stefanko-ch`). Confirm the value from `dbutils.secrets.get("nexus", "r2-datalake/R2_BUCKET")` matches what exists in Cloudflare Dashboard → R2 → Buckets.
+
+**`SocketTimeoutException` or `connection refused`**
+Databricks Classic compute in some regions has egress restrictions to `*.r2.cloudflarestorage.com`. Switch to Serverless compute (default on Free Edition), or check your workspace's network policy.
+
+**`The AWS Access Key Id you provided does not exist in our records`**
+You've probably picked up the wrong secret — double-check you're reading from `r2-datalake/*` and not from the legacy top-level keys. The sync button on the Secrets page cleans those up automatically; if you haven't clicked Sync since upgrading past v0.51.9, do that first.
+
+## Hooking up to a Nexus-side producer
+
+The tutorial above is self-contained — `spark.range(100)` is your "data source." For a real workflow, you probably want Nexus-side tools to land data in R2 so Databricks can pick it up. Two light patterns:
+
+- **Python script inside [code-server](/docs/tutorials/code-server/) using `boto3`**, reading the same keys from Infisical (`/r2-datalake` folder), writing Parquet to `s3://nexus-<domain>-data/incoming/…`. Databricks polls that prefix on a schedule.
+- **[Redpanda-Connect](/docs/tutorials/redpanda-connect/)** with an `aws_s3` output pointed at the R2 endpoint. Same credentials, streams Kafka events straight to R2 objects.
+
+Neither is in scope for this tutorial, but both are natural next steps once you've confirmed the Databricks → R2 round-trip works.
+
+## Next steps
+
+- [Sync Infisical secrets into Databricks](/docs/guides/user-guides/integrations/) — the sync mechanism this tutorial relies on, with screenshots of the Integrations + Secrets pages.
+- [Spark Structured Streaming → Bronze Delta](/docs/tutorials/spark/bronze-delta/) — now that R2 works, you can point the checkpoint and sink locations at `s3a://<bucket>/…` for a real medallion pipeline.

--- a/docs/tutorials/databricks/r2-datalake.md
+++ b/docs/tutorials/databricks/r2-datalake.md
@@ -124,13 +124,20 @@ Good for quick uploads, bucket listings, or one-off object inspection. Uses the 
 
 ```python
 import boto3
+from botocore.config import Config
 
+# Force path-style addressing — botocore picks virtual-host-style by default
+# on some versions, which on R2 can fail or produce the wrong URL shape
+# (`<bucket>.<account>.r2.cloudflarestorage.com`). The path-style form
+# (`<account>.r2.cloudflarestorage.com/<bucket>/…`) is what R2 prefers and
+# is required for consistent behaviour across botocore releases.
 s3 = boto3.client(
     "s3",
     endpoint_url          = dbutils.secrets.get("nexus", "r2-datalake/R2_ENDPOINT"),
     aws_access_key_id     = dbutils.secrets.get("nexus", "r2-datalake/R2_ACCESS_KEY"),
     aws_secret_access_key = dbutils.secrets.get("nexus", "r2-datalake/R2_SECRET_KEY"),
     region_name           = "auto",
+    config                = Config(s3={"addressing_style": "path"}),
 )
 BUCKET = dbutils.secrets.get("nexus", "r2-datalake/R2_BUCKET")
 

--- a/docs/tutorials/databricks/r2-datalake.md
+++ b/docs/tutorials/databricks/r2-datalake.md
@@ -184,7 +184,7 @@ You've probably picked up the wrong secret — double-check you're reading from 
 
 The tutorial above is self-contained — `spark.range(100)` is your "data source." For a real workflow, you probably want Nexus-side tools to land data in R2 so Databricks can pick it up. Two light patterns:
 
-- **Python script inside [code-server](/docs/tutorials/code-server/) using `boto3`**, reading the same keys from Infisical (`/r2-datalake` folder), writing Parquet to `s3://nexus-<domain>-data/incoming/…`. Databricks polls that prefix on a schedule.
+- **Python script inside [code-server](/docs/tutorials/code-server/) using `boto3`**, reading the same keys from Infisical (`/r2-datalake` folder), writing Parquet to `s3://<R2_BUCKET>/incoming/…` (substitute the real bucket name from the `R2_BUCKET` secret — same `nexus-<domain-slug>-data` format used throughout the tutorial). Databricks polls that prefix on a schedule.
 - **[Redpanda-Connect](/docs/tutorials/redpanda-connect/)** with an `aws_s3` output pointed at the R2 endpoint. Same credentials, streams Kafka events straight to R2 objects.
 
 Neither is in scope for this tutorial, but both are natural next steps once you've confirmed the Databricks → R2 round-trip works.

--- a/docs/tutorials/databricks/r2-datalake.md
+++ b/docs/tutorials/databricks/r2-datalake.md
@@ -12,7 +12,12 @@ Nexus-Stack's external data-lake lives in Cloudflare R2. This tutorial shows how
 
 R2 is Nexus's **external-facing** S3 bridge. It's the one S3-compatible endpoint that is reachable from the public internet, which makes it the only Nexus storage that SaaS tools like Databricks can plug into directly.
 
-Internal Nexus services (Spark, Jupyter, LakeFS, Filestash, MinIO) do **not** use R2 — they write to Hetzner Object Storage over the Docker network, which is cheaper, faster, and stays inside the tunnel. So:
+Internal Nexus services do **not** use R2 by default. The shipped config splits internal storage in two directions:
+
+- **Spark, Jupyter, LakeFS, Filestash** — S3-compatible writes go to **Hetzner Object Storage** via its public S3 endpoint. The server lives in a Hetzner datacenter, so this traffic stays inside Hetzner's network — low latency, no Cloudflare egress, no tunnel hop.
+- **MinIO, Garage, SeaweedFS** — self-contained object stores that keep their data on local Docker volumes inside the Nexus server. Same `app-network`, no external dependency.
+
+R2 is layered on top of this for the **external** use case only (Databricks, other SaaS tools that need to reach the data lake from the public internet). So:
 
 - **You want Databricks to read Parquet files from your Nexus data lake → R2** (this tutorial).
 - **You want Jupyter-in-Nexus to write Parquet files for a Nexus-internal pipeline → use LakeFS or Hetzner Object Storage, not R2** (see [docs/stacks/lakefs](/docs/stacks/lakefs/)).

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -18,6 +18,7 @@ The goal: give you one focused skill per page, so you can stitch the ones you ne
 | Pipe an external stream into Redpanda without writing code | [Redpanda Connect → Stream Bluesky firehose](./redpanda-connect/bluesky-stream) |
 | Write SQL against a live event stream | [Flink → Query a Redpanda topic with Flink SQL](./flink/flink-sql-on-redpanda) |
 | Land streaming data in a Delta table on Databricks | [Spark → Write a Kafka stream to a Bronze Delta table](./spark/bronze-delta) |
+| Read the Nexus data lake from a Databricks notebook | [Databricks → Read and write R2](./databricks/r2-datalake) |
 | Just get a terminal and Python working inside Nexus-Stack | [Code-Server → Run curl in the terminal](./code-server/terminal-curl) |
 
 ## Categories
@@ -29,6 +30,7 @@ The goal: give you one focused skill per page, so you can stitch the ones you ne
 | **[Redpanda Connect](./redpanda-connect/)** | YAML-driven pipelines — deploy, manage, real-world Bluesky example | 2 |
 | **[Flink](./flink/)** | Dinky setup, Flink SQL against Redpanda, end-to-end Bluesky walkthrough | 3 |
 | **[Spark Structured Streaming](./spark/)** | Databricks streaming from rate source → Redpanda read → JSON parsing → Bronze Delta | 4 |
+| **[Databricks](./databricks/)** | External Databricks ↔ Nexus workflows — R2 data lake from notebooks | 1 |
 
 ## How to use these
 

--- a/docs/user-guides/integrations.md
+++ b/docs/user-guides/integrations.md
@@ -32,7 +32,7 @@ Inside the `nexus` scope, every key is prefixed with its Infisical folder: `<fol
 | folder `postgres`, key `POSTGRES_USERNAME` | `postgres/POSTGRES_USERNAME` |
 | folder `redpanda`, key `REDPANDA_KAFKA_PUBLIC_URL` | `redpanda/REDPANDA_KAFKA_PUBLIC_URL` |
 | folder `gitea`, key `GITEA_REPO_URL` | `gitea/GITEA_REPO_URL` |
-| folder `r2-datalake`, keys `R2_ENDPOINT` / `R2_ACCESS_KEY` / `R2_SECRET_KEY` / `R2_BUCKET` | `r2-datalake/R2_ENDPOINT` etc. — see the [R2 data-lake tutorial](../tutorials/databricks/r2-datalake.md) |
+| folder `r2-datalake`, keys `R2_ENDPOINT` / `R2_ACCESS_KEY` / `R2_SECRET_KEY` / `R2_BUCKET` | `r2-datalake/R2_ENDPOINT` etc. — see the [R2 data-lake tutorial](/docs/tutorials/databricks/r2-datalake/) |
 
 This matches the folder view on the Control Plane's Secrets page exactly, so whatever you can see there is also what the sync pushes.
 
@@ -136,7 +136,7 @@ Secret values are always shown as `[REDACTED]` in Databricks notebook output —
 
 The four keys under the `r2-datalake/` prefix — `R2_ENDPOINT`, `R2_ACCESS_KEY`, `R2_SECRET_KEY`, `R2_BUCKET` — give a Databricks notebook direct S3-compatible access to your Nexus R2 bucket. Parquet files written from Databricks are visible from Nexus-side tooling (via Infisical-stored credentials), and vice versa.
 
-The full walkthrough lives in [Tutorials → Databricks → Read and write R2 from a notebook](../tutorials/databricks/r2-datalake.md) — PySpark `s3a://` configuration, `boto3` recipes, and the R2-specific quirks (`path.style.access=true`, `region=auto`). The bucket survives `destroy-all` on the Nexus side, so student work persists across stack resets.
+The full walkthrough lives in [Tutorials → Databricks → Read and write R2 from a notebook](/docs/tutorials/databricks/r2-datalake/) — PySpark `s3a://` configuration, `boto3` recipes, and the R2-specific quirks (`path.style.access=true`, `region=auto`). The bucket survives `destroy-all` on the Nexus side, so student work persists across stack resets.
 
 ## Future integrations
 

--- a/docs/user-guides/integrations.md
+++ b/docs/user-guides/integrations.md
@@ -32,6 +32,7 @@ Inside the `nexus` scope, every key is prefixed with its Infisical folder: `<fol
 | folder `postgres`, key `POSTGRES_USERNAME` | `postgres/POSTGRES_USERNAME` |
 | folder `redpanda`, key `REDPANDA_KAFKA_PUBLIC_URL` | `redpanda/REDPANDA_KAFKA_PUBLIC_URL` |
 | folder `gitea`, key `GITEA_REPO_URL` | `gitea/GITEA_REPO_URL` |
+| folder `r2-datalake`, keys `R2_ENDPOINT` / `R2_ACCESS_KEY` / `R2_SECRET_KEY` / `R2_BUCKET` | `r2-datalake/R2_ENDPOINT` etc. — see the [R2 data-lake tutorial](../tutorials/databricks/r2-datalake.md) |
 
 This matches the folder view on the Control Plane's Secrets page exactly, so whatever you can see there is also what the sync pushes.
 
@@ -130,6 +131,12 @@ kafka_url = dbutils.secrets.get(scope="nexus", key="redpanda/REDPANDA_KAFKA_PUBL
 ![Databricks notebook reading a secret with dbutils.secrets.get() and printing [REDACTED] as the value — the expected successful output](./assets/databricks-get-secret.png)
 
 Secret values are always shown as `[REDACTED]` in Databricks notebook output — this is intentional and means the secret was read successfully.
+
+### Reading the Nexus data lake from a notebook
+
+The four keys under the `r2-datalake/` prefix — `R2_ENDPOINT`, `R2_ACCESS_KEY`, `R2_SECRET_KEY`, `R2_BUCKET` — give a Databricks notebook direct S3-compatible access to your Nexus R2 bucket. Parquet files written from Databricks are visible from Nexus-side tooling (via Infisical-stored credentials), and vice versa.
+
+The full walkthrough lives in [Tutorials → Databricks → Read and write R2 from a notebook](../tutorials/databricks/r2-datalake.md) — PySpark `s3a://` configuration, `boto3` recipes, and the R2-specific quirks (`path.style.access=true`, `region=auto`). The bucket survives `destroy-all` on the Nexus side, so student work persists across stack resets.
 
 ## Future integrations
 


### PR DESCRIPTION
## Summary

New tutorial category documenting the external Databricks ↔ R2 data-lake path. After #474 landed, the `r2-datalake/*` keys get mirrored into the Databricks `nexus` secret scope automatically, but there was nothing telling students **how to use them** from a notebook. This PR fills that gap — no infra or code changes, pure docs.

## Motivation

For classroom work we want students to read/write the Nexus data lake from Databricks. The R2 plumbing already works end-to-end:

- `init-r2-state.sh` provisions the `nexus-<domain>-data` bucket + unified API token on first setup.
- Creds land in Infisical under `/r2-datalake` (deploy.sh, gated on all four env vars).
- Control Plane Secrets page renders them; **Sync Now** pushes them to the Databricks `nexus` scope as `r2-datalake/R2_ENDPOINT` etc.
- Bucket + creds are explicitly preserved across `destroy-all` (destroy-all.yml:250-268).

The missing piece was the **last hop**: a notebook-side tutorial showing how to wire `dbutils.secrets.get("nexus", "r2-datalake/…")` into PySpark (`fs.s3a.*`) and `boto3`.

## What changed

- **`docs/tutorials/databricks/r2-datalake.md`** — step-by-step walkthrough:
  - Clear framing that R2 is Nexus's **external** bridge; internal Nexus services (Spark, Jupyter, LakeFS, Filestash) write to Hetzner Object Storage, not R2. Students shouldn't conflate the two.
  - Prerequisites section that catches the two common pre-flight gotchas (missing GH Secrets after first-time setup; forgetting to press **Sync Now** after spin-up).
  - Table explaining the four R2 keys, including the Cloudflare SHA-256-of-token-value convention so nobody tries to derive it themselves.
  - **Path 1: PySpark / s3a://** — full Hadoop config with the three R2-specific points called out (`path.style.access=true`, `region=auto`, `SimpleAWSCredentialsProvider`). `spark.range(100).write.parquet(...)` → read-back → count, with expected output inline.
  - **Path 2: boto3** — same creds, for single-file uploads and object listings.
  - **Path 3: dbutils.fs.mount** — explicitly discouraged (cluster-scoped, being deprecated).
  - Troubleshooting covering the five failure modes the config can surface (UnknownHostException, 403 SignatureDoesNotMatch, NoSuchBucket, SocketTimeout, legacy flat-key leakage from pre-#474 notebooks).
  - Short "Hooking up a Nexus-side producer" pointer to code-server / Redpanda-Connect patterns (out-of-scope for the tutorial itself but the natural next step).
- **`docs/tutorials/databricks/index.md`** — category landing page in the same shape as `docs/tutorials/spark/index.md`.
- **`docs/tutorials/index.md`** — new "Start here if…" row (*"Read the Nexus data lake from a Databricks notebook"*) and a Databricks row in the Categories table.
- **`docs/user-guides/integrations.md`** — new `r2-datalake/*` row in the key-naming table; a "Reading the Nexus data lake from a notebook" section pointing at the tutorial. Mentions that the bucket survives `destroy-all` so students don't panic on stack resets.

## What does NOT change

- No infra (no Tofu, no workflow, no services.yaml).
- No Nexus-internal stack is rewired to R2. Spark/Jupyter stay on Hetzner Object Storage for throughput and egress-cost reasons; that's called out in the tutorial.
- No `services.yaml`, `CLAUDE.md`, or `.github/copilot-instructions.md` changes needed — no new conventions or gates.

## Test plan

- [ ] Tutorial renders cleanly on nexus-stack.ch after merge (`/docs/tutorials/databricks/r2-datalake/`).
- [ ] From a fresh spin-up + **Sync Now**: `dbutils.secrets.list("nexus")` in a Databricks notebook contains `r2-datalake/R2_ENDPOINT`, `R2_ACCESS_KEY`, `R2_SECRET_KEY`, `R2_BUCKET`.
- [ ] PySpark cells from the tutorial run end-to-end: write → read → `count() == 100`.
- [ ] `boto3` cells round-trip: `put_object` + `list_objects_v2` + `get_object`.
- [ ] After `destroy-all.yml` + fresh spin-up, the Parquet files written above are still readable via `spark.read.parquet(...)` — verifies the "persistence across teardown" claim in the doc.
- [ ] Integrations-guide cross-links both directions resolve (user-guide → tutorial, tutorial → user-guide).
