### PR TITLE
feat(portainer): Make Portainer a core service (always enabled)

### DIFF
--- a/.github/scripts/sync-deployed-state.sh
+++ b/.github/scripts/sync-deployed-state.sh
@@ -284,27 +284,6 @@ PYEOF
   else
     echo "  ℹ️  No services to update"
   fi
-
-  # Invariant: every core: true service must be enabled = 1.
-  # The metadata UPDATE above preserves the operator's `enabled` choice on
-  # purpose (so user-toggled non-core services aren't reset). But that
-  # preservation also keeps an existing row at `enabled = 0` when its
-  # `core` flag flips from 0 → 1 across a deploy (e.g. promoting Portainer
-  # to a core service in #492). Force `enabled = 1` for any row where
-  # `core = 1` so the promotion takes effect on existing installs without
-  # the operator having to toggle it manually in the Control Plane UI.
-  echo "  Enforcing core = 1 → enabled = 1 invariant..."
-  set +e
-  WRANGLER_OUTPUT=$(npx wrangler@latest d1 execute "$D1_DATABASE_NAME" \
-    --remote --command "UPDATE services SET enabled = 1 WHERE core = 1 AND enabled = 0;" 2>&1)
-  WRANGLER_EXIT=$?
-  set -e
-  if [ $WRANGLER_EXIT -eq 0 ]; then
-    echo "  ✅ Core-services invariant enforced"
-  else
-    SANITIZED_ERROR=$(sanitize_error "$WRANGLER_OUTPUT")
-    echo "  ⚠️ Core-services invariant UPDATE had issues: $SANITIZED_ERROR" >&2
-  fi
 else
   echo "  ⚠️ services.yaml not found - skipping sync"
 fi
@@ -448,6 +427,41 @@ else
   SANITIZED_ERROR=$(sanitize_error "$FW_DEPLOYED_OUTPUT")
   echo "  ⚠️ Failed to sync firewall deployed state (non-critical)" >&2
   echo "  Error: $SANITIZED_ERROR" >&2
+fi
+
+# Step 4.5: Enforce the `core = 1 → enabled = 1` invariant.
+#
+# The metadata UPDATE in Step 1 preserves the operator's `enabled` choice
+# on purpose (so user-toggled non-core services aren't reset by a yaml
+# sync). But that preservation also keeps an existing row at
+# `enabled = 0` when its `core` flag flips from 0 → 1 across a deploy —
+# e.g. promoting Portainer to a core service in PR #493 — leaving the
+# row out of sync with the new invariant.
+#
+# This step MUST run AFTER Step 3 (services deployed = enabled). If it
+# ran before, Step 3 would propagate the freshly-flipped `enabled = 1`
+# into `deployed = 1` even though the actual container wasn't started
+# in the just-finished spin-up (because deploy.sh saw the OLD enabled
+# list when it ran). The Control Plane would then mis-report the
+# newly-promoted core service as "deployed and running" when it's
+# actually not.
+#
+# Two-phase rollout for the existing-install case:
+#   1. This spin-up: enabled flips from 0 → 1 here, deployed stays 0.
+#      Control Plane shows the service as "selected, pending deploy".
+#   2. Next spin-up: deploy.sh sees enabled = 1, starts the container,
+#      Step 3 propagates deployed = 1.
+echo "  Enforcing core = 1 → enabled = 1 invariant..."
+set +e
+WRANGLER_OUTPUT=$(npx wrangler@latest d1 execute "$D1_DATABASE_NAME" \
+  --remote --command "UPDATE services SET enabled = 1 WHERE core = 1 AND enabled = 0;" 2>&1)
+WRANGLER_EXIT=$?
+set -e
+if [ $WRANGLER_EXIT -eq 0 ]; then
+  echo "  ✅ Core-services invariant enforced"
+else
+  SANITIZED_ERROR=$(sanitize_error "$WRANGLER_OUTPUT")
+  echo "  ⚠️ Core-services invariant UPDATE had issues: $SANITIZED_ERROR" >&2
 fi
 
 # Step 5: Final verification - list all services in D1

--- a/.github/scripts/sync-deployed-state.sh
+++ b/.github/scripts/sync-deployed-state.sh
@@ -435,8 +435,8 @@ fi
 # on purpose (so user-toggled non-core services aren't reset by a yaml
 # sync). But that preservation also keeps an existing row at
 # `enabled = 0` when its `core` flag flips from 0 → 1 across a deploy —
-# e.g. promoting Portainer to a core service in PR #493 — leaving the
-# row out of sync with the new invariant.
+# i.e. when a service is promoted to a core service across deploys —
+# leaving the row out of sync with the new invariant.
 #
 # This step MUST run AFTER Step 3 (services deployed = enabled). If it
 # ran before, Step 3 would propagate the freshly-flipped `enabled = 1`
@@ -454,7 +454,7 @@ fi
 echo "  Enforcing core = 1 → enabled = 1 invariant..."
 set +e
 WRANGLER_OUTPUT=$(npx wrangler@latest d1 execute "$D1_DATABASE_NAME" \
-  --remote --command "UPDATE services SET enabled = 1 WHERE core = 1 AND enabled = 0;" 2>&1)
+  --remote --command "UPDATE services SET enabled = 1, updated_at = datetime('now') WHERE core = 1 AND enabled = 0;" 2>&1)
 WRANGLER_EXIT=$?
 set -e
 if [ $WRANGLER_EXIT -eq 0 ]; then

--- a/.github/scripts/sync-deployed-state.sh
+++ b/.github/scripts/sync-deployed-state.sh
@@ -284,6 +284,27 @@ PYEOF
   else
     echo "  ℹ️  No services to update"
   fi
+
+  # Invariant: every core: true service must be enabled = 1.
+  # The metadata UPDATE above preserves the operator's `enabled` choice on
+  # purpose (so user-toggled non-core services aren't reset). But that
+  # preservation also keeps an existing row at `enabled = 0` when its
+  # `core` flag flips from 0 → 1 across a deploy (e.g. promoting Portainer
+  # to a core service in #492). Force `enabled = 1` for any row where
+  # `core = 1` so the promotion takes effect on existing installs without
+  # the operator having to toggle it manually in the Control Plane UI.
+  echo "  Enforcing core = 1 → enabled = 1 invariant..."
+  set +e
+  WRANGLER_OUTPUT=$(npx wrangler@latest d1 execute "$D1_DATABASE_NAME" \
+    --remote --command "UPDATE services SET enabled = 1 WHERE core = 1 AND enabled = 0;" 2>&1)
+  WRANGLER_EXIT=$?
+  set -e
+  if [ $WRANGLER_EXIT -eq 0 ]; then
+    echo "  ✅ Core-services invariant enforced"
+  else
+    SANITIZED_ERROR=$(sanitize_error "$WRANGLER_OUTPUT")
+    echo "  ⚠️ Core-services invariant UPDATE had issues: $SANITIZED_ERROR" >&2
+  fi
 else
   echo "  ⚠️ services.yaml not found - skipping sync"
 fi

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ After deployment you'll have:
 | **OpenMetadata** | Open-source metadata management for data discovery and governance | [open-metadata.org](https://open-metadata.org) |
 | **pg_ducklake** | PostgreSQL with DuckLake extension - SQL-native lakehouse with S3 storage | [pgducklake.select](https://pgducklake.select) |
 | **pgAdmin** | PostgreSQL administration and development platform | [pgadmin.org](https://www.pgadmin.org) |
-| **Portainer** | Docker container management UI | [portainer.io](https://www.portainer.io) |
+| **Portainer** | Always-on Docker dashboard — first stop for inspecting a misbehaving container (logs, state, restart). Auto-deployed alongside Gitea/Grafana/Infisical | [portainer.io](https://www.portainer.io) |
 | **PostgreSQL** | Powerful open-source relational database (internal-only, no web UI) | [postgresql.org](https://www.postgresql.org) |
 | **Prefect** | Modern Python-native workflow orchestration for data pipelines | [prefect.io](https://www.prefect.io) |
 | **Quickwit** | Cloud-native search engine for log management and analytics | [quickwit.io](https://quickwit.io) |
@@ -222,7 +222,9 @@ Manage your Nexus-Stack infrastructure via web interface at `https://control.YOU
 
 **Pre-select services during Initial Setup:**
 ```bash
-gh workflow run initial-setup.yaml -f enabled_services="grafana,n8n,portainer"
+# Core services (Gitea, Grafana, Infisical, Portainer) are always enabled —
+# pass any additional services you want active on the first spin-up.
+gh workflow run initial-setup.yaml -f enabled_services="n8n,kestra"
 ```
 
 → See [docs/admin-guides/setup-guide.md](docs/admin-guides/setup-guide.md) for configuration details.

--- a/docs/admin-guides/troubleshooting.md
+++ b/docs/admin-guides/troubleshooting.md
@@ -22,7 +22,7 @@ Portainer surfaces the things you're most likely to need:
 
 If Portainer itself is the broken thing (rare — it's a single Go binary, no DB), fall back to SSH and the rest of this guide.
 
-> ℹ️ **Not every "running" container shows a green "healthy" badge.** Stacks that ship as a distroless image (no shell, no `curl`/`wget` — e.g. Portainer itself, SFTPGo) cannot run a CMD-SHELL-based probe and therefore have no `healthcheck:` block in their compose. Docker reports them as just `running` (no health decoration). That's expected; only an actually-coloured **orange "unhealthy"** badge or a `Restarting`/`Exited` status indicates a real problem.
+> ℹ️ **Not every "running" container shows a green "healthy" badge.** Some stacks intentionally omit a `healthcheck:` block — typically because the upstream image is too minimal to support a shell-based probe (no `sh`/`curl`/`wget` available), or because reachability is verified externally via the Cloudflare Tunnel front-door instead. Docker reports those containers as just `running` (no health decoration). That's expected; only an actually-coloured **orange "unhealthy"** badge or a `Restarting`/`Exited` status indicates a real problem. If you need to know which specific stacks are in this category, check each `stacks/<name>/docker-compose.yml` for the presence or absence of `healthcheck:`.
 
 ## Firewall Management
 

--- a/docs/admin-guides/troubleshooting.md
+++ b/docs/admin-guides/troubleshooting.md
@@ -15,7 +15,7 @@ Portainer surfaces the things you're most likely to need:
 | Symptom | Where to look in Portainer |
 |---|---|
 | Service web UI returns 502 / Bad Gateway | Containers → `<service-name>` → check **Status** column. `Restarting` or `Exited` → click into it → **Logs** tab |
-| `docker ps` on the box shows OOM-killed | Containers → `<service-name>` → **Stats** tab → memory graph against `deploy.resources.limits.memory` from the compose |
+| Container restarting repeatedly / exited with code 137 / `docker inspect` shows `OOMKilled: true` | Containers → `<service-name>` → **Stats** tab → memory graph against `deploy.resources.limits.memory` from the compose |
 | Image pull failed during a fresh deploy | Images → search the failing image name → if missing, the worker never pulled it (likely auth / network) |
 | Port collision after enabling a new service | Networks → `app-network` → cross-check the listed containers' published ports |
 | A container won't start and the compose looks fine | Containers → `<name>` → **Inspect** → look at the actual env vars Docker injected vs the `.env` file you expected |

--- a/docs/admin-guides/troubleshooting.md
+++ b/docs/admin-guides/troubleshooting.md
@@ -6,6 +6,22 @@ order: 5
 
 # Troubleshooting Guide
 
+## First stop: open Portainer
+
+Before SSH-ing into the box or hunting through GitHub Actions logs, open Portainer at `https://portainer.<your-domain>`. It's a [core service](../stacks/portainer.md) — always running, never an opt-in — exactly so you can reach it when something else is broken.
+
+Portainer surfaces the things you're most likely to need:
+
+| Symptom | Where to look in Portainer |
+|---|---|
+| Service web UI returns 502 / Bad Gateway | Containers → `<service-name>` → check **Status** column. `Restarting` or `Exited` → click into it → **Logs** tab |
+| `docker ps` on the box shows OOM-killed | Containers → `<service-name>` → **Stats** tab → memory graph against `deploy.resources.limits.memory` from the compose |
+| Image pull failed during a fresh deploy | Images → search the failing image name → if missing, the worker never pulled it (likely auth / network) |
+| Port collision after enabling a new service | Networks → `app-network` → cross-check the listed containers' published ports |
+| A container won't start and the compose looks fine | Containers → `<name>` → **Inspect** → look at the actual env vars Docker injected vs the `.env` file you expected |
+
+If Portainer itself is the broken thing (rare — it's a single Go binary, no DB), fall back to SSH and the rest of this guide.
+
 ## Firewall Management
 
 ### External TCP Access Not Working

--- a/docs/admin-guides/troubleshooting.md
+++ b/docs/admin-guides/troubleshooting.md
@@ -22,6 +22,8 @@ Portainer surfaces the things you're most likely to need:
 
 If Portainer itself is the broken thing (rare — it's a single Go binary, no DB), fall back to SSH and the rest of this guide.
 
+> ℹ️ **Not every "running" container shows a green "healthy" badge.** Stacks that ship as a distroless image (no shell, no `curl`/`wget` — e.g. Portainer itself, SFTPGo) cannot run a CMD-SHELL-based probe and therefore have no `healthcheck:` block in their compose. Docker reports them as just `running` (no health decoration). That's expected; only an actually-coloured **orange "unhealthy"** badge or a `Restarting`/`Exited` status indicates a real problem.
+
 ## Firewall Management
 
 ### External TCP Access Not Working

--- a/docs/stacks/portainer.md
+++ b/docs/stacks/portainer.md
@@ -12,7 +12,7 @@ Portainer is a **core service** in Nexus-Stack: it's auto-deployed alongside Git
 
 What you get out of the box:
 - Container view (state, restart, logs, exec into a shell, resource usage)
-- Image inspection (layers, env, entrypoint, vulnerability scan)
+- Image inspection (layers, env, entrypoint)
 - Volume + network management
 - Stack deployment with Docker Compose (rarely needed in this project — `scripts/deploy.sh` handles stack lifecycle — but useful for ad-hoc experiments)
 

--- a/docs/stacks/portainer.md
+++ b/docs/stacks/portainer.md
@@ -6,20 +6,22 @@ title: "Portainer"
 
 ![Portainer](https://img.shields.io/badge/Portainer-13BEF9?logo=portainer&logoColor=white)
 
-**Docker container management UI**
+**Always-on Docker dashboard — first stop for diagnosing a misbehaving container**
 
-A lightweight management UI that allows you to easily manage your Docker environments:
-- Container management (start, stop, restart, logs)
-- Image management (pull, build, delete)
-- Volume and network management
-- Stack deployment with Docker Compose
-- User access control
+Portainer is a **core service** in Nexus-Stack: it's auto-deployed alongside Gitea, Grafana, and Infisical, and the Control Plane Stacks page does not let you disable it. The reason: when something goes wrong on a deployed stack — container in restart-loop, OOM-killed, image pull failure, port collision — Portainer is the operator's first stop. Requiring an opt-in step before you can see *why* a container won't start would be the wrong design.
+
+What you get out of the box:
+- Container view (state, restart, logs, exec into a shell, resource usage)
+- Image inspection (layers, env, entrypoint, vulnerability scan)
+- Volume + network management
+- Stack deployment with Docker Compose (rarely needed in this project — `scripts/deploy.sh` handles stack lifecycle — but useful for ad-hoc experiments)
 
 | Setting | Value |
 |---------|-------|
 | Default Port | `9090` (→ internal 9000) |
 | Suggested Subdomain | `portainer` |
-| Public Access | **Never** (always protected) |
+| Public Access | **Never** (always protected, Cloudflare Access OTP on top) |
+| Always Enabled | ✓ — `core: true` in `services.yaml`. Cannot be disabled in the Control Plane Stacks page. |
 | Website | [portainer.io](https://www.portainer.io) |
 | Source | [GitHub](https://github.com/portainer/portainer) |
 

--- a/services.yaml
+++ b/services.yaml
@@ -519,7 +519,7 @@ services:
     website: "https://www.portainer.io"
     description: "Always-on Docker dashboard. First stop for diagnosing a misbehaving container — logs, state, restart, image inspection, network and volume views in a single pane."
     long_description: "Portainer is a container management platform that simplifies Docker operations. View running containers, inspect logs, manage images, networks, and volumes through an intuitive web UI. Monitor resource usage, restart services, and deploy new containers without CLI access. Marked `core: true` because diagnosing a stuck container shouldn't require an opt-in step — Portainer ships always-on alongside Gitea, Grafana, and Infisical."
-    image: "portainer/portainer-ce:lts"
+    image: "portainer/portainer-ce:2.27.9"
 
   pgadmin:
     subdomain: "pgadmin"

--- a/services.yaml
+++ b/services.yaml
@@ -15,6 +15,10 @@
 # - gitea: Self-hosted Git service
 # - grafana: Observability platform
 # - infisical: Required for secret management
+# - portainer: Always-on Docker dashboard for diagnosing container state.
+#              When something goes wrong (restart-loop, OOM, port collision,
+#              image pull failure) Portainer is the operator's first stop —
+#              shouldn't require an opt-in to be there when you need it.
 # These services are automatically enabled during initial setup and cannot be
 # disabled from the Control Plane.
 #
@@ -510,10 +514,11 @@ services:
     subdomain: "portainer"
     port: 9090
     public: false
+    core: true
     category: "core"
     website: "https://www.portainer.io"
-    description: "Docker container management UI for easy deployment and monitoring."
-    long_description: "Portainer is a container management platform that simplifies Docker operations. View running containers, inspect logs, manage images, networks, and volumes through an intuitive web UI. Monitor resource usage, restart services, and deploy new containers without CLI access."
+    description: "Always-on Docker dashboard. First stop for diagnosing a misbehaving container — logs, state, restart, image inspection, network and volume views in a single pane."
+    long_description: "Portainer is a container management platform that simplifies Docker operations. View running containers, inspect logs, manage images, networks, and volumes through an intuitive web UI. Monitor resource usage, restart services, and deploy new containers without CLI access. Marked `core: true` because diagnosing a stuck container shouldn't require an opt-in step — Portainer ships always-on alongside Gitea, Grafana, and Infisical."
     image: "portainer/portainer-ce:lts"
 
   pgadmin:

--- a/services.yaml
+++ b/services.yaml
@@ -519,7 +519,7 @@ services:
     website: "https://www.portainer.io"
     description: "Always-on Docker dashboard. First stop for diagnosing a misbehaving container — logs, state, restart, image inspection, network and volume views in a single pane."
     long_description: "Portainer is a container management platform that simplifies Docker operations. View running containers, inspect logs, manage images, networks, and volumes through an intuitive web UI. Monitor resource usage, restart services, and deploy new containers without CLI access. Marked `core: true` because diagnosing a stuck container shouldn't require an opt-in step — Portainer ships always-on alongside Gitea, Grafana, and Infisical."
-    image: "portainer/portainer-ce:2.27.9"
+    image: "portainer/portainer-ce:2.40.0"
 
   pgadmin:
     subdomain: "pgadmin"

--- a/stacks/portainer/docker-compose.yml
+++ b/stacks/portainer/docker-compose.yml
@@ -16,12 +16,12 @@ services:
       resources:
         limits:
           memory: 512m
-    healthcheck:
-      test: ["CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:9000/ || exit 1"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 15s
+    # No healthcheck: portainer/portainer-ce:lts is a distroless image
+    # — no shell, no wget, no curl. Any CMD-SHELL-based probe fails
+    # immediately and Docker labels the container "unhealthy" even
+    # though the service is running fine. We rely on the Cloudflare
+    # Tunnel front-door (a real hang surfaces as a 502 at
+    # https://portainer.<domain>) instead of an in-container probe.
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - portainer_data:/data

--- a/stacks/portainer/docker-compose.yml
+++ b/stacks/portainer/docker-compose.yml
@@ -7,7 +7,7 @@
 
 services:
   portainer:
-    image: ${IMAGE_PORTAINER:-portainer/portainer-ce:lts}
+    image: ${IMAGE_PORTAINER:-portainer/portainer-ce:2.27.9}
     container_name: portainer
     restart: unless-stopped
     ports:
@@ -16,12 +16,12 @@ services:
       resources:
         limits:
           memory: 512m
-    # No healthcheck: portainer/portainer-ce:lts is a distroless image
-    # — no shell, no wget, no curl. Any CMD-SHELL-based probe fails
-    # immediately and Docker labels the container "unhealthy" even
-    # though the service is running fine. We rely on the Cloudflare
-    # Tunnel front-door (a real hang surfaces as a 502 at
-    # https://portainer.<domain>) instead of an in-container probe.
+    # No healthcheck: portainer/portainer-ce ships with no `wget` /
+    # `curl` and the older shell-based probe (`wget --spider …`)
+    # would always exit non-zero, marking the container "unhealthy"
+    # even though the service is running fine. We rely on the
+    # Cloudflare Tunnel front-door (a real hang surfaces as a 502
+    # at https://portainer.<domain>) instead of an in-container probe.
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - portainer_data:/data

--- a/stacks/portainer/docker-compose.yml
+++ b/stacks/portainer/docker-compose.yml
@@ -7,7 +7,14 @@
 
 services:
   portainer:
-    image: ${IMAGE_PORTAINER:-portainer/portainer-ce:2.27.9}
+    image: ${IMAGE_PORTAINER:-portainer/portainer-ce:2.40.0}
+    # Pinned to 2.40.0 (current stable mainline). Note: when bumping
+    # this in future PRs, only bump UPWARD (or wipe portainer_data
+    # volume on a destroy-all). Portainer's BoltDB schema is
+    # forward-only — a downgrade refuses to start with
+    # "database schema version does not align with the server version"
+    # because newer Portainer versions migrate the DB and older
+    # versions can't read the migrated form.
     container_name: portainer
     restart: unless-stopped
     ports:

--- a/stacks/portainer/docker-compose.yml
+++ b/stacks/portainer/docker-compose.yml
@@ -7,7 +7,7 @@
 
 services:
   portainer:
-    image: ${IMAGE_PORTAINER:-portainer/portainer-ce:latest}
+    image: ${IMAGE_PORTAINER:-portainer/portainer-ce:lts}
     container_name: portainer
     restart: unless-stopped
     ports:

--- a/stacks/sftpgo/docker-compose.yml
+++ b/stacks/sftpgo/docker-compose.yml
@@ -102,15 +102,16 @@ services:
       resources:
         limits:
           memory: 512m
-    # No healthcheck: drakkan/sftpgo:v2.7.1 is a distroless image
-    # (`gcr.io/distroless/static-debian12` upstream base) — no shell,
-    # no curl, no wget. Any CMD-SHELL probe fails immediately and
-    # Docker labels the container "unhealthy" even though the service
-    # answers /healthz fine on port 8080. Reachability is verified
-    # externally via the Cloudflare Tunnel (a real hang surfaces as
-    # a 502 at https://sftpgo.<domain>); deploy.sh's auth-aware
-    # readiness probe (in scripts/deploy.sh) covers the cold-start
-    # race during initial spin-up.
+    # No healthcheck: drakkan/sftpgo:v2.7.1 is a minimal image with
+    # `sh` available (deploy.sh's mkdir/chown step uses
+    # `docker exec sftpgo sh -c …` and works) but NO `curl` / `wget`,
+    # so the previous shell-based `curl -sf /healthz` probe always
+    # exited non-zero and marked the container "unhealthy" even
+    # though the HTTP server answers /healthz fine on port 8080.
+    # Reachability is verified externally via the Cloudflare Tunnel
+    # (a real hang surfaces as a 502 at https://sftpgo.<domain>);
+    # deploy.sh's auth-aware readiness probe (in scripts/deploy.sh)
+    # covers the cold-start race during initial spin-up.
     volumes:
       # Docker-named-volume (NOT a bind-mount onto /mnt/nexus-data/).
       # See the top-of-file Persistent state comment for rationale —

--- a/stacks/sftpgo/docker-compose.yml
+++ b/stacks/sftpgo/docker-compose.yml
@@ -102,12 +102,15 @@ services:
       resources:
         limits:
           memory: 512m
-    healthcheck:
-      test: ["CMD-SHELL", "curl -sf http://localhost:8080/healthz || exit 1"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 30s
+    # No healthcheck: drakkan/sftpgo:v2.7.1 is a distroless image
+    # (`gcr.io/distroless/static-debian12` upstream base) — no shell,
+    # no curl, no wget. Any CMD-SHELL probe fails immediately and
+    # Docker labels the container "unhealthy" even though the service
+    # answers /healthz fine on port 8080. Reachability is verified
+    # externally via the Cloudflare Tunnel (a real hang surfaces as
+    # a 502 at https://sftpgo.<domain>); deploy.sh's auth-aware
+    # readiness probe (in scripts/deploy.sh) covers the cold-start
+    # race during initial spin-up.
     volumes:
       # Docker-named-volume (NOT a bind-mount onto /mnt/nexus-data/).
       # See the top-of-file Persistent state comment for rationale —


### PR DESCRIPTION
## Summary

- Promote Portainer from opt-in to core service (`core: true` in `services.yaml`) so it's always running for first-stop container debugging
- Enforce the `core = 1 → enabled = 1` invariant in `sync-deployed-state.sh` so the promotion takes effect on existing installs without operators having to manually re-toggle in the Control Plane
- Pin the Portainer image (was floating `:latest` / `:lts`) to `2.40.0` (current stable mainline) per CLAUDE.md "pin stateful services" rule, with a maintenance note that future bumps must go upward only (Portainer's BoltDB schema is forward-only — downgrading refuses to start with a "schema does not align" fatal)
- Drop the `healthcheck:` block from both `stacks/portainer/docker-compose.yml` and `stacks/sftpgo/docker-compose.yml`. Both images ship without `wget`/`curl`, so the existing CMD-SHELL probes always failed and Docker labelled the containers as **unhealthy** even though they were running fine. Reachability is verified externally via the Cloudflare Tunnel front-door instead (a real hang surfaces as 502 at `https://<service>.<domain>`).
- Refresh README, `docs/stacks/portainer.md`, and `docs/admin-guides/troubleshooting.md` to reflect the always-on status + the no-healthcheck convention

Closes #492.

## Why

When a container goes wrong (restart-loop, OOM, image pull failure, port collision), the operator's first reflex is to open Portainer to read logs and inspect state. Requiring an opt-in toggle before that diagnostic surface exists is backwards — you want Portainer on the box *before* something breaks, not after. Footprint is tiny (single Go binary, ~200 MB resident, no DB), so there's no good reason for it to be optional.

The image-tag pin and the two healthcheck removals came up in PR review as direct consequences of the core-promotion: a now-always-running stateful service shouldn't ride a floating tag, and the operator's "first-stop" view shouldn't be cluttered with false-positive *unhealthy* badges that train people to ignore the badge.

## Changes

| File | What |
|---|---|
| `services.yaml` | Add `core: true` to portainer entry; extend the CORE SERVICES comment block; rewrite the description; pin `image:` to `portainer/portainer-ce:2.40.0` |
| `.github/scripts/sync-deployed-state.sh` | New Step 4.5 (after the deployed-state syncs): `UPDATE services SET enabled = 1, updated_at = now() WHERE core = 1 AND enabled = 0` so existing installs pick up the promotion. Two-phase rollout: enabled flips this run, deployed flips on the next spin-up. |
| `stacks/portainer/docker-compose.yml` | Pin the compose default image to `2.40.0` (matches services.yaml); drop the `healthcheck:` block; add a maintenance note: only bump UPWARD or wipe `portainer_data` (BoltDB schema is forward-only) |
| `stacks/sftpgo/docker-compose.yml` | Drop the `healthcheck:` block. The image has `sh` (deploy.sh's `docker exec sftpgo sh -c …` works) but no `curl`/`wget` — so the existing `curl -sf /healthz` probe always exited non-zero |
| `README.md` | Update the Available Stacks Portainer row + the "Pre-select services" code example |
| `docs/stacks/portainer.md` | Rewrite the headline + add an "Always Enabled ✓" row |
| `docs/admin-guides/troubleshooting.md` | Add a "First stop: open Portainer" preamble with a symptom → Portainer-view lookup table; explanatory note that not every container shows a green "healthy" badge |

## Test plan

- [ ] Initial-setup against this branch completes successfully and the deploy log shows `Core-services invariant enforced` from `sync-deployed-state.sh`
- [ ] On the deployed stack, `https://portainer.<your-domain>` resolves and presents the login (CF Access OTP first, then Portainer admin) — the pinned 2.40.0 binary boots cleanly against a freshly-bootstrapped `portainer_data` volume
- [ ] In the Control Plane Stacks page, Portainer is rendered with the same "always enabled, cannot disable" affordance as Gitea / Grafana / Infisical
- [ ] In Portainer's container list, **neither** the `portainer` row nor the `sftpgo` row shows the previous false-positive *unhealthy* (orange) badge. Both show `running` (green dot, no health decoration) like other healthcheck-less stacks (mailpit, jupyter, marimo)
- [ ] Manually kill a non-core container (`docker kill <name>`) → Portainer Containers view shows it as `Stopped` with logs accessible directly from the UI
- [ ] SFTPGo Web Admin login at `https://sftpgo.<domain>/web/admin/login` works (no behaviour change there, just confirming the healthcheck removal didn't regress functionality)
- [ ] No yellow warnings in the deploy log other than pre-existing ones

## Out of scope

- Switching to a different container-management tool (Dockge / Yacht). Separate, larger discussion.
- Adding healthchecks back via a custom Dockerfile (multi-stage that bundles `wget`). Possible follow-up if/when we have a real need for in-container HTTP probes (e.g. `docker compose --wait` ordering); not warranted for the diagnostic-only signal Portainer + CF Tunnel already give us.
