### PR TITLE
fix(kestra): Raise container memory limit from 1g to 4g

### DIFF
--- a/stacks/kestra/docker-compose.yml
+++ b/stacks/kestra/docker-compose.yml
@@ -67,7 +67,14 @@ services:
     deploy:
       resources:
         limits:
-          memory: 1g
+          # The v1.0 default image bundles ~98 plugin JARs (see note on the
+          # image line above). Plugin metadata alone sits at ~700–900 MB in
+          # the JVM heap, before any flow executions start. With the old
+          # 1 GB cap the JVM spent its time in GC-thrashing (observed 97 %
+          # memory utilisation and 200 %+ CPU on an idle container). 4 GB
+          # matches Kestra's own "many plugins" recommendation and leaves
+          # breathing room for parallel classroom flow executions.
+          memory: 4g
     volumes:
       - kestra-data:/app/storage
       - /var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
## Summary

Raises the Kestra container's memory limit from `1g` to `4g` to match the resource profile of the `v1.0` image (pinned in #481), which bundles ~98 official plugins inline and therefore has a much higher JVM heap baseline than older Kestra versions.

## Symptom observed today

Fresh spin-up on a cax31 with #481 merged and Kestra `v1.0.38` running. Container stats before this fix:

```
NAME     CPU %     MEM USAGE / LIMIT     MEM %
kestra   213.56%   993.1MiB / 1GiB       96.98%
```

The 200 %+ CPU is not real work — it's JVM garbage collection thrashing. The heap sits permanently at its ceiling because the plugin metadata alone (~700–900 MB for ~98 plugin JARs) eats most of the 1 GB budget. Flow-execution state, queue processing, and the web server are all squeezed into what's left.

User-facing symptoms:
- Kestra UI takes ~10 s to render each page after login.
- Server-liveness coordinator logs warnings about non-responding internal services (heartbeat timeouts because the JVM is too busy in GC to respond on time).
- No infrastructure errors in logs — purely resource starvation.

## Root cause

Historical artefact: `memory: 1g` was set in an earlier Kestra era (0.x) when the default image shipped only a handful of plugins. The #481 switch to `kestra/kestra:v1.0` (current LTS, plugins-bundled-by-default) raised the JVM baseline well above the old 1 GB cap, but the compose limit was never revisited.

## Change

```diff
    deploy:
      resources:
        limits:
-         memory: 1g
+         # [inline comment explaining the why]
+         memory: 4g
```

Added an inline comment next to the limit so the next reader doesn't shrink it back to 1 GB without knowing why.

## Why 4 GB

| Component | Estimated RAM |
|---|---|
| JVM + ~98 plugin metadata in heap | 700–900 MB |
| Runtime (Webserver, Scheduler, Executor, Worker, Indexer) | 500–1000 MB |
| GC breathing room | ~500 MB |
| Parallel flow executions (classroom, ~10 concurrent students) | 500–1000 MB |
| **Total realistic peak** | **2.5–3.5 GB** |
| **Limit with 20 % headroom** | **4 GB** |

Matches [Kestra's official guidance](https://kestra.io/docs/installation/docker-compose) ("at least 2 GB, more with many plugins" — we have ~98).

## Server budget check

- Total RAM: 15 GB
- Current usage across active stacks (without memory-starved Kestra): ~3 GB
- Peak with this change: Kestra 4 GB + other services 3 GB = **7 GB used**, **8 GB headroom** for OS, page cache, and future stacks (Trino, Spark, ClickHouse each want 2–4 GB if enabled later).

No risk of OOM at current stack footprint.

## Related

- #481 — pinned `kestra/kestra:v1.0`. This PR is the follow-up that actually matches the runtime to that image's real needs.
- #478 — Kestra → Databricks walkthrough. Tutorial users with ~10 student flows in parallel need this headroom.

## Test plan

- [ ] Merge, run `gh workflow run spin-up.yml`.
- [ ] `ssh nexus "docker stats kestra --no-stream"` → MEM % should drop from 97 % to ~20–25 % at idle.
- [ ] Kestra UI loads pages in <1 s instead of ~10 s.
- [ ] `ssh nexus "docker logs kestra | grep -i 'non-responding'"` → empty after the heartbeat cycle stabilises (2–3 min post-restart).
