### PR TITLE
feat(deploy.sh,seeds): Comprehensive Infisical bootstrap fix + workspace-seeds nexus_seeds/ prefix (closes #501, #503)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -569,7 +569,7 @@ networks:
 
 ### Code Examples (`examples/workspace-seeds/`)
 
-Sample code that ships with Nexus-Stack and gets auto-seeded into every user's Gitea workspace repo on spin-up. **`scripts/deploy.sh` walks `examples/workspace-seeds/` recursively and POSTs each file to the matching path in the workspace repo via Gitea's contents API**, so the on-disk layout under `workspace-seeds/` mirrors the workspace repo 1:1 (`workspace-seeds/kestra/flows/x.yaml` → repo root `kestra/flows/x.yaml`, registered by `system.flow-sync` under namespace `nexus-tutorials`).
+Sample code that ships with Nexus-Stack and gets auto-seeded into every user's Gitea workspace repo on spin-up. **`scripts/deploy.sh` walks `examples/workspace-seeds/` recursively and POSTs each file under the `nexus_seeds/` prefix in the workspace repo via Gitea's contents API**, so `workspace-seeds/kestra/flows/x.yaml` lands at the user repo's `nexus_seeds/kestra/flows/x.yaml`, registered by `system.flow-sync` under namespace `nexus-tutorials`. The `nexus_seeds/` prefix (introduced in #501) keeps Nexus-Stack-managed files visually separated from the user's own course material at the repo root.
 
 When adding or editing seeded examples:
 

--- a/docs/stacks/marimo.md
+++ b/docs/stacks/marimo.md
@@ -44,7 +44,7 @@ The Marimo container is a thin gRPC client — the driver-JVM lives in the dedic
 
 ### Quickstart
 
-A seed notebook ships in every workspace at `marimo/Getting_Started_PySpark.py` (auto-cloned from your Gitea workspace repo on first launch). Open it from `https://marimo.<your-domain>` and hit **Run all**.
+A seed notebook ships in every workspace at `nexus_seeds/marimo/Getting_Started_PySpark.py` (auto-cloned from your Gitea workspace repo on first launch). Open it from `https://marimo.<your-domain>` and hit **Run all**. A second seed notebook `nexus_seeds/marimo/NYC_Taxi_Pipeline.py` shows the bootstrap-to-S3 + Spark-analytics pattern.
 
 The minimal pattern is:
 
@@ -55,7 +55,7 @@ df = spark.createDataFrame([("a", 1), ("b", 2)], ["k", "v"])
 df  # auto-rendered as paginated mo.ui.table.lazy
 ```
 
-The `_nexus_spark` helper (also seeded into the workspace, at `marimo/_nexus_spark.py`) caches a single SparkSession across cells and notebooks within the same Python process — see its docstring for details.
+The `_nexus_spark` helper (also seeded into the workspace, at `nexus_seeds/marimo/_nexus_spark.py`) caches a single SparkSession across cells and notebooks within the same Python process — see its docstring for details.
 
 ### Spark SQL via Ibis
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -32,14 +32,24 @@ examples/workspace-seeds/
 └── sql/                            (when added — DuckDB, Trino, ClickHouse)
 ```
 
-Mapping: every file `examples/workspace-seeds/<path>` is seeded to `<path>` in the workspace Gitea repo (`nexus-<slug>-gitea/<path>`). For example:
+Mapping: every file `examples/workspace-seeds/<path>` is seeded to `nexus_seeds/<path>` in the workspace Gitea repo (`nexus-<slug>-gitea/nexus_seeds/<path>`). For example:
 
-- `examples/workspace-seeds/kestra/flows/r2-taxi-pipeline.yaml` → `nexus-<slug>-gitea/kestra/flows/r2-taxi-pipeline.yaml`
-- `examples/workspace-seeds/notebooks/foo.ipynb` → `nexus-<slug>-gitea/notebooks/foo.ipynb`
+- `examples/workspace-seeds/kestra/flows/r2-taxi-pipeline.yaml` → `nexus-<slug>-gitea/nexus_seeds/kestra/flows/r2-taxi-pipeline.yaml`
+- `examples/workspace-seeds/notebooks/foo.ipynb` → `nexus-<slug>-gitea/nexus_seeds/notebooks/foo.ipynb`
 
-`system.flow-sync` (registered by `deploy.sh`) then syncs `kestra/flows/` into Kestra under target namespace `nexus-tutorials` with `includeChildNamespaces: true` — so `kestra/flows/r2-taxi-pipeline.yaml` lands at `nexus-tutorials.r2-taxi-pipeline`, and any future subdir like `kestra/flows/sub1/foo.yaml` extends to `nexus-tutorials.sub1.foo`.
+The `nexus_seeds/` prefix keeps Nexus-Stack-managed files visually separated from the user's own course material at the workspace-repo root (introduced in #501; pre-existing repos that still have files at the root level continue to work but those files are orphaned — see migration notes below).
 
-This means any file you drop under `workspace-seeds/<dir>/<name>` will appear in every user's workspace at the same `<dir>/<name>` after the next Initial Setup. No `deploy.sh` edit, no new code path.
+`system.flow-sync` (registered by `deploy.sh`) then syncs `nexus_seeds/kestra/flows/` into Kestra under target namespace `nexus-tutorials` with `includeChildNamespaces: true` — so `nexus_seeds/kestra/flows/r2-taxi-pipeline.yaml` lands at `nexus-tutorials.r2-taxi-pipeline`, and any future subdir like `nexus_seeds/kestra/flows/sub1/foo.yaml` extends to `nexus-tutorials.sub1.foo`.
+
+This means any file you drop under `workspace-seeds/<dir>/<name>` will appear in every user's workspace at `nexus_seeds/<dir>/<name>` after the next Initial Setup. No `deploy.sh` edit, no new code path.
+
+### Migration note for pre-#501 workspace repos
+
+Workspace repos created before #501 was merged have seed files at the repo root (`kestra/`, `marimo/`). Those root-level files are NOT auto-deleted on upgrade — `build_folder` (the Gitea seed pusher) is create-only and the migration would risk overwriting user edits. After the upgrade:
+
+- The new seeds appear at `nexus_seeds/<dir>/<file>` (e.g. `nexus_seeds/kestra/flows/r2-taxi-pipeline.yaml`).
+- The old root-level copies become orphaned: Kestra's `system.flow-sync` only scans `nexus_seeds/kestra/flows/` now, and notebook stacks should be updated to look under `nexus_seeds/marimo/` etc.
+- Operators can manually delete the orphaned root-level directories (`kestra/`, `marimo/`) when the team is ready.
 
 ## Subdirectory conventions
 
@@ -52,9 +62,9 @@ Stick to these names so the various services pick the files up correctly:
 
 | Folder | Consumed by | What goes here |
 |---|---|---|
-| `kestra/flows/` | Kestra (via `system.flow-sync`, registered by `deploy.sh`) | Flow definitions in YAML. Files at `kestra/flows/<id>.yaml` register under namespace `nexus-tutorials`; subdirectories extend the namespace (`kestra/flows/sub1/<id>.yaml` → `nexus-tutorials.sub1`). |
+| `kestra/flows/` | Kestra (via `system.flow-sync`, registered by `deploy.sh`) | Flow definitions in YAML. Files at `nexus_seeds/kestra/flows/<id>.yaml` register under namespace `nexus-tutorials`; subdirectories extend the namespace (`nexus_seeds/kestra/flows/sub1/<id>.yaml` → `nexus-tutorials.sub1`). |
 | `kestra/workflows/` | Kestra (via `system.git-sync`, registered by `deploy.sh`) | Helper files referenced by flows: Python scripts, SQL templates, configs. **Not** flow definitions. |
-| `marimo/` | Marimo (cloned from the workspace repo into `/app/notebooks/<repo>/marimo/`) | Marimo notebooks (plain `.py` files using `marimo.App` + `@app.cell`) plus the `_nexus_spark.py` helper that wires `SparkSession.builder.remote("sc://spark-connect:15002")`. Per-stack folder because Marimo's `.py` notebook format is incompatible with Jupyter `.ipynb` and the helper module is Marimo-specific. |
+| `marimo/` | Marimo (cloned from the workspace repo into `/app/notebooks/<repo>/nexus_seeds/marimo/`) | Marimo notebooks (plain `.py` files using `marimo.App` + `@app.cell`) plus the `_nexus_spark.py` helper that wires `SparkSession.builder.remote("sc://spark-connect:15002")`. Per-stack folder because Marimo's `.py` notebook format is incompatible with Jupyter `.ipynb` and the helper module is Marimo-specific. |
 | `notebooks/` | Jupyter, code-server (cloned from the workspace repo) | `.ipynb` notebooks (Jupyter) or `.py` scripts (code-server). NOT for Marimo notebooks — those go in `marimo/`. |
 | `scripts/` | code-server, ad-hoc execution | Shell or Python helpers reused across notebooks. |
 | `dbt/` | code-server, manual `dbt` invocation | A normal dbt project tree (`dbt_project.yml`, `models/`, etc.). |

--- a/examples/README.md
+++ b/examples/README.md
@@ -12,7 +12,7 @@ For now there is only `workspace-seeds/`. If we ever ship reference material tha
 
 ## How `workspace-seeds/` maps to the workspace repo
 
-The directory layout under `workspace-seeds/` mirrors the workspace Gitea repo's root **1:1**. Whatever path a file has under `workspace-seeds/`, that's the path it lands at in the workspace repo:
+The directory layout under `workspace-seeds/` mirrors the **`nexus_seeds/`** subtree of the workspace Gitea repo. Every path you have under `workspace-seeds/<...>` lands at `nexus_seeds/<...>` in the workspace repo (the prefix added in #501 to keep Nexus-Stack-managed files visually separated from user-managed content at the repo root):
 
 Source tree under `examples/workspace-seeds/`:
 

--- a/examples/workspace-seeds/kestra/flows/r2-taxi-pipeline.yaml
+++ b/examples/workspace-seeds/kestra/flows/r2-taxi-pipeline.yaml
@@ -12,12 +12,13 @@ description: |
        endpoint — no compute cluster, no Spark, no warehouse needed.
     3. Log aggregate stats from the result.
 
-  This file was seeded into your Gitea workspace repo from
-  `nexus-stack/examples/workspace-seeds/kestra/flows/r2-taxi-pipeline.yaml`
+  This file was seeded into your Gitea workspace repo at
+  `nexus_seeds/kestra/flows/r2-taxi-pipeline.yaml` (from the
+  Nexus-Stack source `examples/workspace-seeds/kestra/flows/`)
   during Initial Setup. Edit the file in Gitea — Kestra picks up the
-  change within 15 minutes via `system.flow-sync`. Subsequent
-  spin-ups will leave your edits untouched (seeding only adds new
-  files, it never overwrites).
+  change within 15 minutes via `system.flow-sync` (which scans
+  `nexus_seeds/kestra/flows/`). Subsequent spin-ups will leave your
+  edits untouched (seeding only adds new files, it never overwrites).
 
   Want the full year? Extend the `values:` list under `bootstrap`
   to ["01" .. "12"]. The default keeps it light: ~120 MB download

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -2068,6 +2068,20 @@ EOF
 
         # Helper: build folder creation + secrets payload JSON files
         # Usage: build_folder "folder-name" "KEY1" "val1" "KEY2" "val2" ...
+        #
+        # Pairs with an empty value are SKIPPED — neither sent to
+        # Infisical nor included in the upsert payload. This matters
+        # because the API call uses `mode: "upsert"`: passing
+        # KEY="" would overwrite an operator-edited non-empty value
+        # in the Infisical UI with empty, defeating the "user edits
+        # preserved across re-deploys" promise. With the skip, the
+        # caller can pass optional values like `${VAR:-}` without
+        # worrying that an unset VAR will silently wipe a UI-edit.
+        # Net effect: build_folder behaves like create-or-update for
+        # populated values, no-op for empty values. (Note: this
+        # also means rotating a secret to empty in source-of-truth
+        # is NOT propagated — but doing that is a manual operator
+        # action via the UI today, so this trade-off is fine.)
         build_folder() {
             local folder=$1; shift
             # Folder creation payload
@@ -2079,6 +2093,10 @@ EOF
             local jq_filter='{projectId: $pid, environment: $env, secretPath: ("/'"$folder"'"), mode: "upsert", secrets: ['
             local i=0
             while [ $# -ge 2 ]; do
+                if [ -z "$2" ]; then
+                    shift 2
+                    continue
+                fi
                 jq_args+=("--arg" "k$i" "$1" "--arg" "v$i" "$2")
                 [ $i -gt 0 ] && jq_filter+=","
                 jq_filter+='{secretKey: $k'"$i"', secretValue: $v'"$i"'}'

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -2102,13 +2102,34 @@ EOF
                 "R2_BUCKET" "$R2_DATA_BUCKET"
         fi
 
-        if [ -n "$HETZNER_S3_SERVER" ] && [ -n "$HETZNER_S3_ACCESS_KEY" ] && [ -n "$HETZNER_S3_SECRET_KEY" ] && [ -n "$HETZNER_S3_BUCKET_GENERAL" ]; then
+        # Push Hetzner S3 secrets to Infisical whenever credentials are
+        # available, even if not all three bucket names (lakefs, general,
+        # pgducklake) are populated. The previous gate required
+        # $HETZNER_S3_BUCKET_GENERAL — but that's only created when
+        # the control-plane Tofu's `general` bucket resource exists,
+        # which isn't always the case (see #503). Result: notebook
+        # stacks (Marimo via .infisical.env, Jupyter, code-server)
+        # would silently miss all four HETZNER_S3_* env vars even
+        # though the credentials and at least one bucket are
+        # provisioned.
+        # Fallback chain for the canonical HETZNER_S3_BUCKET key
+        # (used by ad-hoc workloads): prefer _general (workloads
+        # bucket by convention), fall back to _lakefs (always
+        # populated when the LakeFS-aware path runs). If neither
+        # is set we still push the rest of the credentials and an
+        # empty HETZNER_S3_BUCKET — the user can override in the
+        # Infisical UI without losing the credentials.
+        if [ -n "$HETZNER_S3_SERVER" ] && [ -n "$HETZNER_S3_ACCESS_KEY" ] && [ -n "$HETZNER_S3_SECRET_KEY" ]; then
+            DEFAULT_HETZNER_BUCKET="${HETZNER_S3_BUCKET_GENERAL:-${HETZNER_S3_BUCKET:-}}"
             build_folder "hetzner-s3" \
                 "HETZNER_S3_ENDPOINT" "https://$HETZNER_S3_SERVER" \
                 "HETZNER_S3_REGION" "$HETZNER_S3_REGION" \
                 "HETZNER_S3_ACCESS_KEY" "$HETZNER_S3_ACCESS_KEY" \
                 "HETZNER_S3_SECRET_KEY" "$HETZNER_S3_SECRET_KEY" \
-                "HETZNER_S3_BUCKET" "$HETZNER_S3_BUCKET_GENERAL"
+                "HETZNER_S3_BUCKET" "$DEFAULT_HETZNER_BUCKET" \
+                "HETZNER_S3_BUCKET_LAKEFS" "${HETZNER_S3_BUCKET:-}" \
+                "HETZNER_S3_BUCKET_GENERAL" "${HETZNER_S3_BUCKET_GENERAL:-}" \
+                "HETZNER_S3_BUCKET_PGDUCKLAKE" "${HETZNER_S3_BUCKET_PGDUCKLAKE:-}"
         fi
 
         if [ -n "$EXTERNAL_S3_ENDPOINT" ] && [ -n "$EXTERNAL_S3_ACCESS_KEY" ] && [ -n "$EXTERNAL_S3_SECRET_KEY" ] && [ -n "$EXTERNAL_S3_BUCKET" ]; then
@@ -3634,7 +3655,19 @@ CFG
             echo "  Seeding workspace files into ${GITEA_REPO_OWNER}/${REPO_NAME}..."
             local SEED_FILE REPO_PATH REPO_PATH_ENC CONTENT_B64 JSON_BODY SEED_STATUS SEED_B64_TMP
             while IFS= read -r -d '' SEED_FILE; do
-                REPO_PATH="${SEED_FILE#$SEED_DIR/}"
+                # Seeds land under `nexus_seeds/<original-path>` in the
+                # workspace repo (#501). E.g., examples/workspace-seeds/
+                # marimo/Getting_Started_PySpark.py → repo's
+                # nexus_seeds/marimo/Getting_Started_PySpark.py. Keeps
+                # Nexus-Stack-managed files visually separated from the
+                # user's own course material at the repo root.
+                # Old root-level paths (`kestra/`, `marimo/`) from
+                # pre-#501 spin-ups become orphaned and can be deleted
+                # by the user — they're harmless because Kestra's
+                # `system.flow-sync` now scans `nexus_seeds/kestra/flows/`
+                # and ignores the old root location. See "Code
+                # Examples" in CLAUDE.md for the full convention.
+                REPO_PATH="nexus_seeds/${SEED_FILE#$SEED_DIR/}"
                 # Defense in depth — restrict to the safe filesystem
                 # subset (ASCII alphanumerics, dot, dash, underscore,
                 # slash). Closes any shell-injection vector if a future
@@ -4278,17 +4311,20 @@ REMOTE_KESTRA_PROBE_EOF
                     #
                     #   - `git-sync` (SyncNamespaceFiles): pulls helper files
                     #     (Python scripts, configs, SQL templates) from the
-                    #     repo's `kestra/workflows/` directory into the
-                    #     namespace's files area — these are NOT flow defs.
+                    #     repo's `nexus_seeds/kestra/workflows/` directory
+                    #     into the namespace's files area — these are NOT
+                    #     flow defs.
                     #
                     #   - `flow-sync` (SyncFlows): pulls flow YAML files from
-                    #     `kestra/flows/` and registers them under namespace
-                    #     `nexus-tutorials`. `targetNamespace: nexus-tutorials` is
-                    #     required by the v1.0 plugin (without it, POST /flows
-                    #     returns 422 "tasks[0].targetNamespace: must not be
-                    #     null"). With `includeChildNamespaces: true`, subdirs
+                    #     `nexus_seeds/kestra/flows/` and registers them under
+                    #     namespace `nexus-tutorials`. `targetNamespace:
+                    #     nexus-tutorials` is required by the v1.0 plugin
+                    #     (without it, POST /flows returns 422
+                    #     "tasks[0].targetNamespace: must not be null").
+                    #     With `includeChildNamespaces: true`, subdirs
                     #     extend the namespace — e.g.
-                    #     `kestra/flows/sub1/foo.yaml` → `nexus-tutorials.sub1`.
+                    #     `nexus_seeds/kestra/flows/sub1/foo.yaml` →
+                    #     `nexus-tutorials.sub1`.
                     #     `delete: true` makes Git the single source of truth
                     #     — UI-only flows get cleaned up on every sync. This
                     #     is the persistence layer that survives destroy-all
@@ -4386,7 +4422,7 @@ tasks:
     username: ${ADMIN_USERNAME}
     password: "{{ secret('\''GITEA_TOKEN'\'') }}"
     namespace: "{{ flow.namespace }}"
-    gitDirectory: kestra/workflows
+    gitDirectory: nexus_seeds/kestra/workflows
 triggers:
   - id: schedule
     type: io.kestra.core.models.triggers.types.Schedule
@@ -4402,7 +4438,7 @@ tasks:
     branch: ${WORKSPACE_BRANCH}
     username: ${ADMIN_USERNAME}
     password: "{{ secret('\''GITEA_TOKEN'\'') }}"
-    gitDirectory: kestra/flows
+    gitDirectory: nexus_seeds/kestra/flows
     targetNamespace: nexus-tutorials
     includeChildNamespaces: true
     delete: true
@@ -4455,7 +4491,7 @@ if [ "\$REGISTER_FAILED" -eq 0 ]; then
                 if [ "\$SEED_FLOW_STATUS" = "200" ]; then
                     echo "    ✓ Seeded flow nexus-tutorials.r2-taxi-pipeline registered in Kestra" >&2
                 else
-                    echo "    ⚠ system.flow-sync ran but nexus-tutorials.r2-taxi-pipeline is not visible (HTTP \$SEED_FLOW_STATUS) — check that kestra/flows/r2-taxi-pipeline.yaml is in the workspace repo and re-execute system.flow-sync from the Kestra UI" >&2
+                    echo "    ⚠ system.flow-sync ran but nexus-tutorials.r2-taxi-pipeline is not visible (HTTP \$SEED_FLOW_STATUS) — check that nexus_seeds/kestra/flows/r2-taxi-pipeline.yaml is in the workspace repo and re-execute system.flow-sync from the Kestra UI" >&2
                 fi
                 ;;
             FAILED|KILLED)

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -2133,10 +2133,18 @@ EOF
         # Fallback chain for the canonical HETZNER_S3_BUCKET key
         # (used by ad-hoc workloads): prefer _general (workloads
         # bucket by convention), fall back to _lakefs (always
-        # populated when the LakeFS-aware path runs). If neither
-        # is set we still push the rest of the credentials and an
-        # empty HETZNER_S3_BUCKET — the user can override in the
-        # Infisical UI without losing the credentials.
+        # populated when the LakeFS-aware path runs).
+        # Empty values from this call are NOT pushed (build_folder
+        # skips empty pairs — see helper definition above). So if
+        # neither _general nor _lakefs is populated, HETZNER_S3_BUCKET
+        # simply WILL NOT exist in Infisical for this run; the
+        # operator can add it via the UI later, and that UI-set
+        # value won't be clobbered on a subsequent spin-up that
+        # also has no source-of-truth value (skip-on-empty preserves
+        # it). Same applies to the explicit per-bucket keys
+        # (_LAKEFS / _GENERAL / _PGDUCKLAKE): they appear in the
+        # Infisical folder only if the corresponding bucket has
+        # actually been provisioned by control-plane Tofu.
         if [ -n "$HETZNER_S3_SERVER" ] && [ -n "$HETZNER_S3_ACCESS_KEY" ] && [ -n "$HETZNER_S3_SECRET_KEY" ]; then
             DEFAULT_HETZNER_BUCKET="${HETZNER_S3_BUCKET_GENERAL:-${HETZNER_S3_BUCKET:-}}"
             build_folder "hetzner-s3" \


### PR DESCRIPTION
## Summary

Two related fixes in one PR — both touch `scripts/deploy.sh`'s seed-and-bootstrap layer, both surfaced during PR #500 testing, and both share the same verification cycle (initial-setup + browser smoke). Bundling them avoids a redundant round-trip through Tofu apply for two adjacent issues.

| Closes | Theme |
|---|---|
| **#503** | Comprehensive Infisical bootstrap — fix for `hetzner-s3` folder being silently skipped |
| **#501** | Workspace-seeds restructure — prefix all seeded paths with `nexus_seeds/` |

## #503 — Infisical hetzner-s3 fix

**Bug:** The existing `build_folder "hetzner-s3"` block (deploy.sh ~line 2105) gated on `$HETZNER_S3_BUCKET_GENERAL` being non-empty. That field is null whenever the control-plane Tofu's `general` bucket resource doesn't materialize — which happens on real installs more often than expected.

**Live evidence (during PR #500 testing):**
- Hetzner S3 credentials were provisioned and showed up in `/opt/docker-server/stacks/spark/.env` (`HETZNER_S3_ENDPOINT/ACCESS_KEY/SECRET_KEY/BUCKET` all populated).
- Yet the Infisical workspace had **no** `hetzner-s3/` folder at all.
- Marimo's `.infisical.env` consequently contained only `GITEA_TOKEN`.
- The NYC_Taxi_Pipeline.py seed notebook's S3 demo cell hit the "skipping S3 demo. Set it via Infisical (key HETZNER_S3_BUCKET) and re-run a spin-up" path — even though the credentials had already been provided as Tofu inputs.

**Fix:**

```diff
- if [ -n "$HETZNER_S3_SERVER" ] && [ -n "$HETZNER_S3_ACCESS_KEY" ] \
-    && [ -n "$HETZNER_S3_SECRET_KEY" ] && [ -n "$HETZNER_S3_BUCKET_GENERAL" ]; then
-     build_folder "hetzner-s3" \
-         "HETZNER_S3_ENDPOINT" "https://$HETZNER_S3_SERVER" \
-         ...
-         "HETZNER_S3_BUCKET" "$HETZNER_S3_BUCKET_GENERAL"
- fi
+ if [ -n "$HETZNER_S3_SERVER" ] && [ -n "$HETZNER_S3_ACCESS_KEY" ] \
+    && [ -n "$HETZNER_S3_SECRET_KEY" ]; then
+     DEFAULT_HETZNER_BUCKET="${HETZNER_S3_BUCKET_GENERAL:-${HETZNER_S3_BUCKET:-}}"
+     build_folder "hetzner-s3" \
+         "HETZNER_S3_ENDPOINT" "https://$HETZNER_S3_SERVER" \
+         "HETZNER_S3_REGION" "$HETZNER_S3_REGION" \
+         "HETZNER_S3_ACCESS_KEY" "$HETZNER_S3_ACCESS_KEY" \
+         "HETZNER_S3_SECRET_KEY" "$HETZNER_S3_SECRET_KEY" \
+         "HETZNER_S3_BUCKET"          "$DEFAULT_HETZNER_BUCKET" \
+         "HETZNER_S3_BUCKET_LAKEFS"   "${HETZNER_S3_BUCKET:-}" \
+         "HETZNER_S3_BUCKET_GENERAL"  "${HETZNER_S3_BUCKET_GENERAL:-}" \
+         "HETZNER_S3_BUCKET_PGDUCKLAKE" "${HETZNER_S3_BUCKET_PGDUCKLAKE:-}"
+ fi
```

Two improvements:
1. Gate relaxed: only requires the credentials (`SERVER + ACCESS_KEY + SECRET_KEY`). Bucket fields populate the canonical `HETZNER_S3_BUCKET` via fallback chain (`_general` → `_lakefs` → empty), so a missing `_general` bucket no longer blocks the entire bootstrap.
2. Three explicit bucket-by-name keys exposed (`_LAKEFS`, `_GENERAL`, `_PGDUCKLAKE`) so consumers that need a specific bucket can grab it directly without indirection through the canonical `HETZNER_S3_BUCKET`.

## #501 — Workspace-seeds `nexus_seeds/` prefix

**Visual problem (post-PR #500 reality):**

```
Bsc_EDS_GIS_FS2026_stefan_koch/
├── cheatsheets/        ← user
├── databricks/         ← user
├── kestra/             ← seed
├── marimo/             ← seed (NEW from PR #500)
├── week02/ ... week10/ ← user
├── .gitignore
└── README.md
```

User-managed and Nexus-Stack-managed content visually indistinguishable at the repo root. Got worse with each new seed type added.

**Fix (one-liner in the seed loop):**

```diff
- REPO_PATH="${SEED_FILE#$SEED_DIR/}"
+ REPO_PATH="nexus_seeds/${SEED_FILE#$SEED_DIR/}"
```

Result:

```
Bsc_EDS_GIS_FS2026_stefan_koch/
├── cheatsheets/         ← user
├── databricks/          ← user
├── nexus_seeds/         ← Nexus-Stack-managed (read-only-by-convention)
│   ├── kestra/flows/r2-taxi-pipeline.yaml
│   └── marimo/
│       ├── _nexus_spark.py
│       ├── Getting_Started_PySpark.py
│       └── NYC_Taxi_Pipeline.py
├── week02/ ... week10/  ← user
├── .gitignore
└── README.md
```

**Knock-on changes:**

- `system.flow-sync` Kestra flow's `gitDirectory: kestra/flows` → `nexus_seeds/kestra/flows`
- `system.git-sync` Kestra flow's `gitDirectory: kestra/workflows` → `nexus_seeds/kestra/workflows`
- Updated error messages + inline comments referencing the new path
- `CLAUDE.md` "Code Examples" section: path convention rewritten
- `examples/README.md`: layout-mapping section + per-folder table updated, **migration note added** for pre-#501 repos
- `docs/stacks/marimo.md`: seed-notebook locations now `nexus_seeds/marimo/...`
- `r2-taxi-pipeline.yaml`'s own self-describing comment updated

## Migration strategy (#501 transition)

NOT auto-migrated. Seed loop is create-only (HTTP POST → 422 SKIPPED for existing files), so legacy root-level files (`kestra/`, `marimo/` from pre-#501 spin-ups) remain untouched in user workspaces. After this PR:

- New seeds appear at `nexus_seeds/<dir>/<file>`.
- Kestra's `system.flow-sync` and `system.git-sync` now scan ONLY the new `nexus_seeds/` paths — old root-level Kestra files become orphaned (still in the repo, but Kestra ignores them).
- Operators delete the orphaned root-level dirs manually when ready.

Auto-migration with content-comparison was considered but rejected: the cost of a wrong delete (user edited the seed → lost changes) outweighs the benefit of clean automatic cleanup, given that the legacy files are harmless if left in place. `examples/README.md` documents the manual cleanup explicitly.

## Test plan

- [ ] **Initial-setup E2E** on a fresh state: `gh workflow run initial-setup.yaml --ref feat/infisical-bootstrap-and-seeds-restructure -f enabled_services=spark,marimo,sftpgo`
- [ ] **#503 verification** — `hetzner-s3` folder appears in Infisical with all 4+3 keys (`HETZNER_S3_ENDPOINT`, `_REGION`, `_ACCESS_KEY`, `_SECRET_KEY`, `_BUCKET`, `_BUCKET_LAKEFS`, `_BUCKET_GENERAL`, `_BUCKET_PGDUCKLAKE`):
  ```bash
  ssh nexus "docker exec marimo env | grep -E '^HETZNER_S3_' | sort"
  ```
  At minimum `HETZNER_S3_ENDPOINT`, `_REGION`, `_ACCESS_KEY`, `_SECRET_KEY` should be present and non-empty. The bucket fields (`HETZNER_S3_BUCKET`, `_LAKEFS`, `_GENERAL`, `_PGDUCKLAKE`) appear ONLY for buckets that control-plane Tofu actually provisioned — `build_folder` skips empty values (Round-1 review fix), so an absent key = unconfigured bucket, NOT a sync error. Operators can add missing keys via the Infisical UI; subsequent spin-ups won't clobber UI-set values (skip-on-empty preserves them).
- [ ] **#501 verification** — workspace repo's file tree:
  ```bash
  ssh nexus "GTOK=...; docker exec gitea curl -sS -H 'Authorization: token \$GTOK' \
    'http://localhost:3000/api/v1/repos/<owner>/<repo>/git/trees/main?recursive=true' | \
    jq -r '.tree[].path' | grep -E '^(kestra|marimo|nexus_seeds)/'"
  ```
  Should show `nexus_seeds/kestra/...`, `nexus_seeds/marimo/...` paths.
- [ ] **Kestra `system.flow-sync` runs successfully** — flow `nexus-tutorials.r2-taxi-pipeline` registers under namespace `nexus-tutorials`, deploy.sh's verification step prints `✓ Seeded flow ... registered in Kestra`.
- [ ] **NYC_Taxi_Pipeline.py end-to-end** — open `https://marimo.<domain>` → navigate `nexus_seeds/marimo/NYC_Taxi_Pipeline.py` → Run All. The S3 bootstrap cell should:
  - Find all 4 `HETZNER_S3_*` env vars populated (no "missing env vars" warning)
  - Run the DuckDB → S3 transfer for both Jan + Feb 2025
  - Spark read-back + SQL aggregation render as paginated tables
- [ ] **Idempotency** — second spin-up doesn't recreate marimo (`.infisical.env` content unchanged → compose hash matches → no recreate).

## Out of scope

- Auto-migration of legacy root-level files in pre-#501 repos (rejected, see "Migration strategy" above)
- Adding new Infisical folder types beyond what's already there (`gitea`, `postgres`, `r2-datalake`, `external-s3`, `hetzner-s3`, ~25 others — already comprehensive)
- code-server Spark integration (#496) — separate PR, will benefit from #503 when it lands

