### PR TITLE
feat(marimo,spark): Marimo via Spark Connect + Marimo Infisical sync (closes #497)

### DIFF
--- a/docs/stacks/marimo.md
+++ b/docs/stacks/marimo.md
@@ -6,20 +6,111 @@ title: "Marimo"
 
 ![Marimo](https://img.shields.io/badge/Marimo-1C1C1C?logo=python&logoColor=white)
 
-**Reactive Python notebook with SQL support**
+**Reactive Python notebook with SQL + Spark Connect support**
 
 Marimo is a reactive Python notebook that's reproducible, git-friendly, and deployable as apps. Features include:
-- Reactive execution - cells auto-update when dependencies change
-- Git-friendly - notebooks stored as pure Python files
-- SQL support - built-in DuckDB for data analysis
-- Interactive UI elements - sliders, buttons, tables
+- Reactive execution — cells auto-update when dependencies change
+- Git-friendly — notebooks stored as pure Python files (no JSON, no merge hell)
+- SQL support — built-in DuckDB for local analysis, Spark SQL via Ibis for cluster work
+- Spark Connect pre-wired — talk to the cluster via `sc://spark-connect:15002`, no JDK or full pyspark in the client
+- Interactive UI elements — sliders, buttons, tables
 - Deploy as web apps or scripts
-- No hidden state - what you see is what you run
+- No hidden state — what you see is what you run
 
 | Setting | Value |
 |---------|-------|
 | Default Port | `2718` |
 | Suggested Subdomain | `marimo` |
 | Public Access | No (contains notebooks/code) |
+| Image | `nexus-marimo:latest-sql-spark` (custom, see [stacks/marimo/Dockerfile](../../stacks/marimo/Dockerfile)) |
 | Website | [marimo.io](https://marimo.io) |
 | Source | [GitHub](https://github.com/marimo-team/marimo) |
+
+## Spark Integration (Spark Connect)
+
+When the Spark stack is also enabled, Marimo can run PySpark workloads against the cluster via the Spark Connect endpoint. Topology:
+
+```
+Marimo container (Python 3.13, no JDK)
+   │ pyspark[connect] + Arrow + gRPC
+   ▼ sc://spark-connect:15002
+spark-connect container (driver-JVM)
+   │ spark://spark-master:7077
+   ▼
+spark-master + spark-worker (executors)
+```
+
+The Marimo container is a thin gRPC client — the driver-JVM lives in the dedicated `spark-connect` service. This means **1 GiB memory is plenty for Marimo**, even for jobs that move large DataFrames; the heavy work happens server-side and only Arrow batches stream back.
+
+### Quickstart
+
+A seed notebook ships in every workspace at `marimo/Getting_Started_PySpark.py` (auto-cloned from your Gitea workspace repo on first launch). Open it from `https://marimo.<your-domain>` and hit **Run all**.
+
+The minimal pattern is:
+
+```python
+from _nexus_spark import get_spark
+spark = get_spark()
+df = spark.createDataFrame([("a", 1), ("b", 2)], ["k", "v"])
+df  # auto-rendered as paginated mo.ui.table.lazy
+```
+
+The `_nexus_spark` helper (also seeded into the workspace, at `marimo/_nexus_spark.py`) caches a single SparkSession across cells and notebooks within the same Python process — see its docstring for details.
+
+### Spark SQL via Ibis
+
+Marimo's `mo.sql(...)` cells are DuckDB-first; for Spark SQL you wire them through Ibis:
+
+```python
+import ibis
+con = ibis.pyspark.connect(spark)
+df.createOrReplaceTempView("employees")
+
+high_earners = mo.sql(
+    "SELECT department, AVG(salary) FROM employees GROUP BY 1",
+    engine=con,
+)
+```
+
+### S3 / Hetzner Object Storage
+
+Hadoop S3A config (`fs.s3a.endpoint`, access key, secret key) is set on the **spark-connect server** side via env vars in `stacks/spark/docker-compose.yml`. The Marimo container also gets `HETZNER_S3_BUCKET` so notebooks can build `s3a://${HETZNER_S3_BUCKET}/...` paths. Setting Hadoop conf on the Marimo client side via `SparkSession.builder.config(...)` is a no-op for Connect — the remote driver doesn't see client-side conf.
+
+### Gotcha: cancelling long Spark jobs
+
+Marimo's red **Stop** button does NOT interrupt blocking gRPC calls. A long Spark query started from Marimo will keep running on the cluster even after Stop is pressed (upstream issue [marimo-team/marimo#3494](https://github.com/marimo-team/marimo/issues/3494)).
+
+To kill a runaway query:
+
+1. Open the Spark Master UI at `https://spark.<your-domain>`
+2. Find the running app (`Running Applications` table)
+3. Click the `(kill)` link next to it
+
+The gRPC stream then fails back to Marimo, which surfaces a clean `MarimoInterrupt` and the cell can be re-run.
+
+### Reactivity vs. Spark state
+
+Marimo's reactive DAG re-runs cells when their upstream changes. The `spark` session is module-level cached in `_nexus_spark.py`, so multiple cells importing it share one Connect channel — Marimo never re-creates the session.
+
+But: Marimo does NOT track mutations to attributes. `spark.conf.set("spark.sql.shuffle.partitions", "4")` from one cell will NOT cause downstream cells to re-execute. **Treat the SparkSession as immutable after build.** If you need a different config, call `_nexus_spark.stop_spark()` and then `get_spark()` again — that's an explicit reset.
+
+## Infisical secrets
+
+Secrets stored in Infisical are auto-synced into the Marimo container's env on every spin-up. Reference them in notebook cells exactly as named in Infisical:
+
+```python
+import os
+access_key = os.environ["R2_ACCESS_KEY"]
+```
+
+The sync writes to a dedicated `.infisical.env` file (not `.env`) so secret keys can't accidentally collide with Compose's `${VAR}` interpolation. Multi-line values (e.g. PEM keys) are skipped with a warning — they need a different transport mechanism (mount-as-file). See `scripts/deploy.sh` "Sync Infisical secrets into Marimo" block for the full mechanism.
+
+## Memory limits
+
+| Container | Limit | Why |
+|---|---|---|
+| `marimo` | 1 GiB | gRPC client only, no driver-JVM. Plenty unless you pull huge `.toPandas()` results. |
+| `spark-connect` | 1.5 GiB | Driver-JVM for ALL Connect clients. Bump if multiple notebooks run heavy queries concurrently. |
+| `spark-worker` | 4 GiB | Executor — same as Jupyter setup. |
+
+If a query OOMs, increase `stacks/spark/docker-compose.yml`'s `spark-connect` `deploy.resources.limits.memory`, NOT the Marimo container's.

--- a/docs/stacks/marimo.md
+++ b/docs/stacks/marimo.md
@@ -22,7 +22,7 @@ Marimo is a reactive Python notebook that's reproducible, git-friendly, and depl
 | Default Port | `2718` |
 | Suggested Subdomain | `marimo` |
 | Public Access | No (contains notebooks/code) |
-| Image | `nexus-marimo:latest-sql-spark` (custom, see [stacks/marimo/Dockerfile](../../stacks/marimo/Dockerfile)) |
+| Image | `nexus-marimo:latest-sql-spark` (custom, see `stacks/marimo/Dockerfile`) |
 | Website | [marimo.io](https://marimo.io) |
 | Source | [GitHub](https://github.com/marimo-team/marimo) |
 

--- a/docs/stacks/spark.md
+++ b/docs/stacks/spark.md
@@ -6,14 +6,15 @@ title: "Apache Spark"
 
 ![Spark](https://img.shields.io/badge/Apache_Spark-E25A1C?logo=apachespark&logoColor=white)
 
-**Distributed data processing engine with standalone cluster (Master + Worker)**
+**Distributed data processing engine with standalone cluster (Master + Worker + Spark Connect)**
 
-Apache Spark provides a unified analytics engine for large-scale data processing. This stack runs a standalone cluster with one master and one worker node, pre-configured with Hetzner Object Storage (S3) access.
+Apache Spark provides a unified analytics engine for large-scale data processing. This stack runs a standalone cluster with one master, one worker, and a Spark Connect server, pre-configured with Hetzner Object Storage (S3) access.
 
 | Setting | Value |
 |---------|-------|
 | Default Port | `8088` (Master Web UI) |
-| Cluster Port | `7077` (internal only) |
+| Classic cluster port | `7077` (internal — Jupyter connects here) |
+| Spark Connect port | `15002` (internal — Marimo / future code-server connect here via `sc://`) |
 | Suggested Subdomain | `spark` |
 | Public Access | No (cluster management) |
 | Website | [spark.apache.org](https://spark.apache.org) |
@@ -23,31 +24,40 @@ Apache Spark provides a unified analytics engine for large-scale data processing
 
 | Container | Image | Purpose |
 |-----------|-------|---------|
-| `spark-master` | `nexus-spark:4.1.1-python3.13` | Cluster manager + Web UI (port 8088) |
+| `spark-master` | `nexus-spark:4.1.1-python3.13` | Cluster manager + Web UI (port 8088); accepts classic-protocol clients on 7077 |
 | `spark-worker` | `nexus-spark:4.1.1-python3.13` | Task executor (connects to master on 7077) |
+| `spark-connect` | `nexus-spark:4.1.1-python3.13` | gRPC server on 15002 — driver-JVM for thin clients (Marimo, code-server). Connects to master like any other Spark application. |
 
-> **Custom image:** The official `apache/spark:4.1.1` ships Python 3.10 (Ubuntu 22.04), but Jupyter uses Python 3.13. PySpark requires matching Python versions between driver and executors. The custom Dockerfile installs Python 3.13 via deadsnakes PPA and adds `hadoop-aws` + AWS SDK v2 JARs for S3A filesystem support.
+> **Custom image:** The official `apache/spark:4.1.1` ships Python 3.10 (Ubuntu 22.04), but our Jupyter / spark-worker setup uses Python 3.13. PySpark requires matching Python versions between driver and executors. The custom Dockerfile installs Python 3.13 via deadsnakes PPA, adds `hadoop-aws` + AWS SDK v2 JARs for S3A filesystem support, and pre-downloads the Spark Connect server JARs (`spark-connect_2.13-4.1.1.jar`, `spark-connect-common_2.13-4.1.1.jar`) into `/opt/spark/jars/` so the Connect server starts without ivy resolution at runtime.
 
 ```
-                    ┌─────────────────────┐
-                    │  Jupyter PySpark     │
-                    │  %%sparksql magic    │
-                    └────────┬────────────┘
-                             │ spark://spark-master:7077
-              ┌──────────────┴──────────────┐
-              │                             │
-     ┌────────┴────────┐          ┌─────────┴────────┐
-     │  Spark Master   │          │  Spark Worker    │
-     │  UI: port 8088  │          │  (no external UI)│
-     └────────┬────────┘          └─────────┬────────┘
-              │                             │
-              └──────────────┬──────────────┘
-                             │ S3 (hadoop-aws)
-                    ┌────────┴────────┐
-                    │ Hetzner Object  │
-                    │ Storage (S3)    │
-                    └─────────────────┘
+   ┌──────────────────────┐          ┌──────────────────────┐
+   │  Jupyter PySpark     │          │  Marimo PySpark      │
+   │  (driver-JVM local)  │          │  (gRPC client only)  │
+   └──────────┬───────────┘          └──────────┬───────────┘
+              │ spark://spark-master:7077       │ sc://spark-connect:15002
+              │ (classic standalone)            │ (gRPC + Arrow)
+              ▼                                 ▼
+     ┌────────────────┐                 ┌──────────────────┐
+     │  Spark Master  │                 │  Spark Connect   │
+     │   UI: 8088     │ ◄───── 7077 ────│   driver-JVM     │
+     │   port 7077    │                 │   port 15002     │
+     └───────┬────────┘                 └─────────┬────────┘
+             │                                    │
+             ▼                                    │
+     ┌────────────────┐                           │
+     │  Spark Worker  │ ◄─── tasks (both ─────────┘
+     │  (executors)   │       protocols converge here)
+     └───────┬────────┘
+             │ S3 (hadoop-aws)
+             ▼
+     ┌────────────────┐
+     │ Hetzner Object │
+     │ Storage (S3)   │
+     └────────────────┘
 ```
+
+Both protocols hit the same worker pool — applications submitted via classic 7077 and via Connect 15002 share the worker's cores and memory according to standard Spark FIFO scheduling.
 
 ### Configuration
 
@@ -63,9 +73,10 @@ Docker resource limits prevent Spark from consuming all server resources:
 |-----------|-----------|-------------|-------------|-----------------|
 | `spark-master` | 1 | 1 GB | 0.25 | 256 MB |
 | `spark-worker` | 2 | 4 GB | 0.5 | 512 MB |
-| **Total** | **3** | **5 GB** | **0.75** | **768 MB** |
+| `spark-connect` | 1 | 1.5 GB | 0.25 | 256 MB |
+| **Total** | **4** | **6.5 GB** | **1.0** | **1024 MB** |
 
-On a cax31 (8 vCPU, 16 GB RAM) this leaves 5 CPU and 11 GB RAM for other services.
+On a cax31 (8 vCPU, 16 GB RAM) this leaves 4 CPU and ~9.5 GB RAM for other services. The `spark-connect` container holds the driver-JVM for ALL Connect clients (Marimo, future code-server) — bump its memory if multiple notebooks run heavy queries concurrently.
 
 ### Usage
 
@@ -74,9 +85,9 @@ On a cax31 (8 vCPU, 16 GB RAM) this leaves 5 CPU and 11 GB RAM for other service
 3. The Web UI shows registered workers, running applications, and completed jobs
 4. Use Jupyter PySpark to submit jobs to the cluster (auto-configured)
 
-### Connecting from Jupyter
+### Connecting from Jupyter (classic protocol)
 
-When both Spark and Jupyter are enabled, Jupyter automatically connects to the cluster:
+When both Spark and Jupyter are enabled, Jupyter automatically connects to the cluster on port 7077:
 
 ```python
 from pyspark.sql import SparkSession
@@ -88,4 +99,23 @@ spark = SparkSession.builder \
 spark.sql("SELECT 1 as test").show()
 ```
 
-> No configuration needed - `SPARK_MASTER` is automatically set to `spark://spark-master:7077` when the Spark stack is enabled.
+> No configuration needed — `SPARK_MASTER` is automatically set to `spark://spark-master:7077` when the Spark stack is enabled. Jupyter's driver-JVM lives in the Jupyter container; the worker runs the executors.
+
+### Connecting from Marimo (Spark Connect)
+
+When both Spark and Marimo are enabled, Marimo talks to the `spark-connect` server at port 15002 via gRPC. The driver-JVM lives in the `spark-connect` container, NOT in Marimo — Marimo is a thin client (no JDK, no full pyspark).
+
+```python
+from pyspark.sql.connect.session import SparkSession
+spark = SparkSession.builder.remote("sc://spark-connect:15002").getOrCreate()
+spark.sql("SELECT 1 as test").show()
+```
+
+A pre-built helper module ships in the workspace seed at `marimo/_nexus_spark.py` — see [docs/stacks/marimo.md](./marimo.md) for the recommended pattern.
+
+### Connect vs. Classic — when to use which
+
+- **Classic (`spark://...:7077`)**: Jupyter today. Driver runs in the client. Full PySpark API surface, including the bits that haven't been ported to Connect yet (some RDD operations, certain UDF modes). Heavier client (needs JDK + full pyspark).
+- **Connect (`sc://...:15002`)**: Marimo today, code-server in the future. Driver runs server-side in the `spark-connect` container. Thin client (gRPC + Arrow). Better fit for reactive notebooks; first-class formatter support in Marimo. Some advanced features have caveats — check the [Spark Connect compatibility matrix](https://spark.apache.org/docs/latest/spark-connect-overview.html#what-is-supported-in-spark-40) before relying on niche APIs.
+
+Both protocols submit applications to the same `spark-master`, so they share the worker's resources.

--- a/docs/stacks/spark.md
+++ b/docs/stacks/spark.md
@@ -14,7 +14,7 @@ Apache Spark provides a unified analytics engine for large-scale data processing
 |---------|-------|
 | Default Port | `8088` (Master Web UI) |
 | Classic cluster port | `7077` (internal — Jupyter connects here) |
-| Spark Connect port | `15002` (internal — Marimo / future code-server connect here via `sc://`) |
+| Spark Connect port | `15002` (internal Docker network only — Marimo / future code-server connect here via `sc://spark-connect:15002`. NOT published to the host or routed via Cloudflare Tunnel.) |
 | Suggested Subdomain | `spark` |
 | Public Access | No (cluster management) |
 | Website | [spark.apache.org](https://spark.apache.org) |

--- a/examples/README.md
+++ b/examples/README.md
@@ -22,7 +22,10 @@ examples/workspace-seeds/
 │   ├── flows/
 │   │   └── r2-taxi-pipeline.yaml
 │   └── workflows/                  (when added — helper files: scripts, configs, SQL templates)
-├── notebooks/                      (when added — Jupyter / Marimo / code-server)
+├── marimo/
+│   ├── _nexus_spark.py             (Spark Connect helper — `from _nexus_spark import get_spark`)
+│   └── Getting_Started_PySpark.py  (seed Marimo notebook demonstrating PySpark + Spark SQL via Ibis)
+├── notebooks/                      (when added — Jupyter / code-server, .ipynb)
 ├── scripts/                        (when added — code-server, ad-hoc execution)
 ├── dbt/                            (when added — code-server, manual `dbt`)
 └── sql/                            (when added — DuckDB, Trino, ClickHouse)
@@ -50,7 +53,8 @@ Stick to these names so the various services pick the files up correctly:
 |---|---|---|
 | `kestra/flows/` | Kestra (via `system.flow-sync`, registered by `deploy.sh`) | Flow definitions in YAML. Files at `kestra/flows/<id>.yaml` register under namespace `nexus-tutorials`; subdirectories extend the namespace (`kestra/flows/sub1/<id>.yaml` → `nexus-tutorials.sub1`). |
 | `kestra/workflows/` | Kestra (via `system.git-sync`, registered by `deploy.sh`) | Helper files referenced by flows: Python scripts, SQL templates, configs. **Not** flow definitions. |
-| `notebooks/` | Jupyter, Marimo, code-server (cloned from the workspace repo) | `.ipynb` notebooks or `.py` scripts. |
+| `marimo/` | Marimo (cloned from the workspace repo into `/app/notebooks/<repo>/marimo/`) | Marimo notebooks (plain `.py` files using `marimo.App` + `@app.cell`) plus the `_nexus_spark.py` helper that wires `SparkSession.builder.remote("sc://spark-connect:15002")`. Per-stack folder because Marimo's `.py` notebook format is incompatible with Jupyter `.ipynb` and the helper module is Marimo-specific. |
+| `notebooks/` | Jupyter, code-server (cloned from the workspace repo) | `.ipynb` notebooks (Jupyter) or `.py` scripts (code-server). NOT for Marimo notebooks — those go in `marimo/`. |
 | `scripts/` | code-server, ad-hoc execution | Shell or Python helpers reused across notebooks. |
 | `dbt/` | code-server, manual `dbt` invocation | A normal dbt project tree (`dbt_project.yml`, `models/`, etc.). |
 | `sql/` | DuckDB, Trino, ClickHouse — anywhere SQL gets pasted | Stand-alone SQL files. |

--- a/examples/README.md
+++ b/examples/README.md
@@ -24,7 +24,8 @@ examples/workspace-seeds/
 │   └── workflows/                  (when added — helper files: scripts, configs, SQL templates)
 ├── marimo/
 │   ├── _nexus_spark.py             (Spark Connect helper — `from _nexus_spark import get_spark`)
-│   └── Getting_Started_PySpark.py  (seed Marimo notebook demonstrating PySpark + Spark SQL via Ibis)
+│   ├── Getting_Started_PySpark.py  (seed Marimo notebook demonstrating PySpark + Spark SQL via Ibis)
+│   └── NYC_Taxi_Pipeline.py        (seed Marimo notebook: NYC TLC bootstrap to Hetzner S3 + Spark analytics — mirror of Kestra's r2-taxi-pipeline)
 ├── notebooks/                      (when added — Jupyter / code-server, .ipynb)
 ├── scripts/                        (when added — code-server, ad-hoc execution)
 ├── dbt/                            (when added — code-server, manual `dbt`)

--- a/examples/workspace-seeds/marimo/Getting_Started_PySpark.py
+++ b/examples/workspace-seeds/marimo/Getting_Started_PySpark.py
@@ -1,0 +1,233 @@
+"""Getting Started with PySpark in Marimo (via Spark Connect).
+
+Pre-wired to talk to the Nexus-Stack Spark cluster at
+sc://spark-connect:15002. The driver-JVM lives in the spark-connect
+container; this notebook is a thin gRPC client.
+
+Run cells top-to-bottom (or all at once — Marimo's reactive DAG handles
+ordering automatically once dependencies are declared).
+"""
+
+import marimo
+
+__generated_with = "0.13.0"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def _():
+    import marimo as mo
+    return (mo,)
+
+
+@app.cell
+def _(mo):
+    mo.md(
+        r"""
+        # Getting Started with PySpark on Marimo
+
+        Connected to **Spark Connect** (`sc://spark-connect:15002`) — the
+        driver-JVM runs server-side, this notebook is a thin gRPC client.
+
+        Run cells in order, or hit **Run all** — Marimo figures out the
+        dependency graph from the function signatures.
+        """
+    )
+    return
+
+
+@app.cell
+def _():
+    # Import the cached SparkSession factory shipped with the workspace
+    # repo (examples/workspace-seeds/marimo/_nexus_spark.py — gets seeded
+    # to your Gitea workspace on every spin-up).
+    from _nexus_spark import get_spark
+
+    spark = get_spark()
+    return (spark,)
+
+
+@app.cell
+def _(mo, spark):
+    mo.md(
+        f"""
+        ## 1. Verify Cluster Connection
+
+        - **Spark version:** `{spark.version}`
+        - **Connect URL:** `sc://spark-connect:15002`
+        - **Session ID:** `{spark.client.session_id}`
+        """
+    )
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md("""## 2. Create a DataFrame""")
+    return
+
+
+@app.cell
+def _(spark):
+    data = [
+        ("Alice", "Engineering", 85000),
+        ("Bob", "Marketing", 72000),
+        ("Charlie", "Engineering", 92000),
+        ("Diana", "Marketing", 68000),
+        ("Eve", "Engineering", 95000),
+        ("Frank", "Sales", 78000),
+    ]
+    df = spark.createDataFrame(data, ["name", "department", "salary"])
+    # Last-cell DataFrame is auto-rendered by Marimo as mo.ui.table.lazy
+    # (the dedicated PySpark Connect formatter shipped in
+    # marimo-team/marimo PR #4615).
+    df
+    return (df,)
+
+
+@app.cell
+def _(mo):
+    mo.md("""## 3. DataFrame Operations""")
+    return
+
+
+@app.cell
+def _(df):
+    # Filter + sort. Returned DataFrame is again auto-rendered.
+    df.filter(df.salary > 75000).orderBy("salary", ascending=False)
+    return
+
+
+@app.cell
+def _(df):
+    from pyspark.sql import functions as F
+
+    df.groupBy("department").agg(
+        F.count("name").alias("employees"),
+        F.avg("salary").alias("avg_salary"),
+        F.max("salary").alias("max_salary"),
+    ).orderBy("department")
+    return (F,)
+
+
+@app.cell
+def _(mo):
+    mo.md(
+        r"""
+        ## 4. Spark SQL via Ibis
+
+        Marimo's `mo.sql(...)` cell needs an explicit engine for Spark.
+        We use [Ibis](https://ibis-project.org)' `pyspark` backend as
+        the bridge — it's the supported way to run Spark SQL in
+        Marimo's reactive SQL cells.
+        """
+    )
+    return
+
+
+@app.cell
+def _(df, spark):
+    import ibis
+
+    # Wrap the existing SparkSession so Ibis can route SQL through it.
+    con = ibis.pyspark.connect(spark)
+
+    # Register the DataFrame as a temp view for SQL access. Ibis's
+    # PySpark backend expects a Spark SQL table name to query.
+    df.createOrReplaceTempView("employees")
+    return con, ibis
+
+
+@app.cell
+def _(con, mo):
+    # mo.sql() with a non-DuckDB engine renders the same paginated UI.
+    # Spark plans + executes server-side, results stream back via Arrow.
+    high_earners = mo.sql(
+        """
+        SELECT department,
+               COUNT(*) AS headcount,
+               ROUND(AVG(salary), 0) AS avg_salary
+        FROM employees
+        GROUP BY department
+        ORDER BY avg_salary DESC
+        """,
+        engine=con,
+    )
+    return (high_earners,)
+
+
+@app.cell
+def _(mo):
+    mo.md(
+        r"""
+        ## 5. Read from Hetzner Object Storage (s3a://)
+
+        Hadoop S3A config is set on the spark-connect server side
+        (Compose env-vars `SPARK_HADOOP_fs_s3a_*`). The bucket name is
+        passed through to this notebook as `HETZNER_S3_BUCKET` — see
+        below for an opt-in read example.
+        """
+    )
+    return
+
+
+@app.cell
+def _(spark):
+    import os
+
+    bucket = os.environ.get("HETZNER_S3_BUCKET", "")
+    if bucket:
+        # Write a small CSV, then read it back. Both happen on the
+        # spark-connect server side; only the resulting Arrow batches
+        # come back to this notebook.
+        sample_path = f"s3a://{bucket}/sample-data/marimo-employees"
+        spark.range(5).selectExpr(
+            "id", "concat('user-', id) AS name", "(id * 1000 + 50000) AS salary"
+        ).coalesce(1).write.mode("overwrite").option("header", True).csv(sample_path)
+        df_s3 = spark.read.csv(sample_path, header=True, inferSchema=True)
+        result_msg = f"Read {df_s3.count()} rows back from {sample_path}"
+        df_s3
+    else:
+        result_msg = (
+            "HETZNER_S3_BUCKET is not set — skipping S3 demo. "
+            "Set it via Infisical (key HETZNER_S3_BUCKET) and re-run a spin-up "
+            "to populate the Marimo container env."
+        )
+        df_s3 = None
+    return bucket, df_s3, os, result_msg, sample_path
+
+
+@app.cell
+def _(mo, result_msg):
+    mo.md(f"**Result:** {result_msg}")
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md(
+        r"""
+        ## 6. Tips & Pitfalls
+
+        - **Stopping a long Spark job:** Marimo's red Stop button does
+          NOT interrupt blocking gRPC calls (upstream issue
+          [marimo-team/marimo#3494](https://github.com/marimo-team/marimo/issues/3494)).
+          To kill a runaway query, open the Spark Master UI at
+          `https://spark.<your-domain>` and click `(kill)` next to
+          the running app — the gRPC stream will fail back to Marimo
+          which then shows MarimoInterrupt cleanly.
+        - **Reactivity vs Spark state:** treat `spark` as immutable
+          after `get_spark()`. Mutations to `spark.conf` from another
+          cell are NOT tracked by Marimo's DAG and can produce
+          surprising results.
+        - **Driver-memory tuning:** the driver-JVM lives in the
+          `spark-connect` container, not here. Bump its memory limit
+          in `stacks/spark/docker-compose.yml` if your queries fail
+          with OOM, NOT the Marimo container's.
+        """
+    )
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/examples/workspace-seeds/marimo/Getting_Started_PySpark.py
+++ b/examples/workspace-seeds/marimo/Getting_Started_PySpark.py
@@ -49,13 +49,20 @@ def _():
 
 @app.cell
 def _(mo, spark):
+    # Local import — NOT returned from this cell. Marimo enforces
+    # single-cell-defines-each-name across the DAG, and the S3 cell
+    # below has its own `import os` block. Keeping `os` cell-local
+    # here avoids that conflict.
+    import os as _os
+
+    _connect_url = _os.environ.get("SPARK_CONNECT_URL", "sc://spark-connect:15002")
     mo.md(
         f"""
         ## 1. Verify Cluster Connection
 
         - **Spark version:** `{spark.version}`
-        - **Connect URL:** `sc://spark-connect:15002`
-        - **Session ID:** `{spark.client.session_id}`
+        - **Connect URL:** `{_connect_url}`
+        - **Session type:** `{type(spark).__module__}.{type(spark).__name__}`
         """
     )
     return

--- a/examples/workspace-seeds/marimo/Getting_Started_PySpark.py
+++ b/examples/workspace-seeds/marimo/Getting_Started_PySpark.py
@@ -107,7 +107,13 @@ def _(df):
 
 @app.cell
 def _(df):
-    from pyspark.sql import functions as F
+    # Spark Connect requires functions from `pyspark.sql.connect.functions`,
+    # NOT the top-level `pyspark.sql.functions` — the latter resolves to the
+    # classic implementation (`pyspark.sql.classic.column._to_java_column`)
+    # which needs a local JVM SparkContext we don't have here. There's no
+    # automatic dispatch between the two in pyspark 4.1; the import path
+    # has to match the session type.
+    from pyspark.sql.connect import functions as F
 
     df.groupBy("department").agg(
         F.count("name").alias("employees"),

--- a/examples/workspace-seeds/marimo/Getting_Started_PySpark.py
+++ b/examples/workspace-seeds/marimo/Getting_Started_PySpark.py
@@ -189,6 +189,13 @@ def _(spark):
     import os
 
     bucket = os.environ.get("HETZNER_S3_BUCKET", "")
+    # Initialize all return-tuple names BEFORE the conditional so
+    # both branches define them. Otherwise the else-branch return
+    # would raise UnboundLocalError on `sample_path` when
+    # HETZNER_S3_BUCKET is unset (the common case before Infisical
+    # has any S3 secrets in it).
+    sample_path = None
+    df_s3 = None
     if bucket:
         # Write a small CSV, then read it back. Both happen on the
         # spark-connect server side; only the resulting Arrow batches
@@ -206,7 +213,6 @@ def _(spark):
             "Set it via Infisical (key HETZNER_S3_BUCKET) and re-run a spin-up "
             "to populate the Marimo container env."
         )
-        df_s3 = None
     return bucket, df_s3, os, result_msg, sample_path
 
 

--- a/examples/workspace-seeds/marimo/Getting_Started_PySpark.py
+++ b/examples/workspace-seeds/marimo/Getting_Started_PySpark.py
@@ -10,7 +10,7 @@ ordering automatically once dependencies are declared).
 
 import marimo
 
-__generated_with = "0.13.0"
+__generated_with = "0.23.4"
 app = marimo.App(width="medium")
 
 

--- a/examples/workspace-seeds/marimo/NYC_Taxi_Pipeline.py
+++ b/examples/workspace-seeds/marimo/NYC_Taxi_Pipeline.py
@@ -40,7 +40,7 @@ the Kestra equivalent uses (DuckDB+httpfs for the stats query).
 
 import marimo
 
-__generated_with = "0.13.0"
+__generated_with = "0.23.4"
 app = marimo.App(width="medium")
 
 

--- a/examples/workspace-seeds/marimo/NYC_Taxi_Pipeline.py
+++ b/examples/workspace-seeds/marimo/NYC_Taxi_Pipeline.py
@@ -3,12 +3,21 @@
 Mirror of the Kestra `r2-taxi-pipeline.yaml` flow, adapted for Marimo:
 
     1. Bootstrap: download monthly Yellow-Taxi parquets from NYC TLC's
-       public CloudFront and upload each to Hetzner Object Storage at
-       `s3a://<HETZNER_S3_BUCKET>/nexus-tutorials/NYC/yellow_tripdata_2025-MM.parquet`.
-       DuckDB does the transfer (it has both HTTP and S3 support built in
-       via httpfs). No compute-cluster round-trip needed.
-    2. Read all months back as a Spark DataFrame via the Connect server.
+       public CloudFront and upload each to Hetzner Object Storage.
+       DuckDB does the transfer via `s3://...` (its httpfs extension's
+       URL scheme — same physical bucket as the s3a:// reads below,
+       just a different client-library URI prefix). No compute-cluster
+       round-trip needed.
+    2. Read all months back as a Spark DataFrame via the Connect server
+       using `s3a://...` (Spark's Hadoop-FileSystem URI scheme; uses
+       hadoop-aws under the hood, which is configured server-side in
+       spark-connect).
     3. Aggregate stats with Spark SQL and render as a paginated table.
+
+Both `s3://` (DuckDB) and `s3a://` (Spark) point at the same physical
+object: `<HETZNER_S3_BUCKET>/nexus-tutorials/NYC/yellow_tripdata_2025-MM.parquet`.
+The two URI schemes are just two clients' conventions for talking to
+S3-compatible storage; the bytes on disk are identical.
 
 Default: 2 months (Jan + Feb 2025). Edit the `months` list to add more.
 The Kestra flow has the same default for the same reason — every student

--- a/examples/workspace-seeds/marimo/NYC_Taxi_Pipeline.py
+++ b/examples/workspace-seeds/marimo/NYC_Taxi_Pipeline.py
@@ -1,0 +1,351 @@
+"""NYC Yellow-Taxi 2025 pipeline — Spark Connect + Marimo.
+
+Mirror of the Kestra `r2-taxi-pipeline.yaml` flow, adapted for Marimo:
+
+    1. Bootstrap: download monthly Yellow-Taxi parquets from NYC TLC's
+       public CloudFront and upload each to Hetzner Object Storage at
+       `s3a://<HETZNER_S3_BUCKET>/nexus-tutorials/NYC/yellow_tripdata_2025-MM.parquet`.
+       DuckDB does the transfer (it has both HTTP and S3 support built in
+       via httpfs). No compute-cluster round-trip needed.
+    2. Read all months back as a Spark DataFrame via the Connect server.
+    3. Aggregate stats with Spark SQL and render as a paginated table.
+
+Default: 2 months (Jan + Feb 2025). Edit the `months` list to add more.
+The Kestra flow has the same default for the same reason — every student
+stack runs this on every "Execute", so a small default keeps CloudFront
+egress and run time low when a cohort hits the button at once.
+
+Pre-reqs:
+    - Marimo + Spark stacks both enabled
+    - Infisical has these secrets (synced into Marimo's env on spin-up):
+        HETZNER_S3_BUCKET, HETZNER_S3_ENDPOINT,
+        HETZNER_S3_ACCESS_KEY, HETZNER_S3_SECRET_KEY
+      Without them, the bootstrap cell raises early with a clear hint.
+
+Why DuckDB for the transfer (not Spark): pyspark[connect] doesn't read
+HTTP URLs natively, and a "download to /tmp then write via Spark" path
+would shuttle 60 MiB per month through the Marimo container. DuckDB's
+httpfs streams directly from CloudFront to S3 in-process — same pattern
+the Kestra equivalent uses (DuckDB+httpfs for the stats query).
+"""
+
+import marimo
+
+__generated_with = "0.13.0"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def _():
+    import marimo as mo
+    return (mo,)
+
+
+@app.cell
+def _(mo):
+    mo.md(
+        r"""
+        # NYC Yellow-Taxi 2025 Pipeline
+
+        End-to-end demo: bootstrap public NYC TLC parquet files into
+        Hetzner Object Storage, then analyse with Spark Connect.
+
+        Mirrors the Kestra flow `nexus-tutorials.r2-taxi-pipeline` —
+        same data source, similar shape, different runtime (Marimo
+        + DuckDB + Spark Connect instead of Kestra + DuckDB).
+        """
+    )
+    return
+
+
+@app.cell
+def _():
+    from _nexus_spark import get_spark
+
+    spark = get_spark()
+    return (spark,)
+
+
+@app.cell
+def _(mo):
+    mo.md(
+        r"""
+        ## 1. Verify Hetzner S3 credentials
+
+        Pulled from Infisical via the `.infisical.env` env_file (see
+        `scripts/deploy.sh` Marimo secret-sync block). If any are
+        missing, fix them in Infisical and re-run a spin-up to
+        repopulate the container env.
+        """
+    )
+    return
+
+
+@app.cell
+def _(mo):
+    import os
+
+    _required = [
+        "HETZNER_S3_BUCKET",
+        "HETZNER_S3_ENDPOINT",
+        "HETZNER_S3_ACCESS_KEY",
+        "HETZNER_S3_SECRET_KEY",
+    ]
+    _missing = [k for k in _required if not os.environ.get(k)]
+
+    if _missing:
+        s3_env_ok = False
+        s3_status_md = mo.md(
+            f"""
+            > ⚠️ **Missing env vars:** `{", ".join(_missing)}`
+            >
+            > Add them to Infisical (any folder), re-run a spin-up, and
+            > the Marimo container will pick them up via the
+            > `.infisical.env` file. The downstream cells will skip
+            > themselves until this is satisfied.
+            """
+        )
+    else:
+        s3_env_ok = True
+        s3_status_md = mo.md(
+            f"""
+            ✓ All four `HETZNER_S3_*` env vars are set.
+
+            - **Bucket:** `{os.environ["HETZNER_S3_BUCKET"]}`
+            - **Endpoint:** `{os.environ["HETZNER_S3_ENDPOINT"]}`
+            """
+        )
+    s3_status_md
+    return os, s3_env_ok
+
+
+@app.cell
+def _(mo):
+    mo.md(
+        r"""
+        ## 2. Months to bootstrap
+
+        Default: Jan + Feb 2025 (~120 MiB total). Extend the list below
+        to bootstrap more months — `["01", ..., "12"]` for the full
+        year (~720 MiB).
+
+        Why a small default: this notebook ships as a seed in every
+        student workspace, so a "Run all" hits CloudFront simultaneously
+        across the cohort. A 2-month default keeps egress + run time
+        modest. Same rationale as the Kestra equivalent.
+        """
+    )
+    return
+
+
+@app.cell
+def _():
+    months = ["01", "02"]
+    return (months,)
+
+
+@app.cell
+def _(mo):
+    mo.md(
+        r"""
+        ## 3. Bootstrap — DuckDB streams CloudFront → Hetzner S3
+
+        DuckDB's `httpfs` extension reads HTTPS and writes S3 in the
+        same query, so each month moves CloudFront → S3 in-process
+        (no /tmp staging, no compute-cluster round-trip).
+
+        Re-running this cell is **idempotent in spirit**: DuckDB's `COPY
+        ... TO` overwrites the destination if it already exists. If
+        you've already bootstrapped these months, re-running just
+        overwrites with byte-identical content (~10s per month due to
+        re-download).
+        """
+    )
+    return
+
+
+@app.cell
+def _(months, os, s3_env_ok):
+    upload_results = []
+    if s3_env_ok:
+        import duckdb
+
+        # Lightweight DuckDB connection — in-memory, no persistence
+        # needed; just a vehicle for the httpfs extension.
+        _con = duckdb.connect(":memory:")
+        _con.execute("INSTALL httpfs; LOAD httpfs;")
+
+        # DuckDB's httpfs config style is global per-connection.
+        # Endpoint must NOT include the scheme prefix (DuckDB adds
+        # http(s):// itself based on s3_use_ssl). Strip it defensively
+        # so users can paste a full URL into Infisical without
+        # breaking things.
+        _endpoint = os.environ["HETZNER_S3_ENDPOINT"]
+        _endpoint_host = _endpoint.replace("https://", "").replace("http://", "")
+        _con.execute(f"SET s3_endpoint = '{_endpoint_host}';")
+        _con.execute(f"SET s3_access_key_id = '{os.environ['HETZNER_S3_ACCESS_KEY']}';")
+        _con.execute(f"SET s3_secret_access_key = '{os.environ['HETZNER_S3_SECRET_KEY']}';")
+        _con.execute("SET s3_url_style = 'path';")
+        _con.execute("SET s3_use_ssl = true;")
+
+        _bucket = os.environ["HETZNER_S3_BUCKET"]
+        for _month in months:
+            _src = (
+                f"https://d37ci6vzurychx.cloudfront.net/trip-data/"
+                f"yellow_tripdata_2025-{_month}.parquet"
+            )
+            # Match the Kestra flow's path: nexus-tutorials/NYC/...
+            # so both seeds end up at the same logical location even
+            # though they target different S3 backends (R2 vs Hetzner).
+            _dst = (
+                f"s3://{_bucket}/nexus-tutorials/NYC/"
+                f"yellow_tripdata_2025-{_month}.parquet"
+            )
+            _con.execute(
+                f"COPY (SELECT * FROM read_parquet('{_src}')) "
+                f"TO '{_dst}' (FORMAT PARQUET);"
+            )
+            upload_results.append({"month": _month, "src": _src, "dst": _dst})
+        _con.close()
+    upload_results
+    return (upload_results,)
+
+
+@app.cell
+def _(mo, s3_env_ok, upload_results):
+    if s3_env_ok and upload_results:
+        bootstrap_summary_md = mo.md(
+            f"✓ Uploaded **{len(upload_results)}** months to "
+            f"`{upload_results[0]['dst'].rsplit('/', 1)[0]}/`"
+        )
+    else:
+        bootstrap_summary_md = mo.md(
+            "⏭️  Bootstrap skipped — see Section 1 for missing env vars."
+        )
+    bootstrap_summary_md
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md(
+        r"""
+        ## 4. Read back via Spark + register as SQL view
+
+        Spark's S3A connector (configured server-side in `spark-connect`)
+        reads the Parquet files directly. The wildcard `2025-*.parquet`
+        catches every month present in S3 — extending `months` above
+        widens the analysis automatically without touching this cell.
+        """
+    )
+    return
+
+
+@app.cell
+def _(os, s3_env_ok, spark):
+    if s3_env_ok:
+        _bucket = os.environ["HETZNER_S3_BUCKET"]
+        trips = spark.read.parquet(
+            f"s3a://{_bucket}/nexus-tutorials/NYC/yellow_tripdata_2025-*.parquet"
+        )
+        trips.createOrReplaceTempView("trips")
+    else:
+        trips = None
+    trips
+    return (trips,)
+
+
+@app.cell
+def _(mo):
+    mo.md(
+        r"""
+        ## 5. Quick stats — Spark SQL
+
+        Same shape as the Kestra flow's DuckDB query, but runs
+        distributed on the spark-worker. Result streams back via
+        Arrow and renders as a Marimo paginated table.
+        """
+    )
+    return
+
+
+@app.cell
+def _(s3_env_ok, spark, trips):
+    if s3_env_ok and trips is not None:
+        stats = spark.sql(
+            """
+            SELECT
+              COUNT(*)                       AS total_trips,
+              ROUND(AVG(trip_distance), 2)   AS avg_distance_mi,
+              ROUND(AVG(total_amount), 2)    AS avg_fare_usd,
+              ROUND(AVG(passenger_count), 2) AS avg_passengers,
+              MIN(tpep_pickup_datetime)      AS earliest_pickup,
+              MAX(tpep_pickup_datetime)      AS latest_pickup
+            FROM trips
+            """
+        )
+    else:
+        stats = None
+    stats
+    return (stats,)
+
+
+@app.cell
+def _(mo):
+    mo.md(
+        r"""
+        ## 6. Per-payment-type breakdown
+
+        Bonus aggregation that wasn't in the Kestra flow — shows the
+        difference Spark makes once the data's in S3: the same query
+        runs distributed on the worker, results stream back as a
+        small Arrow batch.
+        """
+    )
+    return
+
+
+@app.cell
+def _(s3_env_ok, spark, trips):
+    if s3_env_ok and trips is not None:
+        from pyspark.sql.connect import functions as F
+
+        by_payment = (
+            trips.groupBy("payment_type")
+            .agg(
+                F.count("*").alias("trips"),
+                F.round(F.avg("total_amount"), 2).alias("avg_fare_usd"),
+                F.round(F.avg("tip_amount"), 2).alias("avg_tip_usd"),
+            )
+            .orderBy("trips", ascending=False)
+        )
+    else:
+        by_payment = None
+    by_payment
+    return (by_payment,)
+
+
+@app.cell
+def _(mo):
+    mo.md(
+        r"""
+        ## 7. Where to go next
+
+        - **Extend `months` to all 12** to see Spark's distributed-read
+          shine on ~30 M rows. The cluster's single worker handles it
+          comfortably; bumping `spark-worker` cores would speed it up
+          further.
+        - **Compare with the Kestra equivalent** at
+          `nexus-tutorials.r2-taxi-pipeline` — same data, same path
+          shape (`nexus-tutorials/NYC/...`), different runtime. Useful
+          for understanding when to reach for which tool.
+        - **Try Spark SQL via Ibis cells** (see
+          `Getting_Started_PySpark.py`'s Section 4) for SQL with
+          Marimo's reactive DataFrame UI.
+        """
+    )
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/examples/workspace-seeds/marimo/_nexus_spark.py
+++ b/examples/workspace-seeds/marimo/_nexus_spark.py
@@ -1,0 +1,59 @@
+"""SparkSession factory for Marimo notebooks (Spark Connect).
+
+Usage in a Marimo cell:
+
+    from _nexus_spark import get_spark
+    spark = get_spark()
+    df = spark.createDataFrame([("a", 1), ("b", 2)], ["k", "v"])
+    df  # rendered as paginated mo.ui.table.lazy by Marimo's PySpark formatter
+
+The session is cached at module level — multiple cells / multiple notebooks
+calling get_spark() in the same Python process share one Connect channel
+to sc://spark-connect:15002. Marimo's reactive DAG re-runs cells when their
+upstream changes, but module-level state survives — by design here, since
+re-establishing the gRPC channel on every cell run would be wasteful.
+
+The Spark Connect URL is read from $SPARK_CONNECT_URL (set by
+stacks/marimo/docker-compose.yml). Override per-notebook by setting
+os.environ["SPARK_CONNECT_URL"] = "sc://other-cluster:15002" *before* the
+first get_spark() call.
+
+Note on Hadoop / S3 config: Spark Connect does NOT propagate driver-side
+SparkConf to the remote driver — Hadoop properties (s3a endpoint, keys)
+must be set on the spark-connect *server* side via SPARK_HADOOP_* env
+vars (already wired in stacks/spark/docker-compose.yml). Setting them
+here would be a no-op.
+"""
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+# pyspark.sql.connect.session.SparkSession is the Connect client; using it
+# directly (rather than pyspark.sql.SparkSession) avoids ambiguity about
+# which mode is in play.
+from pyspark.sql.connect.session import SparkSession
+
+_session: Optional[SparkSession] = None
+
+
+def get_spark() -> SparkSession:
+    """Return a process-wide Spark Connect session, creating it on first call."""
+    global _session
+    if _session is None:
+        url = os.environ.get("SPARK_CONNECT_URL", "sc://spark-connect:15002")
+        _session = SparkSession.builder.remote(url).getOrCreate()
+    return _session
+
+
+def stop_spark() -> None:
+    """Stop the cached session and clear the module-level reference.
+
+    Use this if you need to fully reset the gRPC channel (rare — most
+    config changes don't require it). After this, the next get_spark()
+    call will create a fresh session.
+    """
+    global _session
+    if _session is not None:
+        _session.stop()
+        _session = None

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -5166,6 +5166,187 @@ REMOTE_JUPYTER_SECRETS_EOF
     fi
 fi
 
+# ==========================================================================
+# Sync Infisical secrets into Marimo as plaintext env-vars (closes #497)
+# ==========================================================================
+# Same pattern as the Jupyter sync block above — see that block's comment
+# for the full rationale (atomic write into a dedicated .infisical.env,
+# deterministic sort, dotenv-quoted values, two outage-safety guards,
+# strict-mode heredoc, etc.). Differences from the Jupyter block:
+#   - Service-gate string: 'marimo' instead of 'jupyter'.
+#   - ENV_FILE / LEGACY_ENV paths: stacks/marimo/ instead of stacks/jupyter/.
+#   - Restart command: docker compose up -d marimo.
+#   - RESULT-line variable names use the MAR_ prefix to keep the runner-side
+#     parsing decoupled from the Jupyter pass.
+# All Round-1..8 hardenings from the Jupyter block carry over verbatim.
+# --------------------------------------------------------------------------
+if echo "$ENABLED_SERVICES" | grep -qw "marimo" \
+    && [ -n "$INFISICAL_TOKEN" ] && [ -n "$PROJECT_ID" ]; then
+    echo "Syncing Infisical secrets into Marimo env..."
+
+    MAR_INF_TOKEN_B64=$(printf '%s' "$INFISICAL_TOKEN" | base64 | tr -d '\n')
+    MAR_INF_PID_B64=$(printf '%s' "$PROJECT_ID" | base64 | tr -d '\n')
+    MAR_INF_ENV_B64=$(printf '%s' "${INFISICAL_ENV:-dev}" | base64 | tr -d '\n')
+    MAR_GTOKEN_B64=$(printf '%s' "${GITEA_TOKEN:-}" | base64 | tr -d '\n')
+
+    MAR_SYNC_OUT=$(ssh nexus "bash -s" <<REMOTE_MARIMO_SECRETS_EOF
+set -euo pipefail
+
+ITOK=\$(printf '%s' '$MAR_INF_TOKEN_B64' | base64 -d)
+PID=\$(printf '%s' '$MAR_INF_PID_B64' | base64 -d)
+INF_ENV=\$(printf '%s' '$MAR_INF_ENV_B64' | base64 -d)
+GTOKEN=\$(printf '%s' '$MAR_GTOKEN_B64' | base64 -d)
+ENV_FILE=/opt/docker-server/stacks/marimo/.infisical.env
+
+CFG=\$(mktemp)
+SEEN=\$(mktemp)
+APPEND=\$(mktemp)
+NEW_BLOCK=\$(mktemp)
+TSV=\$(mktemp)
+TMP_OUT=""
+chmod 600 "\$CFG" "\$APPEND" "\$NEW_BLOCK" "\$TSV"
+trap 'rm -f "\$CFG" "\$SEEN" "\$APPEND" "\$NEW_BLOCK" "\$TSV" "\$TMP_OUT"' EXIT
+printf 'header = "Authorization: Bearer %s"\n' "\$ITOK" > "\$CFG"
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "  ⚠ jq is not installed on the remote VM — Infisical sync needs jq, install with: sudo apt-get install -y jq" >&2
+    echo "RESULT pushed=0 skipped_name=0 skipped_multi=0 failed=0 collisions=0 succeeded=0 wrote=0"
+    exit 0
+fi
+
+LEGACY_ENV=/opt/docker-server/stacks/marimo/.env
+
+PUSHED=0; SKIPPED_NAME=0; SKIPPED_MULTI=0; FAILED=0; COLLISIONS=0; SUCCEEDED=0; WROTE=0
+
+FOLDERS_JSON=\$(curl -sS --config "\$CFG" --get \\
+    --connect-timeout 5 --max-time 15 \\
+    --data-urlencode "workspaceId=\$PID" \\
+    --data-urlencode "environment=\$INF_ENV" \\
+    "http://localhost:8070/api/v1/folders" || echo '{}')
+FOLDERS=\$(printf '%s' "\$FOLDERS_JSON" | jq -r '.folders[]?.name' | LC_ALL=C sort || true)
+FOLDERS=\$(printf '%s\n/\n' "\$FOLDERS")
+
+while IFS= read -r FOLDER; do
+    [ -z "\$FOLDER" ] && continue
+    if [ "\$FOLDER" = "/" ]; then
+        SECRET_PATH="/"; FOLDER_LABEL="<root>"
+    else
+        SECRET_PATH="/\$FOLDER"; FOLDER_LABEL="\$FOLDER"
+    fi
+    SECRETS_JSON=\$(curl -sS --config "\$CFG" --get \\
+        --connect-timeout 5 --max-time 30 \\
+        --data-urlencode "workspaceId=\$PID" \\
+        --data-urlencode "environment=\$INF_ENV" \\
+        --data-urlencode "secretPath=\$SECRET_PATH" \\
+        "http://localhost:8070/api/v3/secrets/raw" || true)
+    if ! printf '%s' "\$SECRETS_JSON" | jq -e '.secrets | type == "array"' >/dev/null; then
+        FAILED=\$((FAILED+1))
+        echo "  ⚠ Infisical fetch '\$FOLDER_LABEL' returned bad shape, skipping" >&2
+        continue
+    fi
+    if ! printf '%s' "\$SECRETS_JSON" | jq -r '.secrets[]? | [.secretKey, (.secretValue | @base64)] | @tsv' > "\$TSV"; then
+        FAILED=\$((FAILED+1))
+        echo "  ⚠ jq TSV extraction failed for folder '\$FOLDER_LABEL' — skipping (folder is NOT counted as succeeded)" >&2
+        continue
+    fi
+    SUCCEEDED=\$((SUCCEEDED+1))
+    while IFS=\$'\t' read -r KEY VALUE_B64; do
+        [ -z "\$KEY" ] && continue
+        if ! printf '%s' "\$KEY" | grep -qE '^[A-Za-z_][A-Za-z0-9_]*\$'; then
+            SKIPPED_NAME=\$((SKIPPED_NAME+1)); continue
+        fi
+        VALUE=\$(printf '%s' "\$VALUE_B64" | base64 -d || true)
+        if printf '%s' "\$VALUE" | grep -q \$'\n'; then
+            SKIPPED_MULTI=\$((SKIPPED_MULTI+1))
+            echo "  ⚠ Skipping multi-line secret '\$KEY' (folder '\$FOLDER_LABEL') — env-file format can't carry newlines reliably" >&2
+            continue
+        fi
+        EXISTING=\$(awk -F'\t' -v k="\$KEY" '\$1 == k {print \$2; exit}' "\$SEEN")
+        if [ -n "\$EXISTING" ]; then
+            COLLISIONS=\$((COLLISIONS+1))
+            echo "  ⚠ Key collision: '\$KEY' in folder '\$FOLDER_LABEL' shadowed by earlier value from folder '\$EXISTING' (first-wins)" >&2
+            continue
+        fi
+        ESCAPED_VALUE=\$(printf '%s' "\$VALUE" | sed -e 's/\\\\/\\\\\\\\/g' -e 's/"/\\\\"/g')
+        printf '%s\t%s\n' "\$KEY" "\$FOLDER_LABEL" >> "\$SEEN"
+        printf '%s="%s"\n' "\$KEY" "\$ESCAPED_VALUE" >> "\$APPEND"
+        PUSHED=\$((PUSHED+1))
+    done < "\$TSV"
+done <<< "\$FOLDERS"
+
+if [ -n "\$GTOKEN" ] && ! grep -qE '^GITEA_TOKEN=' "\$APPEND"; then
+    ESCAPED_GTOKEN=\$(printf '%s' "\$GTOKEN" | sed -e 's/\\\\/\\\\\\\\/g' -e 's/"/\\\\"/g')
+    printf 'GITEA_TOKEN="%s"\n' "\$ESCAPED_GTOKEN" >> "\$APPEND"
+    PUSHED=\$((PUSHED+1))
+fi
+
+if [ "\$SUCCEEDED" -eq 0 ]; then
+    echo "  ⚠ No Infisical folder fetch succeeded — leaving existing \$ENV_FILE untouched" >&2
+    echo "RESULT pushed=0 skipped_name=\$SKIPPED_NAME skipped_multi=\$SKIPPED_MULTI failed=\$FAILED collisions=\$COLLISIONS succeeded=0 wrote=0"
+    exit 0
+fi
+
+if [ "\$PUSHED" -eq 0 ]; then
+    echo "  ⚠ Infisical returned \$SUCCEEDED folder(s) but zero usable secrets — leaving existing \$ENV_FILE untouched (check env slug + token permissions in Infisical)" >&2
+    echo "RESULT pushed=0 skipped_name=\$SKIPPED_NAME skipped_multi=\$SKIPPED_MULTI failed=\$FAILED collisions=\$COLLISIONS succeeded=\$SUCCEEDED wrote=0"
+    exit 0
+fi
+
+{
+    echo "# === BEGIN nexus-secret-sync (Infisical → Marimo env, plaintext, regenerated each spin-up — do not edit by hand) ==="
+    LC_ALL=C sort -t= -k1,1 "\$APPEND"
+    echo "# === END nexus-secret-sync ==="
+} > "\$NEW_BLOCK"
+
+[ -f "\$ENV_FILE" ] || touch "\$ENV_FILE"
+chmod 600 "\$ENV_FILE"
+
+TMP_OUT=\$(mktemp -p "\$(dirname "\$ENV_FILE")" .infisical.env.XXXXXX)
+chmod 600 "\$TMP_OUT"
+sed '/^# === BEGIN nexus-secret-sync/,/^# === END nexus-secret-sync/d' "\$ENV_FILE" > "\$TMP_OUT"
+cat "\$NEW_BLOCK" >> "\$TMP_OUT"
+mv "\$TMP_OUT" "\$ENV_FILE"
+chmod 600 "\$ENV_FILE"
+WROTE=1
+
+if [ -f "\$LEGACY_ENV" ]; then
+    sed -i '/^# === BEGIN nexus-secret-sync/,/^# === END nexus-secret-sync/d' "\$LEGACY_ENV"
+fi
+
+echo "RESULT pushed=\$PUSHED skipped_name=\$SKIPPED_NAME skipped_multi=\$SKIPPED_MULTI failed=\$FAILED collisions=\$COLLISIONS succeeded=\$SUCCEEDED wrote=\$WROTE"
+REMOTE_MARIMO_SECRETS_EOF
+) || MAR_SYNC_OUT=""
+
+    MAR_RESULT_LINE=$(printf '%s\n' "$MAR_SYNC_OUT" | awk '/^RESULT/ {print; exit}')
+    MAR_PUSHED=$(echo "$MAR_RESULT_LINE" | sed -n 's/.*pushed=\([0-9]*\).*/\1/p')
+    MAR_FAILED=$(echo "$MAR_RESULT_LINE" | sed -n 's/.*failed=\([0-9]*\).*/\1/p')
+    MAR_COLLISIONS=$(echo "$MAR_RESULT_LINE" | sed -n 's/.*collisions=\([0-9]*\).*/\1/p')
+    MAR_WROTE=$(echo "$MAR_RESULT_LINE" | sed -n 's/.*wrote=\([0-9]*\).*/\1/p')
+
+    if [ -z "$MAR_PUSHED" ]; then
+        echo -e "${YELLOW}  ⚠ Marimo Infisical sync produced no result — check Infisical reachability + jq presence on the VM${NC}"
+    elif [ "${MAR_WROTE:-0}" -eq 0 ]; then
+        echo -e "${YELLOW}  ⚠ Skipped Marimo .infisical.env update — keeping previous secret set, no restart (see prior warning for cause)${NC}"
+    else
+        if [ "${MAR_FAILED:-0}" -gt 0 ]; then
+            echo -e "${YELLOW}  ⚠ Wrote $MAR_PUSHED Infisical env-vars to Marimo .infisical.env (${MAR_FAILED} folder fetches failed — secret set is incomplete)${NC}"
+        elif [ "${MAR_COLLISIONS:-0}" -gt 0 ]; then
+            echo -e "${YELLOW}  ⚠ Wrote $MAR_PUSHED Infisical env-vars to Marimo .infisical.env (${MAR_COLLISIONS} cross-folder collisions — first-wins applied)${NC}"
+        else
+            echo -e "${GREEN}  ✓ Wrote $MAR_PUSHED Infisical env-vars to Marimo .infisical.env (plaintext, exact key names)${NC}"
+        fi
+
+        MAR_RESTART_RC=0
+        MAR_RESTART_OUT=$(ssh nexus "cd $REMOTE_STACKS_DIR/marimo && docker compose up -d marimo" 2>&1) || MAR_RESTART_RC=$?
+        if [ "$MAR_RESTART_RC" -eq 0 ]; then
+            echo -e "${GREEN}  ✓ Marimo restart-on-change applied${NC}"
+        else
+            echo -e "${YELLOW}  ⚠ docker compose up -d marimo failed (exit $MAR_RESTART_RC) — notebook may still be running with old secrets until next spin-up${NC}"
+            echo "$MAR_RESTART_OUT" | sed 's/^/      /' >&2
+        fi
+    fi
+fi
+
 # Configure Wiki.js admin (uses user_email, not admin)
 if echo "$ENABLED_SERVICES" | grep -qw "wikijs" && [ -n "$WIKIJS_ADMIN_PASS" ]; then
     (

--- a/services.yaml
+++ b/services.yaml
@@ -384,9 +384,9 @@ services:
     public: false
     category: "dev-tools"
     website: "https://marimo.io"
-    description: "Reactive Python notebook with SQL support, reproducible and git-friendly."
-    long_description: "Marimo is a reactive Python notebook that automatically re-executes dependent cells when you modify code. Notebooks are stored as pure Python files (git-friendly), support SQL natively, and can be deployed as interactive web apps. A modern alternative to Jupyter with built-in reproducibility."
-    image: "ghcr.io/marimo-team/marimo:latest-sql"
+    description: "Reactive Python notebook with SQL + Spark Connect support, reproducible and git-friendly."
+    long_description: "Marimo is a reactive Python notebook that automatically re-executes dependent cells when you modify code. Notebooks are stored as pure Python files (git-friendly), support SQL natively, and can be deployed as interactive web apps. Pre-wired to talk to the Spark cluster via Spark Connect (sc://spark-connect:15002) — pyspark[connect] + ibis-framework[pyspark] are pre-installed."
+    image: "nexus-marimo:latest-sql-spark"
 
   meltano:
     port: 5000

--- a/stacks/marimo/Dockerfile
+++ b/stacks/marimo/Dockerfile
@@ -21,7 +21,13 @@
 # footgun. Bump both together.
 # =============================================================================
 
-FROM ghcr.io/marimo-team/marimo:latest-sql
+# Pinned to a specific marimo version for reproducibility AND so the
+# seed notebooks' `__generated_with = "X.Y.Z"` field stays valid (a
+# floating `:latest-sql` tag could pull a marimo older than the seeds'
+# `__generated_with` version, which marimo refuses to open).
+# When bumping: also bump `__generated_with` in
+# examples/workspace-seeds/marimo/*.py to match.
+FROM ghcr.io/marimo-team/marimo:0.23.4-sql
 
 USER root
 

--- a/stacks/marimo/Dockerfile
+++ b/stacks/marimo/Dockerfile
@@ -29,9 +29,12 @@ USER root
 # image is Debian (NOT Alpine) — the previous stacks/marimo/docker-compose.yml
 # used `apk add` which silently failed because apk doesn't exist here;
 # git was simply missing. Install via apt-get at build time so the
-# entrypoint can rely on it.
+# entrypoint can rely on it. `gosu` is a tiny setuid helper used by the
+# entrypoint to drop privileges from root → appuser AFTER chowning the
+# notebook volume (a fresh docker-named-volume is mounted root:root,
+# which the appuser-running marimo can't write to).
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends git && \
+    apt-get install -y --no-install-recommends git gosu && \
     rm -rf /var/lib/apt/lists/*
 
 # Spark Connect client + Ibis adapter. `--no-cache-dir` keeps the layer
@@ -43,4 +46,8 @@ RUN pip install --no-cache-dir \
     "grpcio-status>=1.62" \
     "pyarrow>=15"
 
-USER appuser
+# Stay as root — the entrypoint chowns the notebooks volume then drops
+# to appuser via gosu before exec'ing marimo. We can't drop here
+# because the chown needs root and the entrypoint is what handles
+# the volume init (the volume is mounted AFTER the image is built, so
+# any chown done at build time is overlaid and lost).

--- a/stacks/marimo/Dockerfile
+++ b/stacks/marimo/Dockerfile
@@ -47,8 +47,8 @@ RUN apt-get update && \
 RUN pip install --no-cache-dir \
     "pyspark[connect]==4.1.1" \
     "ibis-framework[pyspark]==10.5.0" \
-    "grpcio==1.71.0" \
-    "grpcio-status==1.71.0" \
+    "grpcio==1.76.0" \
+    "grpcio-status==1.76.0" \
     "pyarrow==19.0.1"
 
 # Stay as root — the entrypoint chowns the notebooks volume then drops

--- a/stacks/marimo/Dockerfile
+++ b/stacks/marimo/Dockerfile
@@ -37,14 +37,19 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends git gosu && \
     rm -rf /var/lib/apt/lists/*
 
-# Spark Connect client + Ibis adapter. `--no-cache-dir` keeps the layer
-# small. Versions pinned to match spark-master 4.1.1.
+# Spark Connect client + Ibis adapter. `--no-cache-dir` keeps the
+# layer small. ALL versions pinned exactly to make rebuilds
+# reproducible — open-ended `>=` constraints would let pip pull a
+# newer grpcio / pyarrow on every rebuild and silently break
+# wire-protocol compat with the spark-connect 4.1.1 server. The
+# pins below match the known-good combination from marimo-team's
+# own pyspark smoke tests.
 RUN pip install --no-cache-dir \
     "pyspark[connect]==4.1.1" \
     "ibis-framework[pyspark]==10.5.0" \
-    "grpcio>=1.62" \
-    "grpcio-status>=1.62" \
-    "pyarrow>=15"
+    "grpcio==1.71.0" \
+    "grpcio-status==1.71.0" \
+    "pyarrow==19.0.1"
 
 # Stay as root — the entrypoint chowns the notebooks volume then drops
 # to appuser via gosu before exec'ing marimo. We can't drop here

--- a/stacks/marimo/Dockerfile
+++ b/stacks/marimo/Dockerfile
@@ -1,0 +1,46 @@
+# =============================================================================
+# Marimo - Reactive Python Notebook with Spark Connect client
+# =============================================================================
+# Base: ghcr.io/marimo-team/marimo:latest-sql (python:3.13-slim, includes
+# marimo[sql] = duckdb + sqlglot + ibis + polars + pyarrow). We layer on
+# git (so the entrypoint can clone the workspace repo from Gitea) and the
+# Spark Connect client packages so notebooks can talk to the spark-connect
+# service via sc://spark-connect:15002 — no JDK or full pyspark needed.
+#
+# Why pyspark[connect] (not full pyspark): connect mode ships the gRPC
+# client + Arrow serialization only. The driver-JVM runs server-side in
+# the spark-connect container, so this image stays slim (no openjdk,
+# ~+40 MiB instead of ~+450 MiB for full pyspark + JDK).
+#
+# Why ibis-framework[pyspark]: gives us mo.sql(..., engine=con) where
+# con = ibis.pyspark.connect(spark). Marimo doesn't have a first-class
+# Spark SQL backend, but Ibis is the supported bridge.
+#
+# Pin the pyspark version exactly to the cluster's Spark version (4.1.1)
+# — wire-protocol skew between Connect client and server is the #1
+# footgun. Bump both together.
+# =============================================================================
+
+FROM ghcr.io/marimo-team/marimo:latest-sql
+
+USER root
+
+# git is needed by the entrypoint's workspace-repo clone. Marimo's base
+# image is Debian (NOT Alpine) — the previous stacks/marimo/docker-compose.yml
+# used `apk add` which silently failed because apk doesn't exist here;
+# git was simply missing. Install via apt-get at build time so the
+# entrypoint can rely on it.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends git && \
+    rm -rf /var/lib/apt/lists/*
+
+# Spark Connect client + Ibis adapter. `--no-cache-dir` keeps the layer
+# small. Versions pinned to match spark-master 4.1.1.
+RUN pip install --no-cache-dir \
+    "pyspark[connect]==4.1.1" \
+    "ibis-framework[pyspark]==10.5.0" \
+    "grpcio>=1.62" \
+    "grpcio-status>=1.62" \
+    "pyarrow>=15"
+
+USER appuser

--- a/stacks/marimo/docker-compose.yml
+++ b/stacks/marimo/docker-compose.yml
@@ -24,23 +24,30 @@ services:
     image: ${IMAGE_MARIMO:-nexus-marimo:latest-sql-spark}
     container_name: marimo
     restart: unless-stopped
-    # Entrypoint just sets up Gitea netrc + clones the workspace repo.
-    # git is installed by the Dockerfile (Marimo's base is Debian, NOT
-    # Alpine — the previous `apk add` was a silent-failure latent bug).
+    # Entrypoint runs as root: (1) chown /app/notebooks to appuser since
+    # a fresh docker-named-volume mounts root-owned regardless of the
+    # image's pre-baked perms, (2) set up Gitea netrc + clone workspace
+    # repo as appuser via gosu, (3) exec marimo as appuser. git, gosu,
+    # and python3 are all installed by the Dockerfile (Marimo's base is
+    # Debian, NOT Alpine — the previous `apk add` was a silent-failure
+    # latent bug, and the chown was missing entirely).
     entrypoint: >
       sh -c "
-        if [ -n \"$$GITEA_USERNAME\" ] && [ -n \"$$GITEA_PASSWORD\" ]; then
-          echo \"machine gitea login $$GITEA_USERNAME password $$GITEA_PASSWORD\" > ~/.netrc;
-          chmod 600 ~/.netrc;
-        fi;
-        if [ -n \"$$GITEA_REPO_URL\" ] && [ ! -d /app/notebooks/$$REPO_NAME/.git ]; then
-          if git clone \"$$GITEA_REPO_URL\" /app/notebooks/$$REPO_NAME; then
-            echo '[marimo] Cloned Git repo into /app/notebooks/'$$REPO_NAME;
-          else
-            echo '[marimo] Warning: Failed to clone '$$GITEA_REPO_URL >&2;
+        chown -R appuser:appuser /app/notebooks;
+        gosu appuser sh -c '
+          if [ -n \"$$GITEA_USERNAME\" ] && [ -n \"$$GITEA_PASSWORD\" ]; then
+            echo \"machine gitea login $$GITEA_USERNAME password $$GITEA_PASSWORD\" > ~/.netrc;
+            chmod 600 ~/.netrc;
           fi;
-        fi;
-        exec marimo edit --host 0.0.0.0 --port 8080 --no-token /app/notebooks
+          if [ -n \"$$GITEA_REPO_URL\" ] && [ ! -d /app/notebooks/$$REPO_NAME/.git ]; then
+            if git clone \"$$GITEA_REPO_URL\" /app/notebooks/$$REPO_NAME; then
+              echo \"[marimo] Cloned Git repo into /app/notebooks/$$REPO_NAME\";
+            else
+              echo \"[marimo] Warning: Failed to clone $$GITEA_REPO_URL\" >&2;
+            fi;
+          fi;
+        ';
+        exec gosu appuser marimo edit --host 0.0.0.0 --port 8080 --no-token /app/notebooks
       "
     env_file:
       - path: .env
@@ -83,7 +90,11 @@ services:
     volumes:
       - marimo_data:/app/notebooks
     healthcheck:
-      test: ["CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:8080/ || exit 1"]
+      # python3 instead of wget — Marimo's Debian-slim base doesn't
+      # include wget (or curl), but python3 is the whole reason this
+      # container exists, so it's guaranteed available.
+      # urlopen raises on non-2xx; sys.exit(0) on success → healthy.
+      test: ["CMD-SHELL", "python3 -c 'import urllib.request, sys; urllib.request.urlopen(\"http://localhost:8080/\").close(); sys.exit(0)' || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/stacks/marimo/docker-compose.yml
+++ b/stacks/marimo/docker-compose.yml
@@ -33,7 +33,9 @@ services:
     # latent bug, and the chown was missing entirely).
     entrypoint: >
       sh -c "
-        chown -R appuser:appuser /app/notebooks;
+        if [ \"$$(stat -c '%U' /app/notebooks)\" != \"appuser\" ]; then
+          chown -R appuser:appuser /app/notebooks;
+        fi;
         gosu appuser sh -c '
           if [ -n \"$$GITEA_USERNAME\" ] && [ -n \"$$GITEA_PASSWORD\" ]; then
             echo \"machine gitea login $$GITEA_USERNAME password $$GITEA_PASSWORD\" > ~/.netrc;
@@ -70,15 +72,15 @@ services:
       # (examples/workspace-seeds/marimo/_nexus_spark.py). Override
       # per-notebook via os.environ if pointing at a different cluster.
       - SPARK_CONNECT_URL=sc://spark-connect:15002
-      # S3 (Hetzner Object Storage) — exposed so Spark sessions built
-      # via the helper module can register Hadoop config for s3a://
-      # paths. The Connect-server side reads its own copy from the
-      # spark-connect compose env; this set lets notebooks see the
-      # bucket name etc. for path construction.
-      - HETZNER_S3_ENDPOINT=${HETZNER_S3_ENDPOINT:-}
-      - HETZNER_S3_ACCESS_KEY=${HETZNER_S3_ACCESS_KEY:-}
-      - HETZNER_S3_SECRET_KEY=${HETZNER_S3_SECRET_KEY:-}
-      - HETZNER_S3_BUCKET=${HETZNER_S3_BUCKET:-}
+      # NOTE: HETZNER_S3_* are intentionally NOT set here. They land
+      # in `.infisical.env` via the secret-sync block in deploy.sh
+      # and reach the container via env_file above. Listing them in
+      # the `environment:` section would override the env_file values
+      # (Compose precedence: environment > env_file) — and since the
+      # `${VAR:-}` interpolation reads from the host's compose .env
+      # (not .infisical.env), these would resolve to empty strings,
+      # silently wiping the Infisical-provided values at container
+      # start. Defeating the entire point of the secret sync.
     deploy:
       resources:
         limits:

--- a/stacks/marimo/docker-compose.yml
+++ b/stacks/marimo/docker-compose.yml
@@ -1,9 +1,16 @@
 # =============================================================================
-# Marimo - Reactive Python Notebook
+# Marimo - Reactive Python Notebook with Spark Connect
 # https://marimo.${DOMAIN}
 # =============================================================================
 # Marimo is a reactive Python notebook that's reproducible, git-friendly,
-# and deployable as apps. SQL variant includes DuckDB and data analysis tools.
+# and deployable as apps. The SQL variant ships DuckDB + Ibis + Polars.
+#
+# Spark integration: this image extends ghcr.io/marimo-team/marimo:latest-sql
+# with pyspark[connect] + ibis-framework[pyspark] (see ./Dockerfile).
+# Notebooks call `from _nexus_spark import get_spark; spark = get_spark()`
+# to get a Spark Connect session against sc://spark-connect:15002. The
+# driver-JVM lives in the spark-connect container — Marimo is gRPC-only,
+# so 1 GiB memory is plenty.
 #
 # Git Integration: If Gitea is enabled, the shared workspace repo is
 # auto-cloned into /app/notebooks/.
@@ -11,9 +18,15 @@
 
 services:
   marimo:
-    image: ${IMAGE_MARIMO:-ghcr.io/marimo-team/marimo:latest-sql}
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: ${IMAGE_MARIMO:-nexus-marimo:latest-sql-spark}
     container_name: marimo
     restart: unless-stopped
+    # Entrypoint just sets up Gitea netrc + clones the workspace repo.
+    # git is installed by the Dockerfile (Marimo's base is Debian, NOT
+    # Alpine — the previous `apk add` was a silent-failure latent bug).
     entrypoint: >
       sh -c "
         if [ -n \"$$GITEA_USERNAME\" ] && [ -n \"$$GITEA_PASSWORD\" ]; then
@@ -21,15 +34,10 @@ services:
           chmod 600 ~/.netrc;
         fi;
         if [ -n \"$$GITEA_REPO_URL\" ] && [ ! -d /app/notebooks/$$REPO_NAME/.git ]; then
-          if ! command -v git >/dev/null 2>&1; then
-            apk add --no-cache git || echo '[marimo] Warning: Failed to install git' >&2;
-          fi;
-          if command -v git >/dev/null 2>&1; then
-            if git clone \"$$GITEA_REPO_URL\" /app/notebooks/$$REPO_NAME; then
-              echo '[marimo] Cloned Git repo into /app/notebooks/'$$REPO_NAME;
-            else
-              echo '[marimo] Warning: Failed to clone '$$GITEA_REPO_URL >&2;
-            fi;
+          if git clone \"$$GITEA_REPO_URL\" /app/notebooks/$$REPO_NAME; then
+            echo '[marimo] Cloned Git repo into /app/notebooks/'$$REPO_NAME;
+          else
+            echo '[marimo] Warning: Failed to clone '$$GITEA_REPO_URL >&2;
           fi;
         fi;
         exec marimo edit --host 0.0.0.0 --port 8080 --no-token /app/notebooks
@@ -37,15 +45,41 @@ services:
     env_file:
       - path: .env
         required: false
+      # Infisical secrets land in a dedicated file (written by
+      # scripts/deploy.sh's secret-sync block). Same pattern as
+      # stacks/jupyter/docker-compose.yml — `.env` would also be
+      # consumed by docker compose for `${VAR}` interpolation in this
+      # file, and a secret named e.g. `IMAGE_MARIMO` could silently
+      # rewrite the compose config. Dedicated file avoids that class
+      # of footgun.
+      - path: .infisical.env
+        required: false
     ports:
       - "2718:8080"
     environment:
       - HOST=0.0.0.0
       - PORT=8080
+      # Default Spark Connect endpoint for the helper module
+      # (examples/workspace-seeds/marimo/_nexus_spark.py). Override
+      # per-notebook via os.environ if pointing at a different cluster.
+      - SPARK_CONNECT_URL=sc://spark-connect:15002
+      # S3 (Hetzner Object Storage) — exposed so Spark sessions built
+      # via the helper module can register Hadoop config for s3a://
+      # paths. The Connect-server side reads its own copy from the
+      # spark-connect compose env; this set lets notebooks see the
+      # bucket name etc. for path construction.
+      - HETZNER_S3_ENDPOINT=${HETZNER_S3_ENDPOINT:-}
+      - HETZNER_S3_ACCESS_KEY=${HETZNER_S3_ACCESS_KEY:-}
+      - HETZNER_S3_SECRET_KEY=${HETZNER_S3_SECRET_KEY:-}
+      - HETZNER_S3_BUCKET=${HETZNER_S3_BUCKET:-}
     deploy:
       resources:
         limits:
-          memory: 512m
+          # 1 GiB is plenty for a Spark Connect client. The driver-JVM
+          # lives in the spark-connect container; Marimo just runs
+          # Python + gRPC + Arrow batches. If notebooks pull huge
+          # .toPandas() results client-side, raise to 2g.
+          memory: 1g
     volumes:
       - marimo_data:/app/notebooks
     healthcheck:

--- a/stacks/spark/Dockerfile
+++ b/stacks/spark/Dockerfile
@@ -11,7 +11,7 @@
 #    (required for s3a:// paths, e.g. Hetzner Object Storage).
 # 3. Downloads Spark Connect server JARs so the master can start a gRPC
 #    Connect endpoint (port 15002) for thin clients (Marimo, code-server,
-#    perspectivisch Jupyter). Classic standalone-cluster on 7077 keeps
+#    eventually Jupyter). Classic standalone-cluster on 7077 keeps
 #    serving Jupyter unchanged.
 # =============================================================================
 

--- a/stacks/spark/Dockerfile
+++ b/stacks/spark/Dockerfile
@@ -1,5 +1,5 @@
 # =============================================================================
-# Apache Spark - Custom image with Python 3.13 and S3A support
+# Apache Spark - Custom image with Python 3.13, S3A, and Spark Connect support
 # =============================================================================
 # The official apache/spark:4.1.1 image is based on Ubuntu 22.04 (Jammy) which
 # ships Python 3.10. Jupyter pyspark-notebook uses Python 3.13 (via conda).
@@ -9,6 +9,10 @@
 # 1. Installs Python 3.13 from the deadsnakes PPA to match Jupyter.
 # 2. Downloads hadoop-aws + AWS SDK v2 JARs for S3A filesystem support
 #    (required for s3a:// paths, e.g. Hetzner Object Storage).
+# 3. Downloads Spark Connect server JARs so the master can start a gRPC
+#    Connect endpoint (port 15002) for thin clients (Marimo, code-server,
+#    perspectivisch Jupyter). Classic standalone-cluster on 7077 keeps
+#    serving Jupyter unchanged.
 # =============================================================================
 
 FROM apache/spark:4.1.1
@@ -58,5 +62,16 @@ RUN curl -fSL https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/3.4.2/
         -o /opt/spark/jars/hadoop-aws-3.4.2.jar && \
     curl -fSL https://repo1.maven.org/maven2/software/amazon/awssdk/bundle/2.29.52/bundle-2.29.52.jar \
         -o /opt/spark/jars/bundle-2.29.52.jar
+
+# Download Spark Connect server JARs. Pre-baking them avoids a ~30s
+# ivy-resolution cold-start every container boot (which is what
+# `--packages org.apache.spark:spark-connect_2.13:4.1.1` would do at
+# runtime). Same pattern as the hadoop-aws JARs above. Pinned to
+# match the apache/spark:4.1.1 base so there's no Scala-major or
+# protobuf-shading mismatch with the rest of the assembly.
+RUN curl -fSL https://repo1.maven.org/maven2/org/apache/spark/spark-connect_2.13/4.1.1/spark-connect_2.13-4.1.1.jar \
+        -o /opt/spark/jars/spark-connect_2.13-4.1.1.jar && \
+    curl -fSL https://repo1.maven.org/maven2/org/apache/spark/spark-connect-common_2.13/4.1.1/spark-connect-common_2.13-4.1.1.jar \
+        -o /opt/spark/jars/spark-connect-common_2.13-4.1.1.jar
 
 USER spark

--- a/stacks/spark/Dockerfile
+++ b/stacks/spark/Dockerfile
@@ -69,9 +69,29 @@ RUN curl -fSL https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/3.4.2/
 # runtime). Same pattern as the hadoop-aws JARs above. Pinned to
 # match the apache/spark:4.1.1 base so there's no Scala-major or
 # protobuf-shading mismatch with the rest of the assembly.
+#
+# Each JAR is verified against Maven Central's published SHA-1
+# checksum so the build fails loudly if the artifact bytes get
+# tampered with at the registry, in transit, or via a
+# cache/CDN-poisoning attack. SHA-1 (not 256/512) because Maven
+# Central only publishes .sha1 and .md5 sidecars for these
+# artifacts — verified live (.sha512 returns 404). SHA-1 is
+# cryptographically weak BUT still effective against random
+# corruption + non-targeted tampering, which is the realistic
+# threat model for a Maven Central CDN-fetch in CI.
+# (The pre-existing hadoop-aws + AWS SDK downloads above don't
+# yet have this guard — TODO in a separate hardening PR; not
+# done here to keep the diff scoped to the new Connect-server
+# addition.)
 RUN curl -fSL https://repo1.maven.org/maven2/org/apache/spark/spark-connect_2.13/4.1.1/spark-connect_2.13-4.1.1.jar \
         -o /opt/spark/jars/spark-connect_2.13-4.1.1.jar && \
+    curl -fSL https://repo1.maven.org/maven2/org/apache/spark/spark-connect_2.13/4.1.1/spark-connect_2.13-4.1.1.jar.sha1 \
+        | awk '{print $1 "  /opt/spark/jars/spark-connect_2.13-4.1.1.jar"}' \
+        | sha1sum -c - && \
     curl -fSL https://repo1.maven.org/maven2/org/apache/spark/spark-connect-common_2.13/4.1.1/spark-connect-common_2.13-4.1.1.jar \
-        -o /opt/spark/jars/spark-connect-common_2.13-4.1.1.jar
+        -o /opt/spark/jars/spark-connect-common_2.13-4.1.1.jar && \
+    curl -fSL https://repo1.maven.org/maven2/org/apache/spark/spark-connect-common_2.13/4.1.1/spark-connect-common_2.13-4.1.1.jar.sha1 \
+        | awk '{print $1 "  /opt/spark/jars/spark-connect-common_2.13-4.1.1.jar"}' \
+        | sha1sum -c -
 
 USER spark

--- a/stacks/spark/docker-compose.yml
+++ b/stacks/spark/docker-compose.yml
@@ -181,6 +181,18 @@ services:
       - spark.connect.grpc.binding.port=15002
       - --conf
       - spark.driver.host=spark-connect
+      # spark.driver.bindAddress=0.0.0.0 is REQUIRED — without it
+      # the driver's RPC server (port 42205+ for executor back-channel)
+      # binds to 127.0.0.1 only, and spark-worker's executors can't
+      # reach it across the Docker app-network. Symptom: every
+      # CoarseGrainedExecutorBackend exits with code 1 immediately
+      # after launch ("Command exited with code 1" in worker logs,
+      # empty stderr/stdout because it dies before logging anything),
+      # crash-looping forever as Standalone keeps re-spawning. Same
+      # rationale as SPARK_MASTER_OPTS=-Dspark.master.bindAddress=0.0.0.0
+      # on spark-master above.
+      - --conf
+      - spark.driver.bindAddress=0.0.0.0
       - --name
       - SparkConnectServer
       # Positional app jar — provides the SparkConnectServer class.

--- a/stacks/spark/docker-compose.yml
+++ b/stacks/spark/docker-compose.yml
@@ -140,8 +140,12 @@ services:
   # We launch via spark-submit so SparkConf is wired up correctly
   # (--master, --conf), and the SparkConnectPlugin gets registered.
   #
-  # Resources: 1.5 GiB driver-heap is plenty — the heavy work happens
-  # on the worker, the Connect server is mostly a gRPC↔Spark adapter.
+  # Resources: container is capped at 1.5 GiB; the driver JVM uses
+  # Spark's default heap (1g) within that, leaving headroom for
+  # native code and gRPC buffers. The heavy work happens on the
+  # worker, the Connect server is mostly a gRPC↔Spark adapter so
+  # the default heap is fine. Bump --driver-memory in the command
+  # below if you see OOMs in connect-server logs.
   # =========================================================================
   spark-connect:
     image: ${IMAGE_SPARK:-nexus-spark:4.1.1-python3.13}
@@ -181,8 +185,14 @@ services:
       # Pre-downloaded by stacks/spark/Dockerfile to avoid runtime
       # ivy resolution.
       - /opt/spark/jars/spark-connect_2.13-4.1.1.jar
-    ports:
-      - "15002:15002"
+    # No `ports:` mapping — clients reach 15002 via the Docker
+    # `app-network` only (`sc://spark-connect:15002`). Publishing
+    # to the host would expose the gRPC endpoint on the VM's
+    # interfaces, contradicting the "no auth on Spark itself,
+    # protected by Cloudflare Tunnel boundary" assumption above.
+    # If host-side debug access is ever needed, add a 127.0.0.1
+    # bind temporarily (`"127.0.0.1:15002:15002"`), don't
+    # publish on 0.0.0.0.
     networks:
       - app-network
       - spark-internal

--- a/stacks/spark/docker-compose.yml
+++ b/stacks/spark/docker-compose.yml
@@ -27,9 +27,11 @@
 # SECURITY:
 # - Protected by Cloudflare Access (email OTP authentication)
 # - No authentication on Spark itself (relies on Cloudflare Access)
-# - Spark Connect 15002 is exposed to the host but only on the Docker
-#   internal network — Cloudflare Tunnel does NOT route it externally.
-#   Clients reach it via the docker app-network only.
+# - Spark Connect 15002 is NOT published to the host. The
+#   spark-connect service has no `ports:` mapping; clients reach it
+#   only from containers on the Docker app-network (e.g. Marimo at
+#   sc://spark-connect:15002). Cloudflare Tunnel does not route it
+#   externally either.
 # =============================================================================
 
 services:

--- a/stacks/spark/docker-compose.yml
+++ b/stacks/spark/docker-compose.yml
@@ -3,16 +3,23 @@
 # =============================================================================
 # Access via: https://spark.${domain} (Master Web UI)
 # Apache Spark provides a unified analytics engine for large-scale data
-# processing. This stack runs a standalone cluster with one master and one
-# worker node.
+# processing. This stack runs a standalone cluster with one master, one
+# worker, and a Spark Connect server.
 #
-# Jupyter PySpark connects to this cluster via spark://spark-master:7077
+# Two client protocols served in parallel:
+#   - Classic (port 7077): Jupyter connects via spark://spark-master:7077.
+#     Driver-JVM lives in the client (Jupyter container).
+#   - Spark Connect (port 15002): Marimo / code-server / future thin clients
+#     connect via sc://spark-connect:15002. Driver-JVM lives in the
+#     spark-connect container, clients are gRPC-only (no JDK needed).
+#
 # S3 access (Hetzner Object Storage) is pre-configured via Hadoop properties.
 #
 # IMAGE: Custom Dockerfile installs Python 3.13 (from deadsnakes PPA) on the
 # official apache/spark:4.1.1 base (Ubuntu 22.04 + Python 3.10) to match
 # Jupyter's Python version. PySpark requires matching minor versions.
-# Also includes hadoop-aws + AWS SDK v2 JARs for S3A filesystem support.
+# Also includes hadoop-aws + AWS SDK v2 JARs for S3A filesystem support
+# and the Spark Connect server JARs.
 #
 # NOTE: Uses /opt/entrypoint.sh + spark-class to run processes in foreground
 # (not start-master.sh/start-worker.sh which are daemon launchers).
@@ -20,6 +27,9 @@
 # SECURITY:
 # - Protected by Cloudflare Access (email OTP authentication)
 # - No authentication on Spark itself (relies on Cloudflare Access)
+# - Spark Connect 15002 is exposed to the host but only on the Docker
+#   internal network — Cloudflare Tunnel does NOT route it externally.
+#   Clients reach it via the docker app-network only.
 # =============================================================================
 
 services:
@@ -116,6 +126,87 @@ services:
     networks:
       - app-network
       - spark-internal
+
+  # =========================================================================
+  # Spark Connect server — gRPC endpoint on port 15002 for thin clients.
+  # =========================================================================
+  # Runs as its own Spark application: a separate driver-JVM that
+  # connects to spark-master at 7077 to schedule tasks on the worker.
+  # Clients (Marimo, future code-server) talk to it via gRPC (`sc://`)
+  # and never need a JVM or pyspark[full] locally.
+  #
+  # The Connect-server class lives in spark-connect_2.13-4.1.1.jar
+  # which is pre-downloaded into /opt/spark/jars/ by the Dockerfile.
+  # We launch via spark-submit so SparkConf is wired up correctly
+  # (--master, --conf), and the SparkConnectPlugin gets registered.
+  #
+  # Resources: 1.5 GiB driver-heap is plenty — the heavy work happens
+  # on the worker, the Connect server is mostly a gRPC↔Spark adapter.
+  # =========================================================================
+  spark-connect:
+    image: ${IMAGE_SPARK:-nexus-spark:4.1.1-python3.13}
+    container_name: spark-connect
+    hostname: spark-connect
+    restart: unless-stopped
+    depends_on:
+      spark-master:
+        condition: service_healthy
+    environment:
+      # S3 (Hetzner Object Storage) — Connect server is also a Spark
+      # driver and submits jobs that may read s3a:// paths.
+      SPARK_HADOOP_fs_s3a_endpoint: ${HETZNER_S3_ENDPOINT:-}
+      SPARK_HADOOP_fs_s3a_access_key: ${HETZNER_S3_ACCESS_KEY:-}
+      SPARK_HADOOP_fs_s3a_secret_key: ${HETZNER_S3_SECRET_KEY:-}
+      SPARK_HADOOP_fs_s3a_path_style_access: "true"
+      SPARK_HADOOP_fs_s3a_impl: org.apache.hadoop.fs.s3a.S3AFileSystem
+    env_file:
+      - path: .env
+        required: false
+    entrypoint: ["/opt/entrypoint.sh"]
+    command:
+      - /opt/spark/bin/spark-submit
+      - --class
+      - org.apache.spark.sql.connect.service.SparkConnectServer
+      - --master
+      - spark://spark-master:7077
+      - --conf
+      - spark.connect.grpc.binding.host=0.0.0.0
+      - --conf
+      - spark.connect.grpc.binding.port=15002
+      - --conf
+      - spark.driver.host=spark-connect
+      - --name
+      - SparkConnectServer
+      # Positional app jar — provides the SparkConnectServer class.
+      # Pre-downloaded by stacks/spark/Dockerfile to avoid runtime
+      # ivy resolution.
+      - /opt/spark/jars/spark-connect_2.13-4.1.1.jar
+    ports:
+      - "15002:15002"
+    networks:
+      - app-network
+      - spark-internal
+    deploy:
+      resources:
+        limits:
+          cpus: "1"
+          memory: 1536m
+        reservations:
+          cpus: "0.25"
+          memory: 256m
+    healthcheck:
+      # TCP-only — the gRPC port either accepts connections or it
+      # doesn't. A real gRPC health probe would need grpcurl which
+      # isn't in the image; bare TCP is enough to know the JVM is
+      # listening.
+      test: ["CMD-SHELL", "bash -c '(echo > /dev/tcp/localhost/15002) >/dev/null 2>&1'"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      # Generous start_period because the Connect server has to bring
+      # up a full SparkContext + register with master + bind gRPC
+      # before it can accept connections.
+      start_period: 90s
 
 networks:
   app-network:


### PR DESCRIPTION
## Summary

Wires Marimo into the Spark cluster as a thin gRPC client via **Spark Connect** (`sc://spark-connect:15002`), and bundles the Marimo Infisical-secret-sync that closes #497.

Architecture: the master now serves both protocols in parallel — classic `spark://...:7077` (Jupyter, unchanged) and the new Connect endpoint `sc://...:15002` (Marimo today, code-server #496 next). The Connect protocol keeps the driver-JVM server-side in a dedicated `spark-connect` container; clients are gRPC-only (no JDK, no full pyspark). That's the futureproof model — same Connect infrastructure will cover code-server without each client carrying its own JVM.

```
   Marimo container (Python 3.13, no JDK)
      │ pyspark[connect] + Arrow + gRPC
      ▼ sc://spark-connect:15002
   spark-connect container (driver-JVM)
      │ spark://spark-master:7077
      ▼
   spark-master + spark-worker (executors)
```

Existing Jupyter remains on classic 7077 — no regression risk to PRs #495 / #499.

## Changes

### Spark Connect server (cluster side)

- **`stacks/spark/Dockerfile`** — pre-download `spark-connect_2.13-4.1.1.jar` + `spark-connect-common_2.13-4.1.1.jar` into `/opt/spark/jars/`. Same pattern as the existing `hadoop-aws` pre-download. Avoids ~30s ivy resolution on every container boot.
- **`stacks/spark/docker-compose.yml`** — new `spark-connect` service running `org.apache.spark.sql.connect.service.SparkConnectServer` as its own Spark application. Connects to `spark-master:7077` to schedule tasks, exposes 15002. TCP healthcheck (no grpcurl in the image). 1.5 GiB driver heap.

### Marimo client side

- **`stacks/marimo/Dockerfile` (NEW)** — `FROM ghcr.io/marimo-team/marimo:latest-sql`, layers on git (apt-get — Marimo's base is **Debian**, the previous entrypoint's `apk add` was a silent-failure latent bug), `pyspark[connect]==4.1.1`, `ibis-framework[pyspark]==10.5.0`, grpcio + pyarrow. ARM64-verified via `docker manifest inspect`.
- **`stacks/marimo/docker-compose.yml`** — image now `nexus-marimo:latest-sql-spark` (built locally), declares `.infisical.env` as a second `env_file:` (same dedicated-file pattern as Jupyter to avoid `${VAR}`-interpolation collisions), memory limit raised 512m → 1g (Connect client, driver lives elsewhere), `SPARK_CONNECT_URL` + `HETZNER_S3_*` env-vars added, latent `apk` bug removed.
- **`services.yaml`** — `image: nexus-marimo:latest-sql-spark`, description updated.

### Workspace seeds

- **`examples/workspace-seeds/marimo/_nexus_spark.py` (NEW)** — module-level cached `get_spark()` factory: `from _nexus_spark import get_spark; spark = get_spark()`.
- **`examples/workspace-seeds/marimo/Getting_Started_PySpark.py` (NEW)** — seed Marimo notebook demonstrating `createDataFrame`, filter/groupBy, **Spark SQL via Ibis** (`mo.sql(..., engine=ibis.pyspark.connect(spark))`), s3a:// read, and a "Tips & Pitfalls" cell documenting the Stop-button caveat ([marimo-team/marimo#3494](https://github.com/marimo-team/marimo/issues/3494)).
- **`examples/workspace-seeds/marimo/NYC_Taxi_Pipeline.py` (NEW)** — seed Marimo notebook that mirrors the Kestra `r2-taxi-pipeline.yaml` flow: bootstraps NYC TLC Yellow-Taxi 2025 parquets from CloudFront into Hetzner Object Storage via DuckDB httpfs, then runs Spark SQL aggregation across all months. Same data + path shape as the Kestra equivalent — useful side-by-side teaching artefact for "when to reach for Kestra vs Spark".
- **`examples/README.md`** — `marimo/` folder added to the layout tree and table; note that `.ipynb` (Jupyter) and `.py` (Marimo) notebook formats are NOT interchangeable, so they live in separate folders.

### Infisical sync (closes #497)

- **`scripts/deploy.sh`** — new "Sync Infisical secrets into Marimo" block right after the Jupyter one. Near-copy of the Jupyter block (just `jupyter` → `marimo` in the gate, paths, restart command, and `MAR_` instead of `JUP_` for the runner-side variables). All safety guards from PR #495 / #499 review-rounds inherited verbatim: strict-mode heredoc, curl timeouts, jq presence check, two-stage validation per folder, `SUCCEEDED==0` + `PUSHED==0` outage guards, dotenv-quoted+escaped values, atomic mv into a dedicated `.infisical.env`, legacy-`.env` migration deferred to success path, restart-stderr capture, awk over grep|head for pipefail safety, `ssh ... || RC=$?` for set -e safety.

### Documentation

- **`docs/stacks/marimo.md`** — Spark Connect setup, S3A note, Stop-button pitfall, reactivity vs. SparkSession state, memory-limit guidance (bump `spark-connect`, NOT marimo, on OOM).
- **`docs/stacks/spark.md`** — architecture diagram redrawn with both 7077 and 15002 paths, spark-connect resource row added, Connect-vs-Classic decision guidance.

## Test plan

- [ ] **ARM64 verification**: `docker manifest inspect ghcr.io/marimo-team/marimo:latest-sql | grep arm64` — passes (verified pre-build).
- [ ] **Spin-up E2E**: `gh workflow run spin-up.yml --ref feat/marimo-spark-connect -f enabled_services=marimo,spark` — green workflow, all containers healthy:
  ```
  ssh nexus "docker ps --filter name=marimo --filter name=spark --format 'table {{.Names}}\t{{.Status}}'"
  ```
- [ ] **Connect server reachable**: `ssh nexus "docker exec spark-connect bash -c '(echo > /dev/tcp/localhost/15002)' && echo OK"`.
- [ ] **Notebook smoke**: open `https://marimo.<domain>` → `Getting_Started_PySpark.py` → Run All:
  - Cell 2 `df` renders as paginated `mo.ui.table.lazy` (Marimo's PySpark Connect formatter)
  - Cell 4 `mo.sql(...)` via Ibis returns a table
  - No `PYTHON_VERSION_MISMATCH` errors
- [ ] **Infisical sync**: `ssh nexus "docker exec marimo env | grep -E 'R2_|HETZNER_|GITEA_TOKEN'"` shows the expected keys. `ssh nexus "ls -la /opt/docker-server/stacks/marimo/.infisical.env"` — file exists, 600 perms.
- [ ] **Memory sanity**: during a Spark job from Marimo, `docker stats marimo` stays well under 1 GiB; `docker stats spark-connect` shows the JVM heap growing there. Confirms Connect topology.
- [ ] **Jupyter regression**: `https://jupyter.<domain>` — existing notebook on `spark://spark-master:7077` still works.
- [ ] **Idempotency**: run spin-up twice in a row without Infisical changes; 2nd run logs `Wrote N Infisical env-vars` and the marimo container is NOT recreated (compose hash unchanged from sorted block).
- [ ] **Stop-button caveat doc**: `docs/stacks/marimo.md` mentions issue #3494 explicitly.

## Out of scope

- **Jupyter migration to Connect** — Jupyter classic 7077 stays. Master serves both protocols in parallel. Migrating Jupyter would be a separate PR.
- **code-server Spark integration (#496)** — separate PR. Will reuse this same Connect server.
- **Spark Connect TLS / auth** — protected today via Cloudflare Tunnel boundary + Docker internal network. 15002 is not routed externally.

Closes #497.

