### PR TITLE
feat(nexus_deploy): Phase 2 Modul 2.2a — compose_runner.py

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1779,133 +1779,22 @@ fi
 echo ""
 echo -e "${YELLOW}[6/7] Starting enabled containers (parallel)...${NC}"
 
-ssh nexus "
-set -euo pipefail
-# Export image versions from global .env
-if [ -f /opt/docker-server/stacks/.env ]; then
-    set -a
-    source /opt/docker-server/stacks/.env
-    set +a
-fi
-
-STARTED_SERVICES=()
-FAILED_SERVICES=()
-PIDS=()
-
-# Virtual services that use a parent stack (defined via 'stack' field in services.yaml)
-VIRTUAL_SERVICES=\"seaweedfs-filer seaweedfs-manager\"
-
-# Map virtual services to their parent stack
-declare -A STACK_PARENTS
-STACK_PARENTS[\"seaweedfs-filer\"]=\"seaweedfs\"
-STACK_PARENTS[\"seaweedfs-manager\"]=\"seaweedfs\"
-
-# Ensure parent stacks are started when virtual services are enabled
-PARENT_STACKS_STARTED=\"\"
-for service in $ENABLED_LIST; do
-    PARENT=\"\${STACK_PARENTS[\$service]:-}\"
-    if [ -n \"\$PARENT\" ] && ! echo \"\$PARENT_STACKS_STARTED\" | grep -qw \"\$PARENT\"; then
-        if [ -f /opt/docker-server/stacks/\$PARENT/docker-compose.yml ]; then
-            echo \"  Starting parent stack: \$PARENT (required by \$service)...\"
-            (cd /opt/docker-server/stacks/\$PARENT && docker compose up -d --build 2>&1) &
-            PID=\$!
-            PIDS+=(\$PID)
-            STARTED_SERVICES+=(\"\$PARENT:\$PID\")
-            PARENT_STACKS_STARTED=\"\$PARENT_STACKS_STARTED \$PARENT\"
-        fi
-    fi
-done
-
-# Services that are started later after their dependencies are ready
-# Woodpecker requires Gitea OAuth credentials, so it starts after Gitea setup
-DEFERRED_SERVICES=\"woodpecker\"
-
-# Fix Dify storage permissions (API/worker run as uid 1001)
-if echo \"$ENABLED_LIST\" | grep -qw \"dify\"; then
-    mkdir -p /mnt/nexus-data/dify/storage /mnt/nexus-data/dify/plugins
-    chown -R 1001:1001 /mnt/nexus-data/dify/storage /mnt/nexus-data/dify/plugins
-fi
-
-for service in $ENABLED_LIST; do
-    echo \"[DEBUG] Checking service: \$service\" >&2
-
-    # Skip virtual services (they're covered by their parent stack)
-    if echo \"\$VIRTUAL_SERVICES\" | grep -qw \"\$service\"; then
-        echo \"[DEBUG] Skipping virtual service \$service (uses parent stack)\" >&2
-        continue
-    fi
-
-    # Skip parent stacks that were already started
-    if echo \"\$PARENT_STACKS_STARTED\" | grep -qw \"\$service\"; then
-        echo \"[DEBUG] Skipping \$service (already started as parent stack)\" >&2
-        continue
-    fi
-
-    # Skip deferred services (started later after dependencies are ready)
-    if echo \"\$DEFERRED_SERVICES\" | grep -qw \"\$service\"; then
-        echo \"[DEBUG] Deferring \$service (started after dependency setup)\" >&2
-        continue
-    fi
-
-    if [ -f /opt/docker-server/stacks/\$service/docker-compose.yml ]; then
-        echo \"  Starting \$service...\"
-        if [ -f /opt/docker-server/stacks/\$service/docker-compose.firewall.yml ]; then
-            echo \"    (with firewall port overrides)\"
-            (cd /opt/docker-server/stacks/\$service && docker compose -f docker-compose.yml -f docker-compose.firewall.yml up -d --build 2>&1) &
-        else
-            (cd /opt/docker-server/stacks/\$service && docker compose up -d --build 2>&1) &
-        fi
-        PID=\$!
-        PIDS+=(\$PID)
-        STARTED_SERVICES+=(\"\$service:\$PID\")
-    else
-        echo \"[DEBUG] docker-compose.yml not found for \$service\" >&2
-        FAILED_SERVICES+=(\"\$service (no docker-compose.yml)\")
-    fi
-done
-
-# Wait for all background jobs and collect exit codes
-FAILED_COUNT=0
-for i in \"\${!PIDS[@]}\"; do
-    PID=\${PIDS[\$i]}
-    SERVICE_PID_PAIR=\${STARTED_SERVICES[\$i]}
-    SERVICE_NAME=\$(echo \"\$SERVICE_PID_PAIR\" | cut -d: -f1)
-    
-    if wait \$PID; then
-        # Verify container is actually running
-        if docker ps --format '{{.Names}}' | grep -q \"^\${SERVICE_NAME}\$\"; then
-            echo \"  ✓ \$SERVICE_NAME started and running\"
-        else
-            echo \"  ⚠️  \$SERVICE_NAME started but container not found in 'docker ps'\" >&2
-            FAILED_SERVICES+=(\"\$SERVICE_NAME (container not running)\")
-            FAILED_COUNT=\$((FAILED_COUNT + 1))
-        fi
-    else
-        EXIT_CODE=\$?
-        echo \"  ✗ \$SERVICE_NAME failed to start (exit code: \$EXIT_CODE)\" >&2
-        FAILED_SERVICES+=(\"\$SERVICE_NAME (exit code: \$EXIT_CODE)\")
-        FAILED_COUNT=\$((FAILED_COUNT + 1))
-    fi
-done
-
-echo ''
-if [ \$FAILED_COUNT -eq 0 ] && [ \${#FAILED_SERVICES[@]} -eq 0 ]; then
-    echo '  ✓ All enabled stacks started successfully'
-else
-    echo \"  ⚠️  Started \${#STARTED_SERVICES[@]} services, \$FAILED_COUNT failed\" >&2
-    echo \"  Failed services: \${FAILED_SERVICES[*]}\" >&2
-    exit 1
-fi
-" 2>&1 | tee /tmp/docker-start.log
-
-DOCKER_EXIT_CODE=${PIPESTATUS[0]}
-if [ $DOCKER_EXIT_CODE -eq 0 ]; then
-    echo -e "${GREEN}  ✓ All containers started successfully${NC}"
-else
-    echo -e "${RED}  ✗ Some containers failed to start${NC}"
-    echo -e "${YELLOW}  Check /tmp/docker-start.log for details${NC}"
-    exit $DOCKER_EXIT_CODE
-fi
+# Migrated from a 130-line ssh heredoc (Phase 2 Modul 2.2a, #505).
+# nexus_deploy.compose_runner expands virtual services to parents,
+# de-dupes, skips deferred services, and runs the parallel
+# docker-compose-up + docker-ps verify loop server-side. Per-service
+# admin-setup hooks (Wikijs/Dify/Metabase/Superset/LakeFS/OpenMetadata/
+# Gitea/Filestash/RedPanda) ship in Modul 2.2b.
+COMPOSE_RC=0
+uv run --quiet --project "$PROJECT_ROOT" \
+    python -m nexus_deploy compose up \
+    --enabled "$(echo "$ENABLED_SERVICES" | tr ' ' ',')" \
+    || COMPOSE_RC=$?
+case "$COMPOSE_RC" in
+    0) echo -e "${GREEN}  ✓ All containers started successfully${NC}" ;;
+    1) echo -e "${YELLOW}  ⚠ Compose-up had partial failures (continuing)${NC}" ;;
+    *) echo -e "${RED}  ✗ Compose-up transport failure (rc=$COMPOSE_RC); aborting${NC}"; exit "$COMPOSE_RC" ;;
+esac
 
 # -----------------------------------------------------------------------------
 # Auto-configure services

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1786,9 +1786,14 @@ echo -e "${YELLOW}[6/7] Starting enabled containers (parallel)...${NC}"
 # admin-setup hooks (Wikijs/Dify/Metabase/Superset/LakeFS/OpenMetadata/
 # Gitea/Filestash/RedPanda) ship in Modul 2.2b.
 COMPOSE_RC=0
+# $ENABLED_SERVICES is newline-separated (`jq -r '.[]'` at L479); we
+# need a comma-list. `tr '\n ' ',,'` converts both newlines AND
+# stray spaces to commas; the Python CLI's `--enabled` parser
+# filters empty entries from leading/trailing/consecutive commas,
+# so trailing `\n` from echo is harmless.
 uv run --quiet --project "$PROJECT_ROOT" \
     python -m nexus_deploy compose up \
-    --enabled "$(echo "$ENABLED_SERVICES" | tr ' ' ',')" \
+    --enabled "$(echo "$ENABLED_SERVICES" | tr '\n ' ',,')" \
     || COMPOSE_RC=$?
 case "$COMPOSE_RC" in
     0) echo -e "${GREEN}  ✓ All containers started successfully${NC}" ;;

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1798,7 +1798,7 @@ uv run --quiet --project "$PROJECT_ROOT" \
 case "$COMPOSE_RC" in
     0) echo -e "${GREEN}  ✓ All containers started successfully${NC}" ;;
     1) echo -e "${YELLOW}  ⚠ Compose-up had partial failures (continuing)${NC}" ;;
-    *) echo -e "${RED}  ✗ Compose-up transport failure (rc=$COMPOSE_RC); aborting${NC}"; exit "$COMPOSE_RC" ;;
+    *) echo -e "${RED}  ✗ Compose-up hard failure (rc=$COMPOSE_RC) — bad args, transport, no parseable RESULT, or unexpected error; check Python stderr above. Aborting.${NC}"; exit "$COMPOSE_RC" ;;
 esac
 
 # -----------------------------------------------------------------------------

--- a/src/nexus_deploy/__main__.py
+++ b/src/nexus_deploy/__main__.py
@@ -7,6 +7,7 @@ Currently:
 - ``secret-sync --stack <jupyter|marimo>`` (#505 Modul 1.2)
 - ``seed --repo <owner>/<name> [--root PATH] [--prefix nexus_seeds/]``
   (#505 Modul 2.1)
+- ``compose up --enabled <comma-list>`` (#505 Modul 2.2a)
 """
 
 from __future__ import annotations
@@ -17,6 +18,7 @@ import sys
 from pathlib import Path
 
 from nexus_deploy import __version__, hello
+from nexus_deploy.compose_runner import run_compose_up
 from nexus_deploy.config import ConfigError, NexusConfig
 from nexus_deploy.infisical import (
     BootstrapEnv,
@@ -465,12 +467,82 @@ def _seed(args: list[str]) -> int:
     return 0
 
 
+def _compose_up(args: list[str]) -> int:
+    """`nexus-deploy compose up --enabled <comma-list>`.
+
+    Renders the parallel ``docker compose up -d --build`` loop for
+    every enabled service, runs it server-side via ssh, parses the
+    RESULT line. Replaces the legacy 130-line ssh heredoc in
+    ``scripts/deploy.sh`` (the [6/7] step). Per-service admin-setup
+    hooks (Wikijs, Dify, etc.) are scoped to Modul 2.2b.
+
+    The comma-list maps directly to deploy.sh's ``$ENABLED_SERVICES``;
+    callers pass it as-is. Virtual-service expansion + parent-stack
+    deduplication + deferred-services skipping happen inside the
+    compose_runner module.
+
+    Exit codes:
+    - 0: all enabled services started + verified running.
+    - 1: at least one service failed but at least one succeeded
+         (deploy.sh continues — the operator sees the per-service
+         ✗ line for diagnosis).
+    - 2: hard failure — invalid args, transport (ssh) failure, no
+         parseable RESULT line. deploy.sh aborts.
+    """
+    if not args or args[0] != "up":
+        print("compose: only 'up' subcommand is supported", file=sys.stderr)
+        return 2
+
+    enabled_str: str | None = None
+    i = 1
+    while i < len(args):
+        if args[i] == "--enabled":
+            if i + 1 >= len(args):
+                print("compose up: --enabled requires a value", file=sys.stderr)
+                return 2
+            enabled_str = args[i + 1]
+            i += 2
+        else:
+            print(f"compose up: unknown arg {args[i]!r}", file=sys.stderr)
+            return 2
+
+    if enabled_str is None:
+        print(
+            "compose up: --enabled <comma-separated-services> is required",
+            file=sys.stderr,
+        )
+        return 2
+
+    enabled = [s.strip() for s in enabled_str.split(",") if s.strip()]
+    if not enabled:
+        # Empty list = nothing to do = success (mirrors deploy.sh's
+        # behaviour when ENABLED_SERVICES is empty).
+        print("compose up: no services enabled, nothing to do")
+        return 0
+
+    try:
+        result = run_compose_up(enabled)
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError) as exc:
+        print(f"compose up: transport failure ({type(exc).__name__})", file=sys.stderr)
+        return 2
+    except Exception as exc:
+        print(f"compose up: unexpected error ({type(exc).__name__})", file=sys.stderr)
+        return 2
+
+    print(f"compose up: started={result.started} failed={result.failed}")
+    if result.failed > 0:
+        if result.started == 0:
+            return 2
+        return 1
+    return 0
+
+
 def main() -> int:
     """Subcommand dispatcher. Shipped subcommands by phase:
 
     - Phase 1: ``config dump-shell``, ``infisical bootstrap``,
       ``secret-sync``
-    - Phase 2: ``seed``
+    - Phase 2: ``seed``, ``compose up``
 
     More land as the migration progresses; see #505.
     """
@@ -489,6 +561,8 @@ def main() -> int:
         return _secret_sync(args[1:])
     if args[:1] == ["seed"]:
         return _seed(args[1:])
+    if args[:1] == ["compose"]:
+        return _compose_up(args[1:])
     print(
         f"nexus_deploy {__version__}: unknown command {' '.join(args)!r}",
         file=sys.stderr,
@@ -498,7 +572,8 @@ def main() -> int:
         "config dump-shell [--tofu-dir PATH (default: tofu/stack) | --stdin], "
         "infisical bootstrap (reads SECRETS_JSON from stdin + env vars), "
         "secret-sync --stack <jupyter|marimo>, "
-        "seed --repo <owner>/<name> [--root PATH] [--prefix nexus_seeds/]",
+        "seed --repo <owner>/<name> [--root PATH] [--prefix nexus_seeds/], "
+        "compose up --enabled <comma-list>",
         file=sys.stderr,
     )
     return 2

--- a/src/nexus_deploy/compose_runner.py
+++ b/src/nexus_deploy/compose_runner.py
@@ -257,11 +257,16 @@ for i in "${{!PIDS[@]}}"; do
     pid=${{PIDS[$i]}}
     name=${{NAMES[$i]}}
     if wait "$pid"; then
-        # `docker ps --format '{{{{.Names}}}}' | grep -q "^name$"`:
-        # the anchored grep regex avoids substring false-matches
-        # (`foo` would otherwise match `foo-bar`). Verified by R4
-        # exec'd-bash test against the substring-trap input.
-        if docker ps --format '{{{{.Names}}}}' | grep -q "^${{name}}$"; then
+        # `docker ps --format '{{{{.Names}}}}' | grep -qFx -- "$name"`:
+        # -F treats $name as a fixed string (so a hypothetical future
+        # stack name with regex metacharacters like `.`, `[`, `*`
+        # can't false-match), -x requires the entire line to match,
+        # and `--` terminates options so a name starting with `-`
+        # doesn't get parsed as a flag. Equivalent semantic to
+        # `^name$` regex but safe for arbitrary inputs. Verified by
+        # R4 exec'd-bash test against substring-trap + regex-meta
+        # inputs.
+        if docker ps --format '{{{{.Names}}}}' | grep -qFx -- "$name"; then
             STARTED=$((STARTED+1))
             echo "  ✓ $name started and running"
         else

--- a/src/nexus_deploy/compose_runner.py
+++ b/src/nexus_deploy/compose_runner.py
@@ -164,15 +164,22 @@ def render_remote_script(
     The script:
       1. ``set -euo pipefail``, ``set -a``+source the global env
          (image-version pins).
-      2. Start each parent stack in parallel (``docker compose up -d
-         --build &``), wait for all to finish.
-      3. Pre-deploy hooks (e.g. Dify storage perms) gated on flags.
-      4. Start each leaf stack in parallel, applying the firewall
-         override file (``-f docker-compose.firewall.yml``) when
-         present on disk.
-      5. Wait for all leaf PIDs, verify each container is in
-         ``docker ps``, emit per-service ✓/✗ to stdout.
-      6. Emit the RESULT line.
+      2. Pre-deploy hooks (e.g. Dify storage perms) gated on flags.
+      3. Spawn ``docker compose up -d --build`` in the background
+         for every parent stack AND every leaf stack — PIDs from
+         both tiers accumulate in a single ``PIDS`` array, no
+         barrier between them. (Acceptable because parents and
+         leaves don't share docker-compose YAML or container
+         dependencies in practice — the parent/leaf split is just
+         a virtual-service-mapping convention, not a startup-order
+         constraint.) Each leaf invocation also applies
+         ``-f docker-compose.firewall.yml`` when present on disk.
+      4. ``wait`` each PID, then verify the container is in
+         ``docker ps`` (R4 — exact-anchor grep). Per-service ✓
+         lines go to stdout; ✗ lines go to stderr (so workflow-
+         log filtering can split happy-path noise from real
+         errors).
+      5. Emit the RESULT line on stdout.
     """
     stacks_q = shlex.quote(stacks_dir)
     env_q = shlex.quote(global_env)

--- a/src/nexus_deploy/compose_runner.py
+++ b/src/nexus_deploy/compose_runner.py
@@ -1,0 +1,323 @@
+"""Parallel ``docker compose up`` runner (Phase 2 Modul 2.2a, #505).
+
+Replaces the 130-line ``ssh nexus "..."`` heredoc in
+``scripts/deploy.sh`` (the legacy block walked the enabled-services
+list, expanded virtual services to their parent stacks, started each
+stack via ``docker compose up -d --build`` in parallel via bash
+``&``/``wait``, and verified each container made it into ``docker
+ps``). Migration target: the foundation only — the per-service admin-
+setup hooks (Wikijs, Dify, Metabase, Superset, LakeFS, OpenMetadata,
+Gitea, Filestash, RedPanda) are scoped to Modul 2.2b and ship in a
+follow-up PR.
+
+Why server-side bash loop (consistent with infisical.py +
+secret_sync.py + seeder.py): one SSH round-trip, bash background-
+jobs are proven, the rendered script is testable as a string. Phase 3
+(#505 Modul 3.1) replaces the bash rendering wholesale with paramiko
++ asyncio.
+
+Eight rounds of hardening preserved (one regression test per round in
+``tests/unit/test_compose_runner.py``):
+
+R1. ``set -euo pipefail`` first executable line.
+R2. Per-stack firewall override applied when
+    ``docker-compose.firewall.yml`` exists on the server.
+R3. Background-jobs + ``wait`` for parallel deploy; failed PIDs
+    surface via the per-service exit code.
+R4. ``docker ps`` verification — a container that ``compose up``
+    "succeeded" but didn't actually start (e.g. immediate exit due
+    to bad config) is counted as failed.
+R5. Virtual-service deduplication: a parent stack started for one
+    virtual service is NOT started a second time when another
+    virtual service from the same parent appears.
+R6. Deferred services skipped (woodpecker — depends on Gitea OAuth
+    credentials, started later in deploy.sh).
+R7. ``set -a`` + ``source /opt/docker-server/stacks/.env`` exports
+    image-version pins to the compose-up environment.
+R8. RESULT line emitted at end with started/failed counts; orchestrator
+    parses it instead of grepping stdout for emoji.
+"""
+
+from __future__ import annotations
+
+import re
+import shlex
+import subprocess
+import sys
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from nexus_deploy import _remote
+
+# Hardcoded deploy-config: virtual services, parent-stack mapping, and
+# deferred services. These live in deploy.sh today (L1796/L1799/L1821);
+# we lift them into module-level constants so the migration is byte-
+# identical. Adding/removing entries here is the same amount of effort
+# as touching deploy.sh. New stacks that don't fit this pattern just
+# don't appear in either set.
+_VIRTUAL_SERVICES: frozenset[str] = frozenset({"seaweedfs-filer", "seaweedfs-manager"})
+_STACK_PARENTS: dict[str, str] = {
+    "seaweedfs-filer": "seaweedfs",
+    "seaweedfs-manager": "seaweedfs",
+}
+_DEFERRED_SERVICES: frozenset[str] = frozenset({"woodpecker"})
+
+# Server-side stacks dir (mirror of deploy.sh's REMOTE_STACKS_DIR).
+_REMOTE_STACKS_DIR = "/opt/docker-server/stacks"
+
+# Server-side env file with image-version pins; sourced into the
+# compose-up environment via `set -a; source ...; set +a`.
+_REMOTE_GLOBAL_ENV = "/opt/docker-server/stacks/.env"
+
+# RESULT-line shape (same wire-format family as infisical / secret_sync
+# / seeder — `RESULT key=value key=value`). started/failed are counts;
+# the human-readable per-service status reaches the operator via stderr
+# warnings forwarded from the remote loop.
+_RESULT_PATTERN = re.compile(
+    r"^RESULT started=(?P<started>\d+) failed=(?P<failed>\d+)$",
+    re.MULTILINE,
+)
+
+
+@dataclass(frozen=True)
+class ComposeUpResult:
+    """Counters parsed from the remote ``RESULT`` line.
+
+    ``started`` counts services that both reported ``compose up``
+    success AND were observed in ``docker ps`` afterwards (R4
+    invariant). ``failed`` counts everything else: compose-up
+    non-zero exit, container missing from ``docker ps`` post-up,
+    missing ``docker-compose.yml`` for an enabled service.
+    """
+
+    started: int
+    failed: int
+
+    @property
+    def is_success(self) -> bool:
+        """True iff zero failures."""
+        return self.failed == 0
+
+
+# ---------------------------------------------------------------------------
+# Pure-logic helpers — virtual-service resolution.
+# ---------------------------------------------------------------------------
+
+
+def expand_targets(enabled: list[str]) -> tuple[list[str], list[str]]:
+    """Resolve the enabled list into (parent_stacks, leaf_stacks).
+
+    Parent stacks are derived from the ``_STACK_PARENTS`` map for any
+    virtual service in ``enabled``. Each parent is added once even if
+    multiple virtual children are enabled (R5). Leaf stacks are the
+    remaining services minus virtuals, parents-already-included, and
+    deferred services (R6).
+
+    Returns the two lists in source order (caller sees the same order
+    deploy.sh did, which the operator relies on for log debugging).
+    """
+    parents: list[str] = []
+    seen_parents: set[str] = set()
+    for svc in enabled:
+        parent = _STACK_PARENTS.get(svc)
+        if parent and parent not in seen_parents:
+            parents.append(parent)
+            seen_parents.add(parent)
+
+    leaves: list[str] = []
+    seen_leaves: set[str] = set()
+    for svc in enabled:
+        if svc in _VIRTUAL_SERVICES:
+            continue
+        if svc in seen_parents:
+            continue  # already covered as a parent above
+        if svc in _DEFERRED_SERVICES:
+            continue
+        if svc in seen_leaves:
+            continue
+        leaves.append(svc)
+        seen_leaves.add(svc)
+
+    return parents, leaves
+
+
+# ---------------------------------------------------------------------------
+# Bash rendering — produces the server-side script that
+# `_remote.ssh_run_script` will exec via stdin.
+# ---------------------------------------------------------------------------
+
+
+def render_remote_script(
+    *,
+    parents: list[str],
+    leaves: list[str],
+    dify_storage_prep: bool = False,
+    stacks_dir: str = _REMOTE_STACKS_DIR,
+    global_env: str = _REMOTE_GLOBAL_ENV,
+) -> str:
+    """Render the bash that does parallel ``docker compose up`` + verify.
+
+    All inputs are shlex-quoted. Service names land in a bash array
+    (one per line, quoted) so spaces / special chars in a hypothetical
+    future stack name can't break the loop.
+
+    The script:
+      1. ``set -euo pipefail``, ``set -a``+source the global env
+         (image-version pins).
+      2. Start each parent stack in parallel (``docker compose up -d
+         --build &``), wait for all to finish.
+      3. Pre-deploy hooks (e.g. Dify storage perms) gated on flags.
+      4. Start each leaf stack in parallel, applying the firewall
+         override file (``-f docker-compose.firewall.yml``) when
+         present on disk.
+      5. Wait for all leaf PIDs, verify each container is in
+         ``docker ps``, emit per-service ✓/✗ to stdout.
+      6. Emit the RESULT line.
+    """
+    stacks_q = shlex.quote(stacks_dir)
+    env_q = shlex.quote(global_env)
+    parents_q = " ".join(shlex.quote(p) for p in parents)
+    leaves_q = " ".join(shlex.quote(le) for le in leaves)
+
+    dify_block = ""
+    if dify_storage_prep:
+        # Mirror deploy.sh:1823-1827 — Dify API/worker run as uid 1001,
+        # storage + plugins dirs need ownership match. Idempotent.
+        dify_block = """
+mkdir -p /mnt/nexus-data/dify/storage /mnt/nexus-data/dify/plugins
+chown -R 1001:1001 /mnt/nexus-data/dify/storage /mnt/nexus-data/dify/plugins
+"""
+
+    return f"""set -euo pipefail
+
+STACKS_DIR={stacks_q}
+GLOBAL_ENV={env_q}
+
+# Source image-version pins so compose-up sees the right tags.
+if [ -f "$GLOBAL_ENV" ]; then
+    set -a
+    # shellcheck disable=SC1090
+    source "$GLOBAL_ENV"
+    set +a
+fi
+
+PARENTS=({parents_q})
+LEAVES=({leaves_q})
+{dify_block}
+STARTED=0
+FAILED=0
+PIDS=()
+NAMES=()
+
+# 1. Start parent stacks first (parallel).
+for svc in "${{PARENTS[@]}}"; do
+    if [ -f "$STACKS_DIR/$svc/docker-compose.yml" ]; then
+        ( cd "$STACKS_DIR/$svc" && docker compose up -d --build 2>&1 ) &
+        PIDS+=($!)
+        NAMES+=("$svc")
+    else
+        echo "  ⚠ docker-compose.yml missing for parent $svc" >&2
+        FAILED=$((FAILED+1))
+    fi
+done
+
+# 2. Start leaf stacks in parallel, applying firewall override if present.
+for svc in "${{LEAVES[@]}}"; do
+    if [ ! -f "$STACKS_DIR/$svc/docker-compose.yml" ]; then
+        echo "  ⚠ docker-compose.yml missing for $svc" >&2
+        FAILED=$((FAILED+1))
+        continue
+    fi
+    if [ -f "$STACKS_DIR/$svc/docker-compose.firewall.yml" ]; then
+        ( cd "$STACKS_DIR/$svc" && docker compose -f docker-compose.yml -f docker-compose.firewall.yml up -d --build 2>&1 ) &
+    else
+        ( cd "$STACKS_DIR/$svc" && docker compose up -d --build 2>&1 ) &
+    fi
+    PIDS+=($!)
+    NAMES+=("$svc")
+done
+
+# 3. Wait for all PIDs, verify container is running for each.
+for i in "${{!PIDS[@]}}"; do
+    pid=${{PIDS[$i]}}
+    name=${{NAMES[$i]}}
+    if wait "$pid"; then
+        # docker ps -f name=^foo$ excludes substring matches (e.g. "foo-bar" wouldn't match "^foo$")
+        if docker ps --format '{{{{.Names}}}}' | grep -q "^${{name}}$"; then
+            STARTED=$((STARTED+1))
+            echo "  ✓ $name started and running"
+        else
+            FAILED=$((FAILED+1))
+            echo "  ✗ $name compose up succeeded but container not in 'docker ps'" >&2
+        fi
+    else
+        rc=$?
+        FAILED=$((FAILED+1))
+        echo "  ✗ $name compose up failed (rc=$rc)" >&2
+    fi
+done
+
+echo "RESULT started=$STARTED failed=$FAILED"
+"""
+
+
+def parse_result(stdout: str) -> ComposeUpResult | None:
+    """Extract the ``RESULT`` line from remote stdout.
+
+    Returns None if no parseable RESULT line — caller (CLI) maps that
+    to the same hard-failure path missing-stdin would.
+    """
+    match = _RESULT_PATTERN.search(stdout)
+    if match is None:
+        return None
+    g = match.groupdict()
+    return ComposeUpResult(started=int(g["started"]), failed=int(g["failed"]))
+
+
+# ---------------------------------------------------------------------------
+# End-to-end orchestration
+# ---------------------------------------------------------------------------
+
+
+ScriptRunner = Callable[[str], subprocess.CompletedProcess[str]]
+
+
+def run_compose_up(
+    enabled: list[str],
+    *,
+    dify_storage_prep: bool | None = None,
+    script_runner: ScriptRunner | None = None,
+) -> ComposeUpResult:
+    """Render → exec → parse.
+
+    ``dify_storage_prep`` defaults to True iff ``"dify"`` is in
+    ``enabled`` — caller can override (tests pass False to skip the
+    chown block, production lets the default fire).
+
+    Returns ``ComposeUpResult(started=0, failed=len(enabled))`` if the
+    remote script produced no parseable RESULT line — same defensive
+    parse pattern as seeder.py / secret_sync.py.
+
+    ``script_runner`` is a dependency-injection seam for tests;
+    production callers leave it None.
+    """
+    parents, leaves = expand_targets(enabled)
+    actual_dify = dify_storage_prep if dify_storage_prep is not None else "dify" in enabled
+
+    script = render_remote_script(parents=parents, leaves=leaves, dify_storage_prep=actual_dify)
+
+    run_script = script_runner or (lambda s: _remote.ssh_run_script(s))
+    completed = run_script(script)
+
+    # Forward remote per-service ✓/✗ + warnings to local stderr (Modul-1.2
+    # Round-4 pattern). The RESULT wire-format line is stripped.
+    for line in completed.stdout.splitlines():
+        if not line.startswith("RESULT "):
+            sys.stderr.write(line + "\n")
+
+    result = parse_result(completed.stdout)
+    if result is None:
+        # No RESULT — count every requested service as failed (mirrors
+        # seeder.py's assumption that none of them landed).
+        return ComposeUpResult(started=0, failed=len(parents) + len(leaves))
+    return result

--- a/src/nexus_deploy/compose_runner.py
+++ b/src/nexus_deploy/compose_runner.py
@@ -216,7 +216,15 @@ FAILED=0
 PIDS=()
 NAMES=()
 
-# 1. Start parent stacks first (parallel).
+# 1. Start parent stacks (parallel — see docstring for why no barrier
+#    between parents and leaves).
+# DELIBERATE DIVERGENCE from legacy deploy.sh: the bash version had
+# no `else` branch on the parent-stack `[ -f ... ]` check — a missing
+# parent compose.yml was silently skipped (no FAILED++). We treat it
+# as a real configuration error: a virtual service is enabled, its
+# parent is implied, and the parent's compose.yml is missing —
+# operators need to know. The leaf-stack branch always counted this
+# as failed, so we just unify the two tiers (STRICTLY-MORE-CORRECT).
 for svc in "${{PARENTS[@]}}"; do
     if [ -f "$STACKS_DIR/$svc/docker-compose.yml" ]; then
         ( cd "$STACKS_DIR/$svc" && docker compose up -d --build 2>&1 ) &
@@ -249,7 +257,10 @@ for i in "${{!PIDS[@]}}"; do
     pid=${{PIDS[$i]}}
     name=${{NAMES[$i]}}
     if wait "$pid"; then
-        # docker ps -f name=^foo$ excludes substring matches (e.g. "foo-bar" wouldn't match "^foo$")
+        # `docker ps --format '{{{{.Names}}}}' | grep -q "^name$"`:
+        # the anchored grep regex avoids substring false-matches
+        # (`foo` would otherwise match `foo-bar`). Verified by R4
+        # exec'd-bash test against the substring-trap input.
         if docker ps --format '{{{{.Names}}}}' | grep -q "^${{name}}$"; then
             STARTED=$((STARTED+1))
             echo "  ✓ $name started and running"

--- a/src/nexus_deploy/compose_runner.py
+++ b/src/nexus_deploy/compose_runner.py
@@ -49,17 +49,23 @@ from dataclasses import dataclass
 
 from nexus_deploy import _remote
 
-# Hardcoded deploy-config: virtual services, parent-stack mapping, and
-# deferred services. These live in deploy.sh today (L1796/L1799/L1821);
-# we lift them into module-level constants so the migration is byte-
-# identical. Adding/removing entries here is the same amount of effort
-# as touching deploy.sh. New stacks that don't fit this pattern just
-# don't appear in either set.
-_VIRTUAL_SERVICES: frozenset[str] = frozenset({"seaweedfs-filer", "seaweedfs-manager"})
+# Hardcoded deploy-config: parent-stack mapping and deferred services.
+# These live in deploy.sh today (L1796/L1799/L1821); we lift them into
+# module-level constants so the migration is byte-identical.
+# Adding/removing entries here is the same amount of effort as touching
+# deploy.sh. New stacks that don't fit either pattern just don't appear.
+#
+# `_VIRTUAL_SERVICES` is derived from `_STACK_PARENTS.keys()` rather
+# than maintained as a separate frozenset so the two can't drift —
+# previously they were both manually listed and a round-4 review
+# pointed out the duplication risk (a service could be treated as
+# virtual yet have no parent mapping → skipped from leaves AND from
+# parents → silently never started).
 _STACK_PARENTS: dict[str, str] = {
     "seaweedfs-filer": "seaweedfs",
     "seaweedfs-manager": "seaweedfs",
 }
+_VIRTUAL_SERVICES: frozenset[str] = frozenset(_STACK_PARENTS.keys())
 _DEFERRED_SERVICES: frozenset[str] = frozenset({"woodpecker"})
 
 # Server-side stacks dir (mirror of deploy.sh's REMOTE_STACKS_DIR).
@@ -175,10 +181,15 @@ def render_remote_script(
          constraint.) Each leaf invocation also applies
          ``-f docker-compose.firewall.yml`` when present on disk.
       4. ``wait`` each PID, then verify the container is in
-         ``docker ps`` (R4 — exact-anchor grep). Per-service ✓
-         lines go to stdout; ✗ lines go to stderr (so workflow-
-         log filtering can split happy-path noise from real
-         errors).
+         ``docker ps`` (R4 — fixed-string + line-exact grep). The
+         rendered bash splits per-service ✓ to stdout and ✗ to
+         stderr, but ``_remote.ssh_run_script(merge_stderr=True)``
+         merges them on capture, and ``run_compose_up`` then
+         forwards every non-RESULT line to local stderr. Net
+         operator UX: both ✓ and ✗ land in the workflow-log
+         stderr stream alongside the bash warnings, in source
+         order. Phase 3 (paramiko refactor) can preserve the
+         split if desired.
       5. Emit the RESULT line on stdout.
     """
     stacks_q = shlex.quote(stacks_dir)

--- a/tests/unit/test_compose_runner.py
+++ b/tests/unit/test_compose_runner.py
@@ -27,6 +27,19 @@ from nexus_deploy.compose_runner import (
 # ---------------------------------------------------------------------------
 
 
+def test_virtual_services_derived_from_stack_parents_keys() -> None:
+    """`_VIRTUAL_SERVICES` is derived from `_STACK_PARENTS.keys()` —
+    they cannot drift. Round-4 finding: previously they were two
+    independent sources of truth, and a service listed in
+    `_VIRTUAL_SERVICES` but missing from `_STACK_PARENTS` would
+    have been silently never started (skipped from leaves AND
+    parents). The derivation closes that risk.
+    """
+    from nexus_deploy.compose_runner import _STACK_PARENTS, _VIRTUAL_SERVICES
+
+    assert frozenset(_STACK_PARENTS.keys()) == _VIRTUAL_SERVICES
+
+
 def test_expand_targets_no_virtuals() -> None:
     """All-leaf input: parents empty, leaves preserve order."""
     parents, leaves = expand_targets(["jupyter", "marimo", "gitea"])

--- a/tests/unit/test_compose_runner.py
+++ b/tests/unit/test_compose_runner.py
@@ -120,8 +120,13 @@ def test_round_4_docker_ps_verification_via_bash_exec() -> None:
     Modul-2.0 lesson: dispatch logic that LOOKS right but behaves
     wrong (e.g. grep matching substrings instead of exact names) is
     a real risk. We extract the verification snippet and run it
-    against four scenarios. This is the test that would have caught
-    a substring-match bug in production where 'foo' matched 'foo-bar'.
+    against six scenarios.
+
+    Round-3 finding: switched from `grep -q "^name$"` (regex anchors)
+    to `grep -qFx -- "name"` (fixed-string + line-exact + arg-end
+    sentinel) so that container names containing regex metacharacters
+    (`.`, `[`, `*`) can't false-match. The two new cases at the bottom
+    pin this — they would have failed under the old regex form.
     """
     cases = [
         # (docker_ps_output, target_name, expected_match)
@@ -129,11 +134,17 @@ def test_round_4_docker_ps_verification_via_bash_exec() -> None:
         ("foo-bar\nfoo-baz\n", "foo", False),  # substring → must NOT match
         ("\n", "foo", False),
         ("foo\n", "FOO", False),  # case-sensitive
+        # Regex-metachar safety (round-3 fix). Under the old
+        # `^name$` regex, `foo.bar` as a pattern would match `fooXbar`
+        # because `.` is "any char". Fixed-string `grep -F` rejects.
+        ("fooXbar\n", "foo.bar", False),
+        # Exact-match still works with fixed-string + metachar in name
+        ("foo.bar\n", "foo.bar", True),
     ]
     for ps_output, name, expected in cases:
         snippet = f"""
 set -euo pipefail
-echo {shlex_quote(ps_output)} | grep -q "^{name}$" && echo match || echo nomatch
+printf '%s' {shlex_quote(ps_output)} | grep -qFx -- {shlex_quote(name)} && echo match || echo nomatch
 """
         out = subprocess.run(
             ["bash", "-c", snippet], capture_output=True, text=True, check=False

--- a/tests/unit/test_compose_runner.py
+++ b/tests/unit/test_compose_runner.py
@@ -338,6 +338,55 @@ def test_cli_compose_up_empty_enabled_returns_zero() -> None:
     assert "nothing to do" in out
 
 
+def test_cli_compose_up_tolerates_empty_csv_entries() -> None:
+    """Leading/trailing/consecutive commas are filtered; deploy.sh's
+    `tr '\\n ' ',,'` of newline-separated $ENABLED_SERVICES produces a
+    trailing comma (echo appends \\n), and operators sometimes pass
+    `--enabled "a,,b"` by accident. Both must result in a clean
+    parse, not a phantom empty-string service.
+
+    Regression for round-1 finding on PR #513: the deploy.sh side
+    was sending `"jupyter\\nmarimo"` (newlines preserved) which the
+    Python parser would have treated as a single service — fix is
+    on the deploy.sh side (`tr '\\n ' ',,'`); this test verifies the
+    Python parser does the right thing with the resulting CSV.
+    """
+    # Will fail with rc=2 because /does/not/exist isn't a directory,
+    # but we're testing that "a,,b,c," parses to ["a", "b", "c"] (3
+    # services), not ["a", "", "b", "c", ""] (5 with phantom empties).
+    # The phantom-empty case would crash on root.is_dir() check
+    # because of how the orchestrator expand the empty string.
+    # With a non-existent root the CLI returns rc=0 (skips compose-up
+    # entirely) for ALL non-empty entries we feed it.
+    # Here we just verify rc != 2 (no parser-side rejection of empties).
+    # Use a non-existent --enabled list that would trigger rc=2 if
+    # parsed badly; clean parsing reaches the runner mock-free path.
+    # Simpler: rely on the mock-injection test below instead. Just
+    # check the CLI accepts the CSV form.
+    # Actually the ssh_run_script call WILL fire. Skip this CLI-level
+    # test; the unit test below covers the parser semantic.
+
+
+def test_run_compose_up_filters_empty_csv_entries() -> None:
+    """expand_targets handles empty / duplicate inputs cleanly.
+
+    Regression-test the PARSER side of the round-1 deploy.sh bug:
+    deploy.sh's `tr '\\n ' ',,'` may produce empty entries between
+    consecutive separators or at trailing position. The CLI's
+    list-comprehension filter `[s.strip() for s in ... if s.strip()]`
+    drops them; expand_targets' dedupe handles repeats. Result: a
+    CSV like `",jupyter,,marimo,"` resolves to the same targets as
+    `"jupyter,marimo"`.
+    """
+    # Simulate what the CLI parser produces from a messy CSV
+    raw = ",jupyter,,marimo,"
+    enabled = [s.strip() for s in raw.split(",") if s.strip()]
+    assert enabled == ["jupyter", "marimo"]
+    parents, leaves = expand_targets(enabled)
+    assert parents == []
+    assert leaves == ["jupyter", "marimo"]
+
+
 def test_cli_compose_up_unknown_arg_returns_2() -> None:
     rc, _, err = _run_cli(["up", "--enabled", "jupyter", "--bogus"])
     assert rc == 2

--- a/tests/unit/test_compose_runner.py
+++ b/tests/unit/test_compose_runner.py
@@ -1,0 +1,351 @@
+"""Tests for nexus_deploy.compose_runner — Phase 2 Modul 2.2a (#505).
+
+Eight round-tagged invariant tests (one per deploy.sh hardening round)
+plus virtual-service expansion tests, exec'd-bash regression tests for
+the parallel-deploy semantics, and CLI integration covering rc=0/1/2.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from typing import Any
+
+import pytest
+
+from nexus_deploy.compose_runner import (
+    ComposeUpResult,
+    expand_targets,
+    parse_result,
+    render_remote_script,
+    run_compose_up,
+)
+
+# ---------------------------------------------------------------------------
+# expand_targets — virtual-service resolution
+# ---------------------------------------------------------------------------
+
+
+def test_expand_targets_no_virtuals() -> None:
+    """All-leaf input: parents empty, leaves preserve order."""
+    parents, leaves = expand_targets(["jupyter", "marimo", "gitea"])
+    assert parents == []
+    assert leaves == ["jupyter", "marimo", "gitea"]
+
+
+def test_round_5_parent_dedupe_two_virtual_children() -> None:
+    """R5 — parent stack appears once even with two virtual children enabled."""
+    parents, leaves = expand_targets(["seaweedfs-filer", "seaweedfs-manager"])
+    assert parents == ["seaweedfs"]
+    assert leaves == []
+
+
+def test_round_5_parent_skipped_in_leaves_when_already_added() -> None:
+    """R5 — explicit parent + child means parent is started once, not twice."""
+    parents, leaves = expand_targets(["seaweedfs", "seaweedfs-filer"])
+    assert parents == ["seaweedfs"]
+    # Explicit "seaweedfs" must not appear in leaves
+    assert "seaweedfs" not in leaves
+    assert leaves == []
+
+
+def test_round_6_deferred_services_skipped() -> None:
+    """R6 — woodpecker is deferred (started later in deploy.sh)."""
+    parents, leaves = expand_targets(["jupyter", "woodpecker", "gitea"])
+    assert parents == []
+    assert "woodpecker" not in leaves
+    assert leaves == ["jupyter", "gitea"]
+
+
+def test_expand_targets_preserves_source_order() -> None:
+    """Source order is preserved (operators rely on it for log debug)."""
+    parents, leaves = expand_targets(["c", "a", "seaweedfs-filer", "b", "seaweedfs-manager", "z"])
+    assert parents == ["seaweedfs"]
+    assert leaves == ["c", "a", "b", "z"]
+
+
+def test_expand_targets_handles_duplicates_in_input() -> None:
+    """Duplicate enabled entries don't duplicate compose-up calls."""
+    _, leaves = expand_targets(["jupyter", "jupyter", "marimo"])
+    assert leaves == ["jupyter", "marimo"]
+
+
+# ---------------------------------------------------------------------------
+# render_remote_script — locks the 8 hardening rounds in the rendered bash
+# ---------------------------------------------------------------------------
+
+
+def _render_default(**kwargs: Any) -> str:
+    defaults: dict[str, Any] = {
+        "parents": [],
+        "leaves": ["jupyter", "marimo"],
+    }
+    defaults.update(kwargs)
+    return render_remote_script(**defaults)
+
+
+def test_round_1_set_euo_pipefail_first_executable_line() -> None:
+    """R1 — `set -euo pipefail` is the first command."""
+    script = _render_default()
+    first_executable = next(
+        line for line in script.splitlines() if line and not line.startswith("#")
+    )
+    assert first_executable == "set -euo pipefail"
+
+
+def test_round_2_firewall_override_check_present() -> None:
+    """R2 — per-stack firewall override applied when present on disk."""
+    script = _render_default(leaves=["minio"])
+    # The conditional check must appear
+    assert "docker-compose.firewall.yml" in script
+    # And the compose invocation form must use both files when present
+    assert "-f docker-compose.yml -f docker-compose.firewall.yml" in script
+
+
+def test_round_3_parallel_deploy_via_background_jobs() -> None:
+    """R3 — leaf compose-up runs in background; PIDs collected for `wait`."""
+    script = _render_default(leaves=["jupyter", "marimo"])
+    # Background-jobs marker
+    assert "&\n" in script
+    # PID collection
+    assert "PIDS+=($!)" in script
+    # Wait loop
+    assert 'wait "$pid"' in script
+
+
+def test_round_4_docker_ps_verification_via_bash_exec() -> None:
+    """R4 — `docker ps` verification logic, executed via bash.
+
+    Modul-2.0 lesson: dispatch logic that LOOKS right but behaves
+    wrong (e.g. grep matching substrings instead of exact names) is
+    a real risk. We extract the verification snippet and run it
+    against four scenarios. This is the test that would have caught
+    a substring-match bug in production where 'foo' matched 'foo-bar'.
+    """
+    cases = [
+        # (docker_ps_output, target_name, expected_match)
+        ("foo\nbar\nbaz\n", "foo", True),
+        ("foo-bar\nfoo-baz\n", "foo", False),  # substring → must NOT match
+        ("\n", "foo", False),
+        ("foo\n", "FOO", False),  # case-sensitive
+    ]
+    for ps_output, name, expected in cases:
+        snippet = f"""
+set -euo pipefail
+echo {shlex_quote(ps_output)} | grep -q "^{name}$" && echo match || echo nomatch
+"""
+        out = subprocess.run(
+            ["bash", "-c", snippet], capture_output=True, text=True, check=False
+        ).stdout.strip()
+        assert (out == "match") is expected, (
+            f"ps={ps_output!r} name={name!r} expected={expected} got={out!r}"
+        )
+
+
+def shlex_quote(s: str) -> str:
+    """Local helper because we need bash quoting in the test snippet."""
+    import shlex as _shlex
+
+    return _shlex.quote(s)
+
+
+def test_round_7_global_env_sourced_with_set_a() -> None:
+    """R7 — global env (image-version pins) sourced via `set -a; source ...`."""
+    script = _render_default()
+    assert 'if [ -f "$GLOBAL_ENV" ]; then' in script
+    assert "set -a" in script
+    assert 'source "$GLOBAL_ENV"' in script
+    assert "set +a" in script
+
+
+def test_round_8_result_line_emitted() -> None:
+    """R8 — RESULT line at end with started+failed counts."""
+    script = _render_default()
+    last_lines = [line for line in script.splitlines() if line.strip()][-3:]
+    assert any('echo "RESULT started=' in line for line in last_lines)
+
+
+def test_render_dify_storage_prep_only_when_flagged() -> None:
+    """Dify chown block only present when dify_storage_prep=True."""
+    without = _render_default(dify_storage_prep=False)
+    assert "/mnt/nexus-data/dify/storage" not in without
+    assert "chown -R 1001:1001" not in without
+
+    with_dify = _render_default(dify_storage_prep=True)
+    assert "/mnt/nexus-data/dify/storage" in with_dify
+    assert "chown -R 1001:1001 /mnt/nexus-data/dify/storage" in with_dify
+
+
+def test_render_handles_empty_lists() -> None:
+    """Empty parents + leaves still produces a parseable RESULT (started=0 failed=0)."""
+    script = render_remote_script(parents=[], leaves=[])
+    # Bash arrays with zero elements don't enter the `for` loop
+    assert "PARENTS=()" in script
+    assert "LEAVES=()" in script
+    assert 'echo "RESULT started=$STARTED failed=$FAILED"' in script
+
+
+def test_render_special_chars_in_service_name_quoted() -> None:
+    """shlex.quote protects against future stack names with special chars.
+
+    Realistically deploy.sh's STACK_PARENTS map is hardcoded to
+    safe ASCII names, but defence in depth: a future contributor
+    adding 'foo bar' would not break the rendered bash.
+    """
+    script = render_remote_script(parents=["foo-bar"], leaves=["a;b"])
+    assert "'a;b'" in script  # shlex-quoted form
+
+
+# ---------------------------------------------------------------------------
+# parse_result
+# ---------------------------------------------------------------------------
+
+
+def test_parse_result_happy() -> None:
+    out = "RESULT started=8 failed=0"
+    assert parse_result(out) == ComposeUpResult(started=8, failed=0)
+
+
+def test_parse_result_with_warnings_above() -> None:
+    out = (
+        "  ✓ jupyter started and running\n"
+        "  ✗ marimo compose up failed (rc=1)\n"
+        "RESULT started=1 failed=1"
+    )
+    assert parse_result(out) == ComposeUpResult(started=1, failed=1)
+
+
+def test_parse_result_no_match() -> None:
+    assert parse_result("garbage output") is None
+
+
+def test_compose_up_result_is_success() -> None:
+    assert ComposeUpResult(started=5, failed=0).is_success is True
+    assert ComposeUpResult(started=0, failed=0).is_success is True
+    assert ComposeUpResult(started=5, failed=2).is_success is False
+
+
+# ---------------------------------------------------------------------------
+# run_compose_up — orchestration
+# ---------------------------------------------------------------------------
+
+
+def _ok_runner(stdout: str) -> Any:
+    def runner(_script: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(args=["ssh"], returncode=0, stdout=stdout, stderr="")
+
+    return runner
+
+
+def test_run_compose_up_happy_path() -> None:
+    out = "RESULT started=2 failed=0"
+    result = run_compose_up(["jupyter", "marimo"], script_runner=_ok_runner(out))
+    assert result == ComposeUpResult(started=2, failed=0)
+
+
+def test_run_compose_up_no_result_attributes_failure_to_count(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """No RESULT line → failed=count of (parents+leaves)."""
+    result = run_compose_up(
+        ["jupyter", "marimo", "seaweedfs-filer"],
+        script_runner=_ok_runner("garbage output"),
+    )
+    # parents=[seaweedfs], leaves=[jupyter, marimo] → 3 services
+    assert result.failed == 3
+    assert result.started == 0
+
+
+def test_run_compose_up_forwards_remote_warnings_to_local_stderr(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Modul-1.2 Round-4 lesson: remote ✓/✗ lines reach local stderr."""
+    out = (
+        "  ✓ jupyter started and running\n"
+        "  ✗ marimo compose up failed (rc=1)\n"
+        "RESULT started=1 failed=1"
+    )
+    run_compose_up(["jupyter", "marimo"], script_runner=_ok_runner(out))
+    captured = capsys.readouterr()
+    assert "jupyter started and running" in captured.err
+    assert "marimo compose up failed" in captured.err
+    # RESULT line is wire-format, must NOT pollute stderr
+    assert "RESULT started=" not in captured.err
+
+
+def test_run_compose_up_dify_default_when_dify_in_enabled() -> None:
+    """dify_storage_prep defaults to True iff 'dify' is in enabled."""
+    captured_script: dict[str, str] = {}
+
+    def capture(script: str) -> subprocess.CompletedProcess[str]:
+        captured_script["script"] = script
+        return subprocess.CompletedProcess(
+            args=["ssh"], returncode=0, stdout="RESULT started=1 failed=0", stderr=""
+        )
+
+    run_compose_up(["jupyter", "dify"], script_runner=capture)
+    assert "/mnt/nexus-data/dify/storage" in captured_script["script"]
+
+
+def test_run_compose_up_dify_omitted_when_dify_not_in_enabled() -> None:
+    captured_script: dict[str, str] = {}
+
+    def capture(script: str) -> subprocess.CompletedProcess[str]:
+        captured_script["script"] = script
+        return subprocess.CompletedProcess(
+            args=["ssh"], returncode=0, stdout="RESULT started=1 failed=0", stderr=""
+        )
+
+    run_compose_up(["jupyter"], script_runner=capture)
+    assert "/mnt/nexus-data/dify/storage" not in captured_script["script"]
+
+
+# ---------------------------------------------------------------------------
+# CLI integration
+# ---------------------------------------------------------------------------
+
+
+def _run_cli(args: list[str], env: dict[str, str] | None = None) -> tuple[int, str, str]:
+    full_env = os.environ.copy()
+    if env:
+        full_env.update(env)
+    proc = subprocess.run(
+        [sys.executable, "-m", "nexus_deploy", "compose", *args],
+        capture_output=True,
+        text=True,
+        env=full_env,
+    )
+    return proc.returncode, proc.stdout, proc.stderr
+
+
+def test_cli_compose_missing_subcommand_returns_2() -> None:
+    rc, _, err = _run_cli([])
+    assert rc == 2
+    assert "only 'up' subcommand" in err
+
+
+def test_cli_compose_up_missing_enabled_returns_2() -> None:
+    rc, _, err = _run_cli(["up"])
+    assert rc == 2
+    assert "--enabled" in err
+
+
+def test_cli_compose_up_empty_enabled_returns_zero() -> None:
+    """Empty list = nothing to do = success."""
+    rc, out, _ = _run_cli(["up", "--enabled", ""])
+    assert rc == 0
+    assert "nothing to do" in out
+
+
+def test_cli_compose_up_unknown_arg_returns_2() -> None:
+    rc, _, err = _run_cli(["up", "--enabled", "jupyter", "--bogus"])
+    assert rc == 2
+    assert "unknown arg" in err
+
+
+def test_cli_compose_up_subcommand_typo_returns_2() -> None:
+    """`compose down`, `compose restart`, etc. all rejected."""
+    rc, _, err = _run_cli(["down", "--enabled", "x"])
+    assert rc == 2
+    assert "only 'up'" in err

--- a/tests/unit/test_compose_runner.py
+++ b/tests/unit/test_compose_runner.py
@@ -186,6 +186,26 @@ def test_render_handles_empty_lists() -> None:
     assert 'echo "RESULT started=$STARTED failed=$FAILED"' in script
 
 
+def test_render_missing_parent_compose_counted_as_failed_strict_divergence() -> None:
+    """DELIBERATE divergence from legacy deploy.sh: a missing
+    parent docker-compose.yml is counted as failed (legacy bash
+    silently skipped). Documented in the rendered-script comment;
+    this test pins the divergence so a future round-trip back to
+    legacy semantics requires touching the test (forcing reviewer
+    awareness)."""
+    script = render_remote_script(parents=["seaweedfs"], leaves=[])
+    # The conditional + FAILED increment must be present
+    assert 'if [ -f "$STACKS_DIR/$svc/docker-compose.yml" ]' in script
+    assert "missing for parent" in script
+    # Both parent + leaf branches increment FAILED on missing compose.yml
+    # → the loop appears twice (one per branch); count via the
+    # specific FAILED+=1 pattern. We expect two occurrences.
+    assert script.count("FAILED=$((FAILED+1))") >= 2
+    # The DELIBERATE DIVERGENCE comment must be present so a
+    # reviewer flipping the behaviour back to legacy sees the rationale
+    assert "DELIBERATE DIVERGENCE" in script
+
+
 def test_render_special_chars_in_service_name_quoted() -> None:
     """shlex.quote protects against future stack names with special chars.
 
@@ -338,35 +358,6 @@ def test_cli_compose_up_empty_enabled_returns_zero() -> None:
     assert "nothing to do" in out
 
 
-def test_cli_compose_up_tolerates_empty_csv_entries() -> None:
-    """Leading/trailing/consecutive commas are filtered; deploy.sh's
-    `tr '\\n ' ',,'` of newline-separated $ENABLED_SERVICES produces a
-    trailing comma (echo appends \\n), and operators sometimes pass
-    `--enabled "a,,b"` by accident. Both must result in a clean
-    parse, not a phantom empty-string service.
-
-    Regression for round-1 finding on PR #513: the deploy.sh side
-    was sending `"jupyter\\nmarimo"` (newlines preserved) which the
-    Python parser would have treated as a single service — fix is
-    on the deploy.sh side (`tr '\\n ' ',,'`); this test verifies the
-    Python parser does the right thing with the resulting CSV.
-    """
-    # Will fail with rc=2 because /does/not/exist isn't a directory,
-    # but we're testing that "a,,b,c," parses to ["a", "b", "c"] (3
-    # services), not ["a", "", "b", "c", ""] (5 with phantom empties).
-    # The phantom-empty case would crash on root.is_dir() check
-    # because of how the orchestrator expand the empty string.
-    # With a non-existent root the CLI returns rc=0 (skips compose-up
-    # entirely) for ALL non-empty entries we feed it.
-    # Here we just verify rc != 2 (no parser-side rejection of empties).
-    # Use a non-existent --enabled list that would trigger rc=2 if
-    # parsed badly; clean parsing reaches the runner mock-free path.
-    # Simpler: rely on the mock-injection test below instead. Just
-    # check the CLI accepts the CSV form.
-    # Actually the ssh_run_script call WILL fire. Skip this CLI-level
-    # test; the unit test below covers the parser semantic.
-
-
 def test_run_compose_up_filters_empty_csv_entries() -> None:
     """expand_targets handles empty / duplicate inputs cleanly.
 
@@ -398,3 +389,72 @@ def test_cli_compose_up_subcommand_typo_returns_2() -> None:
     rc, _, err = _run_cli(["down", "--enabled", "x"])
     assert rc == 2
     assert "only 'up'" in err
+
+
+# ---------------------------------------------------------------------------
+# CLI rc-mapping unit tests — monkeypatch run_compose_up to exercise the
+# rc=1 (partial) and rc=2-from-no-RESULT paths without spinning a subprocess.
+# Subprocess-based tests above only exercise rc=0/2-from-arg-validation;
+# these fill the gap (round-2 finding on PR #513).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("started", "failed", "expected_rc"),
+    [
+        (5, 0, 0),  # all success
+        (3, 2, 1),  # partial: some succeeded, some failed → rc=1
+        (0, 4, 2),  # nothing succeeded → rc=2 (orchestrator should abort)
+        (0, 0, 0),  # zero-zero (e.g. all virtuals collapsed) → rc=0
+    ],
+)
+def test_compose_up_cli_rc_mapping(
+    monkeypatch: pytest.MonkeyPatch, started: int, failed: int, expected_rc: int
+) -> None:
+    """Verify the rc=0/1/2 contract via direct `_compose_up` call."""
+    from nexus_deploy.__main__ import _compose_up
+
+    def fake_run(_enabled: list[str]) -> ComposeUpResult:
+        return ComposeUpResult(started=started, failed=failed)
+
+    monkeypatch.setattr("nexus_deploy.__main__.run_compose_up", fake_run)
+    rc = _compose_up(["up", "--enabled", "jupyter,marimo"])
+    assert rc == expected_rc
+
+
+def test_compose_up_cli_rc2_on_unexpected_exception(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Programming errors → rc=2 (NOT Python's default rc=1, which would
+    collide with the partial-failure semantic). Exception class only
+    in stderr; no str/repr that could leak attribute values."""
+    from nexus_deploy.__main__ import _compose_up
+
+    def boom(_enabled: list[str]) -> ComposeUpResult:
+        raise RuntimeError("secret-bearing-message-NEVER-print")
+
+    monkeypatch.setattr("nexus_deploy.__main__.run_compose_up", boom)
+    rc = _compose_up(["up", "--enabled", "jupyter"])
+    assert rc == 2
+    captured = capsys.readouterr()
+    assert "RuntimeError" in captured.err
+    assert "secret-bearing-message-NEVER-print" not in captured.err
+    assert "secret-bearing-message-NEVER-print" not in captured.out
+
+
+def test_compose_up_cli_rc2_on_transport_failure(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """ssh/rsync failure → rc=2. exc.cmd must NOT leak to stderr."""
+    from nexus_deploy.__main__ import _compose_up
+
+    def boom(_enabled: list[str]) -> ComposeUpResult:
+        raise subprocess.CalledProcessError(255, ["ssh", "with-secret-arg"])
+
+    monkeypatch.setattr("nexus_deploy.__main__.run_compose_up", boom)
+    rc = _compose_up(["up", "--enabled", "jupyter"])
+    assert rc == 2
+    captured = capsys.readouterr()
+    assert "transport failure" in captured.err
+    assert "with-secret-arg" not in captured.err
+    assert "with-secret-arg" not in captured.out


### PR DESCRIPTION
## Summary

Phase 2 Modul 2.2a — migrate the 130-line ssh heredoc in `scripts/deploy.sh` (the `[6/7]` parallel container-startup block) to a typed Python module. **Foundation only**: per-service admin-setup hooks (Wikijs, Dify, Metabase, Superset, LakeFS, OpenMetadata, Gitea, Filestash, RedPanda) are scoped to **Modul 2.2b** — split because the hooks add ~500 lines of unrelated complexity scattered across deploy.sh, and a 700-line single PR would burn 8+ Copilot rounds.

**deploy.sh shrinks from 4643 → 4514 lines (−129).** Cumulative Phase 1+2 delta: 5539 → 4514 (−1025 lines, ~18.5%).

## Server-side execution

Same pattern as `infisical.py` / `secret_sync.py` / `seeder.py`: one SSH round-trip, bash background-jobs proven for parallelism, rendered script is testable as a string. Phase 3 (Modul 3.1) replaces the bash rendering wholesale with paramiko + asyncio.

## Service-config

deploy.sh's hardcoded service-config is lifted into module-level constants:

```python
_VIRTUAL_SERVICES = {"seaweedfs-filer", "seaweedfs-manager"}
_STACK_PARENTS = {"seaweedfs-filer": "seaweedfs", "seaweedfs-manager": "seaweedfs"}
_DEFERRED_SERVICES = {"woodpecker"}
```

`expand_targets(enabled)` resolves into `(parents, leaves)` preserving source order, deduplicating parents, skipping deferred services + virtuals-covered-by-parents.

## Eight rounds of hardening, eight named regression tests

| # | Round | Test |
|---|---|---|
| R1 | `set -euo pipefail` first executable line | `test_round_1_set_euo_pipefail_first_executable_line` |
| R2 | Per-stack `docker-compose.firewall.yml` override applied when present | `test_round_2_firewall_override_check_present` |
| R3 | Background-jobs (`&`) + `wait` for parallel deploy | `test_round_3_parallel_deploy_via_background_jobs` |
| R4 | `docker ps` verification | `test_round_4_docker_ps_verification_via_bash_exec` (**exec'd bash** — 4 cases including the `'foo' matches 'foo-bar'` substring-match trap that `^name$` anchored grep avoids) |
| R5 | Parent-stack dedupe (two virtual children → one parent) | `test_round_5_parent_dedupe_two_virtual_children` + `test_round_5_parent_skipped_in_leaves_when_already_added` |
| R6 | Deferred services skipped (woodpecker) | `test_round_6_deferred_services_skipped` |
| R7 | Global env sourced via `set -a; source …; set +a` | `test_round_7_global_env_sourced_with_set_a` |
| R8 | `RESULT` line emitted at end | `test_round_8_result_line_emitted` |

Plus orthogonal tests: source-order preservation, duplicate handling, empty-list handling, Dify storage-prep gating, special-char shlex quoting, parse_result variants, CLI integration covering rc=0/1/2.

## CLI contract

```
uv run python -m nexus_deploy compose up \
    --enabled "jupyter,marimo,seaweedfs-filer,seaweedfs-manager,gitea"
```

| rc | Meaning | deploy.sh handling |
|---|---|---|
| 0 | All services started + verified in `docker ps` | `✓ All containers started successfully` |
| 1 | At least one failed but at least one succeeded | yellow warning, continue |
| 2 | Bad args / transport / unexpected error / no parseable RESULT | red, abort |

## Quality gates

- `ruff format --check`, `ruff check` — clean
- `mypy --strict` — clean
- `pytest` — 232/232 pass (was 203; +29 new tests)
- Coverage — **100%** on `src/nexus_deploy/compose_runner.py`, 100% project total
- `bash -n scripts/deploy.sh` — parses

## Test plan

- [ ] CI green
- [ ] Manual spin-up on test VM with `enabled_services=jupyter,marimo`:
  - `compose up: started=N failed=0` where N = enabled count + parent expansions
  - All containers visible in `docker ps`
  - Per-service `✓ ... started and running` lines visible in workflow log

## Out of scope

- **Per-service admin-setup hooks** (Wikijs, Dify, Metabase, Superset, LakeFS, OpenMetadata, Gitea, Filestash, RedPanda) — Modul 2.2b will migrate them as a single module since they share the "wait for healthy → POST setup API" pattern but each has its own API quirk.
- Switching from server-side bash to local asyncio + paramiko — Phase 3 wholesale.

Closes part of #505 (Phase 2 sub-tasks 2.2a).
