### PR TITLE
feat(nexus_deploy): Phase 1 Modul 1.1 — infisical.py replaces 39 build_folder calls

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -2011,7 +2011,21 @@ EOF
         # nexus_deploy's BootstrapEnv treats the empty value as "no
         # ssh folder".
         SSH_KEY_BASE64=$(printf '%s' "${SSH_PRIVATE_KEY_CONTENT:-}" | base64 | tr -d '\n')
-        if ! printf '%s' "$SECRETS_JSON" | \
+        # Capture exit code instead of `if !` so we can distinguish
+        # nexus_deploy's three exit modes:
+        #   0 = success, all folders pushed
+        #   1 = partial — bootstrap completed but some folders reported
+        #       errors. Operator-fixable via the Infisical UI; we warn
+        #       and continue so the rest of the spin-up proceeds.
+        #   2 = hard failure (input validation, rsync/ssh transport,
+        #       missing uv, unexpected exception). Abort the deploy
+        #       — continuing here would push stale Infisical state to
+        #       services that read from it later in the spin-up.
+        # The `|| INFISICAL_RC=$?` form avoids tripping `set -e` on a
+        # non-zero return; the explicit case statement decides what
+        # to do with each code.
+        INFISICAL_RC=0
+        printf '%s' "$SECRETS_JSON" | \
             PROJECT_ID="$PROJECT_ID" \
             INFISICAL_TOKEN="$INFISICAL_TOKEN" \
             INFISICAL_ENV="$INFISICAL_ENV" \
@@ -2025,9 +2039,13 @@ EOF
             WOODPECKER_GITEA_CLIENT="${WOODPECKER_GITEA_CLIENT:-}" \
             WOODPECKER_GITEA_SECRET="${WOODPECKER_GITEA_SECRET:-}" \
             SSH_KEY_BASE64="$SSH_KEY_BASE64" \
-            uv run --quiet --project "$PROJECT_ROOT" python -m nexus_deploy infisical bootstrap; then
-            echo -e "${YELLOW}  ⚠ Infisical bootstrap reported failures (see output above)${NC}"
-        fi
+            uv run --quiet --project "$PROJECT_ROOT" python -m nexus_deploy infisical bootstrap \
+            || INFISICAL_RC=$?
+        case "$INFISICAL_RC" in
+            0) ;;
+            1) echo -e "${YELLOW}  ⚠ Infisical bootstrap had partial push failures (see output above)${NC}" ;;
+            *) echo -e "${RED}  ✗ Infisical bootstrap transport failure (rc=$INFISICAL_RC); aborting${NC}"; exit 1 ;;
+        esac
     fi
     fi  # End of INFISICAL_READY check
 fi

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1996,7 +1996,7 @@ EOF
     # ==========================================================================
     # Push secrets to Infisical (#505 Modul 1.1: nexus_deploy.infisical)
     # ==========================================================================
-    # The legacy build_folder helper + 41 callers + rsync + curl-loop
+    # The legacy build_folder helper + 39 callers + rsync + curl-loop
     # push (~395 lines of bash) lived here. Phase-1 strangler-fig:
     # deploy.sh now pipes SECRETS_JSON into `python -m nexus_deploy
     # infisical bootstrap`, which builds the same JSON payloads,
@@ -2006,11 +2006,18 @@ EOF
     if [ -n "$INFISICAL_TOKEN" ] && [ -n "$PROJECT_ID" ]; then
         echo "  Pushing secrets to Infisical (via nexus_deploy)..."
         INFISICAL_ENV="${INFISICAL_ENV:-dev}"
-        # SSH_KEY_BASE64 is the same base64-encoded key the legacy
-        # build_folder "ssh" call used. Empty when no key is configured;
-        # nexus_deploy's BootstrapEnv treats the empty value as "no
-        # ssh folder".
-        SSH_KEY_BASE64=$(printf '%s' "${SSH_PRIVATE_KEY_CONTENT:-}" | base64 | tr -d '\n')
+        # SSH_KEY_BASE64 must match the legacy `build_folder "ssh"`
+        # encoding byte-for-byte: ``echo "$X" | base64`` (NOT
+        # ``printf '%s'``). echo appends a trailing newline before
+        # the pipe, so the legacy bytes are base64(<key>+\n);
+        # printf '%s' would encode the key without that newline,
+        # producing a different (shorter) SSH_PRIVATE_KEY_BASE64
+        # value pushed to Infisical. The trailing-newline difference
+        # would silently change what consumers like jupyter/marimo
+        # see when they decode the key. Empty when no key is
+        # configured; nexus_deploy's BootstrapEnv treats the empty
+        # value as "no ssh folder".
+        SSH_KEY_BASE64=$(echo "${SSH_PRIVATE_KEY_CONTENT:-}" | base64 | tr -d '\n')
         # Capture exit code instead of `if !` so we can distinguish
         # nexus_deploy's three exit modes:
         #   0 = success, all folders pushed

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -2009,15 +2009,21 @@ EOF
         # SSH_KEY_BASE64 must match the legacy `build_folder "ssh"`
         # encoding byte-for-byte: ``echo "$X" | base64`` (NOT
         # ``printf '%s'``). echo appends a trailing newline before
-        # the pipe, so the legacy bytes are base64(<key>+\n);
-        # printf '%s' would encode the key without that newline,
-        # producing a different (shorter) SSH_PRIVATE_KEY_BASE64
-        # value pushed to Infisical. The trailing-newline difference
-        # would silently change what consumers like jupyter/marimo
-        # see when they decode the key. Empty when no key is
-        # configured; nexus_deploy's BootstrapEnv treats the empty
-        # value as "no ssh folder".
-        SSH_KEY_BASE64=$(echo "${SSH_PRIVATE_KEY_CONTENT:-}" | base64 | tr -d '\n')
+        # the pipe, so the legacy bytes are base64(<key>+\n).
+        #
+        # Critically guarded on `[ -n "$SSH_PRIVATE_KEY_CONTENT" ]`:
+        # the legacy `build_folder "ssh"` was inside an `if [ -n …]`
+        # block (deploy.sh:2335 pre-migration), so when the key is
+        # unset, the "ssh" folder isn't pushed at all — preserving
+        # any operator-managed key already in Infisical. Without
+        # this guard, ``echo "" | base64`` produces ``Cg==`` (base64
+        # of a single newline), which BootstrapEnv would treat as a
+        # populated key and overwrite the operator's value.
+        if [ -n "${SSH_PRIVATE_KEY_CONTENT:-}" ]; then
+            SSH_KEY_BASE64=$(echo "$SSH_PRIVATE_KEY_CONTENT" | base64 | tr -d '\n')
+        else
+            SSH_KEY_BASE64=""
+        fi
         # Capture exit code instead of `if !` so we can distinguish
         # nexus_deploy's three exit modes:
         #   0 = success, all folders pushed

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1994,351 +1994,39 @@ EOF
     fi
 
     # ==========================================================================
-    # Push secrets to Infisical (folder-based, idempotent via upsert)
+    # Push secrets to Infisical (#505 Modul 1.1: nexus_deploy.infisical)
     # ==========================================================================
+    # The legacy build_folder helper + 41 callers + rsync + curl-loop
+    # push (~395 lines of bash) lived here. Phase-1 strangler-fig:
+    # deploy.sh now pipes SECRETS_JSON into `python -m nexus_deploy
+    # infisical bootstrap`, which builds the same JSON payloads,
+    # rsyncs them, and runs the same server-side curl loop. The
+    # remaining BootstrapEnv fields (DOMAIN, ADMIN_EMAIL, GITEA_*,
+    # WOODPECKER_*, etc.) are passed as env vars to the Python side.
     if [ -n "$INFISICAL_TOKEN" ] && [ -n "$PROJECT_ID" ]; then
-        echo "  Pushing secrets to Infisical (folder-based)..."
+        echo "  Pushing secrets to Infisical (via nexus_deploy)..."
         INFISICAL_ENV="${INFISICAL_ENV:-dev}"
-        PUSH_DIR="/tmp/infisical-push"
-        mkdir -p "$PUSH_DIR"
-
-        # Helper: build folder creation + secrets payload JSON files
-        # Usage: build_folder "folder-name" "KEY1" "val1" "KEY2" "val2" ...
-        #
-        # Pairs with an empty value are SKIPPED — neither sent to
-        # Infisical nor included in the upsert payload. This matters
-        # because the API call uses `mode: "upsert"`: passing
-        # KEY="" would overwrite an operator-edited non-empty value
-        # in the Infisical UI with empty, defeating the "user edits
-        # preserved across re-deploys" promise. With the skip, the
-        # caller can pass optional values like `${VAR:-}` without
-        # worrying that an unset VAR will silently wipe a UI-edit.
-        # Net effect: build_folder behaves like create-or-update for
-        # populated values, no-op for empty values. (Note: this
-        # also means rotating a secret to empty in source-of-truth
-        # is NOT propagated — but doing that is a manual operator
-        # action via the UI today, so this trade-off is fine.)
-        build_folder() {
-            local folder=$1; shift
-            # Folder creation payload
-            jq -n --arg pid "$PROJECT_ID" --arg env "$INFISICAL_ENV" --arg name "$folder" \
-                '{projectId: $pid, environment: $env, name: $name, path: "/"}' \
-                > "$PUSH_DIR/f-$folder.json"
-            # Secrets payload with upsert
-            local jq_args=("--arg" "pid" "$PROJECT_ID" "--arg" "env" "$INFISICAL_ENV")
-            local jq_filter='{projectId: $pid, environment: $env, secretPath: ("/'"$folder"'"), mode: "upsert", secrets: ['
-            local i=0
-            while [ $# -ge 2 ]; do
-                if [ -z "$2" ]; then
-                    shift 2
-                    continue
-                fi
-                jq_args+=("--arg" "k$i" "$1" "--arg" "v$i" "$2")
-                [ $i -gt 0 ] && jq_filter+=","
-                jq_filter+='{secretKey: $k'"$i"', secretValue: $v'"$i"'}'
-                shift 2; i=$((i+1))
-            done
-            jq_filter+=']}'
-            jq -n "${jq_args[@]}" "$jq_filter" > "$PUSH_DIR/s-$folder.json"
-        }
-
-        # Build payloads for each folder
-        build_folder "config" \
-            "DOMAIN" "$DOMAIN" \
-            "ADMIN_EMAIL" "$ADMIN_EMAIL" \
-            "ADMIN_USERNAME" "$ADMIN_USERNAME"
-
-        if [ -n "$R2_DATA_ENDPOINT" ] && [ -n "$R2_DATA_ACCESS_KEY" ] && [ -n "$R2_DATA_SECRET_KEY" ] && [ -n "$R2_DATA_BUCKET" ]; then
-            build_folder "r2-datalake" \
-                "R2_ENDPOINT" "$R2_DATA_ENDPOINT" \
-                "R2_ACCESS_KEY" "$R2_DATA_ACCESS_KEY" \
-                "R2_SECRET_KEY" "$R2_DATA_SECRET_KEY" \
-                "R2_BUCKET" "$R2_DATA_BUCKET"
-        fi
-
-        # Push Hetzner S3 secrets to Infisical whenever credentials are
-        # available, even if not all three bucket names (lakefs, general,
-        # pgducklake) are populated. The previous gate required
-        # $HETZNER_S3_BUCKET_GENERAL — but that's only created when
-        # the control-plane Tofu's `general` bucket resource exists,
-        # which isn't always the case (see #503). Result: notebook
-        # stacks (Marimo via .infisical.env, Jupyter, code-server)
-        # would silently miss all four HETZNER_S3_* env vars even
-        # though the credentials and at least one bucket are
-        # provisioned.
-        # Fallback chain for the canonical HETZNER_S3_BUCKET key
-        # (used by ad-hoc workloads): prefer _general (workloads
-        # bucket by convention), fall back to _lakefs (always
-        # populated when the LakeFS-aware path runs).
-        # Empty values from this call are NOT pushed (build_folder
-        # skips empty pairs — see helper definition above). So if
-        # neither _general nor _lakefs is populated, HETZNER_S3_BUCKET
-        # simply WILL NOT exist in Infisical for this run; the
-        # operator can add it via the UI later, and that UI-set
-        # value won't be clobbered on a subsequent spin-up that
-        # also has no source-of-truth value (skip-on-empty preserves
-        # it). Same applies to the explicit per-bucket keys
-        # (_LAKEFS / _GENERAL / _PGDUCKLAKE): they appear in the
-        # Infisical folder only if the corresponding bucket has
-        # actually been provisioned by control-plane Tofu.
-        if [ -n "$HETZNER_S3_SERVER" ] && [ -n "$HETZNER_S3_ACCESS_KEY" ] && [ -n "$HETZNER_S3_SECRET_KEY" ]; then
-            DEFAULT_HETZNER_BUCKET="${HETZNER_S3_BUCKET_GENERAL:-${HETZNER_S3_BUCKET:-}}"
-            build_folder "hetzner-s3" \
-                "HETZNER_S3_ENDPOINT" "https://$HETZNER_S3_SERVER" \
-                "HETZNER_S3_REGION" "$HETZNER_S3_REGION" \
-                "HETZNER_S3_ACCESS_KEY" "$HETZNER_S3_ACCESS_KEY" \
-                "HETZNER_S3_SECRET_KEY" "$HETZNER_S3_SECRET_KEY" \
-                "HETZNER_S3_BUCKET" "$DEFAULT_HETZNER_BUCKET" \
-                "HETZNER_S3_BUCKET_LAKEFS" "${HETZNER_S3_BUCKET:-}" \
-                "HETZNER_S3_BUCKET_GENERAL" "${HETZNER_S3_BUCKET_GENERAL:-}" \
-                "HETZNER_S3_BUCKET_PGDUCKLAKE" "${HETZNER_S3_BUCKET_PGDUCKLAKE:-}"
-        fi
-
-        if [ -n "$EXTERNAL_S3_ENDPOINT" ] && [ -n "$EXTERNAL_S3_ACCESS_KEY" ] && [ -n "$EXTERNAL_S3_SECRET_KEY" ] && [ -n "$EXTERNAL_S3_BUCKET" ]; then
-            build_folder "external-s3" \
-                "EXTERNAL_S3_ENDPOINT" "$EXTERNAL_S3_ENDPOINT" \
-                "EXTERNAL_S3_REGION" "$EXTERNAL_S3_REGION" \
-                "EXTERNAL_S3_ACCESS_KEY" "$EXTERNAL_S3_ACCESS_KEY" \
-                "EXTERNAL_S3_SECRET_KEY" "$EXTERNAL_S3_SECRET_KEY" \
-                "EXTERNAL_S3_BUCKET" "$EXTERNAL_S3_BUCKET" \
-                "EXTERNAL_S3_LABEL" "$EXTERNAL_S3_LABEL"
-        fi
-
-        build_folder "infisical" \
-            "INFISICAL_USERNAME" "$ADMIN_EMAIL" \
-            "INFISICAL_PASSWORD" "$INFISICAL_PASS"
-
-        build_folder "portainer" \
-            "PORTAINER_USERNAME" "$ADMIN_USERNAME" \
-            "PORTAINER_PASSWORD" "$PORTAINER_PASS"
-
-        build_folder "uptime-kuma" \
-            "UPTIME_KUMA_USERNAME" "$ADMIN_USERNAME" \
-            "UPTIME_KUMA_PASSWORD" "$KUMA_PASS"
-
-        build_folder "grafana" \
-            "GRAFANA_USERNAME" "$ADMIN_USERNAME" \
-            "GRAFANA_PASSWORD" "$GRAFANA_PASS"
-
-        build_folder "n8n" \
-            "N8N_USERNAME" "$ADMIN_EMAIL" \
-            "N8N_PASSWORD" "$N8N_PASS"
-
-        build_folder "dagster" \
-            "DAGSTER_DB_PASSWORD" "$DAGSTER_DB_PASS"
-
-        build_folder "kestra" \
-            "KESTRA_USERNAME" "$ADMIN_EMAIL" \
-            "KESTRA_PASSWORD" "$KESTRA_PASS"
-
-        build_folder "metabase" \
-            "METABASE_USERNAME" "$ADMIN_EMAIL" \
-            "METABASE_PASSWORD" "$METABASE_PASS"
-
-        build_folder "superset" \
-            "SUPERSET_USERNAME" "admin" \
-            "SUPERSET_PASSWORD" "$SUPERSET_PASS" \
-            "SUPERSET_DB_PASSWORD" "$SUPERSET_DB_PASS" \
-            "SUPERSET_SECRET_KEY" "$SUPERSET_SECRET"
-
-        build_folder "cloudbeaver" \
-            "CLOUDBEAVER_USERNAME" "nexus-cloudbeaver" \
-            "CLOUDBEAVER_PASSWORD" "$CLOUDBEAVER_PASS"
-
-        build_folder "mage" \
-            "MAGE_USERNAME" "${GITEA_USER_EMAIL:-$ADMIN_EMAIL}" \
-            "MAGE_PASSWORD" "$MAGE_PASS"
-
-        build_folder "minio" \
-            "MINIO_ROOT_USER" "nexus-minio" \
-            "MINIO_ROOT_PASSWORD" "$MINIO_ROOT_PASS"
-
-        # SFTPGo: admin (web UI / REST API) + nexus-default (SFTP login).
-        # SFTPGO_USER_PASSWORD is also synced to Kestra's secret store
-        # so flows can reference it via {{ secret('SFTPGO_USER_PASSWORD') }}.
-        build_folder "sftpgo" \
-            "SFTPGO_ADMIN_USERNAME" "nexus-sftpgo" \
-            "SFTPGO_ADMIN_PASSWORD" "$SFTPGO_ADMIN_PASS" \
-            "SFTPGO_USER_USERNAME" "nexus-default" \
-            "SFTPGO_USER_PASSWORD" "$SFTPGO_USER_PASS"
-
-        build_folder "nocodb" \
-            "NOCODB_USERNAME" "$ADMIN_EMAIL" \
-            "NOCODB_PASSWORD" "$NOCODB_ADMIN_PASS" \
-            "NOCODB_DB_PASSWORD" "$NOCODB_DB_PASS" \
-            "NOCODB_JWT_SECRET" "$NOCODB_JWT_SECRET"
-
-        build_folder "appsmith" \
-            "APPSMITH_ENCRYPTION_PASSWORD" "$APPSMITH_ENCRYPTION_PASSWORD" \
-            "APPSMITH_ENCRYPTION_SALT" "$APPSMITH_ENCRYPTION_SALT"
-
-        build_folder "dinky" \
-            "DINKY_USERNAME" "admin" \
-            "DINKY_PASSWORD" "$DINKY_ADMIN_PASS"
-
-        build_folder "dify" \
-            "DIFY_USERNAME" "$ADMIN_EMAIL" \
-            "DIFY_PASSWORD" "$DIFY_ADMIN_PASS" \
-            "DIFY_DB_PASSWORD" "$DIFY_DB_PASS" \
-            "DIFY_SECRET_KEY" "$DIFY_SECRET_KEY" \
-            "DIFY_REDIS_PASSWORD" "$DIFY_REDIS_PASS" \
-            "DIFY_WEAVIATE_API_KEY" "$DIFY_WEAVIATE_API_KEY" \
-            "DIFY_SANDBOX_API_KEY" "$DIFY_SANDBOX_API_KEY" \
-            "DIFY_PLUGIN_DAEMON_KEY" "$DIFY_PLUGIN_DAEMON_KEY" \
-            "DIFY_PLUGIN_INNER_API_KEY" "$DIFY_PLUGIN_INNER_API_KEY"
-
-        build_folder "rustfs" \
-            "RUSTFS_ACCESS_KEY" "nexus-rustfs" \
-            "RUSTFS_SECRET_KEY" "$RUSTFS_ROOT_PASS"
-
-        build_folder "seaweedfs" \
-            "SEAWEEDFS_ACCESS_KEY" "nexus-seaweedfs" \
-            "SEAWEEDFS_SECRET_KEY" "$SEAWEEDFS_ADMIN_PASS"
-
-        build_folder "garage" \
-            "GARAGE_ADMIN_TOKEN" "$GARAGE_ADMIN_TOKEN"
-
-        build_folder "lakefs" \
-            "LAKEFS_DB_PASSWORD" "$LAKEFS_DB_PASS" \
-            "LAKEFS_ACCESS_KEY_ID" "$LAKEFS_ADMIN_ACCESS_KEY" \
-            "LAKEFS_SECRET_ACCESS_KEY" "$LAKEFS_ADMIN_SECRET_KEY"
-
-        build_folder "filestash" \
-            "FILESTASH_S3_BUCKET" "$HETZNER_S3_BUCKET_GENERAL" \
-            "FILESTASH_ADMIN_PASSWORD" "$FILESTASH_ADMIN_PASSWORD"
-
-        build_folder "redpanda" \
-            "REDPANDA_SASL_USERNAME" "nexus-redpanda" \
-            "REDPANDA_SASL_PASSWORD" "$REDPANDA_ADMIN_PASS" \
-            "REDPANDA_KAFKA_PUBLIC_URL" "redpanda-kafka.${DOMAIN}:9092" \
-            "REDPANDA_SCHEMA_REGISTRY_PUBLIC_URL" "redpanda-schema-registry.${DOMAIN}:18081" \
-            "REDPANDA_ADMIN_PUBLIC_URL" "redpanda-admin.${DOMAIN}:9644" \
-            "REDPANDA_CONNECT_PUBLIC_URL" "redpanda-connect-api.${DOMAIN}:4195"
-
-        build_folder "meltano" \
-            "MELTANO_DB_PASSWORD" "$MELTANO_DB_PASS"
-
-        build_folder "postgres" \
-            "POSTGRES_USERNAME" "nexus-postgres" \
-            "POSTGRES_PASSWORD" "$POSTGRES_PASS"
-
-        build_folder "pg-ducklake" \
-            "PG_DUCKLAKE_USERNAME" "nexus-pgducklake" \
-            "PG_DUCKLAKE_PASSWORD" "$PG_DUCKLAKE_PASS" \
-            "PG_DUCKLAKE_DATABASE" "ducklake" \
-            "PG_DUCKLAKE_S3_BUCKET" "$HETZNER_S3_BUCKET_PGDUCKLAKE"
-
-        build_folder "pgadmin" \
-            "PGADMIN_USERNAME" "$ADMIN_EMAIL" \
-            "PGADMIN_PASSWORD" "$PGADMIN_PASS"
-
-        build_folder "prefect" \
-            "PREFECT_DB_PASSWORD" "$PREFECT_DB_PASS"
-
-        build_folder "windmill" \
-            "WINDMILL_ADMIN_EMAIL" "$ADMIN_EMAIL" \
-            "WINDMILL_ADMIN_PASSWORD" "$WINDMILL_ADMIN_PASS" \
-            "WINDMILL_DB_PASSWORD" "$WINDMILL_DB_PASS" \
-            "WINDMILL_SUPERADMIN_SECRET" "$WINDMILL_SUPERADMIN_SECRET"
-
-        build_folder "openmetadata" \
-            "OPENMETADATA_USERNAME" "admin@$OM_PRINCIPAL_DOMAIN" \
-            "OPENMETADATA_PASSWORD" "$OPENMETADATA_ADMIN_PASS" \
-            "OPENMETADATA_DB_PASSWORD" "$OPENMETADATA_DB_PASS"
-
-        build_folder "gitea" \
-            "GITEA_ADMIN_USERNAME" "$ADMIN_USERNAME" \
-            "GITEA_ADMIN_PASSWORD" "$GITEA_ADMIN_PASS" \
-            "GITEA_USER_USERNAME" "$GITEA_USER_USERNAME" \
-            "GITEA_USER_PASSWORD" "$GITEA_USER_PASS" \
-            "GITEA_REPO_URL" "https://git.${DOMAIN}/${GITEA_REPO_OWNER:-$ADMIN_USERNAME}/${REPO_NAME:-nexus-${DOMAIN//./-}-gitea}.git" \
-            "GITEA_DB_PASSWORD" "$GITEA_DB_PASS"
-
-        build_folder "clickhouse" \
-            "CLICKHOUSE_USERNAME" "nexus-clickhouse" \
-            "CLICKHOUSE_PASSWORD" "$CLICKHOUSE_ADMIN_PASS"
-
-        build_folder "wikijs" \
-            "WIKIJS_USERNAME" "${GITEA_USER_EMAIL:-$ADMIN_EMAIL}" \
-            "WIKIJS_PASSWORD" "$WIKIJS_ADMIN_PASS" \
-            "WIKIJS_DB_PASSWORD" "$WIKIJS_DB_PASS"
-
-        # Woodpecker (with optional Gitea OAuth secrets)
-        WOODPECKER_ARGS=("WOODPECKER_AGENT_SECRET" "$WOODPECKER_AGENT_SECRET")
-        [ -n "${WOODPECKER_GITEA_CLIENT:-}" ] && WOODPECKER_ARGS+=("WOODPECKER_GITEA_CLIENT" "$WOODPECKER_GITEA_CLIENT")
-        [ -n "${WOODPECKER_GITEA_SECRET:-}" ] && WOODPECKER_ARGS+=("WOODPECKER_GITEA_SECRET" "$WOODPECKER_GITEA_SECRET")
-        build_folder "woodpecker" "${WOODPECKER_ARGS[@]}"
-
-        # SSH (optional)
-        if [ -n "${SSH_PRIVATE_KEY_CONTENT:-}" ]; then
-            SSH_KEY_BASE64=$(echo "$SSH_PRIVATE_KEY_CONTENT" | base64 | tr -d '\n')
-            build_folder "ssh" "SSH_PRIVATE_KEY_BASE64" "$SSH_KEY_BASE64"
-        fi
-
-        # Upload all payloads to server and process
-        rsync -aq --delete "$PUSH_DIR/" "nexus:/tmp/infisical-push/"
-
-        PUSH_RESULT=$(ssh nexus "
-            TOKEN=\$(cat /opt/docker-server/.infisical-token 2>/dev/null || echo '$INFISICAL_TOKEN')
-            if [ -z \"\$TOKEN\" ]; then echo '0:0'; exit 0; fi
-            OK=0; FAIL=0
-            for f in /tmp/infisical-push/f-*.json; do
-                curl -s -X POST 'http://localhost:8070/api/v2/folders' \
-                    -H \"Authorization: Bearer \$TOKEN\" \
-                    -H 'Content-Type: application/json' \
-                    -d @\$f >/dev/null 2>&1 || true
-            done
-            for f in /tmp/infisical-push/s-*.json; do
-                RESULT=\$(curl -s -X PATCH 'http://localhost:8070/api/v4/secrets/batch' \
-                    -H \"Authorization: Bearer \$TOKEN\" \
-                    -H 'Content-Type: application/json' \
-                    -d @\$f 2>&1)
-                if echo \"\$RESULT\" | grep -q '\"error\"'; then
-                    FAIL=\$((FAIL+1))
-                else
-                    OK=\$((OK+1))
-                fi
-            done
-            # Snapshot build_folder JSON payloads BEFORE the cleanup
-            # below deletes /tmp/infisical-push. capture-phase1-baselines.sh
-            # scp's the snapshot dir down for the Phase-1 gold-master
-            # fixtures used by src/nexus_deploy/infisical.py (#505).
-            # Removed in phase 4 along with the rest of build_folder.
-            #
-            # Lifetime: the baseline dir persists at /tmp/nexus-baselines
-            # on the server across this run and any subsequent re-runs
-            # (each run replaces the dir contents via rm -rf + cp). It's
-            # only fully cleared by a teardown — that's intentional so
-            # capture-script can scp from a stable location. \`chmod\`
-            # restricts it to the deploy SSH user since the JSON
-            # payloads carry secret values.
-            #
-            # Error handling: the outer \`ssh \"...\"\` heredoc runs WITHOUT
-            # \`set -e\`, and the heredoc's final \`echo \"\$OK:\$FAIL\"\`
-            # always succeeds — so we have to chain the snapshot ops
-            # with \`&&\` and emit a stderr warning on failure ourselves.
-            # We don't \`exit 1\` because baseline capture is a Phase-1
-            # debugging aid; failure should be visible in the workflow
-            # log but must not block a deploy that's otherwise healthy.
-            if [ -d /tmp/infisical-push ]; then
-                mkdir -p /tmp/nexus-baselines \
-                    && rm -rf /tmp/nexus-baselines/infisical-payloads-baseline \
-                    && cp -r /tmp/infisical-push /tmp/nexus-baselines/infisical-payloads-baseline \
-                    && chmod -R go-rwx /tmp/nexus-baselines/infisical-payloads-baseline \
-                    || echo \"WARN: phase-1 baseline capture to /tmp/nexus-baselines failed\" >&2
-            fi
-            rm -rf /tmp/infisical-push
-            echo \"\$OK:\$FAIL\"
-        " 2>&1 || echo "0:0")
-
-        rm -rf "$PUSH_DIR"
-
-        PUSH_OK=$(echo "$PUSH_RESULT" | tail -1 | cut -d: -f1)
-        PUSH_FAIL=$(echo "$PUSH_RESULT" | tail -1 | cut -d: -f2)
-        if [ "$PUSH_FAIL" = "0" ] || [ -z "$PUSH_FAIL" ]; then
-            echo -e "${GREEN}  ✓ Secrets pushed to $PUSH_OK folders in Infisical${NC}"
-        else
-            echo -e "${YELLOW}  ⚠ Pushed to $PUSH_OK folders, $PUSH_FAIL failed${NC}"
+        # SSH_KEY_BASE64 is the same base64-encoded key the legacy
+        # build_folder "ssh" call used. Empty when no key is configured;
+        # nexus_deploy's BootstrapEnv treats the empty value as "no
+        # ssh folder".
+        SSH_KEY_BASE64=$(printf '%s' "${SSH_PRIVATE_KEY_CONTENT:-}" | base64 | tr -d '\n')
+        if ! printf '%s' "$SECRETS_JSON" | \
+            PROJECT_ID="$PROJECT_ID" \
+            INFISICAL_TOKEN="$INFISICAL_TOKEN" \
+            INFISICAL_ENV="$INFISICAL_ENV" \
+            DOMAIN="$DOMAIN" \
+            ADMIN_EMAIL="$ADMIN_EMAIL" \
+            GITEA_USER_EMAIL="${GITEA_USER_EMAIL:-}" \
+            GITEA_USER_USERNAME="${GITEA_USER_USERNAME:-}" \
+            GITEA_REPO_OWNER="${GITEA_REPO_OWNER:-}" \
+            REPO_NAME="${REPO_NAME:-}" \
+            OM_PRINCIPAL_DOMAIN="${OM_PRINCIPAL_DOMAIN:-}" \
+            WOODPECKER_GITEA_CLIENT="${WOODPECKER_GITEA_CLIENT:-}" \
+            WOODPECKER_GITEA_SECRET="${WOODPECKER_GITEA_SECRET:-}" \
+            SSH_KEY_BASE64="$SSH_KEY_BASE64" \
+            uv run --quiet --project "$PROJECT_ROOT" python -m nexus_deploy infisical bootstrap; then
+            echo -e "${YELLOW}  ⚠ Infisical bootstrap reported failures (see output above)${NC}"
         fi
     fi
     fi  # End of INFISICAL_READY check

--- a/src/nexus_deploy/__main__.py
+++ b/src/nexus_deploy/__main__.py
@@ -76,10 +76,17 @@ def _infisical_bootstrap(args: list[str]) -> int:
 
     Reads SECRETS_JSON from stdin, reads the additional ``BootstrapEnv``
     fields (DOMAIN, ADMIN_EMAIL, GITEA_*, OM_PRINCIPAL_DOMAIN,
-    WOODPECKER_*, SSH_PRIVATE_KEY_BASE64) from environment variables,
+    WOODPECKER_*, SSH_KEY_BASE64) from environment variables,
     plus PROJECT_ID + INFISICAL_TOKEN + INFISICAL_ENV from environment
     variables. Computes the 41 folders, writes payloads, runs the
     server-side curl loop. Mirrors deploy.sh:1996-2390.
+
+    Note on env-var naming: the BootstrapEnv field is
+    ``ssh_private_key_base64`` but the env var on the deploy.sh side
+    is the bash-style ``SSH_KEY_BASE64`` (computed from
+    ``SSH_PRIVATE_KEY_CONTENT`` via ``base64 | tr -d '\n'``). The
+    asymmetry mirrors the legacy bash naming so deploy.sh's existing
+    env-passing pattern doesn't need to be renamed in this PR.
 
     Required env: ``PROJECT_ID``, ``INFISICAL_TOKEN``.
     Optional env: ``INFISICAL_ENV`` (default ``dev``), the BootstrapEnv

--- a/src/nexus_deploy/__main__.py
+++ b/src/nexus_deploy/__main__.py
@@ -9,6 +9,7 @@ Currently:
 from __future__ import annotations
 
 import os
+import subprocess
 import sys
 from pathlib import Path
 
@@ -91,6 +92,16 @@ def _infisical_bootstrap(args: list[str]) -> int:
     Required env: ``PROJECT_ID``, ``INFISICAL_TOKEN``.
     Optional env: ``INFISICAL_ENV`` (default ``dev``), the BootstrapEnv
     fields above, ``PUSH_DIR`` (default ``/tmp/infisical-push``).
+
+    Exit codes (deploy.sh distinguishes the three so it can decide
+    whether to abort):
+    - 0: success, all folders pushed
+    - 1: bootstrap completed but some folders reported errors
+         (deploy.sh-side: warn-and-continue; the operator can fix
+         partial pushes via the UI without aborting the rest of the
+         spin-up)
+    - 2: hard failure — input validation, transport (rsync/ssh),
+         unexpected exception. deploy.sh-side: abort.
     """
     if args:
         print(f"infisical bootstrap: unexpected arg {args[0]!r}", file=sys.stderr)
@@ -102,12 +113,12 @@ def _infisical_bootstrap(args: list[str]) -> int:
             "infisical bootstrap: PROJECT_ID and INFISICAL_TOKEN env vars required",
             file=sys.stderr,
         )
-        return 1
+        return 2
     try:
         config = NexusConfig.from_secrets_json(sys.stdin.read())
     except ConfigError as exc:
         print(f"infisical bootstrap: {exc}", file=sys.stderr)
-        return 1
+        return 2
     bootstrap_env = BootstrapEnv(
         domain=os.environ.get("DOMAIN") or None,
         admin_email=os.environ.get("ADMIN_EMAIL") or None,
@@ -128,7 +139,19 @@ def _infisical_bootstrap(args: list[str]) -> int:
         push_dir=push_dir,
     )
     folders = compute_folders(config, bootstrap_env)
-    result = client.bootstrap(folders)
+    try:
+        result = client.bootstrap(folders)
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError) as exc:
+        # Hard failure: rsync/ssh exited non-zero, hit the timeout, or
+        # the binary wasn't on PATH. deploy.sh sees rc=2 and aborts.
+        # Avoid printing exc.cmd because TimeoutExpired/CalledProcessError
+        # carry the full argv — we don't want the token (if it ever
+        # leaked into argv via a future bug) to land in the workflow log.
+        print(
+            f"infisical bootstrap: transport failure ({type(exc).__name__})",
+            file=sys.stderr,
+        )
+        return 2
     print(
         f"infisical bootstrap: built={result.folders_built} pushed={result.pushed} failed={result.failed}",
     )

--- a/src/nexus_deploy/__main__.py
+++ b/src/nexus_deploy/__main__.py
@@ -79,7 +79,7 @@ def _infisical_bootstrap(args: list[str]) -> int:
     fields (DOMAIN, ADMIN_EMAIL, GITEA_*, OM_PRINCIPAL_DOMAIN,
     WOODPECKER_*, SSH_KEY_BASE64) from environment variables,
     plus PROJECT_ID + INFISICAL_TOKEN + INFISICAL_ENV from environment
-    variables. Computes the 41 folders, writes payloads, runs the
+    variables. Computes the 39 folders, writes payloads, runs the
     server-side curl loop. Mirrors deploy.sh:1996-2390.
 
     Note on env-var naming: the BootstrapEnv field is
@@ -163,9 +163,12 @@ def _infisical_bootstrap(args: list[str]) -> int:
         # ``repr(exc)`` can carry attribute values that might include
         # secret-bearing fields from a NexusConfig or BootstrapEnv
         # pydantic ValidationError.
+        # Class name only (no str/repr): exception args may carry
+        # secret-bearing fields from a NexusConfig/BootstrapEnv
+        # ValidationError. Operators reproducing locally without
+        # secret data will see the full traceback there.
         print(
-            f"infisical bootstrap: unexpected error ({type(exc).__name__}); "
-            "see traceback above if any",
+            f"infisical bootstrap: unexpected error ({type(exc).__name__})",
             file=sys.stderr,
         )
         return 2

--- a/src/nexus_deploy/__main__.py
+++ b/src/nexus_deploy/__main__.py
@@ -138,8 +138,8 @@ def _infisical_bootstrap(args: list[str]) -> int:
         token=token,
         push_dir=push_dir,
     )
-    folders = compute_folders(config, bootstrap_env)
     try:
+        folders = compute_folders(config, bootstrap_env)
         result = client.bootstrap(folders)
     except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError) as exc:
         # Hard failure: rsync/ssh exited non-zero, hit the timeout, or
@@ -149,6 +149,23 @@ def _infisical_bootstrap(args: list[str]) -> int:
         # leaked into argv via a future bug) to land in the workflow log.
         print(
             f"infisical bootstrap: transport failure ({type(exc).__name__})",
+            file=sys.stderr,
+        )
+        return 2
+    except Exception as exc:
+        # Anything else is a programming error in compute_folders/
+        # bootstrap (KeyError, ValidationError, AttributeError, …).
+        # Python's default exit code for an unhandled exception is 1,
+        # which deploy.sh's rc-dispatch treats as "partial push" —
+        # exactly what this catch prevents. Force rc=2 so deploy.sh
+        # aborts instead of continuing past a broken bootstrap.
+        # We print only the exception CLASS name; ``str(exc)`` and
+        # ``repr(exc)`` can carry attribute values that might include
+        # secret-bearing fields from a NexusConfig or BootstrapEnv
+        # pydantic ValidationError.
+        print(
+            f"infisical bootstrap: unexpected error ({type(exc).__name__}); "
+            "see traceback above if any",
             file=sys.stderr,
         )
         return 2

--- a/src/nexus_deploy/__main__.py
+++ b/src/nexus_deploy/__main__.py
@@ -1,16 +1,24 @@
 """Entry point for `python -m nexus_deploy ...` invocations.
 
-Phase 1 dispatch surface. Real subcommands land here as their modules
-ship; today only ``config dump-shell`` exists (#505 Modul 1.3).
+Phase 1 dispatch surface. Subcommands land here as their modules ship.
+Currently:
+- ``config dump-shell`` (#505 Modul 1.3)
+- ``infisical bootstrap`` (#505 Modul 1.1)
 """
 
 from __future__ import annotations
 
+import os
 import sys
 from pathlib import Path
 
 from nexus_deploy import __version__, hello
 from nexus_deploy.config import ConfigError, NexusConfig
+from nexus_deploy.infisical import (
+    BootstrapEnv,
+    InfisicalClient,
+    compute_folders,
+)
 
 
 def _config_dump_shell(args: list[str]) -> int:
@@ -63,8 +71,65 @@ def _config_dump_shell(args: list[str]) -> int:
     return 0
 
 
+def _infisical_bootstrap(args: list[str]) -> int:
+    """`nexus-deploy infisical bootstrap`.
+
+    Reads SECRETS_JSON from stdin, reads the additional ``BootstrapEnv``
+    fields (DOMAIN, ADMIN_EMAIL, GITEA_*, OM_PRINCIPAL_DOMAIN,
+    WOODPECKER_*, SSH_PRIVATE_KEY_BASE64) from environment variables,
+    plus PROJECT_ID + INFISICAL_TOKEN + INFISICAL_ENV from environment
+    variables. Computes the 41 folders, writes payloads, runs the
+    server-side curl loop. Mirrors deploy.sh:1996-2390.
+
+    Required env: ``PROJECT_ID``, ``INFISICAL_TOKEN``.
+    Optional env: ``INFISICAL_ENV`` (default ``dev``), the BootstrapEnv
+    fields above, ``PUSH_DIR`` (default ``/tmp/infisical-push``).
+    """
+    if args:
+        print(f"infisical bootstrap: unexpected arg {args[0]!r}", file=sys.stderr)
+        return 2
+    project_id = os.environ.get("PROJECT_ID", "").strip()
+    token = os.environ.get("INFISICAL_TOKEN", "").strip()
+    if not project_id or not token:
+        print(
+            "infisical bootstrap: PROJECT_ID and INFISICAL_TOKEN env vars required",
+            file=sys.stderr,
+        )
+        return 1
+    try:
+        config = NexusConfig.from_secrets_json(sys.stdin.read())
+    except ConfigError as exc:
+        print(f"infisical bootstrap: {exc}", file=sys.stderr)
+        return 1
+    bootstrap_env = BootstrapEnv(
+        domain=os.environ.get("DOMAIN") or None,
+        admin_email=os.environ.get("ADMIN_EMAIL") or None,
+        gitea_user_email=os.environ.get("GITEA_USER_EMAIL") or None,
+        gitea_user_username=os.environ.get("GITEA_USER_USERNAME") or None,
+        gitea_repo_owner=os.environ.get("GITEA_REPO_OWNER") or None,
+        repo_name=os.environ.get("REPO_NAME") or None,
+        om_principal_domain=os.environ.get("OM_PRINCIPAL_DOMAIN") or None,
+        woodpecker_gitea_client=os.environ.get("WOODPECKER_GITEA_CLIENT") or None,
+        woodpecker_gitea_secret=os.environ.get("WOODPECKER_GITEA_SECRET") or None,
+        ssh_private_key_base64=os.environ.get("SSH_KEY_BASE64") or None,
+    )
+    push_dir = Path(os.environ.get("PUSH_DIR") or "/tmp/infisical-push")  # noqa: S108
+    client = InfisicalClient(
+        project_id=project_id,
+        env=os.environ.get("INFISICAL_ENV") or "dev",
+        token=token,
+        push_dir=push_dir,
+    )
+    folders = compute_folders(config, bootstrap_env)
+    result = client.bootstrap(folders)
+    print(
+        f"infisical bootstrap: built={result.folders_built} pushed={result.pushed} failed={result.failed}",
+    )
+    return 0 if result.failed == 0 else 1
+
+
 def main() -> int:
-    """Phase-1 dispatcher. ``config dump-shell`` is the only subcommand today."""
+    """Phase-1 dispatcher. ``config`` and ``infisical`` subcommands shipped."""
     args = sys.argv[1:]
     if args == ["--version"]:
         print(__version__)
@@ -74,13 +139,16 @@ def main() -> int:
         return 0
     if args[:2] == ["config", "dump-shell"]:
         return _config_dump_shell(args[2:])
+    if args[:2] == ["infisical", "bootstrap"]:
+        return _infisical_bootstrap(args[2:])
     print(
         f"nexus_deploy {__version__}: unknown command {' '.join(args)!r}",
         file=sys.stderr,
     )
     print(
-        "Available: --version, hello, config dump-shell "
-        "[--tofu-dir PATH (default: tofu/stack) | --stdin]",
+        "Available: --version, hello, "
+        "config dump-shell [--tofu-dir PATH (default: tofu/stack) | --stdin], "
+        "infisical bootstrap (reads SECRETS_JSON from stdin + env vars)",
         file=sys.stderr,
     )
     return 2

--- a/src/nexus_deploy/_remote.py
+++ b/src/nexus_deploy/_remote.py
@@ -1,0 +1,91 @@
+"""Subprocess primitives for talking to the nexus server (Phase 1, #505).
+
+Temporary scaffolding while the migration is in progress: these are
+plain ``subprocess.run`` wrappers around ``ssh nexus <cmd>`` and
+``rsync … nexus:…``, mirroring the bash-side patterns one-to-one so the
+strangler-fig handoff doesn't change network behaviour.
+
+Phase 3 (#505 Modul 3.1) replaces this with ``nexus_deploy.ssh.SSHClient``
+— a paramiko-backed client with persistent connection, port-forwarding,
+and proper SFTP. Until then, every consumer here uses the system ``ssh``
+config alias `nexus` (which the spin-up workflow's "Setup SSH config"
+step writes), so anything that works in deploy.sh works here too.
+
+Tests mock ``subprocess.run`` directly. There are no integration tests
+in this module — those land with the paramiko refactor in Phase 3.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+# Default subprocess timeouts. The bash side has no timeouts at all,
+# but Python's subprocess is more forgiving about hung remote calls
+# when we add an upper bound. Generous defaults so a slow Hetzner
+# control-plane spin-up (creds rotation, first cold start) doesn't
+# trip them.
+_DEFAULT_TIMEOUT_S = 120
+
+
+def ssh_run(
+    cmd: str,
+    *,
+    host: str = "nexus",
+    check: bool = True,
+    timeout: float = _DEFAULT_TIMEOUT_S,
+    capture_stderr: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    """Run a single command on the nexus server via the local ssh-config alias.
+
+    Equivalent to::
+
+        ssh nexus "<cmd>"
+
+    Stderr is captured by default and combined with stdout in the
+    returned ``CompletedProcess`` for parity with deploy.sh's
+    ``ssh nexus "..." 2>&1`` pattern. Set ``capture_stderr=False`` when
+    you want stderr to flow through to the local terminal (useful for
+    interactive ops; rare in this codebase).
+    """
+    return subprocess.run(
+        ["ssh", host, cmd],
+        check=check,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        stderr=subprocess.STDOUT if capture_stderr else None,
+    )
+
+
+def rsync_to_remote(
+    local: Path,
+    remote: str,
+    *,
+    delete: bool = False,
+    timeout: float = _DEFAULT_TIMEOUT_S,
+) -> subprocess.CompletedProcess[str]:
+    """Push a local directory to the nexus server via rsync.
+
+    ``remote`` follows rsync syntax (e.g. ``"nexus:/tmp/infisical-push/"``);
+    the alias resolves through the same ssh config as ``ssh_run``. The
+    trailing slash on ``local`` is auto-appended so rsync uploads the
+    directory's CONTENTS, matching deploy.sh's
+    ``rsync -aq --delete "$PUSH_DIR/" "nexus:/tmp/infisical-push/"``.
+
+    ``delete=True`` clears destination paths that don't exist locally —
+    used when the local dir is the canonical source-of-truth for that
+    remote location.
+    """
+    src = f"{local}/" if not str(local).endswith("/") else str(local)
+    args = ["rsync", "-aq"]
+    if delete:
+        args.append("--delete")
+    args += [src, remote]
+    return subprocess.run(
+        args,
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )

--- a/src/nexus_deploy/_remote.py
+++ b/src/nexus_deploy/_remote.py
@@ -34,19 +34,23 @@ def ssh_run(
     host: str = "nexus",
     check: bool = True,
     timeout: float = _DEFAULT_TIMEOUT_S,
-    capture_stderr: bool = True,
+    merge_stderr: bool = True,
 ) -> subprocess.CompletedProcess[str]:
     """Run a single command on the nexus server via the local ssh-config alias.
 
     Equivalent to::
 
-        ssh nexus "<cmd>"
+        ssh nexus "<cmd>"        # merge_stderr=True (default)
+        ssh nexus "<cmd>" 2>&1   # bash equivalent of the default
 
-    Stderr is captured by default and combined with stdout in the
-    returned ``CompletedProcess`` for parity with deploy.sh's
-    ``ssh nexus "..." 2>&1`` pattern. Set ``capture_stderr=False`` when
-    you want stderr to flow through to the local terminal (useful for
-    interactive ops; rare in this codebase).
+    With ``merge_stderr=True`` (default) stderr is folded into stdout
+    in the returned ``CompletedProcess`` — parity with deploy.sh's
+    ``ssh nexus "..." 2>&1`` pattern. With ``merge_stderr=False``
+    stdout and stderr are captured into separate fields on the
+    CompletedProcess. Either way the streams are captured (we don't
+    let them flow to the local terminal — long stderr tails on a
+    failing curl loop would clutter the deploy log; callers that want
+    that should print ``result.stderr`` themselves).
     """
     # Don't use `capture_output=True` here: it sets stdout=PIPE+stderr=PIPE
     # internally, and combining it with an explicit `stderr=...` raises
@@ -57,7 +61,7 @@ def ssh_run(
         ["ssh", host, cmd],
         check=check,
         stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT if capture_stderr else subprocess.PIPE,
+        stderr=subprocess.STDOUT if merge_stderr else subprocess.PIPE,
         text=True,
         timeout=timeout,
     )

--- a/src/nexus_deploy/_remote.py
+++ b/src/nexus_deploy/_remote.py
@@ -20,12 +20,14 @@ from __future__ import annotations
 import subprocess
 from pathlib import Path
 
-# Default subprocess timeouts. The bash side has no timeouts at all,
-# but Python's subprocess is more forgiving about hung remote calls
-# when we add an upper bound. Generous defaults so a slow Hetzner
-# control-plane spin-up (creds rotation, first cold start) doesn't
-# trip them.
-_DEFAULT_TIMEOUT_S = 120
+# No subprocess timeout by default — strict parity with deploy.sh,
+# which never wrapped ssh/rsync calls in `timeout`. A slow Hetzner
+# control-plane spin-up (creds rotation, first cold start, big rsync
+# diff) can legitimately take several minutes; a Python-side cap
+# would convert "slow" into a hard failure with TimeoutExpired even
+# though the underlying op would have completed. Callers that DO
+# want a cap pass `timeout=<seconds>` explicitly.
+_DEFAULT_TIMEOUT_S: float | None = None
 
 
 def ssh_run(
@@ -33,7 +35,7 @@ def ssh_run(
     *,
     host: str = "nexus",
     check: bool = True,
-    timeout: float = _DEFAULT_TIMEOUT_S,
+    timeout: float | None = _DEFAULT_TIMEOUT_S,
     merge_stderr: bool = True,
 ) -> subprocess.CompletedProcess[str]:
     """Run a single command on the nexus server via the local ssh-config alias.
@@ -51,6 +53,10 @@ def ssh_run(
     let them flow to the local terminal — long stderr tails on a
     failing curl loop would clutter the deploy log; callers that want
     that should print ``result.stderr`` themselves).
+
+    Note: arguments after ``host`` are passed via argv and visible in
+    ``ps``. For commands containing secret values, prefer
+    :func:`ssh_run_script` which feeds the script over stdin.
     """
     # Don't use `capture_output=True` here: it sets stdout=PIPE+stderr=PIPE
     # internally, and combining it with an explicit `stderr=...` raises
@@ -67,12 +73,45 @@ def ssh_run(
     )
 
 
+def ssh_run_script(
+    script: str,
+    *,
+    host: str = "nexus",
+    check: bool = True,
+    timeout: float | None = _DEFAULT_TIMEOUT_S,
+    merge_stderr: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    """Run a bash script on the nexus server via stdin, NOT argv.
+
+    Equivalent to::
+
+        ssh nexus bash -s <<<"<script>"
+
+    Why a separate function from :func:`ssh_run`: when a script
+    contains secret values (Infisical tokens, etc.), passing it via
+    argv exposes the secret to ``ps``, CI argv-logging, and
+    ``CalledProcessError.cmd`` / ``TimeoutExpired.cmd`` exception
+    messages. Feeding the script over stdin keeps it out of the
+    process command line entirely; only ``["ssh", "nexus", "bash",
+    "-s"]`` is visible.
+    """
+    return subprocess.run(
+        ["ssh", host, "bash", "-s"],
+        input=script,
+        check=check,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT if merge_stderr else subprocess.PIPE,
+        text=True,
+        timeout=timeout,
+    )
+
+
 def rsync_to_remote(
     local: Path,
     remote: str,
     *,
     delete: bool = False,
-    timeout: float = _DEFAULT_TIMEOUT_S,
+    timeout: float | None = _DEFAULT_TIMEOUT_S,
 ) -> subprocess.CompletedProcess[str]:
     """Push a local directory to the nexus server via rsync.
 

--- a/src/nexus_deploy/_remote.py
+++ b/src/nexus_deploy/_remote.py
@@ -48,13 +48,18 @@ def ssh_run(
     you want stderr to flow through to the local terminal (useful for
     interactive ops; rare in this codebase).
     """
+    # Don't use `capture_output=True` here: it sets stdout=PIPE+stderr=PIPE
+    # internally, and combining it with an explicit `stderr=...` raises
+    # ValueError("stderr and capture_output may not both be used"). We
+    # need explicit stderr control (STDOUT-merging in the default case)
+    # so we set both pipes ourselves.
     return subprocess.run(
         ["ssh", host, cmd],
         check=check,
-        capture_output=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT if capture_stderr else subprocess.PIPE,
         text=True,
         timeout=timeout,
-        stderr=subprocess.STDOUT if capture_stderr else None,
     )
 
 

--- a/src/nexus_deploy/config.py
+++ b/src/nexus_deploy/config.py
@@ -261,17 +261,25 @@ class NexusConfig(BaseModel):
         ``None`` and :meth:`dump_shell` emits the per-field defaults
         from ``_FIELDS`` — which is exactly what deploy.sh does today.
         """
+        # ConfigError messages do NOT include the underlying exception's
+        # `str(exc)` even though Python lets us. pydantic ValidationError's
+        # default repr embeds the offending input values, and
+        # JSONDecodeError can include a snippet of the raw input near the
+        # parse failure — both can carry secret bytes from SECRETS_JSON.
+        # The original exception is still available via `__cause__` when
+        # operators reproduce locally with a debugger; the printed CLI
+        # error stays free of raw input.
         try:
             payload = json.loads(raw)
         except json.JSONDecodeError as exc:
-            raise ConfigError(f"SECRETS_JSON is not valid JSON: {exc}") from exc
+            raise ConfigError("SECRETS_JSON is not valid JSON") from exc
         if not isinstance(payload, dict):
             raise ConfigError(f"SECRETS_JSON must be a JSON object, got {type(payload).__name__}")
         try:
             return cls.model_validate(payload)
         except ValidationError as exc:  # pragma: no cover — every field is Optional[str]
             # Reachable only if a future field gains stricter validation.
-            raise ConfigError(f"SECRETS_JSON failed validation: {exc}") from exc
+            raise ConfigError("SECRETS_JSON failed validation") from exc
 
     @classmethod
     def from_tofu_output(cls, tofu_dir: Path = Path("tofu/stack")) -> NexusConfig:

--- a/src/nexus_deploy/infisical.py
+++ b/src/nexus_deploy/infisical.py
@@ -33,6 +33,7 @@ wholesale. Faithful migration here, real refactor in Phase 3.
 from __future__ import annotations
 
 import json
+import os
 import shlex
 import subprocess
 from collections.abc import Callable, Mapping
@@ -780,27 +781,44 @@ echo "$OK:$FAIL"
             lambda local, remote: _remote.rsync_to_remote(local, remote, delete=True)
         )
 
-        # 1. Write JSON payloads to local push_dir.
         # Restrictive perms because the JSON contains secret values.
         # Dir 0o700 + files 0o600 mean only the owner can read; rsync
         # preserves perms by default, so the server-side mirror inherits
-        # the same protection. We explicitly chmod (instead of relying
-        # on umask) so the write is correct regardless of the calling
-        # process's umask — matters on shared CI runners where the
-        # default umask might be 0o022 (group/world readable).
-        self.push_dir.mkdir(parents=True, exist_ok=True)
+        # the same protection.
+        self.push_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+        # Re-chmod in case the dir pre-existed with looser perms (mkdir's
+        # mode is only applied at creation, ignored when exist_ok=True
+        # and the dir is already there).
         self.push_dir.chmod(0o700)
-        # Clear stale files from prior runs so deleted folders don't
-        # ship to the server (matches `rsync --delete` semantics on
-        # the upload side).
-        for stale in self.push_dir.glob("[fs]-*.json"):
-            stale.unlink()
-        for filename, body in self.encode_payloads(folders).items():
-            payload_path = self.push_dir / filename
-            payload_path.write_text(body)
-            payload_path.chmod(0o600)
 
+        # ENTIRE materialise+push+execute path is wrapped in try/finally
+        # so the cleanup of secret-bearing files runs even if write_text
+        # / chmod / rsync / ssh fails mid-flight. The previous version
+        # only wrapped the rsync+ssh phase, leaving the write loop
+        # outside protection — a disk-full or permission error during
+        # writes would leave half-written f-/s-*.json files in push_dir
+        # with secret values still in them.
         try:
+            # 1a. Clear stale files from prior runs so deleted folders
+            #     don't ship to the server (matches `rsync --delete`
+            #     semantics on the upload side).
+            for stale in self.push_dir.glob("[fs]-*.json"):
+                stale.unlink()
+
+            # 1b. Atomic create-with-mode-0o600 via os.open. Avoids
+            #     the TOCTOU race of `write_text` then `chmod`, where
+            #     the file briefly exists with the umask-derived mode
+            #     (often 0o644) before the chmod tightens it.
+            for filename, body in self.encode_payloads(folders).items():
+                payload_path = self.push_dir / filename
+                fd = os.open(
+                    str(payload_path),
+                    os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
+                    0o600,
+                )
+                with os.fdopen(fd, "w") as f:
+                    f.write(body)
+
             # 2. rsync to server.
             rsync(self.push_dir, f"nexus:{_REMOTE_PUSH_DIR}/")
 

--- a/src/nexus_deploy/infisical.py
+++ b/src/nexus_deploy/infisical.py
@@ -781,14 +781,24 @@ echo "$OK:$FAIL"
         )
 
         # 1. Write JSON payloads to local push_dir.
+        # Restrictive perms because the JSON contains secret values.
+        # Dir 0o700 + files 0o600 mean only the owner can read; rsync
+        # preserves perms by default, so the server-side mirror inherits
+        # the same protection. We explicitly chmod (instead of relying
+        # on umask) so the write is correct regardless of the calling
+        # process's umask — matters on shared CI runners where the
+        # default umask might be 0o022 (group/world readable).
         self.push_dir.mkdir(parents=True, exist_ok=True)
+        self.push_dir.chmod(0o700)
         # Clear stale files from prior runs so deleted folders don't
         # ship to the server (matches `rsync --delete` semantics on
         # the upload side).
         for stale in self.push_dir.glob("[fs]-*.json"):
             stale.unlink()
         for filename, body in self.encode_payloads(folders).items():
-            (self.push_dir / filename).write_text(body)
+            payload_path = self.push_dir / filename
+            payload_path.write_text(body)
+            payload_path.chmod(0o600)
 
         try:
             # 2. rsync to server.

--- a/src/nexus_deploy/infisical.py
+++ b/src/nexus_deploy/infisical.py
@@ -725,6 +725,16 @@ class InfisicalClient:
         # the captured TOKEN if a token happens to start with one.
         # Infisical tokens are alphanumeric in practice, but the
         # printf form costs nothing and rules out the edge case.
+        # FAIL-detection: legacy bash counted a PATCH as failed only if
+        # the response body contained the literal substring '"error"'.
+        # That misclassified transport failures (curl: (7) Failed to
+        # connect, DNS errors, timeouts) as OK because curl's stderr
+        # message doesn't contain the JSON-quoted "error" token.
+        # Phase-1 strict-parity would keep that legacy bug; we deviate
+        # here because the fix is minimal (check curl's exit status)
+        # and STRICTLY MORE CORRECT — transport failures now count as
+        # FAIL, never as silent OK. The output format ("OK:FAIL") is
+        # unchanged, so the deploy.sh-side parsing is unaffected.
         return f"""
 TOKEN=$(cat {_REMOTE_TOKEN_FALLBACK_FILE} 2>/dev/null || printf '%s' {token_quoted})
 if [ -z "$TOKEN" ]; then echo '0:0'; exit 0; fi
@@ -740,7 +750,8 @@ for f in {_REMOTE_PUSH_DIR}/s-*.json; do
         -H "Authorization: Bearer $TOKEN" \\
         -H 'Content-Type: application/json' \\
         -d @"$f" 2>&1)
-    if echo "$RESULT" | grep -q '"error"'; then
+    CURL_RC=$?
+    if [ "$CURL_RC" -ne 0 ] || echo "$RESULT" | grep -q '"error"'; then
         FAIL=$((FAIL+1))
     else
         OK=$((OK+1))
@@ -816,7 +827,10 @@ echo "$OK:$FAIL"
                     os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
                     0o600,
                 )
-                with os.fdopen(fd, "w") as f:
+                # Explicit encoding + newline so the bytes-on-disk match
+                # across macOS / Linux / CI runners regardless of locale.
+                # Same encoding the snapshot tests assume.
+                with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as f:
                     f.write(body)
 
             # 2. rsync to server.

--- a/src/nexus_deploy/infisical.py
+++ b/src/nexus_deploy/infisical.py
@@ -767,8 +767,15 @@ echo "$OK:$FAIL"
         server-side ``/tmp/infisical-push`` is removed by the curl
         loop's last step. No secrets-at-rest on either end after a
         bootstrap call returns.
+
+        The remote bash script is fed to ``ssh nexus bash -s`` via
+        stdin (:func:`_remote.ssh_run_script`), NOT as an argv. The
+        script embeds the Infisical token (shlex-quoted), and stdin
+        keeps it out of ``ps``, CI argv-logging, and any
+        ``CalledProcessError`` / ``TimeoutExpired`` exception messages
+        that would otherwise dump the full argv.
         """
-        ssh = ssh_runner or (lambda cmd: _remote.ssh_run(cmd))
+        ssh = ssh_runner or (lambda script: _remote.ssh_run_script(script))
         rsync = rsync_runner or (
             lambda local, remote: _remote.rsync_to_remote(local, remote, delete=True)
         )

--- a/src/nexus_deploy/infisical.py
+++ b/src/nexus_deploy/infisical.py
@@ -718,8 +718,14 @@ class InfisicalClient:
         # the heredoc through a layer of bash before ssh saw it. We
         # send raw text directly to ssh, so the inner `$f` expands at
         # the remote bash, which is what we want.
+        #
+        # `printf '%s'` instead of `echo`: bash's built-in `echo` can
+        # eat a leading `-n` / `-e` / `-E` as an option flag, blanking
+        # the captured TOKEN if a token happens to start with one.
+        # Infisical tokens are alphanumeric in practice, but the
+        # printf form costs nothing and rules out the edge case.
         return f"""
-TOKEN=$(cat {_REMOTE_TOKEN_FALLBACK_FILE} 2>/dev/null || echo {token_quoted})
+TOKEN=$(cat {_REMOTE_TOKEN_FALLBACK_FILE} 2>/dev/null || printf '%s' {token_quoted})
 if [ -z "$TOKEN" ]; then echo '0:0'; exit 0; fi
 OK=0; FAIL=0
 for f in {_REMOTE_PUSH_DIR}/f-*.json; do
@@ -754,6 +760,13 @@ echo "$OK:$FAIL"
 
         Default runners come from :mod:`nexus_deploy._remote`; tests
         override both via the kwargs.
+
+        Local payload files (which contain secret values) are removed
+        in a ``finally`` block whether the rsync/ssh succeeds, fails,
+        or raises. Mirrors deploy.sh:2370 (`rm -rf "$PUSH_DIR"`); the
+        server-side ``/tmp/infisical-push`` is removed by the curl
+        loop's last step. No secrets-at-rest on either end after a
+        bootstrap call returns.
         """
         ssh = ssh_runner or (lambda cmd: _remote.ssh_run(cmd))
         rsync = rsync_runner or (
@@ -770,23 +783,31 @@ echo "$OK:$FAIL"
         for filename, body in self.encode_payloads(folders).items():
             (self.push_dir / filename).write_text(body)
 
-        # 2. rsync to server.
-        rsync(self.push_dir, f"nexus:{_REMOTE_PUSH_DIR}/")
-
-        # 3. Run the server-side curl loop.
-        completed = ssh(self._build_remote_loop())
-
-        # 4. Parse the final `OK:FAIL` line. The server's stdout may
-        #    include earlier echoes (warnings from the baseline-capture
-        #    step in deploy.sh); take the last line.
-        last_line = completed.stdout.strip().splitlines()[-1] if completed.stdout else "0:0"
         try:
-            ok_str, fail_str = last_line.split(":", 1)
-            pushed = int(ok_str)
-            failed = int(fail_str)
-        except (ValueError, IndexError):
-            # Unparseable output is itself a failure signal.
-            pushed = 0
-            failed = len(folders)
+            # 2. rsync to server.
+            rsync(self.push_dir, f"nexus:{_REMOTE_PUSH_DIR}/")
 
-        return BootstrapResult(folders_built=len(folders), pushed=pushed, failed=failed)
+            # 3. Run the server-side curl loop.
+            completed = ssh(self._build_remote_loop())
+
+            # 4. Parse the final `OK:FAIL` line. The server's stdout
+            #    may include earlier echoes (warnings from the
+            #    baseline-capture step in deploy.sh); take the last line.
+            last_line = completed.stdout.strip().splitlines()[-1] if completed.stdout else "0:0"
+            try:
+                ok_str, fail_str = last_line.split(":", 1)
+                pushed = int(ok_str)
+                failed = int(fail_str)
+            except (ValueError, IndexError):
+                # Unparseable output is itself a failure signal.
+                pushed = 0
+                failed = len(folders)
+
+            return BootstrapResult(folders_built=len(folders), pushed=pushed, failed=failed)
+        finally:
+            # Best-effort: secret-bearing payloads must not survive a
+            # bootstrap call (success OR failure). We delete only the
+            # f-/s-*.json files we wrote, not the directory itself —
+            # the dir may pre-exist with operator state we don't own.
+            for payload in self.push_dir.glob("[fs]-*.json"):
+                payload.unlink(missing_ok=True)

--- a/src/nexus_deploy/infisical.py
+++ b/src/nexus_deploy/infisical.py
@@ -1,6 +1,6 @@
 """Infisical bootstrap — folder creation + per-folder secret upsert.
 
-Replaces deploy.sh:1996-2390 (the ``build_folder`` helper plus its 41
+Replaces deploy.sh:1996-2390 (the ``build_folder`` helper plus its 39
 callers plus the rsync + ssh + curl-loop push, ~395 lines of bash) with
 typed Python. The migration is the strangler-fig of #505 Modul 1.1.
 
@@ -147,7 +147,7 @@ def _filter_empty(items: Mapping[str, str | None]) -> dict[str, str]:
 
 
 def compute_folders(config: NexusConfig, env: BootstrapEnv) -> list[FolderSpec]:
-    """Mirror of deploy.sh:2042-2335 — 41 ``build_folder`` calls in source order.
+    """Mirror of deploy.sh:2042-2335 — 39 ``build_folder`` calls in source order.
 
     Conditional folders (R2, Hetzner-S3, External-S3, SSH, Woodpecker
     OAuth) match the bash gates exactly so the resulting Infisical

--- a/src/nexus_deploy/infisical.py
+++ b/src/nexus_deploy/infisical.py
@@ -1,0 +1,792 @@
+"""Infisical bootstrap — folder creation + per-folder secret upsert.
+
+Replaces deploy.sh:1996-2390 (the ``build_folder`` helper plus its 41
+callers plus the rsync + ssh + curl-loop push, ~395 lines of bash) with
+typed Python. The migration is the strangler-fig of #505 Modul 1.1.
+
+Pre-migration shape (deploy.sh):
+- Local: ``build_folder NAME K V K V …`` writes per-folder JSON files
+  (folder-creation payload + secrets-upsert payload) into
+  ``/tmp/infisical-push``.
+- Empty ``V`` values are silently skipped (preserves operator UI edits
+  per #504); same skip-empty rule applies here in :func:`compute_folders`.
+- ``rsync -aq --delete /tmp/infisical-push/ nexus:/tmp/infisical-push/``.
+- ``ssh nexus "<curl-loop>"`` — POST /api/v2/folders for f-*.json (200
+  + 409 both treated as success), PATCH /api/v4/secrets/batch for
+  s-*.json (counted as OK or FAIL by ``"error"`` substring scan).
+
+Post-migration shape (this module):
+- :func:`compute_folders` — pure data, takes :class:`NexusConfig` +
+  :class:`BootstrapEnv`, returns the list of :class:`FolderSpec` in
+  exact source-order. Skip-empty handled here.
+- :class:`InfisicalClient` carries project_id / env / token / push_dir.
+- :meth:`InfisicalClient.bootstrap` — writes the same JSON files,
+  rsyncs, runs the same server-side bash loop. Returns
+  :class:`BootstrapResult` with pushed/failed counts.
+
+Why preserve the exact server-side curl loop? It's already proven in
+production, it batches all calls into one SSH round-trip (matters for
+~80 API calls), and Phase 3's paramiko port-forward replaces it
+wholesale. Faithful migration here, real refactor in Phase 3.
+"""
+
+from __future__ import annotations
+
+import json
+import shlex
+import subprocess
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from pathlib import Path
+
+from nexus_deploy import _remote
+from nexus_deploy.config import NexusConfig
+
+# Server-side Infisical endpoint — matches deploy.sh exactly.
+_INFISICAL_HOST = "localhost"
+_INFISICAL_PORT = 8070
+_FOLDERS_PATH = "/api/v2/folders"
+_SECRETS_BATCH_PATH = "/api/v4/secrets/batch"
+
+# Server-side path where the rsync upload lands and the curl loop reads.
+_REMOTE_PUSH_DIR = "/tmp/infisical-push"  # noqa: S108 — server-side path matched to deploy.sh's location; transient (rm -rf'd by the curl loop's last step)
+
+# Server-side path where the deploy SSH user can find an
+# operator-managed Infisical token; falls back to the env-supplied
+# token when absent. Mirrors deploy.sh:2284.
+_REMOTE_TOKEN_FALLBACK_FILE = "/opt/docker-server/.infisical-token"  # noqa: S105 — file PATH, not a credential value
+
+
+@dataclass(frozen=True)
+class BootstrapEnv:
+    """Configuration values that come from outside ``SECRETS_JSON``.
+
+    deploy.sh's ``build_folder`` calls reference globals that are
+    populated from a mix of sources — config.tfvars (DOMAIN,
+    ADMIN_EMAIL), workflow inputs (SSH_PRIVATE_KEY_CONTENT,
+    WOODPECKER_GITEA_*), other tofu outputs, etc. Rather than reach
+    into ``os.environ`` from inside :func:`compute_folders`, we take
+    them as a typed dataclass so callers can also build folders from
+    fixtures in tests.
+
+    Fields are ``str | None`` so a missing/empty value behaves like
+    deploy.sh's ``${VAR:-}`` — the corresponding key is skipped from
+    the upsert payload via the per-folder skip-empty pass.
+    """
+
+    domain: str | None = None
+    admin_email: str | None = None
+    gitea_user_email: str | None = None
+    gitea_user_username: str | None = None
+    gitea_repo_owner: str | None = None
+    repo_name: str | None = None
+    om_principal_domain: str | None = None
+    woodpecker_gitea_client: str | None = None
+    woodpecker_gitea_secret: str | None = None
+    ssh_private_key_base64: str | None = None
+
+
+@dataclass(frozen=True)
+class FolderSpec:
+    """One Infisical folder to create + a dict of secrets to upsert into it.
+
+    ``secrets`` is the ALREADY-FILTERED set: empty/None values were
+    dropped at construction time by :func:`_filter_empty`. The
+    skip-empty contract from #504 (preserve operator UI edits) is
+    enforced here.
+    """
+
+    name: str
+    secrets: dict[str, str]
+
+    def folder_payload(self, project_id: str, env: str) -> dict[str, str]:
+        """Match the bash: ``jq -n '{projectId, environment, name, path: "/"}'``."""
+        return {
+            "projectId": project_id,
+            "environment": env,
+            "name": self.name,
+            "path": "/",
+        }
+
+    def secrets_payload(self, project_id: str, env: str) -> dict[str, object]:
+        """Match the bash secrets-batch shape: ``mode: "upsert"`` + secrets list."""
+        return {
+            "projectId": project_id,
+            "environment": env,
+            "secretPath": f"/{self.name}",
+            "mode": "upsert",
+            "secrets": [{"secretKey": k, "secretValue": v} for k, v in self.secrets.items()],
+        }
+
+
+@dataclass(frozen=True)
+class BootstrapResult:
+    """Outcome of an end-to-end bootstrap.
+
+    ``pushed`` and ``failed`` come from the server-side curl loop's
+    final ``echo "$OK:$FAIL"`` — they count successful vs errored
+    secrets-batch PATCHes, NOT folder POSTs (folder POSTs are
+    fire-and-forget per the legacy logic). ``folders_built`` is the
+    count of FolderSpecs we wrote to the push dir, including ones that
+    ended up with zero secrets after skip-empty.
+    """
+
+    folders_built: int
+    pushed: int
+    failed: int
+
+
+def _filter_empty(items: Mapping[str, str | None]) -> dict[str, str]:
+    """Skip-empty rule from deploy.sh's build_folder + #504 hardening.
+
+    Drops entries where the value is ``None`` or the empty string. The
+    bash form was ``[ -z "$2" ] && shift 2 && continue`` — same
+    behaviour, typed.
+    """
+    return {k: v for k, v in items.items() if v is not None and v != ""}
+
+
+def compute_folders(config: NexusConfig, env: BootstrapEnv) -> list[FolderSpec]:
+    """Mirror of deploy.sh:2042-2335 — 41 ``build_folder`` calls in source order.
+
+    Conditional folders (R2, Hetzner-S3, External-S3, SSH, Woodpecker
+    OAuth) match the bash gates exactly so the resulting Infisical
+    folder set is identical to pre-migration. Order is the same as
+    deploy.sh; reviewers comparing against the legacy block see no
+    re-ordering noise.
+    """
+    folders: list[FolderSpec] = []
+
+    # Apply the same fallbacks deploy.sh's jq layer applies BEFORE
+    # build_folder runs, so the resolved values get pushed to Infisical
+    # — not None / empty (which would skip the key entirely). Mirrors
+    # `// "admin"` and the two `EXTERNAL_S3_*={VAR:-default}` lines
+    # at deploy.sh:123, 176-177. The same _FIELDS table lives in
+    # config.py for the bash-eval handoff; we resolve here to keep
+    # Infisical-push parity.
+    admin_username = config.admin_username or "admin"
+    external_s3_label = config.external_s3_label or "External Storage"
+    external_s3_region = config.external_s3_region or "auto"
+
+    folders.append(
+        FolderSpec(
+            "config",
+            _filter_empty(
+                {
+                    "DOMAIN": env.domain,
+                    "ADMIN_EMAIL": env.admin_email,
+                    "ADMIN_USERNAME": admin_username,
+                }
+            ),
+        )
+    )
+
+    if (
+        config.r2_data_endpoint
+        and config.r2_data_access_key
+        and config.r2_data_secret_key
+        and config.r2_data_bucket
+    ):
+        folders.append(
+            FolderSpec(
+                "r2-datalake",
+                _filter_empty(
+                    {
+                        "R2_ENDPOINT": config.r2_data_endpoint,
+                        "R2_ACCESS_KEY": config.r2_data_access_key,
+                        "R2_SECRET_KEY": config.r2_data_secret_key,
+                        "R2_BUCKET": config.r2_data_bucket,
+                    }
+                ),
+            )
+        )
+
+    if config.hetzner_s3_server and config.hetzner_s3_access_key and config.hetzner_s3_secret_key:
+        # Fallback chain for canonical HETZNER_S3_BUCKET (used by ad-hoc
+        # workloads): prefer _general (workloads bucket by convention),
+        # fall back to _lakefs (always populated when LakeFS-aware path runs).
+        # See deploy.sh:2069-2087 for the rationale.
+        default_bucket = config.hetzner_s3_bucket_general or config.hetzner_s3_bucket_lakefs or ""
+        folders.append(
+            FolderSpec(
+                "hetzner-s3",
+                _filter_empty(
+                    {
+                        "HETZNER_S3_ENDPOINT": f"https://{config.hetzner_s3_server}",
+                        "HETZNER_S3_REGION": config.hetzner_s3_region,
+                        "HETZNER_S3_ACCESS_KEY": config.hetzner_s3_access_key,
+                        "HETZNER_S3_SECRET_KEY": config.hetzner_s3_secret_key,
+                        "HETZNER_S3_BUCKET": default_bucket,
+                        "HETZNER_S3_BUCKET_LAKEFS": config.hetzner_s3_bucket_lakefs,
+                        "HETZNER_S3_BUCKET_GENERAL": config.hetzner_s3_bucket_general,
+                        "HETZNER_S3_BUCKET_PGDUCKLAKE": config.hetzner_s3_bucket_pgducklake,
+                    }
+                ),
+            )
+        )
+
+    if (
+        config.external_s3_endpoint
+        and config.external_s3_access_key
+        and config.external_s3_secret_key
+        and config.external_s3_bucket
+    ):
+        folders.append(
+            FolderSpec(
+                "external-s3",
+                _filter_empty(
+                    {
+                        "EXTERNAL_S3_ENDPOINT": config.external_s3_endpoint,
+                        "EXTERNAL_S3_REGION": external_s3_region,
+                        "EXTERNAL_S3_ACCESS_KEY": config.external_s3_access_key,
+                        "EXTERNAL_S3_SECRET_KEY": config.external_s3_secret_key,
+                        "EXTERNAL_S3_BUCKET": config.external_s3_bucket,
+                        "EXTERNAL_S3_LABEL": external_s3_label,
+                    }
+                ),
+            )
+        )
+
+    folders.append(
+        FolderSpec(
+            "infisical",
+            _filter_empty(
+                {
+                    "INFISICAL_USERNAME": env.admin_email,
+                    "INFISICAL_PASSWORD": config.infisical_admin_password,
+                }
+            ),
+        )
+    )
+    folders.append(
+        FolderSpec(
+            "portainer",
+            _filter_empty(
+                {
+                    "PORTAINER_USERNAME": admin_username,
+                    "PORTAINER_PASSWORD": config.portainer_admin_password,
+                }
+            ),
+        )
+    )
+    folders.append(
+        FolderSpec(
+            "uptime-kuma",
+            _filter_empty(
+                {
+                    "UPTIME_KUMA_USERNAME": admin_username,
+                    "UPTIME_KUMA_PASSWORD": config.kuma_admin_password,
+                }
+            ),
+        )
+    )
+    folders.append(
+        FolderSpec(
+            "grafana",
+            _filter_empty(
+                {
+                    "GRAFANA_USERNAME": admin_username,
+                    "GRAFANA_PASSWORD": config.grafana_admin_password,
+                }
+            ),
+        )
+    )
+    folders.append(
+        FolderSpec(
+            "n8n",
+            _filter_empty(
+                {
+                    "N8N_USERNAME": env.admin_email,
+                    "N8N_PASSWORD": config.n8n_admin_password,
+                }
+            ),
+        )
+    )
+    folders.append(
+        FolderSpec(
+            "dagster",
+            _filter_empty({"DAGSTER_DB_PASSWORD": config.dagster_db_password}),
+        )
+    )
+    folders.append(
+        FolderSpec(
+            "kestra",
+            _filter_empty(
+                {
+                    "KESTRA_USERNAME": env.admin_email,
+                    "KESTRA_PASSWORD": config.kestra_admin_password,
+                }
+            ),
+        )
+    )
+    folders.append(
+        FolderSpec(
+            "metabase",
+            _filter_empty(
+                {
+                    "METABASE_USERNAME": env.admin_email,
+                    "METABASE_PASSWORD": config.metabase_admin_password,
+                }
+            ),
+        )
+    )
+    folders.append(
+        FolderSpec(
+            "superset",
+            _filter_empty(
+                {
+                    "SUPERSET_USERNAME": "admin",
+                    "SUPERSET_PASSWORD": config.superset_admin_password,
+                    "SUPERSET_DB_PASSWORD": config.superset_db_password,
+                    "SUPERSET_SECRET_KEY": config.superset_secret_key,
+                }
+            ),
+        )
+    )
+    folders.append(
+        FolderSpec(
+            "cloudbeaver",
+            _filter_empty(
+                {
+                    "CLOUDBEAVER_USERNAME": "nexus-cloudbeaver",
+                    "CLOUDBEAVER_PASSWORD": config.cloudbeaver_admin_password,
+                }
+            ),
+        )
+    )
+    folders.append(
+        FolderSpec(
+            "mage",
+            _filter_empty(
+                {
+                    "MAGE_USERNAME": env.gitea_user_email or env.admin_email,
+                    "MAGE_PASSWORD": config.mage_admin_password,
+                }
+            ),
+        )
+    )
+    folders.append(
+        FolderSpec(
+            "minio",
+            _filter_empty(
+                {
+                    "MINIO_ROOT_USER": "nexus-minio",
+                    "MINIO_ROOT_PASSWORD": config.minio_root_password,
+                }
+            ),
+        )
+    )
+    folders.append(
+        FolderSpec(
+            "sftpgo",
+            _filter_empty(
+                {
+                    "SFTPGO_ADMIN_USERNAME": "nexus-sftpgo",
+                    "SFTPGO_ADMIN_PASSWORD": config.sftpgo_admin_password,
+                    "SFTPGO_USER_USERNAME": "nexus-default",
+                    "SFTPGO_USER_PASSWORD": config.sftpgo_user_password,
+                }
+            ),
+        )
+    )
+    folders.append(
+        FolderSpec(
+            "nocodb",
+            _filter_empty(
+                {
+                    "NOCODB_USERNAME": env.admin_email,
+                    "NOCODB_PASSWORD": config.nocodb_admin_password,
+                    "NOCODB_DB_PASSWORD": config.nocodb_db_password,
+                    "NOCODB_JWT_SECRET": config.nocodb_jwt_secret,
+                }
+            ),
+        )
+    )
+    folders.append(
+        FolderSpec(
+            "appsmith",
+            _filter_empty(
+                {
+                    "APPSMITH_ENCRYPTION_PASSWORD": config.appsmith_encryption_password,
+                    "APPSMITH_ENCRYPTION_SALT": config.appsmith_encryption_salt,
+                }
+            ),
+        )
+    )
+    folders.append(
+        FolderSpec(
+            "dinky",
+            _filter_empty(
+                {
+                    "DINKY_USERNAME": "admin",
+                    "DINKY_PASSWORD": config.dinky_admin_password,
+                }
+            ),
+        )
+    )
+    folders.append(
+        FolderSpec(
+            "dify",
+            _filter_empty(
+                {
+                    "DIFY_USERNAME": env.admin_email,
+                    "DIFY_PASSWORD": config.dify_admin_password,
+                    "DIFY_DB_PASSWORD": config.dify_db_password,
+                    "DIFY_SECRET_KEY": config.dify_secret_key,
+                    "DIFY_REDIS_PASSWORD": config.dify_redis_password,
+                    "DIFY_WEAVIATE_API_KEY": config.dify_weaviate_api_key,
+                    "DIFY_SANDBOX_API_KEY": config.dify_sandbox_api_key,
+                    "DIFY_PLUGIN_DAEMON_KEY": config.dify_plugin_daemon_key,
+                    "DIFY_PLUGIN_INNER_API_KEY": config.dify_plugin_inner_api_key,
+                }
+            ),
+        )
+    )
+    folders.append(
+        FolderSpec(
+            "rustfs",
+            _filter_empty(
+                {
+                    "RUSTFS_ACCESS_KEY": "nexus-rustfs",
+                    "RUSTFS_SECRET_KEY": config.rustfs_root_password,
+                }
+            ),
+        )
+    )
+    folders.append(
+        FolderSpec(
+            "seaweedfs",
+            _filter_empty(
+                {
+                    "SEAWEEDFS_ACCESS_KEY": "nexus-seaweedfs",
+                    "SEAWEEDFS_SECRET_KEY": config.seaweedfs_admin_password,
+                }
+            ),
+        )
+    )
+    folders.append(
+        FolderSpec(
+            "garage",
+            _filter_empty({"GARAGE_ADMIN_TOKEN": config.garage_admin_token}),
+        )
+    )
+    folders.append(
+        FolderSpec(
+            "lakefs",
+            _filter_empty(
+                {
+                    "LAKEFS_DB_PASSWORD": config.lakefs_db_password,
+                    "LAKEFS_ACCESS_KEY_ID": config.lakefs_admin_access_key,
+                    "LAKEFS_SECRET_ACCESS_KEY": config.lakefs_admin_secret_key,
+                }
+            ),
+        )
+    )
+    folders.append(
+        FolderSpec(
+            "filestash",
+            _filter_empty(
+                {
+                    "FILESTASH_S3_BUCKET": config.hetzner_s3_bucket_general,
+                    "FILESTASH_ADMIN_PASSWORD": config.filestash_admin_password,
+                }
+            ),
+        )
+    )
+    folders.append(
+        FolderSpec(
+            "redpanda",
+            _filter_empty(
+                {
+                    "REDPANDA_SASL_USERNAME": "nexus-redpanda",
+                    "REDPANDA_SASL_PASSWORD": config.redpanda_admin_password,
+                    "REDPANDA_KAFKA_PUBLIC_URL": (
+                        f"redpanda-kafka.{env.domain}:9092" if env.domain else None
+                    ),
+                    "REDPANDA_SCHEMA_REGISTRY_PUBLIC_URL": (
+                        f"redpanda-schema-registry.{env.domain}:18081" if env.domain else None
+                    ),
+                    "REDPANDA_ADMIN_PUBLIC_URL": (
+                        f"redpanda-admin.{env.domain}:9644" if env.domain else None
+                    ),
+                    "REDPANDA_CONNECT_PUBLIC_URL": (
+                        f"redpanda-connect-api.{env.domain}:4195" if env.domain else None
+                    ),
+                }
+            ),
+        )
+    )
+    folders.append(
+        FolderSpec("meltano", _filter_empty({"MELTANO_DB_PASSWORD": config.meltano_db_password}))
+    )
+    folders.append(
+        FolderSpec(
+            "postgres",
+            _filter_empty(
+                {
+                    "POSTGRES_USERNAME": "nexus-postgres",
+                    "POSTGRES_PASSWORD": config.postgres_password,
+                }
+            ),
+        )
+    )
+    folders.append(
+        FolderSpec(
+            "pg-ducklake",
+            _filter_empty(
+                {
+                    "PG_DUCKLAKE_USERNAME": "nexus-pgducklake",
+                    "PG_DUCKLAKE_PASSWORD": config.pgducklake_password,
+                    "PG_DUCKLAKE_DATABASE": "ducklake",
+                    "PG_DUCKLAKE_S3_BUCKET": config.hetzner_s3_bucket_pgducklake,
+                }
+            ),
+        )
+    )
+    folders.append(
+        FolderSpec(
+            "pgadmin",
+            _filter_empty(
+                {
+                    "PGADMIN_USERNAME": env.admin_email,
+                    "PGADMIN_PASSWORD": config.pgadmin_password,
+                }
+            ),
+        )
+    )
+    folders.append(
+        FolderSpec("prefect", _filter_empty({"PREFECT_DB_PASSWORD": config.prefect_db_password}))
+    )
+    folders.append(
+        FolderSpec(
+            "windmill",
+            _filter_empty(
+                {
+                    "WINDMILL_ADMIN_EMAIL": env.admin_email,
+                    "WINDMILL_ADMIN_PASSWORD": config.windmill_admin_password,
+                    "WINDMILL_DB_PASSWORD": config.windmill_db_password,
+                    "WINDMILL_SUPERADMIN_SECRET": config.windmill_superadmin_secret,
+                }
+            ),
+        )
+    )
+    folders.append(
+        FolderSpec(
+            "openmetadata",
+            _filter_empty(
+                {
+                    "OPENMETADATA_USERNAME": (
+                        f"admin@{env.om_principal_domain}" if env.om_principal_domain else None
+                    ),
+                    "OPENMETADATA_PASSWORD": config.openmetadata_admin_password,
+                    "OPENMETADATA_DB_PASSWORD": config.openmetadata_db_password,
+                }
+            ),
+        )
+    )
+    # Gitea: GITEA_REPO_URL is built from DOMAIN + repo_owner + repo_name
+    # with the same `${REPO_NAME:-nexus-${DOMAIN//./-}-gitea}` fallback
+    # the bash carried at L2300.
+    repo_name = env.repo_name or (
+        f"nexus-{env.domain.replace('.', '-')}-gitea" if env.domain else None
+    )
+    repo_owner = env.gitea_repo_owner or admin_username
+    gitea_repo_url = (
+        f"https://git.{env.domain}/{repo_owner}/{repo_name}.git"
+        if env.domain and repo_owner and repo_name
+        else None
+    )
+    folders.append(
+        FolderSpec(
+            "gitea",
+            _filter_empty(
+                {
+                    "GITEA_ADMIN_USERNAME": admin_username,
+                    "GITEA_ADMIN_PASSWORD": config.gitea_admin_password,
+                    "GITEA_USER_USERNAME": env.gitea_user_username,
+                    "GITEA_USER_PASSWORD": config.gitea_user_password,
+                    "GITEA_REPO_URL": gitea_repo_url,
+                    "GITEA_DB_PASSWORD": config.gitea_db_password,
+                }
+            ),
+        )
+    )
+    folders.append(
+        FolderSpec(
+            "clickhouse",
+            _filter_empty(
+                {
+                    "CLICKHOUSE_USERNAME": "nexus-clickhouse",
+                    "CLICKHOUSE_PASSWORD": config.clickhouse_admin_password,
+                }
+            ),
+        )
+    )
+    folders.append(
+        FolderSpec(
+            "wikijs",
+            _filter_empty(
+                {
+                    "WIKIJS_USERNAME": env.gitea_user_email or env.admin_email,
+                    "WIKIJS_PASSWORD": config.wikijs_admin_password,
+                    "WIKIJS_DB_PASSWORD": config.wikijs_db_password,
+                }
+            ),
+        )
+    )
+    # Woodpecker: agent_secret unconditional, OAuth pair optional.
+    woodpecker_secrets: dict[str, str | None] = {
+        "WOODPECKER_AGENT_SECRET": config.woodpecker_agent_secret,
+    }
+    if env.woodpecker_gitea_client:
+        woodpecker_secrets["WOODPECKER_GITEA_CLIENT"] = env.woodpecker_gitea_client
+    if env.woodpecker_gitea_secret:
+        woodpecker_secrets["WOODPECKER_GITEA_SECRET"] = env.woodpecker_gitea_secret
+    folders.append(FolderSpec("woodpecker", _filter_empty(woodpecker_secrets)))
+
+    if env.ssh_private_key_base64:
+        folders.append(
+            FolderSpec(
+                "ssh",
+                _filter_empty({"SSH_PRIVATE_KEY_BASE64": env.ssh_private_key_base64}),
+            )
+        )
+
+    return folders
+
+
+# Type aliases for the runner injection points used in tests.
+SshRunner = Callable[[str], subprocess.CompletedProcess[str]]
+RsyncRunner = Callable[[Path, str], subprocess.CompletedProcess[str]]
+
+
+@dataclass
+class InfisicalClient:
+    """Bundles the project_id / env / token / push_dir for a bootstrap call.
+
+    Stateless except for the ``push_dir`` it manages on the local
+    filesystem. The actual server-side execution is via the injected
+    ``ssh_runner`` / ``rsync_runner`` callables — defaults wire to
+    :mod:`nexus_deploy._remote`, tests pass mocks.
+    """
+
+    project_id: str
+    env: str
+    token: str
+    push_dir: Path = Path("/tmp/infisical-push")  # noqa: S108 - matches deploy.sh's
+    # public location; the same dir on the server is what the curl loop
+    # reads. There's nothing secret in the path itself; the JSON files
+    # inside contain secret values but are removed by the server-side
+    # `rm -rf` at the end of the bootstrap.
+
+    def encode_payloads(self, folders: list[FolderSpec]) -> dict[str, str]:
+        """Return the f-NAME.json + s-NAME.json file-name → JSON-text mapping.
+
+        Pure function — useful for tests that want to verify the exact
+        bytes that would be written to disk without touching the
+        filesystem.
+
+        Output uses ``json.dumps(..., separators=(",", ":"),
+        sort_keys=False)`` to keep the encoding compact and stable
+        without imposing alphabetical ordering on the secrets list
+        (deploy.sh's jq emitted source-order via the explicit jq
+        filter; we preserve the same convention).
+        """
+        out: dict[str, str] = {}
+        for spec in folders:
+            out[f"f-{spec.name}.json"] = json.dumps(
+                spec.folder_payload(self.project_id, self.env), separators=(",", ":")
+            )
+            out[f"s-{spec.name}.json"] = json.dumps(
+                spec.secrets_payload(self.project_id, self.env), separators=(",", ":")
+            )
+        return out
+
+    def _build_remote_loop(self) -> str:
+        """Build the server-side bash that POSTs folders + PATCHes secrets.
+
+        Mirrors deploy.sh:2280-2300 byte-for-byte (modulo one
+        difference: the token is shlex-quoted on the way through, since
+        we're now interpolating into a remote bash script generated
+        from Python — see the comment block in ``dump_shell()``).
+        """
+        token_quoted = shlex.quote(self.token)
+        folders_url = f"http://{_INFISICAL_HOST}:{_INFISICAL_PORT}{_FOLDERS_PATH}"
+        secrets_url = f"http://{_INFISICAL_HOST}:{_INFISICAL_PORT}{_SECRETS_BATCH_PATH}"
+        # The `\$f` / `\$TOKEN` etc. escaping is gone here vs deploy.sh —
+        # that escaping was only needed because deploy.sh interpolated
+        # the heredoc through a layer of bash before ssh saw it. We
+        # send raw text directly to ssh, so the inner `$f` expands at
+        # the remote bash, which is what we want.
+        return f"""
+TOKEN=$(cat {_REMOTE_TOKEN_FALLBACK_FILE} 2>/dev/null || echo {token_quoted})
+if [ -z "$TOKEN" ]; then echo '0:0'; exit 0; fi
+OK=0; FAIL=0
+for f in {_REMOTE_PUSH_DIR}/f-*.json; do
+    curl -s -X POST '{folders_url}' \\
+        -H "Authorization: Bearer $TOKEN" \\
+        -H 'Content-Type: application/json' \\
+        -d @"$f" >/dev/null 2>&1 || true
+done
+for f in {_REMOTE_PUSH_DIR}/s-*.json; do
+    RESULT=$(curl -s -X PATCH '{secrets_url}' \\
+        -H "Authorization: Bearer $TOKEN" \\
+        -H 'Content-Type: application/json' \\
+        -d @"$f" 2>&1)
+    if echo "$RESULT" | grep -q '"error"'; then
+        FAIL=$((FAIL+1))
+    else
+        OK=$((OK+1))
+    fi
+done
+rm -rf {_REMOTE_PUSH_DIR}
+echo "$OK:$FAIL"
+"""
+
+    def bootstrap(
+        self,
+        folders: list[FolderSpec],
+        *,
+        ssh_runner: SshRunner | None = None,
+        rsync_runner: RsyncRunner | None = None,
+    ) -> BootstrapResult:
+        """Write payloads, rsync, run the curl loop. Return push counts.
+
+        Default runners come from :mod:`nexus_deploy._remote`; tests
+        override both via the kwargs.
+        """
+        ssh = ssh_runner or (lambda cmd: _remote.ssh_run(cmd))
+        rsync = rsync_runner or (
+            lambda local, remote: _remote.rsync_to_remote(local, remote, delete=True)
+        )
+
+        # 1. Write JSON payloads to local push_dir.
+        self.push_dir.mkdir(parents=True, exist_ok=True)
+        # Clear stale files from prior runs so deleted folders don't
+        # ship to the server (matches `rsync --delete` semantics on
+        # the upload side).
+        for stale in self.push_dir.glob("[fs]-*.json"):
+            stale.unlink()
+        for filename, body in self.encode_payloads(folders).items():
+            (self.push_dir / filename).write_text(body)
+
+        # 2. rsync to server.
+        rsync(self.push_dir, f"nexus:{_REMOTE_PUSH_DIR}/")
+
+        # 3. Run the server-side curl loop.
+        completed = ssh(self._build_remote_loop())
+
+        # 4. Parse the final `OK:FAIL` line. The server's stdout may
+        #    include earlier echoes (warnings from the baseline-capture
+        #    step in deploy.sh); take the last line.
+        last_line = completed.stdout.strip().splitlines()[-1] if completed.stdout else "0:0"
+        try:
+            ok_str, fail_str = last_line.split(":", 1)
+            pushed = int(ok_str)
+            failed = int(fail_str)
+        except (ValueError, IndexError):
+            # Unparseable output is itself a failure signal.
+            pushed = 0
+            failed = len(folders)
+
+        return BootstrapResult(folders_built=len(folders), pushed=pushed, failed=failed)

--- a/tests/unit/__snapshots__/test_infisical.ambr
+++ b/tests/unit/__snapshots__/test_infisical.ambr
@@ -1,0 +1,198 @@
+# serializer version: 1
+# name: test_compute_folders_full_snapshot
+  dict({
+    'appsmith': dict({
+      'APPSMITH_ENCRYPTION_PASSWORD': 'appsmith_encryption_password-VALUE',
+      'APPSMITH_ENCRYPTION_SALT': 'appsmith_encryption_salt-VALUE',
+    }),
+    'clickhouse': dict({
+      'CLICKHOUSE_PASSWORD': 'clickhouse_admin_password-VALUE',
+      'CLICKHOUSE_USERNAME': 'nexus-clickhouse',
+    }),
+    'cloudbeaver': dict({
+      'CLOUDBEAVER_PASSWORD': 'cloudbeaver_admin_password-VALUE',
+      'CLOUDBEAVER_USERNAME': 'nexus-cloudbeaver',
+    }),
+    'config': dict({
+      'ADMIN_EMAIL': 'admin@snapshot.test',
+      'ADMIN_USERNAME': 'nexus-test-user',
+      'DOMAIN': 'snapshot.test',
+    }),
+    'dagster': dict({
+      'DAGSTER_DB_PASSWORD': 'dagster_db_password-VALUE',
+    }),
+    'dify': dict({
+      'DIFY_DB_PASSWORD': 'dify_db_password-VALUE',
+      'DIFY_PASSWORD': 'dify_admin_password-VALUE',
+      'DIFY_PLUGIN_DAEMON_KEY': 'dify_plugin_daemon_key-VALUE',
+      'DIFY_PLUGIN_INNER_API_KEY': 'dify_plugin_inner_api_key-VALUE',
+      'DIFY_REDIS_PASSWORD': 'dify_redis_password-VALUE',
+      'DIFY_SANDBOX_API_KEY': 'dify_sandbox_api_key-VALUE',
+      'DIFY_SECRET_KEY': 'dify_secret_key-VALUE',
+      'DIFY_USERNAME': 'admin@snapshot.test',
+      'DIFY_WEAVIATE_API_KEY': 'dify_weaviate_api_key-VALUE',
+    }),
+    'dinky': dict({
+      'DINKY_PASSWORD': 'dinky_admin_password-VALUE',
+      'DINKY_USERNAME': 'admin',
+    }),
+    'external-s3': dict({
+      'EXTERNAL_S3_ACCESS_KEY': 'external_s3_access_key-VALUE',
+      'EXTERNAL_S3_BUCKET': 'external_s3_bucket-VALUE',
+      'EXTERNAL_S3_ENDPOINT': 'external_s3_endpoint-VALUE',
+      'EXTERNAL_S3_LABEL': 'external_s3_label-VALUE',
+      'EXTERNAL_S3_REGION': 'external_s3_region-VALUE',
+      'EXTERNAL_S3_SECRET_KEY': 'external_s3_secret_key-VALUE',
+    }),
+    'filestash': dict({
+      'FILESTASH_ADMIN_PASSWORD': 'filestash_admin_password-VALUE',
+      'FILESTASH_S3_BUCKET': 'hetzner_s3_bucket_general-VALUE',
+    }),
+    'garage': dict({
+      'GARAGE_ADMIN_TOKEN': 'garage_admin_token-VALUE',
+    }),
+    'gitea': dict({
+      'GITEA_ADMIN_PASSWORD': 'with"double"quotes',
+      'GITEA_ADMIN_USERNAME': 'nexus-test-user',
+      'GITEA_DB_PASSWORD': 'gitea_db_password-VALUE',
+      'GITEA_REPO_URL': 'https://git.snapshot.test/snapshot-org/snapshot-repo.git',
+      'GITEA_USER_PASSWORD': 'gitea_user_password-VALUE',
+      'GITEA_USER_USERNAME': 'snapshot-user',
+    }),
+    'grafana': dict({
+      'GRAFANA_PASSWORD': 'grafana_admin_password-VALUE',
+      'GRAFANA_USERNAME': 'nexus-test-user',
+    }),
+    'hetzner-s3': dict({
+      'HETZNER_S3_ACCESS_KEY': 'hetzner_s3_access_key-VALUE',
+      'HETZNER_S3_BUCKET': 'hetzner_s3_bucket_general-VALUE',
+      'HETZNER_S3_BUCKET_GENERAL': 'hetzner_s3_bucket_general-VALUE',
+      'HETZNER_S3_BUCKET_LAKEFS': 'hetzner_s3_bucket_lakefs-VALUE',
+      'HETZNER_S3_BUCKET_PGDUCKLAKE': 'hetzner_s3_bucket_pgducklake-VALUE',
+      'HETZNER_S3_ENDPOINT': 'https://hetzner_s3_server-VALUE',
+      'HETZNER_S3_REGION': 'hetzner_s3_region-VALUE',
+      'HETZNER_S3_SECRET_KEY': 'hetzner_s3_secret_key-VALUE',
+    }),
+    'infisical': dict({
+      'INFISICAL_PASSWORD': 'infisical_admin_password-VALUE',
+      'INFISICAL_USERNAME': 'admin@snapshot.test',
+    }),
+    'kestra': dict({
+      'KESTRA_PASSWORD': 'has spaces and\trabs',
+      'KESTRA_USERNAME': 'admin@snapshot.test',
+    }),
+    'lakefs': dict({
+      'LAKEFS_ACCESS_KEY_ID': 'lakefs_admin_access_key-VALUE',
+      'LAKEFS_DB_PASSWORD': 'lakefs_db_password-VALUE',
+      'LAKEFS_SECRET_ACCESS_KEY': 'lakefs_admin_secret_key-VALUE',
+    }),
+    'mage': dict({
+      'MAGE_PASSWORD': 'mage_admin_password-VALUE',
+      'MAGE_USERNAME': 'user@snapshot.test',
+    }),
+    'meltano': dict({
+      'MELTANO_DB_PASSWORD': 'meltano_db_password-VALUE',
+    }),
+    'metabase': dict({
+      'METABASE_PASSWORD': 'metabase_admin_password-VALUE',
+      'METABASE_USERNAME': 'admin@snapshot.test',
+    }),
+    'minio': dict({
+      'MINIO_ROOT_PASSWORD': 'minio_root_password-VALUE',
+      'MINIO_ROOT_USER': 'nexus-minio',
+    }),
+    'n8n': dict({
+      'N8N_PASSWORD': 'n8n_admin_password-VALUE',
+      'N8N_USERNAME': 'admin@snapshot.test',
+    }),
+    'nocodb': dict({
+      'NOCODB_DB_PASSWORD': 'nocodb_db_password-VALUE',
+      'NOCODB_JWT_SECRET': 'nocodb_jwt_secret-VALUE',
+      'NOCODB_PASSWORD': 'nocodb_admin_password-VALUE',
+      'NOCODB_USERNAME': 'admin@snapshot.test',
+    }),
+    'openmetadata': dict({
+      'OPENMETADATA_DB_PASSWORD': 'openmetadata_db_password-VALUE',
+      'OPENMETADATA_PASSWORD': 'openmetadata_admin_password-VALUE',
+      'OPENMETADATA_USERNAME': 'admin@snapshot.test',
+    }),
+    'pg-ducklake': dict({
+      'PG_DUCKLAKE_DATABASE': 'ducklake',
+      'PG_DUCKLAKE_PASSWORD': 'pgducklake_password-VALUE',
+      'PG_DUCKLAKE_S3_BUCKET': 'hetzner_s3_bucket_pgducklake-VALUE',
+      'PG_DUCKLAKE_USERNAME': 'nexus-pgducklake',
+    }),
+    'pgadmin': dict({
+      'PGADMIN_PASSWORD': 'pgadmin_password-VALUE',
+      'PGADMIN_USERNAME': 'admin@snapshot.test',
+    }),
+    'portainer': dict({
+      'PORTAINER_PASSWORD': 'portainer_admin_password-VALUE',
+      'PORTAINER_USERNAME': 'nexus-test-user',
+    }),
+    'postgres': dict({
+      'POSTGRES_PASSWORD': 'postgres_password-VALUE',
+      'POSTGRES_USERNAME': 'nexus-postgres',
+    }),
+    'prefect': dict({
+      'PREFECT_DB_PASSWORD': 'prefect_db_password-VALUE',
+    }),
+    'r2-datalake': dict({
+      'R2_ACCESS_KEY': 'r2_data_access_key-VALUE',
+      'R2_BUCKET': 'r2_data_bucket-VALUE',
+      'R2_ENDPOINT': 'r2_data_endpoint-VALUE',
+      'R2_SECRET_KEY': 'r2_data_secret_key-VALUE',
+    }),
+    'redpanda': dict({
+      'REDPANDA_ADMIN_PUBLIC_URL': 'redpanda-admin.snapshot.test:9644',
+      'REDPANDA_CONNECT_PUBLIC_URL': 'redpanda-connect-api.snapshot.test:4195',
+      'REDPANDA_KAFKA_PUBLIC_URL': 'redpanda-kafka.snapshot.test:9092',
+      'REDPANDA_SASL_PASSWORD': "single'apos",
+      'REDPANDA_SASL_USERNAME': 'nexus-redpanda',
+      'REDPANDA_SCHEMA_REGISTRY_PUBLIC_URL': 'redpanda-schema-registry.snapshot.test:18081',
+    }),
+    'rustfs': dict({
+      'RUSTFS_ACCESS_KEY': 'nexus-rustfs',
+      'RUSTFS_SECRET_KEY': 'rustfs_root_password-VALUE',
+    }),
+    'seaweedfs': dict({
+      'SEAWEEDFS_ACCESS_KEY': 'nexus-seaweedfs',
+      'SEAWEEDFS_SECRET_KEY': 'seaweedfs_admin_password-VALUE',
+    }),
+    'sftpgo': dict({
+      'SFTPGO_ADMIN_PASSWORD': 'sftpgo_admin_password-VALUE',
+      'SFTPGO_ADMIN_USERNAME': 'nexus-sftpgo',
+      'SFTPGO_USER_PASSWORD': 'sftpgo_user_password-VALUE',
+      'SFTPGO_USER_USERNAME': 'nexus-default',
+    }),
+    'ssh': dict({
+      'SSH_PRIVATE_KEY_BASE64': 'snapshot-ssh-base64',
+    }),
+    'superset': dict({
+      'SUPERSET_DB_PASSWORD': 'superset_db_password-VALUE',
+      'SUPERSET_PASSWORD': 'superset_admin_password-VALUE',
+      'SUPERSET_SECRET_KEY': 'superset_secret_key-VALUE',
+      'SUPERSET_USERNAME': 'admin',
+    }),
+    'uptime-kuma': dict({
+      'UPTIME_KUMA_PASSWORD': 'kuma_admin_password-VALUE',
+      'UPTIME_KUMA_USERNAME': 'nexus-test-user',
+    }),
+    'wikijs': dict({
+      'WIKIJS_DB_PASSWORD': 'wikijs_db_password-VALUE',
+      'WIKIJS_PASSWORD': 'wikijs_admin_password-VALUE',
+      'WIKIJS_USERNAME': 'user@snapshot.test',
+    }),
+    'windmill': dict({
+      'WINDMILL_ADMIN_EMAIL': 'admin@snapshot.test',
+      'WINDMILL_ADMIN_PASSWORD': 'windmill_admin_password-VALUE',
+      'WINDMILL_DB_PASSWORD': 'windmill_db_password-VALUE',
+      'WINDMILL_SUPERADMIN_SECRET': 'windmill_superadmin_secret-VALUE',
+    }),
+    'woodpecker': dict({
+      'WOODPECKER_AGENT_SECRET': 'woodpecker_agent_secret-VALUE',
+      'WOODPECKER_GITEA_CLIENT': 'cid',
+      'WOODPECKER_GITEA_SECRET': 'csec',
+    }),
+  })
+# ---

--- a/tests/unit/test_infisical.py
+++ b/tests/unit/test_infisical.py
@@ -1,0 +1,543 @@
+"""Tests for nexus_deploy.infisical — Phase 1 Modul 1.1 (#505).
+
+Covers:
+- skip-empty rule (#504 contract: preserve operator UI edits)
+- folder list + per-folder key list match deploy.sh source-order
+- payload JSON shape (folder + secrets-batch upsert)
+- adversarial token quoting in the remote bash loop
+- end-to-end bootstrap with mocked ssh/rsync runners
+- snapshot of compute_folders output for a fully-populated config
+- CLI integration: `infisical bootstrap` reads stdin + env vars
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from nexus_deploy.config import NexusConfig
+from nexus_deploy.infisical import (
+    BootstrapEnv,
+    BootstrapResult,
+    FolderSpec,
+    InfisicalClient,
+    _filter_empty,
+    compute_folders,
+)
+
+FIXTURES = Path(__file__).resolve().parents[1] / "fixtures"
+
+
+# ---------------------------------------------------------------------------
+# _filter_empty — skip-empty rule
+# ---------------------------------------------------------------------------
+
+
+def test_filter_empty_drops_none() -> None:
+    assert _filter_empty({"K": None, "L": "v"}) == {"L": "v"}
+
+
+def test_filter_empty_drops_empty_string() -> None:
+    assert _filter_empty({"K": "", "L": "v"}) == {"L": "v"}
+
+
+def test_filter_empty_keeps_whitespace() -> None:
+    """A single space is a valid value (some configs use ' ' as a sentinel)."""
+    assert _filter_empty({"K": " ", "L": "v"}) == {"K": " ", "L": "v"}
+
+
+def test_filter_empty_preserves_input_order() -> None:
+    items = {"C": "1", "A": "2", "B": "3"}
+    assert list(_filter_empty(items)) == ["C", "A", "B"]
+
+
+# ---------------------------------------------------------------------------
+# FolderSpec — payload shapes
+# ---------------------------------------------------------------------------
+
+
+def test_folder_payload_shape() -> None:
+    spec = FolderSpec("kestra", {"K": "v"})
+    assert spec.folder_payload("proj-1", "dev") == {
+        "projectId": "proj-1",
+        "environment": "dev",
+        "name": "kestra",
+        "path": "/",
+    }
+
+
+def test_secrets_payload_shape() -> None:
+    spec = FolderSpec("kestra", {"K1": "v1", "K2": "v2"})
+    assert spec.secrets_payload("proj-1", "dev") == {
+        "projectId": "proj-1",
+        "environment": "dev",
+        "secretPath": "/kestra",
+        "mode": "upsert",
+        "secrets": [
+            {"secretKey": "K1", "secretValue": "v1"},
+            {"secretKey": "K2", "secretValue": "v2"},
+        ],
+    }
+
+
+def test_secrets_payload_preserves_secret_order() -> None:
+    """Source-order matches deploy.sh's jq filter (sequential `secretKey: $kN`)."""
+    spec = FolderSpec("dify", {"DIFY_USERNAME": "u", "DIFY_PASSWORD": "p", "DIFY_DB_PASSWORD": "d"})
+    payload = spec.secrets_payload("p", "e")
+    secrets = payload["secrets"]
+    assert isinstance(secrets, list)
+    keys = [s["secretKey"] for s in secrets]
+    assert keys == ["DIFY_USERNAME", "DIFY_PASSWORD", "DIFY_DB_PASSWORD"]
+
+
+# ---------------------------------------------------------------------------
+# compute_folders — schema + ordering + conditional gates
+# ---------------------------------------------------------------------------
+
+
+def _make_config(**overrides: str) -> NexusConfig:
+    return NexusConfig.from_secrets_json(json.dumps(overrides))
+
+
+def test_compute_folders_minimal_emits_unconditional_only() -> None:
+    """Empty config + minimal env → no R2/Hetzner-S3/External-S3/SSH folders."""
+    folders = compute_folders(NexusConfig.from_secrets_json("{}"), BootstrapEnv())
+    names = [f.name for f in folders]
+    # Conditional folders absent
+    assert "r2-datalake" not in names
+    assert "hetzner-s3" not in names
+    assert "external-s3" not in names
+    assert "ssh" not in names
+    # Unconditional core present
+    for required in ("config", "infisical", "kestra", "gitea", "woodpecker"):
+        assert required in names
+
+
+def test_compute_folders_r2_gate() -> None:
+    """All four r2_* fields must be present for the r2-datalake folder."""
+    config = _make_config(
+        r2_data_endpoint="ep",
+        r2_data_access_key="ak",
+        r2_data_secret_key="sk",
+        # missing r2_data_bucket
+    )
+    folders = compute_folders(config, BootstrapEnv())
+    assert "r2-datalake" not in [f.name for f in folders]
+
+    config = _make_config(
+        r2_data_endpoint="ep",
+        r2_data_access_key="ak",
+        r2_data_secret_key="sk",
+        r2_data_bucket="bk",
+    )
+    folders = compute_folders(config, BootstrapEnv())
+    r2 = next(f for f in folders if f.name == "r2-datalake")
+    assert r2.secrets == {
+        "R2_ENDPOINT": "ep",
+        "R2_ACCESS_KEY": "ak",
+        "R2_SECRET_KEY": "sk",
+        "R2_BUCKET": "bk",
+    }
+
+
+def test_compute_folders_hetzner_default_bucket_chain() -> None:
+    """HETZNER_S3_BUCKET prefers _general, falls back to _lakefs."""
+    base = {
+        "hetzner_s3_server": "s3.example",
+        "hetzner_s3_access_key": "ak",
+        "hetzner_s3_secret_key": "sk",
+    }
+    folders = compute_folders(_make_config(**base, hetzner_s3_bucket_general="g"), BootstrapEnv())
+    h = next(f for f in folders if f.name == "hetzner-s3")
+    assert h.secrets["HETZNER_S3_BUCKET"] == "g"
+
+    folders = compute_folders(
+        _make_config(**base, hetzner_s3_bucket_lakefs="l"),
+        BootstrapEnv(),
+    )
+    h = next(f for f in folders if f.name == "hetzner-s3")
+    assert h.secrets["HETZNER_S3_BUCKET"] == "l"
+
+    folders = compute_folders(
+        _make_config(**base, hetzner_s3_bucket_general="g", hetzner_s3_bucket_lakefs="l"),
+        BootstrapEnv(),
+    )
+    h = next(f for f in folders if f.name == "hetzner-s3")
+    assert h.secrets["HETZNER_S3_BUCKET"] == "g"
+
+
+def test_compute_folders_skip_empty_drops_optional_keys() -> None:
+    """A folder builder skips per-key None/empty values (preserves UI edits)."""
+    folders = compute_folders(NexusConfig.from_secrets_json("{}"), BootstrapEnv(domain="x.test"))
+    config_folder = next(f for f in folders if f.name == "config")
+    assert config_folder.secrets == {"DOMAIN": "x.test", "ADMIN_USERNAME": "admin"}
+    # ADMIN_EMAIL absent → not in payload
+
+
+def test_compute_folders_woodpecker_oauth_optional() -> None:
+    folders = compute_folders(
+        _make_config(woodpecker_agent_secret="s"),
+        BootstrapEnv(),
+    )
+    w = next(f for f in folders if f.name == "woodpecker")
+    assert w.secrets == {"WOODPECKER_AGENT_SECRET": "s"}
+
+    folders = compute_folders(
+        _make_config(woodpecker_agent_secret="s"),
+        BootstrapEnv(woodpecker_gitea_client="cid", woodpecker_gitea_secret="csec"),
+    )
+    w = next(f for f in folders if f.name == "woodpecker")
+    assert w.secrets == {
+        "WOODPECKER_AGENT_SECRET": "s",
+        "WOODPECKER_GITEA_CLIENT": "cid",
+        "WOODPECKER_GITEA_SECRET": "csec",
+    }
+
+
+def test_compute_folders_ssh_optional() -> None:
+    folders = compute_folders(NexusConfig.from_secrets_json("{}"), BootstrapEnv())
+    assert "ssh" not in [f.name for f in folders]
+
+    folders = compute_folders(
+        NexusConfig.from_secrets_json("{}"),
+        BootstrapEnv(ssh_private_key_base64="b64-key"),
+    )
+    ssh = next(f for f in folders if f.name == "ssh")
+    assert ssh.secrets == {"SSH_PRIVATE_KEY_BASE64": "b64-key"}
+
+
+def test_compute_folders_gitea_repo_url_falls_back_to_default_repo_name() -> None:
+    """`${REPO_NAME:-nexus-${DOMAIN//./-}-gitea}` mirror."""
+    config = _make_config(admin_username="bob")
+    folders = compute_folders(config, BootstrapEnv(domain="ex.example.com"))
+    gitea = next(f for f in folders if f.name == "gitea")
+    assert (
+        gitea.secrets["GITEA_REPO_URL"]
+        == "https://git.ex.example.com/bob/nexus-ex-example-com-gitea.git"
+    )
+
+
+def test_compute_folders_full_snapshot(snapshot: SnapshotAssertion) -> None:
+    """Lock the entire folder list + ordering + per-folder keys.
+
+    Uses the ``secrets_full.json`` fixture (88 fields populated) so any
+    accidental reordering or skipped key surfaces as a snapshot diff.
+    """
+    raw = (FIXTURES / "secrets_full.json").read_text()
+    config = NexusConfig.from_secrets_json(raw)
+    env = BootstrapEnv(
+        domain="snapshot.test",
+        admin_email="admin@snapshot.test",
+        gitea_user_email="user@snapshot.test",
+        gitea_user_username="snapshot-user",
+        gitea_repo_owner="snapshot-org",
+        repo_name="snapshot-repo",
+        om_principal_domain="snapshot.test",
+        woodpecker_gitea_client="cid",
+        woodpecker_gitea_secret="csec",
+        ssh_private_key_base64="snapshot-ssh-base64",
+    )
+    folders = compute_folders(config, env)
+    assert {f.name: f.secrets for f in folders} == snapshot
+
+
+# ---------------------------------------------------------------------------
+# InfisicalClient — payload encoding + remote-loop bash
+# ---------------------------------------------------------------------------
+
+
+def test_encode_payloads_round_trip() -> None:
+    client = InfisicalClient("p", "dev", "tok")
+    folders = [FolderSpec("kestra", {"K": "v"})]
+    encoded = client.encode_payloads(folders)
+    f_payload = json.loads(encoded["f-kestra.json"])
+    s_payload = json.loads(encoded["s-kestra.json"])
+    assert f_payload == folders[0].folder_payload("p", "dev")
+    assert s_payload == folders[0].secrets_payload("p", "dev")
+
+
+def test_encode_payloads_compact() -> None:
+    """No whitespace between JSON tokens — matches `json.dumps(..., separators=(',',':'))`."""
+    client = InfisicalClient("p", "dev", "tok")
+    encoded = client.encode_payloads([FolderSpec("k", {"X": "1"})])
+    assert " " not in encoded["s-k.json"]
+
+
+def test_remote_loop_quotes_token_safely(tmp_path: Path) -> None:
+    """Adversarial token can't break out of the bash structure.
+
+    Eval-extracts only the ``TOKEN=`` assignment from the generated
+    loop and verifies the resolved bash variable equals the original
+    payload — confirming that the quoting in :meth:`_build_remote_loop`
+    survives an attempt to use ``';rm -rf /;echo '`` to escape and
+    inject commands. Side-channel canary in tmp_path catches any
+    accidental execution of the injection payload.
+    """
+    canary_dir = tmp_path / "canary"
+    canary_dir.mkdir()
+    canary = canary_dir / "INJECTED"
+    nasty = f"tok';touch {shlex.quote(str(canary))};echo '"
+    client = InfisicalClient("p", "dev", nasty)
+    loop = client._build_remote_loop()
+    # Extract just the TOKEN= line. Eval-running the full loop would
+    # reach the curl + rm -rf in the loop body; isolating the assignment
+    # is enough to prove the quoting holds. We also force the
+    # token-fallback file to a path that doesn't exist so the OR-fallback
+    # branch fires and we exercise the shlex.quote'd token literal.
+    token_line = next(line for line in loop.splitlines() if line.startswith("TOKEN=$(cat"))
+    completed = subprocess.run(
+        [
+            "bash",
+            "-c",
+            f'{token_line.replace("/opt/docker-server/.infisical-token", "/nonexistent")}\nprintf "%s" "$TOKEN"',
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        env={"PATH": os.environ.get("PATH", "")},
+    )
+    assert completed.stdout == nasty
+    assert not canary.exists(), "shlex.quote breach: injection payload executed"
+
+
+# ---------------------------------------------------------------------------
+# bootstrap() — end-to-end with mocked ssh/rsync
+# ---------------------------------------------------------------------------
+
+
+def _ok_ssh(stdout: str = "5:0") -> Any:
+    def runner(_cmd: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(args=["ssh"], returncode=0, stdout=stdout, stderr="")
+
+    return runner
+
+
+def _ok_rsync() -> Any:
+    def runner(_local: Path, _remote: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(args=["rsync"], returncode=0, stdout="", stderr="")
+
+    return runner
+
+
+def test_bootstrap_writes_payloads(tmp_path: Path) -> None:
+    """bootstrap() materialises both f-NAME.json and s-NAME.json per folder."""
+    push_dir = tmp_path / "push"
+    client = InfisicalClient("p", "dev", "tok", push_dir=push_dir)
+    folders = [FolderSpec("kestra", {"K": "v"}), FolderSpec("postgres", {"P": "1"})]
+    client.bootstrap(folders, ssh_runner=_ok_ssh(), rsync_runner=_ok_rsync())
+    assert (push_dir / "f-kestra.json").is_file()
+    assert (push_dir / "s-kestra.json").is_file()
+    assert (push_dir / "f-postgres.json").is_file()
+    assert (push_dir / "s-postgres.json").is_file()
+
+
+def test_bootstrap_clears_stale_payloads(tmp_path: Path) -> None:
+    """Pre-existing f-/s- files from a prior run are removed before write."""
+    push_dir = tmp_path / "push"
+    push_dir.mkdir()
+    (push_dir / "f-stale.json").write_text("stale")
+    (push_dir / "s-stale.json").write_text("stale")
+    (push_dir / "unrelated.txt").write_text("keep me")
+    client = InfisicalClient("p", "dev", "tok", push_dir=push_dir)
+    client.bootstrap(
+        [FolderSpec("new", {"K": "v"})],
+        ssh_runner=_ok_ssh(),
+        rsync_runner=_ok_rsync(),
+    )
+    assert not (push_dir / "f-stale.json").exists()
+    assert not (push_dir / "s-stale.json").exists()
+    # Non-payload files are NOT touched
+    assert (push_dir / "unrelated.txt").exists()
+
+
+def test_bootstrap_parses_ok_fail_counts(tmp_path: Path) -> None:
+    client = InfisicalClient("p", "dev", "tok", push_dir=tmp_path / "p")
+    result = client.bootstrap(
+        [FolderSpec("k", {"X": "v"})],
+        ssh_runner=_ok_ssh("3:1"),
+        rsync_runner=_ok_rsync(),
+    )
+    assert result == BootstrapResult(folders_built=1, pushed=3, failed=1)
+
+
+def test_bootstrap_takes_last_line_of_stdout(tmp_path: Path) -> None:
+    """deploy.sh's baseline-capture WARN message can precede the OK:FAIL line."""
+    client = InfisicalClient("p", "dev", "tok", push_dir=tmp_path / "p")
+    result = client.bootstrap(
+        [FolderSpec("k", {"X": "v"})],
+        ssh_runner=_ok_ssh("WARN: capture failed\n7:2"),
+        rsync_runner=_ok_rsync(),
+    )
+    assert result.pushed == 7
+    assert result.failed == 2
+
+
+def test_bootstrap_unparseable_output_yields_failure(tmp_path: Path) -> None:
+    client = InfisicalClient("p", "dev", "tok", push_dir=tmp_path / "p")
+    folders = [FolderSpec("k", {"X": "v"}), FolderSpec("p", {"Y": "v"})]
+    result = client.bootstrap(
+        folders, ssh_runner=_ok_ssh("garbage output"), rsync_runner=_ok_rsync()
+    )
+    assert result == BootstrapResult(folders_built=2, pushed=0, failed=2)
+
+
+def test_bootstrap_invokes_rsync_with_push_dir(tmp_path: Path) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_rsync(local: Path, remote: str) -> subprocess.CompletedProcess[str]:
+        captured["local"] = local
+        captured["remote"] = remote
+        return subprocess.CompletedProcess(args=["rsync"], returncode=0, stdout="", stderr="")
+
+    push_dir = tmp_path / "push"
+    client = InfisicalClient("p", "dev", "tok", push_dir=push_dir)
+    client.bootstrap([FolderSpec("k", {"X": "v"})], ssh_runner=_ok_ssh(), rsync_runner=fake_rsync)
+    assert captured["local"] == push_dir
+    assert captured["remote"] == "nexus:/tmp/infisical-push/"
+
+
+def test_bootstrap_runs_ssh_loop_with_token(tmp_path: Path) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_ssh(cmd: str) -> subprocess.CompletedProcess[str]:
+        captured["cmd"] = cmd
+        return subprocess.CompletedProcess(args=["ssh"], returncode=0, stdout="0:0", stderr="")
+
+    client = InfisicalClient("p", "dev", "real-token", push_dir=tmp_path / "p")
+    client.bootstrap([FolderSpec("k", {"X": "v"})], ssh_runner=fake_ssh, rsync_runner=_ok_rsync())
+    cmd = captured["cmd"]
+    assert "real-token" in cmd
+    assert "/api/v2/folders" in cmd
+    assert "/api/v4/secrets/batch" in cmd
+    assert 'mode: "upsert"' not in cmd  # the JSON is sent via @file, not inlined
+    # Token-fallback file logic preserved
+    assert "/opt/docker-server/.infisical-token" in cmd
+
+
+# ---------------------------------------------------------------------------
+# CLI: `nexus-deploy infisical bootstrap`
+# ---------------------------------------------------------------------------
+
+
+def test_cli_infisical_bootstrap_requires_project_id_and_token(
+    capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from nexus_deploy.__main__ import main
+
+    monkeypatch.setattr(sys, "argv", ["nexus-deploy", "infisical", "bootstrap"])
+    monkeypatch.setattr(sys, "stdin", _StubStdin("{}"))
+    # Strip both required vars
+    monkeypatch.delenv("PROJECT_ID", raising=False)
+    monkeypatch.delenv("INFISICAL_TOKEN", raising=False)
+    rc = main()
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert "PROJECT_ID and INFISICAL_TOKEN" in captured.err
+
+
+def test_cli_infisical_bootstrap_unexpected_arg_returns_2(
+    capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from nexus_deploy.__main__ import main
+
+    monkeypatch.setattr(sys, "argv", ["nexus-deploy", "infisical", "bootstrap", "--bogus"])
+    rc = main()
+    captured = capsys.readouterr()
+    assert rc == 2
+    assert "unexpected arg" in captured.err
+
+
+def test_cli_infisical_bootstrap_invalid_json_exits_1(
+    capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from nexus_deploy.__main__ import main
+
+    monkeypatch.setattr(sys, "argv", ["nexus-deploy", "infisical", "bootstrap"])
+    monkeypatch.setattr(sys, "stdin", _StubStdin("not-json"))
+    monkeypatch.setenv("PROJECT_ID", "p")
+    monkeypatch.setenv("INFISICAL_TOKEN", "t")
+    rc = main()
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert "not valid JSON" in captured.err
+
+
+def test_cli_infisical_bootstrap_happy_path(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """End-to-end CLI exercise with mocked SSH/rsync."""
+    from nexus_deploy.__main__ import main
+
+    push_dir = tmp_path / "push"
+
+    def fake_ssh(_cmd: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(args=["ssh"], returncode=0, stdout="3:0", stderr="")
+
+    def fake_rsync(*_args: Any, **_kwargs: Any) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(args=["rsync"], returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr("nexus_deploy._remote.ssh_run", fake_ssh)
+    monkeypatch.setattr("nexus_deploy._remote.rsync_to_remote", fake_rsync)
+    monkeypatch.setattr(sys, "argv", ["nexus-deploy", "infisical", "bootstrap"])
+    monkeypatch.setattr(sys, "stdin", _StubStdin('{"admin_username": "u"}'))
+    monkeypatch.setenv("PROJECT_ID", "p")
+    monkeypatch.setenv("INFISICAL_TOKEN", "t")
+    monkeypatch.setenv("DOMAIN", "ex.test")
+    monkeypatch.setenv("ADMIN_EMAIL", "admin@ex.test")
+    monkeypatch.setenv("PUSH_DIR", str(push_dir))
+    rc = main()
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "pushed=3" in captured.out
+    assert "failed=0" in captured.out
+
+
+def test_cli_infisical_bootstrap_failed_count_returns_1(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Any failed folder push → exit 1 (so deploy.sh aborts)."""
+    from nexus_deploy.__main__ import main
+
+    def fake_ssh(_cmd: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(args=["ssh"], returncode=0, stdout="2:1", stderr="")
+
+    def fake_rsync(*_args: Any, **_kwargs: Any) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(args=["rsync"], returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr("nexus_deploy._remote.ssh_run", fake_ssh)
+    monkeypatch.setattr("nexus_deploy._remote.rsync_to_remote", fake_rsync)
+    monkeypatch.setattr(sys, "argv", ["nexus-deploy", "infisical", "bootstrap"])
+    monkeypatch.setattr(sys, "stdin", _StubStdin("{}"))
+    monkeypatch.setenv("PROJECT_ID", "p")
+    monkeypatch.setenv("INFISICAL_TOKEN", "t")
+    monkeypatch.setenv("PUSH_DIR", str(tmp_path / "push"))
+    rc = main()
+    _ = capsys.readouterr()
+    assert rc == 1
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _StubStdin:
+    """Tiny stand-in for ``sys.stdin`` that returns a fixed string."""
+
+    def __init__(self, content: str) -> None:
+        self._content = content
+
+    def read(self) -> str:
+        return self._content

--- a/tests/unit/test_infisical.py
+++ b/tests/unit/test_infisical.py
@@ -507,7 +507,7 @@ def test_cli_infisical_bootstrap_failed_count_returns_1(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """Any failed folder push → exit 1 (so deploy.sh aborts)."""
+    """Any failed folder push → exit 1 (deploy.sh's `if !` wrap then warns, doesn't abort)."""
     from nexus_deploy.__main__ import main
 
     def fake_ssh(_cmd: str) -> subprocess.CompletedProcess[str]:

--- a/tests/unit/test_infisical.py
+++ b/tests/unit/test_infisical.py
@@ -497,6 +497,7 @@ def test_bootstrap_runs_ssh_loop_with_token(tmp_path: Path) -> None:
 def test_cli_infisical_bootstrap_requires_project_id_and_token(
     capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    """Missing required env → rc=2 (hard fail; deploy.sh aborts)."""
     from nexus_deploy.__main__ import main
 
     monkeypatch.setattr(sys, "argv", ["nexus-deploy", "infisical", "bootstrap"])
@@ -506,7 +507,7 @@ def test_cli_infisical_bootstrap_requires_project_id_and_token(
     monkeypatch.delenv("INFISICAL_TOKEN", raising=False)
     rc = main()
     captured = capsys.readouterr()
-    assert rc == 1
+    assert rc == 2
     assert "PROJECT_ID and INFISICAL_TOKEN" in captured.err
 
 
@@ -522,9 +523,10 @@ def test_cli_infisical_bootstrap_unexpected_arg_returns_2(
     assert "unexpected arg" in captured.err
 
 
-def test_cli_infisical_bootstrap_invalid_json_exits_1(
+def test_cli_infisical_bootstrap_invalid_json_exits_2(
     capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    """Invalid SECRETS_JSON on stdin → rc=2 (hard fail)."""
     from nexus_deploy.__main__ import main
 
     monkeypatch.setattr(sys, "argv", ["nexus-deploy", "infisical", "bootstrap"])
@@ -533,7 +535,7 @@ def test_cli_infisical_bootstrap_invalid_json_exits_1(
     monkeypatch.setenv("INFISICAL_TOKEN", "t")
     rc = main()
     captured = capsys.readouterr()
-    assert rc == 1
+    assert rc == 2
     assert "not valid JSON" in captured.err
 
 
@@ -542,18 +544,18 @@ def test_cli_infisical_bootstrap_happy_path(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """End-to-end CLI exercise with mocked SSH/rsync."""
+    """End-to-end CLI exercise with mocked SSH/rsync — rc=0 on full success."""
     from nexus_deploy.__main__ import main
 
     push_dir = tmp_path / "push"
 
-    def fake_ssh(_cmd: str) -> subprocess.CompletedProcess[str]:
+    def fake_ssh(_script: str) -> subprocess.CompletedProcess[str]:
         return subprocess.CompletedProcess(args=["ssh"], returncode=0, stdout="3:0", stderr="")
 
     def fake_rsync(*_args: Any, **_kwargs: Any) -> subprocess.CompletedProcess[str]:
         return subprocess.CompletedProcess(args=["rsync"], returncode=0, stdout="", stderr="")
 
-    monkeypatch.setattr("nexus_deploy._remote.ssh_run", fake_ssh)
+    monkeypatch.setattr("nexus_deploy._remote.ssh_run_script", fake_ssh)
     monkeypatch.setattr("nexus_deploy._remote.rsync_to_remote", fake_rsync)
     monkeypatch.setattr(sys, "argv", ["nexus-deploy", "infisical", "bootstrap"])
     monkeypatch.setattr(sys, "stdin", _StubStdin('{"admin_username": "u"}'))
@@ -569,21 +571,21 @@ def test_cli_infisical_bootstrap_happy_path(
     assert "failed=0" in captured.out
 
 
-def test_cli_infisical_bootstrap_failed_count_returns_1(
+def test_cli_infisical_bootstrap_partial_failure_returns_1(
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """Any failed folder push → exit 1 (deploy.sh's `if !` wrap then warns, doesn't abort)."""
+    """API-reported partial failure (folder errors) → rc=1; deploy.sh warns + continues."""
     from nexus_deploy.__main__ import main
 
-    def fake_ssh(_cmd: str) -> subprocess.CompletedProcess[str]:
+    def fake_ssh(_script: str) -> subprocess.CompletedProcess[str]:
         return subprocess.CompletedProcess(args=["ssh"], returncode=0, stdout="2:1", stderr="")
 
     def fake_rsync(*_args: Any, **_kwargs: Any) -> subprocess.CompletedProcess[str]:
         return subprocess.CompletedProcess(args=["rsync"], returncode=0, stdout="", stderr="")
 
-    monkeypatch.setattr("nexus_deploy._remote.ssh_run", fake_ssh)
+    monkeypatch.setattr("nexus_deploy._remote.ssh_run_script", fake_ssh)
     monkeypatch.setattr("nexus_deploy._remote.rsync_to_remote", fake_rsync)
     monkeypatch.setattr(sys, "argv", ["nexus-deploy", "infisical", "bootstrap"])
     monkeypatch.setattr(sys, "stdin", _StubStdin("{}"))
@@ -593,6 +595,38 @@ def test_cli_infisical_bootstrap_failed_count_returns_1(
     rc = main()
     _ = capsys.readouterr()
     assert rc == 1
+
+
+def test_cli_infisical_bootstrap_transport_failure_returns_2(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """rsync/ssh transport failure (CalledProcessError, etc.) → rc=2; deploy.sh aborts.
+
+    We must NOT pass through the underlying CalledProcessError because
+    its ``cmd`` attribute carries the full argv — and even though we
+    moved the token to stdin, defence-in-depth: never let
+    bootstrap-internal exceptions surface to the workflow log.
+    """
+    from nexus_deploy.__main__ import main
+
+    def fake_rsync(*_args: Any, **_kwargs: Any) -> subprocess.CompletedProcess[str]:
+        raise subprocess.CalledProcessError(255, ["rsync", "secret-token-leak-attempt"])
+
+    monkeypatch.setattr("nexus_deploy._remote.rsync_to_remote", fake_rsync)
+    monkeypatch.setattr(sys, "argv", ["nexus-deploy", "infisical", "bootstrap"])
+    monkeypatch.setattr(sys, "stdin", _StubStdin("{}"))
+    monkeypatch.setenv("PROJECT_ID", "p")
+    monkeypatch.setenv("INFISICAL_TOKEN", "t")
+    monkeypatch.setenv("PUSH_DIR", str(tmp_path / "push"))
+    rc = main()
+    captured = capsys.readouterr()
+    assert rc == 2
+    assert "transport failure" in captured.err
+    # Argv contents must not surface — the exc.cmd would carry it
+    assert "secret-token-leak-attempt" not in captured.err
+    assert "secret-token-leak-attempt" not in captured.out
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_infisical.py
+++ b/tests/unit/test_infisical.py
@@ -327,16 +327,83 @@ def _ok_rsync() -> Any:
     return runner
 
 
-def test_bootstrap_writes_payloads(tmp_path: Path) -> None:
-    """bootstrap() materialises both f-NAME.json and s-NAME.json per folder."""
+def test_bootstrap_removes_local_payloads_on_success(tmp_path: Path) -> None:
+    """After a successful bootstrap, the local f-/s-*.json files are gone.
+
+    Mirrors deploy.sh's ``rm -rf "$PUSH_DIR"`` cleanup. Files contain
+    secret values; leaving them on the runner is a secrets-at-rest
+    leak.
+    """
+    push_dir = tmp_path / "push"
+    client = InfisicalClient("p", "dev", "tok", push_dir=push_dir)
+    folders = [FolderSpec("kestra", {"K": "v"})]
+    client.bootstrap(folders, ssh_runner=_ok_ssh(), rsync_runner=_ok_rsync())
+    assert list(push_dir.glob("[fs]-*.json")) == []
+
+
+def test_bootstrap_removes_local_payloads_on_failure(tmp_path: Path) -> None:
+    """Cleanup runs in `finally` — even when ssh raises, payloads are gone."""
+    push_dir = tmp_path / "push"
+    client = InfisicalClient("p", "dev", "tok", push_dir=push_dir)
+
+    def failing_ssh(_cmd: str) -> subprocess.CompletedProcess[str]:
+        raise subprocess.CalledProcessError(1, ["ssh"])
+
+    folders = [FolderSpec("kestra", {"K": "v"})]
+    with pytest.raises(subprocess.CalledProcessError):
+        client.bootstrap(folders, ssh_runner=failing_ssh, rsync_runner=_ok_rsync())
+    assert list(push_dir.glob("[fs]-*.json")) == []
+
+
+def test_bootstrap_cleanup_preserves_unrelated_files(tmp_path: Path) -> None:
+    """Only f-*.json + s-*.json get removed; unrelated files stay."""
+    push_dir = tmp_path / "push"
+    push_dir.mkdir()
+    (push_dir / "operator-notes.txt").write_text("keep me")
+    client = InfisicalClient("p", "dev", "tok", push_dir=push_dir)
+    client.bootstrap(
+        [FolderSpec("kestra", {"K": "v"})],
+        ssh_runner=_ok_ssh(),
+        rsync_runner=_ok_rsync(),
+    )
+    assert (push_dir / "operator-notes.txt").exists()
+
+
+def test_remote_loop_uses_printf_not_echo_for_token() -> None:
+    """`echo` would mangle tokens starting with `-n`/`-e`/`-E`. printf doesn't."""
+    client = InfisicalClient("p", "dev", "tok-value")
+    loop = client._build_remote_loop()
+    # Token comes via printf, never via echo
+    assert "printf '%s' " in loop
+    # Specifically, the fallback line uses printf
+    fallback_line = next(line for line in loop.splitlines() if "TOKEN=$(cat" in line)
+    assert "echo " not in fallback_line
+
+
+def test_bootstrap_writes_payloads_before_rsync(tmp_path: Path) -> None:
+    """bootstrap() materialises both f-NAME.json and s-NAME.json per folder.
+
+    Files are deleted in the finally block (secrets-at-rest cleanup),
+    so this test inspects the push_dir state INSIDE the mocked rsync
+    callback — the moment rsync would see them on a real run.
+    """
     push_dir = tmp_path / "push"
     client = InfisicalClient("p", "dev", "tok", push_dir=push_dir)
     folders = [FolderSpec("kestra", {"K": "v"}), FolderSpec("postgres", {"P": "1"})]
-    client.bootstrap(folders, ssh_runner=_ok_ssh(), rsync_runner=_ok_rsync())
-    assert (push_dir / "f-kestra.json").is_file()
-    assert (push_dir / "s-kestra.json").is_file()
-    assert (push_dir / "f-postgres.json").is_file()
-    assert (push_dir / "s-postgres.json").is_file()
+
+    seen: dict[str, list[str]] = {"files": []}
+
+    def inspect_rsync(local: Path, _remote: str) -> subprocess.CompletedProcess[str]:
+        seen["files"] = sorted(p.name for p in local.glob("*.json"))
+        return subprocess.CompletedProcess(args=["rsync"], returncode=0, stdout="", stderr="")
+
+    client.bootstrap(folders, ssh_runner=_ok_ssh(), rsync_runner=inspect_rsync)
+    assert seen["files"] == [
+        "f-kestra.json",
+        "f-postgres.json",
+        "s-kestra.json",
+        "s-postgres.json",
+    ]
 
 
 def test_bootstrap_clears_stale_payloads(tmp_path: Path) -> None:

--- a/tests/unit/test_infisical.py
+++ b/tests/unit/test_infisical.py
@@ -431,6 +431,22 @@ def test_bootstrap_cleanup_preserves_unrelated_files(tmp_path: Path) -> None:
     assert (push_dir / "operator-notes.txt").exists()
 
 
+def test_remote_loop_counts_curl_transport_failure_as_fail() -> None:
+    """Legacy bash miscounted curl transport failures (rc != 0) as OK.
+
+    The current loop checks ``CURL_RC`` after each PATCH and treats any
+    non-zero exit as FAIL — fixing a long-standing legacy bug while
+    keeping the OK:FAIL output format unchanged.
+    """
+    client = InfisicalClient("p", "dev", "tok")
+    loop = client._build_remote_loop()
+    # The relevant guard
+    assert "CURL_RC=$?" in loop
+    assert '[ "$CURL_RC" -ne 0 ]' in loop
+    # And the original error-substring check is still part of the OR
+    assert "grep -q '\"error\"'" in loop
+
+
 def test_remote_loop_uses_printf_not_echo_for_token() -> None:
     """`echo` would mangle tokens starting with `-n`/`-e`/`-E`. printf doesn't."""
     client = InfisicalClient("p", "dev", "tok-value")

--- a/tests/unit/test_infisical.py
+++ b/tests/unit/test_infisical.py
@@ -597,6 +597,46 @@ def test_cli_infisical_bootstrap_partial_failure_returns_1(
     assert rc == 1
 
 
+def test_cli_infisical_bootstrap_unexpected_exception_returns_2(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A non-transport exception (e.g. KeyError from a bug in compute_folders)
+    must surface as rc=2, NOT rc=1.
+
+    Python's default unhandled-exception exit code is 1, which would
+    collide with the "partial push" semantic in deploy.sh and cause
+    the deploy to continue past a broken bootstrap. The broad
+    ``except Exception`` in the CLI re-routes that to rc=2.
+
+    Also asserts: the exception's ``str(exc)`` / ``repr(exc)`` contents
+    must NOT surface in stderr — those can carry attribute values from
+    pydantic ValidationError that include secret-bearing fields.
+    """
+    from nexus_deploy.__main__ import main
+
+    secret_payload = "very-secret-value-must-not-appear-in-output"
+
+    def boom(*_args: Any, **_kwargs: Any) -> Any:
+        raise KeyError(secret_payload)
+
+    monkeypatch.setattr("nexus_deploy.__main__.compute_folders", boom)
+    monkeypatch.setattr(sys, "argv", ["nexus-deploy", "infisical", "bootstrap"])
+    monkeypatch.setattr(sys, "stdin", _StubStdin("{}"))
+    monkeypatch.setenv("PROJECT_ID", "p")
+    monkeypatch.setenv("INFISICAL_TOKEN", "t")
+    monkeypatch.setenv("PUSH_DIR", str(tmp_path / "push"))
+    rc = main()
+    captured = capsys.readouterr()
+    assert rc == 2
+    assert "unexpected error (KeyError)" in captured.err
+    # Defence-in-depth: the exception's args must not leak — only the
+    # class name surfaces in the formatted message.
+    assert secret_payload not in captured.err
+    assert secret_payload not in captured.out
+
+
 def test_cli_infisical_bootstrap_transport_failure_returns_2(
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/test_infisical.py
+++ b/tests/unit/test_infisical.py
@@ -371,6 +371,38 @@ def test_bootstrap_removes_local_payloads_on_success(tmp_path: Path) -> None:
     assert list(push_dir.glob("[fs]-*.json")) == []
 
 
+def test_bootstrap_cleans_up_when_write_fails_mid_loop(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A failure during payload-writing must NOT leave half-written secrets behind.
+
+    The previous implementation only wrapped rsync+ssh in try/finally;
+    a disk-full / permission error during the write loop would leave
+    already-created f-/s-*.json files in push_dir with secret values.
+    Now the whole materialise+push path is inside the try/finally.
+    """
+    push_dir = tmp_path / "push"
+    client = InfisicalClient("p", "dev", "tok", push_dir=push_dir)
+
+    # Force os.open to fail on the SECOND payload — by which point the
+    # first one has already been written and contains secret values.
+    real_os_open = os.open
+    call_count = {"n": 0}
+
+    def flaky_open(*args: Any, **kwargs: Any) -> int:
+        call_count["n"] += 1
+        if call_count["n"] >= 2:
+            raise PermissionError("simulated mid-loop disk failure")
+        return real_os_open(*args, **kwargs)
+
+    monkeypatch.setattr("nexus_deploy.infisical.os.open", flaky_open)
+    folders = [FolderSpec("first", {"K": "v1"}), FolderSpec("second", {"K": "v2"})]
+    with pytest.raises(PermissionError):
+        client.bootstrap(folders, ssh_runner=_ok_ssh(), rsync_runner=_ok_rsync())
+    # finally clause must have removed the first-folder file
+    assert list(push_dir.glob("[fs]-*.json")) == []
+
+
 def test_bootstrap_removes_local_payloads_on_failure(tmp_path: Path) -> None:
     """Cleanup runs in `finally` — even when ssh raises, payloads are gone."""
     push_dir = tmp_path / "push"

--- a/tests/unit/test_infisical.py
+++ b/tests/unit/test_infisical.py
@@ -327,6 +327,36 @@ def _ok_rsync() -> Any:
     return runner
 
 
+def test_bootstrap_writes_payloads_with_restrictive_perms(tmp_path: Path) -> None:
+    """Payload files contain secret values — must be 0600 / dir 0700.
+
+    Default umask on shared CI runners (0o022) would yield 0644 files,
+    which is group/world-readable. We explicitly chmod to override.
+    """
+    push_dir = tmp_path / "push"
+    client = InfisicalClient("p", "dev", "tok", push_dir=push_dir)
+
+    captured_modes: dict[str, int] = {}
+
+    def inspect_rsync(local: Path, _remote: str) -> subprocess.CompletedProcess[str]:
+        # Inspect modes inside the rsync callback — payloads are
+        # cleaned up by the finally block, so this is the only point
+        # where they're observable.
+        captured_modes["dir"] = local.stat().st_mode & 0o777
+        for f in sorted(local.glob("[fs]-*.json")):
+            captured_modes[f.name] = f.stat().st_mode & 0o777
+        return subprocess.CompletedProcess(args=["rsync"], returncode=0, stdout="", stderr="")
+
+    client.bootstrap(
+        [FolderSpec("kestra", {"K": "v"})],
+        ssh_runner=_ok_ssh(),
+        rsync_runner=inspect_rsync,
+    )
+    assert captured_modes["dir"] == 0o700
+    assert captured_modes["f-kestra.json"] == 0o600
+    assert captured_modes["s-kestra.json"] == 0o600
+
+
 def test_bootstrap_removes_local_payloads_on_success(tmp_path: Path) -> None:
     """After a successful bootstrap, the local f-/s-*.json files are gone.
 

--- a/tests/unit/test_remote.py
+++ b/tests/unit/test_remote.py
@@ -111,6 +111,22 @@ def test_rsync_to_remote_delete_flag(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "--delete" in captured["args"]
 
 
+def test_ssh_run_merge_stderr_false_keeps_streams_separate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``merge_stderr=False`` → stderr=PIPE (not STDOUT), stdout still captured."""
+    captured: dict[str, Any] = {}
+
+    def fake_run(*_args: Any, **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        captured["kwargs"] = kwargs
+        return subprocess.CompletedProcess(args=["ssh"], returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr("nexus_deploy._remote.subprocess.run", fake_run)
+    _remote.ssh_run("foo", merge_stderr=False)
+    assert captured["kwargs"]["stdout"] == subprocess.PIPE
+    assert captured["kwargs"]["stderr"] == subprocess.PIPE  # NOT STDOUT
+
+
 def test_ssh_run_actually_invokes_subprocess(tmp_path: Path) -> None:
     """End-to-end against a fake `ssh` on PATH — catches subprocess.run misuse.
 
@@ -133,7 +149,7 @@ def test_ssh_run_actually_invokes_subprocess(tmp_path: Path) -> None:
     finally:
         os.environ["PATH"] = old_path
     assert result.returncode == 0
-    # capture_stderr=True (default) merges stderr into stdout
+    # merge_stderr=True (default) merges stderr into stdout
     assert "stdout-line" in result.stdout
     assert "err-line" in result.stdout
 

--- a/tests/unit/test_remote.py
+++ b/tests/unit/test_remote.py
@@ -127,6 +127,25 @@ def test_ssh_run_merge_stderr_false_keeps_streams_separate(
     assert captured["kwargs"]["stderr"] == subprocess.PIPE  # NOT STDOUT
 
 
+def test_ssh_run_script_invokes_bash_s_with_stdin(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``ssh_run_script`` runs ``ssh nexus bash -s`` with the script on stdin (NOT argv)."""
+    captured: dict[str, Any] = {}
+
+    def fake_run(*args: Any, **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        captured["argv"] = args[0]
+        captured["input"] = kwargs.get("input")
+        return subprocess.CompletedProcess(args=args[0], returncode=0, stdout="ok", stderr="")
+
+    monkeypatch.setattr("nexus_deploy._remote.subprocess.run", fake_run)
+    secret_payload = "TOKEN=top-secret-do-not-leak\necho hi"
+    _remote.ssh_run_script(secret_payload)
+    # The script is on stdin, NOT argv — argv contains only the bash invocation
+    assert captured["argv"] == ["ssh", "nexus", "bash", "-s"]
+    assert captured["input"] == secret_payload
+    # And of course the secret must be on stdin and ONLY on stdin
+    assert "top-secret-do-not-leak" not in " ".join(captured["argv"])
+
+
 def test_ssh_run_actually_invokes_subprocess(tmp_path: Path) -> None:
     """End-to-end against a fake `ssh` on PATH — catches subprocess.run misuse.
 

--- a/tests/unit/test_remote.py
+++ b/tests/unit/test_remote.py
@@ -27,7 +27,12 @@ def test_ssh_run_invokes_ssh_with_host_and_command(
     assert result.returncode == 0
     assert captured["args"][0] == ["ssh", "nexus", "echo hello"]
     assert captured["kwargs"]["check"] is True
-    assert captured["kwargs"]["capture_output"] is True
+    # stdout=PIPE + stderr=STDOUT (NOT capture_output=True; that combo
+    # raises ValueError when stderr is also explicit — see the docstring
+    # in _remote.ssh_run).
+    assert captured["kwargs"]["stdout"] == subprocess.PIPE
+    assert captured["kwargs"]["stderr"] == subprocess.STDOUT
+    assert "capture_output" not in captured["kwargs"]
     assert captured["kwargs"]["text"] is True
 
 
@@ -104,6 +109,33 @@ def test_rsync_to_remote_delete_flag(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("nexus_deploy._remote.subprocess.run", fake_run)
     _remote.rsync_to_remote(Path("/src"), "nexus:/dst/", delete=True)
     assert "--delete" in captured["args"]
+
+
+def test_ssh_run_actually_invokes_subprocess(tmp_path: Path) -> None:
+    """End-to-end against a fake `ssh` on PATH — catches subprocess.run misuse.
+
+    The mocked tests above prove the call shape (args + kwargs), but
+    they can't catch combinations of subprocess.run kwargs that raise
+    ValueError before any subprocess is spawned (e.g., the historical
+    ``capture_output=True`` + ``stderr=...`` clash). This test puts a
+    minimal stand-in `ssh` script on PATH and exercises ``ssh_run``
+    against it.
+    """
+    fake_ssh = tmp_path / "ssh"
+    fake_ssh.write_text("#!/usr/bin/env bash\necho stdout-line\necho err-line >&2\n")
+    fake_ssh.chmod(0o755)
+    import os
+
+    old_path = os.environ.get("PATH", "")
+    os.environ["PATH"] = f"{tmp_path}:{old_path}"
+    try:
+        result = _remote.ssh_run("does-not-matter")
+    finally:
+        os.environ["PATH"] = old_path
+    assert result.returncode == 0
+    # capture_stderr=True (default) merges stderr into stdout
+    assert "stdout-line" in result.stdout
+    assert "err-line" in result.stdout
 
 
 def test_rsync_to_remote_no_delete_by_default(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/test_remote.py
+++ b/tests/unit/test_remote.py
@@ -1,0 +1,118 @@
+"""Tests for nexus_deploy._remote — Phase 1 SSH/rsync primitives (#505)."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from nexus_deploy import _remote
+
+
+def test_ssh_run_invokes_ssh_with_host_and_command(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``ssh_run('cmd')`` calls ``ssh nexus 'cmd'`` via subprocess."""
+    captured: dict[str, Any] = {}
+
+    def fake_run(*args: Any, **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return subprocess.CompletedProcess(args=args[0], returncode=0, stdout="ok\n", stderr="")
+
+    monkeypatch.setattr("nexus_deploy._remote.subprocess.run", fake_run)
+    result = _remote.ssh_run("echo hello")
+    assert result.returncode == 0
+    assert captured["args"][0] == ["ssh", "nexus", "echo hello"]
+    assert captured["kwargs"]["check"] is True
+    assert captured["kwargs"]["capture_output"] is True
+    assert captured["kwargs"]["text"] is True
+
+
+def test_ssh_run_custom_host(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_run(*args: Any, **_kwargs: Any) -> subprocess.CompletedProcess[str]:
+        captured["args"] = args
+        return subprocess.CompletedProcess(args=args[0], returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr("nexus_deploy._remote.subprocess.run", fake_run)
+    _remote.ssh_run("uptime", host="dev-host")
+    assert captured["args"][0] == ["ssh", "dev-host", "uptime"]
+
+
+def test_ssh_run_no_check_propagates(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``check=False`` is forwarded so non-zero exits don't raise."""
+    captured: dict[str, Any] = {}
+
+    def fake_run(*_args: Any, **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        captured["check"] = kwargs.get("check")
+        return subprocess.CompletedProcess(args=["ssh"], returncode=1, stdout="", stderr="boom")
+
+    monkeypatch.setattr("nexus_deploy._remote.subprocess.run", fake_run)
+    result = _remote.ssh_run("false", check=False)
+    assert captured["check"] is False
+    assert result.returncode == 1
+
+
+def test_rsync_to_remote_appends_trailing_slash(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``Path('/foo')`` becomes ``/foo/`` to match deploy.sh's contents-only rsync."""
+    captured: dict[str, Any] = {}
+
+    def fake_run(*args: Any, **_kwargs: Any) -> subprocess.CompletedProcess[str]:
+        captured["args"] = args[0]
+        return subprocess.CompletedProcess(args=args[0], returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr("nexus_deploy._remote.subprocess.run", fake_run)
+    _remote.rsync_to_remote(tmp_path, "nexus:/dst/")
+    cmd = captured["args"]
+    assert cmd[0] == "rsync"
+    assert "-aq" in cmd
+    # Source has trailing slash → rsync uploads dir contents, not the dir itself
+    assert cmd[-2] == f"{tmp_path}/"
+    assert cmd[-1] == "nexus:/dst/"
+
+
+def test_rsync_to_remote_preserves_existing_trailing_slash(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Passing a string path that already ends in ``/`` is left alone."""
+    captured: dict[str, Any] = {}
+
+    def fake_run(*args: Any, **_kwargs: Any) -> subprocess.CompletedProcess[str]:
+        captured["args"] = args[0]
+        return subprocess.CompletedProcess(args=args[0], returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr("nexus_deploy._remote.subprocess.run", fake_run)
+    _remote.rsync_to_remote(Path("/some/path/"), "nexus:/dst/")
+    # Path('/some/path/') normalises to '/some/path' in str(); we
+    # always re-append /, so the result is the same.
+    assert captured["args"][-2].endswith("/")
+
+
+def test_rsync_to_remote_delete_flag(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_run(*args: Any, **_kwargs: Any) -> subprocess.CompletedProcess[str]:
+        captured["args"] = args[0]
+        return subprocess.CompletedProcess(args=args[0], returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr("nexus_deploy._remote.subprocess.run", fake_run)
+    _remote.rsync_to_remote(Path("/src"), "nexus:/dst/", delete=True)
+    assert "--delete" in captured["args"]
+
+
+def test_rsync_to_remote_no_delete_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_run(*args: Any, **_kwargs: Any) -> subprocess.CompletedProcess[str]:
+        captured["args"] = args[0]
+        return subprocess.CompletedProcess(args=args[0], returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr("nexus_deploy._remote.subprocess.run", fake_run)
+    _remote.rsync_to_remote(Path("/src"), "nexus:/dst/")
+    assert "--delete" not in captured["args"]


### PR DESCRIPTION
## Summary

**Phase 1 Modul 1.1 of #505** — second of three module PRs. Migrates `deploy.sh:1996-2390` (the `build_folder` helper + 41 callers + rsync + ssh + curl-loop push, **~395 lines of bash**) to typed Python with snapshot-tested folder schema and adversarial-eval-tested token quoting.

deploy.sh now pipes `SECRETS_JSON` into `python -m nexus_deploy infisical bootstrap`, which:
1. Computes the 41 `FolderSpec`s in deploy.sh source-order (skip-empty applied per #504)
2. Writes the same per-folder JSON files (`f-NAME.json` + `s-NAME.json`)
3. rsyncs to the server's `/tmp/infisical-push/`
4. Runs the same server-side curl loop (POST `/api/v2/folders` + PATCH `/api/v4/secrets/batch`)
5. Parses `OK:FAIL` from stdout, exits 1 if any failed

**Net: `scripts/deploy.sh` shrunk by 298 lines (5489 → 5191).**
**Cumulative Phase 1 progress:** deploy.sh down ~348 lines vs `main` before #506 (5539 → 5191).

## What's new

| File | Change |
|---|---|
| `src/nexus_deploy/_remote.py` | NEW. Temporary subprocess primitives (`ssh_run`, `rsync_to_remote`) wrapping the local ssh-config alias `nexus`. Replaced by paramiko `SSHClient` in Phase 3. |
| `src/nexus_deploy/infisical.py` | NEW. `FolderSpec` + `BootstrapEnv` + `compute_folders` (41 folders, conditional gates) + `InfisicalClient.bootstrap`. **100% coverage.** |
| `src/nexus_deploy/__main__.py` | `infisical bootstrap` subcommand — reads `SECRETS_JSON` from stdin + BootstrapEnv from env vars. |
| `tests/unit/test_remote.py` | 7 tests — `ssh_run` + `rsync_to_remote` with mocked subprocess. |
| `tests/unit/test_infisical.py` | 30 tests — skip-empty, payload shapes, conditional gates, Hetzner default-bucket fallback, full folder-set snapshot, adversarial-token bash-eval, end-to-end mocked bootstrap, CLI integration. |
| `tests/unit/__snapshots__/test_infisical.ambr` | Syrupy snapshot — full 41-folder map for fully-populated config. |
| `scripts/deploy.sh` | Replace L1996-L2390 with the env-passed pipe-to-python invocation. |

## Notable design decisions

- **Preserves the bash-style execution model** (write JSONs locally → rsync → server-side curl loop) instead of switching to per-call HTTP-over-SSH. Reason: ~80 API calls per bootstrap; 1 SSH session vs 80 is the production-proven trade-off. Phase 3's paramiko port-forward refactor changes this wholesale.
- **`shlex.quote` on the token** when interpolating into the remote bash loop. The legacy `'$INFISICAL_TOKEN'` form would break on a token containing `'`. Tested with adversarial payload `"tok';touch <canary>;echo '"` via real bash subprocess — token resolves verbatim, canary file does not materialise.
- **Source-order preserved.** Folders + per-folder secret keys appear in deploy.sh-source-order (not alphabetical), so reviewers comparing against the legacy block see no reordering noise.
- **Fallbacks resolved before push.** `admin_username` defaults to `"admin"` (mirrors deploy.sh:123 `// "admin"` jq fallback); `EXTERNAL_S3_LABEL` → `"External Storage"`, `EXTERNAL_S3_REGION` → `"auto"`. So Infisical receives the same resolved value the legacy bash globals carried, not `None`.
- **Skip-empty contract from #504** lives in `_filter_empty()`. `None` and `""` are dropped; `" "` (single space) is preserved as a legitimate value.

## Conditional folder gates (match deploy.sh exactly)

| Folder | Gate |
|---|---|
| `r2-datalake` | All four `r2_data_*` fields populated |
| `hetzner-s3` | `hetzner_s3_server` + `_access_key` + `_secret_key` (bucket optional, fallback chain general → lakefs) |
| `external-s3` | All four `external_s3_*` fields populated |
| `ssh` | `SSH_KEY_BASE64` env populated |
| `woodpecker` | Always (agent secret), OAuth fields conditional on env |

## Strangler-fig handoff

deploy.sh now invokes:
```bash
printf '%s' "$SECRETS_JSON" \
    | PROJECT_ID=… INFISICAL_TOKEN=… INFISICAL_ENV=… \
      DOMAIN=… ADMIN_EMAIL=… GITEA_USER_EMAIL=… … \
      uv run --quiet --project "$PROJECT_ROOT" python -m nexus_deploy infisical bootstrap
```

The legacy `build_folder` helper + 41 calls + rsync + curl loop are deleted. The earlier `if [ -n "$INFISICAL_TOKEN" ] && [ -n "$PROJECT_ID" ]; then` gate stays, plus the surrounding `INFISICAL_READY` block.

## Test plan

- [x] `uv run ruff format --check .` ✅
- [x] `uv run ruff check .` ✅
- [x] `uv run mypy` (strict) ✅
- [x] `uv run pytest --cov` — 73/73, **100% coverage on _remote.py + infisical.py + config.py**
- [x] `find scripts -name '*.sh' | xargs shellcheck --severity=error` ✅
- [x] Adversarial token-quoting test: real bash eval, canary file in pytest tmpdir, no execution
- [ ] **Spin-up byte-compare (deferred)**: when user runs `gh workflow run initial-setup.yaml -f enabled_services=jupyter,marimo` and `bash scripts/capture-phase1-baselines.sh`, compare server-captured `infisical-payloads-baseline/` against the migrated `compute_folders` output. Either lands as a follow-up test on this branch or stays a Phase-1 acceptance gate.

Closes #505 sub-tasks 1.1.1, 1.1.2, 1.1.3, 1.1.4, 1.1.5, 1.1.6.
