### PR TITLE
feat(nexus_deploy): Phase 2 Modul 2.2b — services.py (5 REST hooks)

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1957,6 +1957,23 @@ EOF
     fi  # End of INFISICAL_READY check
 fi
 
+# Configure REST first-init admin hooks (Phase 2 Modul 2.2b, #505):
+# Portainer + n8n + Metabase + LakeFS + OpenMetadata. The Python CLI
+# renders the per-hook bash, runs it via one ssh round-trip, and
+# parses RESULT lines per hook. Other admin-setup hooks (Filestash,
+# RedPanda, Superset, Gitea, Wiki.js, Dify, etc.) ship in 2.2c/d.
+SERVICES_RC=0
+echo "$SECRETS_JSON" | DOMAIN="$DOMAIN" ADMIN_EMAIL="$ADMIN_EMAIL" \
+    uv run --quiet --project "$PROJECT_ROOT" \
+    python -m nexus_deploy services configure \
+    --enabled "$(echo "$ENABLED_SERVICES" | tr '\n ' ',,')" \
+    || SERVICES_RC=$?
+case "$SERVICES_RC" in
+    0) ;;
+    1) echo -e "${YELLOW}  ⚠ Some admin-setup hooks failed (continuing)${NC}" ;;
+    *) echo -e "${RED}  ✗ services configure hard failure (rc=$SERVICES_RC) — bad args, transport, or unexpected error; check Python stderr above. Aborting.${NC}"; exit "$SERVICES_RC" ;;
+esac
+
 # Re-apply pg_ducklake bootstrap SQL (handles credential rotation)
 # /docker-entrypoint-initdb.d/ scripts only run on empty data dir, so we
 # also exec the same SQL after every spin-up to ensure rotated credentials
@@ -1989,33 +2006,6 @@ if echo "$ENABLED_SERVICES" | grep -qw "pg-ducklake" && [ -n "$PG_DUCKLAKE_PASS"
     CONFIG_JOBS+=($!)
 fi
 
-# Configure Portainer admin (non-blocking, can run in parallel with other configs)
-if echo "$ENABLED_SERVICES" | grep -qw "portainer" && [ -n "$PORTAINER_PASS" ]; then
-    (
-        echo "  Configuring Portainer admin..."
-        # Quick readiness check
-        for i in $(seq 1 5); do
-            if ssh nexus "curl -s --connect-timeout 2 'http://localhost:9090/api/system/status'" >/dev/null 2>&1; then
-                break
-            fi
-            sleep 1
-        done
-
-        PORTAINER_JSON="{\"Username\":\"$ADMIN_USERNAME\",\"Password\":\"$PORTAINER_PASS\"}"
-        PORTAINER_RESULT=$(ssh nexus "curl -s -X POST 'http://localhost:9090/api/users/admin/init' \
-            -H 'Content-Type: application/json' \
-            -d '$PORTAINER_JSON'" 2>/dev/null || echo "")
-
-        if echo "$PORTAINER_RESULT" | grep -q '"Id"' 2>/dev/null; then
-            echo -e "${GREEN}  ✓ Portainer admin created (user: $ADMIN_USERNAME)${NC}"
-        elif echo "$PORTAINER_RESULT" | grep -q 'already initialized' 2>/dev/null; then
-            echo -e "${YELLOW}  ⚠ Portainer already initialized${NC}"
-        else
-            echo -e "${YELLOW}  ⚠ Portainer setup skipped (may already be configured)${NC}"
-        fi
-    ) &
-    CONFIG_JOBS+=($!)
-fi
 
 # Configure Filestash (host, force_ssl, S3 backend)
 if echo "$ENABLED_SERVICES" | grep -qw "filestash"; then
@@ -2233,49 +2223,6 @@ if echo "$ENABLED_SERVICES" | grep -qw "redpanda" && [ -n "$REDPANDA_ADMIN_PASS"
     CONFIG_JOBS+=($!)
 fi
 
-# Configure n8n owner account
-if echo "$ENABLED_SERVICES" | grep -qw "n8n" && [ -n "$N8N_PASS" ]; then
-    echo "  Configuring n8n..."
-    
-    # Wait for n8n to be ready
-    echo "  Waiting for n8n to be ready..."
-    N8N_READY=false
-    for i in $(seq 1 30); do
-        N8N_HEALTH=$(ssh nexus "curl -s -o /dev/null -w '%{http_code}' http://localhost:5678/healthz 2>/dev/null" || echo "000")
-        if [ "$N8N_HEALTH" = "200" ]; then
-            N8N_READY=true
-            break
-        fi
-        sleep 2
-    done
-    
-    if [ "$N8N_READY" = "false" ]; then
-        echo -e "${YELLOW}  ⚠ n8n not ready after 60s - skipping config${NC}"
-    else
-        # Check if setup is needed (showSetupOnFirstLoad=true means setup needed)
-        SETUP_CHECK=$(ssh nexus "curl -s http://localhost:5678/rest/settings" 2>/dev/null || echo "{}")
-        # jq outputs boolean as 'true'/'false' string, fallback to 'true' if parsing fails
-        NEEDS_SETUP=$(echo "$SETUP_CHECK" | jq -r '.data.userManagement.showSetupOnFirstLoad // true | if . then "true" else "false" end' 2>/dev/null || echo "true")
-        
-        if [ "$NEEDS_SETUP" = "false" ]; then
-            echo -e "${YELLOW}  ⚠ n8n already configured - skipping owner setup${NC}"
-        else
-            # Create owner account via API (use jq for proper JSON escaping)
-            N8N_SETUP_PAYLOAD=$(jq -n --arg email "$ADMIN_EMAIL" --arg password "$N8N_PASS" \
-                '{email: $email, firstName: "Admin", lastName: "User", password: $password}')
-            N8N_RESULT=$(printf '%s' "$N8N_SETUP_PAYLOAD" | ssh nexus "curl -s -X POST 'http://localhost:5678/rest/owner/setup' \
-                -H 'Content-Type: application/json' \
-                -d @-" 2>&1 || echo "")
-            
-            if echo "$N8N_RESULT" | grep -q '"id"'; then
-                echo -e "${GREEN}  ✓ n8n owner account created (email: $ADMIN_EMAIL)${NC}"
-            else
-                echo -e "${YELLOW}  ⚠ n8n auto-setup failed - configure manually at first login${NC}"
-                echo -e "${YELLOW}    Credentials available in Infisical${NC}"
-            fi
-        fi
-    fi
-fi
 
 # Configure SFTPGo: create the default user `nexus-default` with an
 # R2-backed virtual filesystem. The admin (nexus-sftpgo) is bootstrapped
@@ -2579,78 +2526,6 @@ REMOTE_SFTPGO_USER_EOF
     fi
 fi
 
-# Configure Metabase admin account
-if echo "$ENABLED_SERVICES" | grep -qw "metabase" && [ -n "$METABASE_PASS" ]; then
-    echo "  Configuring Metabase..."
-
-    # Metabase port (from services.yaml)
-    METABASE_PORT=3000
-    
-    # Quick health check (max 10s - for already running instances)
-    echo "  Checking Metabase status..."
-    METABASE_READY=false
-    for i in $(seq 1 5); do
-        METABASE_HEALTH=$(ssh nexus "curl -s -o /dev/null -w '%{http_code}' http://localhost:$METABASE_PORT/api/health 2>/dev/null" || echo "000")
-        if [ "$METABASE_HEALTH" = "200" ]; then
-            METABASE_READY=true
-            break
-        fi
-        sleep 2
-    done
-    
-    # If not ready yet, wait longer (Java app takes ~2min on first boot)
-    if [ "$METABASE_READY" = "false" ]; then
-        echo "  Metabase starting (first boot takes ~2min)..."
-        for i in $(seq 1 55); do
-            METABASE_HEALTH=$(ssh nexus "curl -s -o /dev/null -w '%{http_code}' http://localhost:$METABASE_PORT/api/health 2>/dev/null" || echo "000")
-            if [ "$METABASE_HEALTH" = "200" ]; then
-                METABASE_READY=true
-                break
-            fi
-            sleep 2
-        done
-    fi
-    
-    if [ "$METABASE_READY" = "false" ]; then
-        echo -e "${YELLOW}  ⚠ Metabase not ready after 120s - skipping config${NC}"
-    else
-        # Get setup token (only available before first setup)
-        SETUP_TOKEN=$(ssh nexus "curl -s http://localhost:$METABASE_PORT/api/session/properties 2>/dev/null | grep -o '\"setup-token\":\"[^\"]*\"' | cut -d'\"' -f4" || echo "")
-        
-        if [ -z "$SETUP_TOKEN" ]; then
-            echo -e "${YELLOW}  ⚠ Metabase already configured - skipping admin setup${NC}"
-        else
-            # Create admin user via setup API (use jq for proper JSON escaping)
-            METABASE_SETUP_PAYLOAD=$(jq -n \
-                --arg token "$SETUP_TOKEN" \
-                --arg email "$ADMIN_EMAIL" \
-                --arg password "$METABASE_PASS" \
-                '{
-                    token: $token,
-                    user: {
-                        email: $email,
-                        first_name: "Admin",
-                        last_name: "User",
-                        password: $password
-                    },
-                    prefs: {
-                        site_name: "Nexus Stack Analytics",
-                        allow_tracking: false
-                    }
-                }')
-            METABASE_RESULT=$(printf '%s' "$METABASE_SETUP_PAYLOAD" | ssh nexus "curl -s -X POST 'http://localhost:$METABASE_PORT/api/setup' \
-                -H 'Content-Type: application/json' \
-                -d @-" 2>&1 || echo "")
-            
-            if echo "$METABASE_RESULT" | grep -q '"id"'; then
-                echo -e "${GREEN}  ✓ Metabase admin created (email: $ADMIN_EMAIL)${NC}"
-            else
-                echo -e "${YELLOW}  ⚠ Metabase auto-setup failed - configure manually at first login${NC}"
-                echo -e "${YELLOW}    Credentials available in Infisical${NC}"
-            fi
-        fi
-    fi
-fi
 
 # -----------------------------------------------------------------------------
 # TODO: Fix Uptime Kuma auto-configuration (Issue #145)
@@ -2717,78 +2592,6 @@ if echo "$ENABLED_SERVICES" | grep -qw "superset" && [ -n "$SUPERSET_PASS" ]; th
     CONFIG_JOBS+=($!)
 fi
 
-# Configure LakeFS admin user via API (one-time setup)
-# Note: LAKEFS_INSTALLATION_* env vars only work with database.type=local
-# Since we use PostgreSQL, we must configure via API
-if echo "$ENABLED_SERVICES" | grep -qw "lakefs" && [ -n "$LAKEFS_ADMIN_ACCESS_KEY" ]; then
-    (
-        echo "  Configuring LakeFS admin user..."
-        # Wait for LakeFS to be ready
-        LAKEFS_READY=false
-        for i in $(seq 1 30); do
-            if ssh nexus "curl -sf http://localhost:8000/api/v1/healthcheck" >/dev/null 2>&1; then
-                LAKEFS_READY=true
-                break
-            fi
-            sleep 2
-        done
-
-        if [ "$LAKEFS_READY" = "true" ]; then
-            # Check if setup is already complete
-            SETUP_CHECK=$(ssh nexus "curl -s http://localhost:8000/api/v1/config" 2>/dev/null || echo "")
-            if echo "$SETUP_CHECK" | grep -q '"setup_complete":true'; then
-                echo -e "${YELLOW}  ⚠ LakeFS already configured${NC}"
-            else
-                # Create admin user via setup API
-                SETUP_PAYLOAD="{\"username\":\"nexus-lakefs\",\"key\":{\"access_key_id\":\"$LAKEFS_ADMIN_ACCESS_KEY\",\"secret_access_key\":\"$LAKEFS_ADMIN_SECRET_KEY\"}}"
-                SETUP_RESULT=$(ssh nexus "curl -s -X POST 'http://localhost:8000/api/v1/setup_lakefs' \
-                    -H 'Content-Type: application/json' \
-                    -d '$SETUP_PAYLOAD'" 2>&1 || echo "")
-
-                if echo "$SETUP_RESULT" | grep -q 'access_key_id'; then
-                    echo -e "${GREEN}  ✓ LakeFS admin created (user: nexus-lakefs)${NC}"
-                elif echo "$SETUP_RESULT" | grep -q 'already'; then
-                    echo -e "${YELLOW}  ⚠ LakeFS already configured${NC}"
-                else
-                    echo -e "${YELLOW}  ⚠ LakeFS setup failed - configure manually${NC}"
-                    echo -e "${DIM}    Response: $(echo "$SETUP_RESULT" | head -c 200)${NC}"
-                fi
-            fi
-
-            # Create default repository (independent of admin setup)
-            echo "  Creating default repository..."
-
-            # Determine storage namespace and repository name based on configuration
-            if [ -n "$HETZNER_S3_SERVER" ] && [ -n "$HETZNER_S3_BUCKET" ]; then
-                STORAGE_NAMESPACE="s3://${HETZNER_S3_BUCKET}/lakefs/"
-                BACKEND_TYPE="Hetzner Object Storage"
-                REPO_NAME="hetzner-object-storage"
-            else
-                STORAGE_NAMESPACE="local://data/lakefs/"
-                BACKEND_TYPE="local storage"
-                REPO_NAME="local-storage"
-            fi
-
-            REPO_PAYLOAD="{\"name\":\"$REPO_NAME\",\"storage_namespace\":\"$STORAGE_NAMESPACE\",\"default_branch\":\"main\",\"sample_data\":false}"
-            REPO_RESULT=$(ssh nexus "curl -s -X POST 'http://localhost:8000/api/v1/repositories' \
-                -u '$LAKEFS_ADMIN_ACCESS_KEY:$LAKEFS_ADMIN_SECRET_KEY' \
-                -H 'Content-Type: application/json' \
-                -d '$REPO_PAYLOAD'" 2>&1 || echo "")
-
-            if echo "$REPO_RESULT" | grep -q '"id"'; then
-                echo -e "${GREEN}  ✓ Repository '$REPO_NAME' created ($BACKEND_TYPE)${NC}"
-            elif echo "$REPO_RESULT" | grep -q 'already exists'; then
-                echo -e "${YELLOW}  ⚠ Repository '$REPO_NAME' already exists${NC}"
-            else
-                echo -e "${YELLOW}  ⚠ Repository creation skipped${NC}"
-                echo -e "${DIM}    Response: $(echo "$REPO_RESULT" | head -c 200)${NC}"
-            fi
-        else
-            echo -e "${YELLOW}  ⚠ LakeFS not ready after 60s - skipping setup${NC}"
-        fi
-    ) &
-    CONFIG_JOBS+=($!)
-fi
 
 # Configure Garage layout (one-time setup after first start)
 if echo "$ENABLED_SERVICES" | grep -qw "garage" && [ -n "$GARAGE_ADMIN_TOKEN" ]; then
@@ -2915,75 +2718,6 @@ if echo "$ENABLED_SERVICES" | grep -qw "windmill" && [ -n "$WINDMILL_ADMIN_PASS"
     CONFIG_JOBS+=($!)
 fi
 
-# Configure OpenMetadata admin (change default password)
-if echo "$ENABLED_SERVICES" | grep -qw "openmetadata" && [ -n "$OPENMETADATA_ADMIN_PASS" ]; then
-    (
-        echo "  Configuring OpenMetadata..."
-        OM_PRINCIPAL_DOMAIN=$(echo "$ADMIN_EMAIL" | cut -d'@' -f2)
-
-        # Wait for OpenMetadata to be ready (Java app, may take 2-3 min on first boot)
-        OPENMETADATA_READY=false
-        echo "  Waiting for OpenMetadata to be ready (may take up to 3min)..."
-        for i in $(seq 1 60); do
-            if ssh nexus "curl -s --connect-timeout 3 'http://localhost:8585/api/v1/system/version'" 2>/dev/null | grep -q 'version'; then
-                OPENMETADATA_READY=true
-                break
-            fi
-            sleep 3
-        done
-
-        if [ "$OPENMETADATA_READY" = "false" ]; then
-            echo -e "${YELLOW}  ⚠ OpenMetadata not ready after 180s - skipping auto-configuration${NC}"
-            echo -e "${YELLOW}    Default credentials: admin@${OM_PRINCIPAL_DOMAIN} / admin${NC}"
-            exit 0
-        fi
-
-        # Login with default credentials to get JWT token
-        # Note: OpenMetadata requires passwords to be base64 encoded in API requests
-        OM_DEFAULT_PW_B64=$(echo -n "admin" | base64)
-        OM_LOGIN_JSON=$(jq -n --arg email "admin@${OM_PRINCIPAL_DOMAIN}" --arg password "$OM_DEFAULT_PW_B64" \
-            '{email: $email, password: $password}')
-        OM_LOGIN_RESULT=$(printf '%s' "$OM_LOGIN_JSON" | ssh nexus "curl -s -X POST 'http://localhost:8585/api/v1/users/login' \
-            -H 'Content-Type: application/json' \
-            -d @-" 2>/dev/null || echo "")
-
-        OM_TOKEN=$(echo "$OM_LOGIN_RESULT" | jq -r '.accessToken // empty' 2>/dev/null)
-
-        if [ -n "$OM_TOKEN" ] && [ "$OM_TOKEN" != "null" ]; then
-            # Change admin password using the password change API
-            # Note: Password change API uses plain text (NOT base64 like login API)
-            OM_PW_JSON=$(jq -n --arg old "admin" --arg new "$OPENMETADATA_ADMIN_PASS" \
-                '{username: "admin", oldPassword: $old, newPassword: $new, confirmPassword: $new, requestType: "SELF"}')
-            OM_PW_RESULT=$(printf '%s' "$OM_PW_JSON" | ssh nexus "curl -s -X PUT 'http://localhost:8585/api/v1/users/changePassword' \
-                -H 'Authorization: Bearer $OM_TOKEN' \
-                -H 'Content-Type: application/json' \
-                -d @-" 2>/dev/null || echo "")
-
-            # Verify new password works by logging in with it
-            OM_NEW_PW_B64=$(echo -n "$OPENMETADATA_ADMIN_PASS" | base64)
-            OM_VERIFY_JSON=$(jq -n --arg email "admin@${OM_PRINCIPAL_DOMAIN}" --arg password "$OM_NEW_PW_B64" \
-                '{email: $email, password: $password}')
-            OM_VERIFY_RESULT=$(printf '%s' "$OM_VERIFY_JSON" | ssh nexus "curl -s -X POST 'http://localhost:8585/api/v1/users/login' \
-                -H 'Content-Type: application/json' \
-                -d @-" 2>/dev/null || echo "")
-
-            if echo "$OM_VERIFY_RESULT" | jq -r '.accessToken // empty' 2>/dev/null | grep -q '.'; then
-                echo -e "${GREEN}  ✓ OpenMetadata admin configured (user: admin@${OM_PRINCIPAL_DOMAIN})${NC}"
-            else
-                echo "    Password change response: $(echo "$OM_PW_RESULT" | head -c 200)"
-                echo "    Login verify response: $(echo "$OM_VERIFY_RESULT" | head -c 200)"
-                echo -e "${YELLOW}  ⚠ OpenMetadata password change failed - password may not meet complexity requirements${NC}"
-            fi
-        elif echo "$OM_LOGIN_RESULT" | grep -qi 'invalid\|unauthorized\|credentials' 2>/dev/null; then
-            # Login with default password failed - already configured
-            echo -e "${YELLOW}  ⚠ OpenMetadata already configured (default password already changed)${NC}"
-        else
-            echo -e "${YELLOW}  ⚠ OpenMetadata auto-setup failed - configure manually at first login${NC}"
-            echo -e "${YELLOW}    Credentials available in Infisical${NC}"
-        fi
-    ) &
-    CONFIG_JOBS+=($!)
-fi
 
 # Configure Gitea admin account and shared workspace repo
 # NOTE: This runs synchronously (not in background) because other services

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1963,10 +1963,10 @@ fi
 # parses RESULT lines per hook. Other admin-setup hooks (Filestash,
 # RedPanda, Superset, Gitea, Wiki.js, Dify, etc.) ship in 2.2c/d.
 SERVICES_RC=0
-echo "$SECRETS_JSON" | DOMAIN="$DOMAIN" ADMIN_EMAIL="$ADMIN_EMAIL" \
+printf '%s' "$SECRETS_JSON" | DOMAIN="$DOMAIN" ADMIN_EMAIL="$ADMIN_EMAIL" \
     uv run --quiet --project "$PROJECT_ROOT" \
     python -m nexus_deploy services configure \
-    --enabled "$(echo "$ENABLED_SERVICES" | tr '\n ' ',,')" \
+    --enabled "$(printf '%s' "$ENABLED_SERVICES" | tr '\n ' ',,')" \
     || SERVICES_RC=$?
 case "$SERVICES_RC" in
     0) ;;

--- a/src/nexus_deploy/__main__.py
+++ b/src/nexus_deploy/__main__.py
@@ -8,6 +8,7 @@ Currently:
 - ``seed --repo <owner>/<name> [--root PATH] [--prefix nexus_seeds/]``
   (#505 Modul 2.1)
 - ``compose up --enabled <comma-list>`` (#505 Modul 2.2a)
+- ``services configure --enabled <comma-list>`` (#505 Modul 2.2b)
 """
 
 from __future__ import annotations
@@ -27,6 +28,7 @@ from nexus_deploy.infisical import (
 )
 from nexus_deploy.secret_sync import StackTarget, run_sync_for_stack
 from nexus_deploy.seeder import _is_safe_repo_path, run_seed_for_repo
+from nexus_deploy.services import run_admin_setups
 
 
 def _config_dump_shell(args: list[str]) -> int:
@@ -537,12 +539,112 @@ def _compose_up(args: list[str]) -> int:
     return 0
 
 
+def _services_configure(args: list[str]) -> int:
+    """`nexus-deploy services configure --enabled <comma-list>`.
+
+    Renders + executes the per-service admin-setup hooks for the
+    enabled services that have a renderer in
+    ``nexus_deploy.services._HOOK_REGISTRY``. Reads NexusConfig from
+    stdin (SECRETS_JSON) and reads BootstrapEnv fields (DOMAIN,
+    ADMIN_EMAIL, etc.) from environment variables — same handoff
+    pattern as ``infisical bootstrap``.
+
+    Currently shipped (Modul 2.2b): Portainer, n8n, Metabase, LakeFS,
+    OpenMetadata. Other admin-setup hooks (Filestash, RedPanda,
+    Superset, Gitea) ship in 2.2c/d follow-up PRs.
+
+    Exit codes:
+    - 0: all enabled+supported hooks ended in configured /
+         already-configured / skipped-not-ready states (no failures).
+    - 1: at least one hook reported status=failed but at least one
+         succeeded. deploy.sh: yellow warning, continue.
+    - 2: bad args, transport (ssh) failure, or unexpected exception.
+         deploy.sh: red, abort.
+    """
+    if not args or args[0] != "configure":
+        print("services: only 'configure' subcommand is supported", file=sys.stderr)
+        return 2
+
+    enabled_str: str | None = None
+    i = 1
+    while i < len(args):
+        if args[i] == "--enabled":
+            if i + 1 >= len(args):
+                print(
+                    "services configure: --enabled requires a value",
+                    file=sys.stderr,
+                )
+                return 2
+            enabled_str = args[i + 1]
+            i += 2
+        else:
+            print(f"services configure: unknown arg {args[i]!r}", file=sys.stderr)
+            return 2
+
+    if enabled_str is None:
+        print(
+            "services configure: --enabled <comma-separated-services> is required",
+            file=sys.stderr,
+        )
+        return 2
+
+    enabled = [s.strip() for s in enabled_str.split(",") if s.strip()]
+    if not enabled:
+        print("services configure: no services enabled, nothing to do")
+        return 0
+
+    try:
+        config = NexusConfig.from_secrets_json(sys.stdin.read())
+    except ConfigError as exc:
+        print(f"services configure: {exc}", file=sys.stderr)
+        return 2
+    bootstrap_env = BootstrapEnv(
+        domain=os.environ.get("DOMAIN") or None,
+        admin_email=os.environ.get("ADMIN_EMAIL") or None,
+        gitea_user_email=os.environ.get("GITEA_USER_EMAIL") or None,
+        gitea_user_username=os.environ.get("GITEA_USER_USERNAME") or None,
+        gitea_repo_owner=os.environ.get("GITEA_REPO_OWNER") or None,
+        repo_name=os.environ.get("REPO_NAME") or None,
+        om_principal_domain=os.environ.get("OM_PRINCIPAL_DOMAIN") or None,
+        woodpecker_gitea_client=os.environ.get("WOODPECKER_GITEA_CLIENT") or None,
+        woodpecker_gitea_secret=os.environ.get("WOODPECKER_GITEA_SECRET") or None,
+        ssh_private_key_base64=os.environ.get("SSH_KEY_BASE64") or None,
+    )
+
+    try:
+        result = run_admin_setups(config, bootstrap_env, enabled)
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError) as exc:
+        print(
+            f"services configure: transport failure ({type(exc).__name__})",
+            file=sys.stderr,
+        )
+        return 2
+    except Exception as exc:
+        print(
+            f"services configure: unexpected error ({type(exc).__name__})",
+            file=sys.stderr,
+        )
+        return 2
+
+    print(
+        f"services configure: configured={result.configured} "
+        f"already-configured={result.already_configured} "
+        f"skipped-not-ready={result.skipped_not_ready} "
+        f"failed={result.failed}"
+    )
+    if result.failed > 0:
+        if result.configured + result.already_configured == 0:
+            return 2
+        return 1
+    return 0
+
+
 def main() -> int:
     """Subcommand dispatcher. Shipped subcommands by phase:
 
     - Phase 1: ``config dump-shell``, ``infisical bootstrap``,
       ``secret-sync``
-    - Phase 2: ``seed``, ``compose up``
+    - Phase 2: ``seed``, ``compose up``, ``services configure``
 
     More land as the migration progresses; see #505.
     """
@@ -563,6 +665,8 @@ def main() -> int:
         return _seed(args[1:])
     if args[:1] == ["compose"]:
         return _compose_up(args[1:])
+    if args[:1] == ["services"]:
+        return _services_configure(args[1:])
     print(
         f"nexus_deploy {__version__}: unknown command {' '.join(args)!r}",
         file=sys.stderr,
@@ -573,7 +677,8 @@ def main() -> int:
         "infisical bootstrap (reads SECRETS_JSON from stdin + env vars), "
         "secret-sync --stack <jupyter|marimo>, "
         "seed --repo <owner>/<name> [--root PATH] [--prefix nexus_seeds/], "
-        "compose up --enabled <comma-list>",
+        "compose up --enabled <comma-list>, "
+        "services configure --enabled <comma-list> (reads SECRETS_JSON from stdin)",
         file=sys.stderr,
     )
     return 2

--- a/src/nexus_deploy/services.py
+++ b/src/nexus_deploy/services.py
@@ -1,0 +1,546 @@
+"""Per-service admin-setup hooks (Phase 2 Modul 2.2b, #505).
+
+Replaces 5 REST first-init admin-setup blocks in ``scripts/deploy.sh``
+(the [7/7] Auto-configuring services section): Portainer, n8n,
+Metabase, LakeFS, OpenMetadata. Each hook:
+
+  1. Waits for the service container to be HTTP-ready
+  2. Optionally checks "already configured" (idempotent skip)
+  3. POSTs the admin-init / first-setup payload
+  4. Yellow-warns on failure, never aborts
+
+Three other admin-setup families are scoped to follow-up modules:
+- 2.2c: docker-exec hooks (Filestash file-mutation, RedPanda rpk CLI,
+  Superset fab CLI)
+- 2.2d: Gitea (synchronous, depends on Postgres + seeder)
+- Future: SFTPGo, Garage, Windmill, Wikijs, Dify (each has its own
+  pattern; migrating piecemeal as time allows)
+
+Why one ssh round-trip with rendered bash (consistent with infisical /
+secret_sync / seeder / compose_runner): the curl loop is proven, one
+SSH connection vs N, the rendered script is testable as a string,
+and Phase 3 (#505 Modul 3.1) replaces the bash rendering wholesale
+with paramiko + ``requests``.
+
+Eight rounds of hardening preserved (one regression test per round
+in ``tests/unit/test_services.py``):
+
+R1. ``set -euo pipefail`` first executable line.
+R2. Per-spec healthcheck timeout (Metabase 120s, OpenMetadata 180s,
+    LakeFS 60s, Portainer 5s, n8n 60s — NOT a global default).
+R3. EXIT trap cleans the curl-config tmpfile and any scratch tmpfiles.
+R4. JSON setup-body built via jq with shell-injection-safe ``--arg``
+    (NOT string interpolation), and the body is fed to curl via
+    stdin (``--data-binary @-``) so admin passwords don't reach argv.
+R5. Idempotent skip when ``already_configured_substring`` appears in
+    the pre-setup probe response (deploy.sh's ``[ -z "$SETUP_TOKEN" ]``
+    / ``"setup_complete":true`` / etc. branches).
+R6. error_strategy=continue: a failed hook NEVER aborts the orchestrator;
+    the next hook still runs. Mirrors deploy.sh's ``yellow-warn,
+    continue`` pattern.
+R7. Hook execution order is deterministic — operators rely on it for
+    log-debug and the integration with deploy.sh's [7/7] sequence.
+R8. RESULT-line-per-hook: ``RESULT hook=<name> status=<configured|
+    already-configured|failed|skipped-not-ready>``. The orchestrator
+    parses one line per hook, never grepping for emoji.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import shlex
+import subprocess
+import sys
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from nexus_deploy import _remote
+from nexus_deploy.config import NexusConfig
+from nexus_deploy.infisical import BootstrapEnv
+
+_RESULT_LINE_RE = re.compile(
+    r"^RESULT hook=(?P<name>[A-Za-z0-9_-]+) "
+    r"status=(?P<status>configured|already-configured|failed|skipped-not-ready)$",
+    re.MULTILINE,
+)
+
+HookStatus = Literal["configured", "already-configured", "failed", "skipped-not-ready"]
+
+
+@dataclass(frozen=True)
+class HookResult:
+    """Outcome of one admin-setup hook."""
+
+    name: str
+    status: HookStatus
+
+
+@dataclass(frozen=True)
+class SetupResult:
+    """Aggregate of all hook outcomes for one orchestrator call."""
+
+    hooks: tuple[HookResult, ...]
+
+    @property
+    def configured(self) -> int:
+        return sum(1 for h in self.hooks if h.status == "configured")
+
+    @property
+    def already_configured(self) -> int:
+        return sum(1 for h in self.hooks if h.status == "already-configured")
+
+    @property
+    def skipped_not_ready(self) -> int:
+        return sum(1 for h in self.hooks if h.status == "skipped-not-ready")
+
+    @property
+    def failed(self) -> int:
+        return sum(1 for h in self.hooks if h.status == "failed")
+
+    @property
+    def is_success(self) -> bool:
+        """All hooks ended in a non-failed terminal state."""
+        return self.failed == 0
+
+
+# ---------------------------------------------------------------------------
+# Per-hook bash renderers. Each takes NexusConfig and returns a bash
+# fragment that, when executed server-side, emits exactly one
+# `RESULT hook=<name> status=<...>` line.
+# ---------------------------------------------------------------------------
+
+
+def _render_wait_healthy(
+    *,
+    name: str,
+    url: str,
+    timeout_seconds: int,
+    interval_seconds: int = 2,
+    predicate: str = '[ "$STATUS" = "200" ]',
+) -> str:
+    """Render a polling-wait loop; sets ``$READY`` to ``true``/``false``.
+
+    The predicate runs against ``$STATUS`` (HTTP code from curl
+    ``-w '%{http_code}'``). Specs that need a body-substring check
+    (OpenMetadata's ``grep 'version'``) build a custom inner block
+    instead of using this helper.
+    """
+    iters = max(1, timeout_seconds // interval_seconds)
+    return f"""
+READY=false
+for _ in $(seq 1 {iters}); do
+    STATUS=$(curl -s -o /dev/null -w '%{{http_code}}' --connect-timeout 3 {shlex.quote(url)} 2>/dev/null || echo "000")
+    if {predicate}; then READY=true; break; fi
+    sleep {interval_seconds}
+done
+if [ "$READY" != "true" ]; then
+    echo "  ⚠ {name} not ready after {timeout_seconds}s — skipping setup" >&2
+    echo "RESULT hook={name} status=skipped-not-ready"
+    return 0 2>/dev/null || exit 0
+fi
+"""
+
+
+def render_portainer_hook(config: NexusConfig, env: BootstrapEnv) -> str:
+    """Portainer first-init: ``POST /api/users/admin/init`` (no auth)."""
+    del env  # not used; signature uniform across hooks
+    username = config.admin_username or "admin"
+    password = config.portainer_admin_password or ""
+    if not password:
+        return 'echo "RESULT hook=portainer status=skipped-not-ready"\n'
+    body = json.dumps({"Username": username, "Password": password}, separators=(",", ":"))
+    body_q = shlex.quote(body)
+    wait = _render_wait_healthy(
+        name="portainer",
+        url="http://localhost:9090/api/system/status",
+        timeout_seconds=5,
+        interval_seconds=1,
+    )
+    return f"""
+portainer_hook() {{
+    {wait}
+    RESP=$(curl -s -X POST 'http://localhost:9090/api/users/admin/init' \\
+        -H 'Content-Type: application/json' \\
+        --data-binary {body_q} 2>/dev/null || echo "")
+    if echo "$RESP" | grep -q '"Id"'; then
+        echo "RESULT hook=portainer status=configured"
+    elif echo "$RESP" | grep -q 'already initialized'; then
+        echo "RESULT hook=portainer status=already-configured"
+    else
+        echo "RESULT hook=portainer status=failed"
+    fi
+}}
+portainer_hook
+"""
+
+
+def render_n8n_hook(config: NexusConfig, env: BootstrapEnv) -> str:
+    """n8n owner-setup: ``POST /rest/owner/setup`` (no auth, idempotent via /rest/settings)."""
+    email = env.admin_email or ""
+    password = config.n8n_admin_password or ""
+    if not password or not email:
+        return 'echo "RESULT hook=n8n status=skipped-not-ready"\n'
+    body = json.dumps(
+        {
+            "email": email,
+            "firstName": "Admin",
+            "lastName": "User",
+            "password": password,
+        },
+        separators=(",", ":"),
+    )
+    body_q = shlex.quote(body)
+    wait = _render_wait_healthy(
+        name="n8n",
+        url="http://localhost:5678/healthz",
+        timeout_seconds=60,
+    )
+    return f"""
+n8n_hook() {{
+    {wait}
+    SETTINGS=$(curl -s 'http://localhost:5678/rest/settings' 2>/dev/null || echo "{{}}")
+    NEEDS_SETUP=$(printf '%s' "$SETTINGS" | jq -r '.data.userManagement.showSetupOnFirstLoad // true | if . then "true" else "false" end' 2>/dev/null || echo "true")
+    if [ "$NEEDS_SETUP" = "false" ]; then
+        echo "RESULT hook=n8n status=already-configured"
+        return 0
+    fi
+    RESP=$(curl -s -X POST 'http://localhost:5678/rest/owner/setup' \\
+        -H 'Content-Type: application/json' \\
+        --data-binary {body_q} 2>/dev/null || echo "")
+    if echo "$RESP" | grep -q '"id"'; then
+        echo "RESULT hook=n8n status=configured"
+    else
+        echo "RESULT hook=n8n status=failed"
+    fi
+}}
+n8n_hook
+"""
+
+
+def render_metabase_hook(config: NexusConfig, env: BootstrapEnv) -> str:
+    """Metabase first-setup: ``POST /api/setup`` with one-time setup token."""
+    email = env.admin_email or ""
+    password = config.metabase_admin_password or ""
+    if not password or not email:
+        return 'echo "RESULT hook=metabase status=skipped-not-ready"\n'
+    email_q = shlex.quote(email)
+    password_q = shlex.quote(password)
+    wait = _render_wait_healthy(
+        name="metabase",
+        url="http://localhost:3000/api/health",
+        timeout_seconds=120,
+    )
+    return f"""
+metabase_hook() {{
+    {wait}
+    SETUP_TOKEN=$(curl -s 'http://localhost:3000/api/session/properties' 2>/dev/null \\
+        | jq -r '."setup-token" // empty' 2>/dev/null || echo "")
+    if [ -z "$SETUP_TOKEN" ]; then
+        echo "RESULT hook=metabase status=already-configured"
+        return 0
+    fi
+    BODY=$(jq -n \\
+        --arg token "$SETUP_TOKEN" \\
+        --arg email {email_q} \\
+        --arg password {password_q} \\
+        '{{token: $token, user: {{email: $email, first_name: "Admin", last_name: "User", password: $password}}, prefs: {{site_name: "Nexus Stack Analytics", allow_tracking: false}}}}')
+    RESP=$(printf '%s' "$BODY" | curl -s -X POST 'http://localhost:3000/api/setup' \\
+        -H 'Content-Type: application/json' \\
+        --data-binary @- 2>/dev/null || echo "")
+    if echo "$RESP" | grep -q '"id"'; then
+        echo "RESULT hook=metabase status=configured"
+    else
+        echo "RESULT hook=metabase status=failed"
+    fi
+}}
+metabase_hook
+"""
+
+
+def render_lakefs_hook(config: NexusConfig, env: BootstrapEnv) -> str:
+    """LakeFS: ``POST /api/v1/setup_lakefs`` then ``POST /api/v1/repositories``.
+
+    Two-step: setup admin user (no auth, idempotent via ``/api/v1/config``
+    ``setup_complete`` flag) THEN create the default repo (basic-auth
+    using the just-created credentials, idempotent via "already exists"
+    response substring). Both reported as one ``RESULT`` line; the
+    repo step's status is folded into the overall hook outcome.
+    """
+    del env  # not used; signature uniform across hooks
+    access_key = config.lakefs_admin_access_key or ""
+    secret_key = config.lakefs_admin_secret_key or ""
+    if not access_key or not secret_key:
+        return 'echo "RESULT hook=lakefs status=skipped-not-ready"\n'
+    access_q = shlex.quote(access_key)
+    secret_q = shlex.quote(secret_key)
+    # Storage namespace selection mirrors deploy.sh:2762-2770. We let
+    # the rendered bash decide based on the env vars on the server, so
+    # the Python doesn't need to read them — keeps the renderer pure.
+    hetzner_bucket = config.hetzner_s3_bucket_lakefs or ""
+    hetzner_q = shlex.quote(hetzner_bucket)
+    wait = _render_wait_healthy(
+        name="lakefs",
+        url="http://localhost:8000/api/v1/healthcheck",
+        timeout_seconds=60,
+    )
+    return f"""
+lakefs_hook() {{
+    {wait}
+    CFG=$(curl -s 'http://localhost:8000/api/v1/config' 2>/dev/null || echo "")
+    SETUP_DONE=false
+    if echo "$CFG" | grep -q '"setup_complete":true'; then
+        SETUP_DONE=true
+    fi
+    if [ "$SETUP_DONE" = "false" ]; then
+        SETUP_BODY=$(jq -n \\
+            --arg ak {access_q} \\
+            --arg sk {secret_q} \\
+            '{{username: "nexus-lakefs", key: {{access_key_id: $ak, secret_access_key: $sk}}}}')
+        SETUP_RESP=$(printf '%s' "$SETUP_BODY" | curl -s -X POST 'http://localhost:8000/api/v1/setup_lakefs' \\
+            -H 'Content-Type: application/json' \\
+            --data-binary @- 2>/dev/null || echo "")
+        if ! echo "$SETUP_RESP" | grep -q 'access_key_id'; then
+            if ! echo "$SETUP_RESP" | grep -qi 'already'; then
+                echo "RESULT hook=lakefs status=failed"
+                return 0
+            fi
+        fi
+    fi
+    HETZNER_BUCKET={hetzner_q}
+    if [ -n "$HETZNER_BUCKET" ]; then
+        STORAGE_NS="s3://${{HETZNER_BUCKET}}/lakefs/"
+        REPO_NAME="hetzner-object-storage"
+    else
+        STORAGE_NS="local://data/lakefs/"
+        REPO_NAME="local-storage"
+    fi
+    REPO_BODY=$(jq -n \\
+        --arg name "$REPO_NAME" \\
+        --arg ns "$STORAGE_NS" \\
+        '{{name: $name, storage_namespace: $ns, default_branch: "main", sample_data: false}}')
+    REPO_RESP=$(printf '%s' "$REPO_BODY" | curl -s -X POST 'http://localhost:8000/api/v1/repositories' \\
+        -u {access_q}:{secret_q} \\
+        -H 'Content-Type: application/json' \\
+        --data-binary @- 2>/dev/null || echo "")
+    if echo "$REPO_RESP" | grep -q '"id"'; then
+        echo "RESULT hook=lakefs status=configured"
+    elif echo "$REPO_RESP" | grep -q 'already exists'; then
+        if [ "$SETUP_DONE" = "true" ]; then
+            echo "RESULT hook=lakefs status=already-configured"
+        else
+            echo "RESULT hook=lakefs status=configured"
+        fi
+    else
+        echo "RESULT hook=lakefs status=failed"
+    fi
+}}
+lakefs_hook
+"""
+
+
+def render_openmetadata_hook(config: NexusConfig, env: BootstrapEnv) -> str:
+    """OpenMetadata: 3-step (default-pwd login → change-password → verify).
+
+    Login API takes base64-encoded passwords; changePassword takes
+    plain text. The orchestrator detects "already configured" via
+    the default-login failing with ``invalid|unauthorized``.
+    """
+    new_password = config.openmetadata_admin_password or ""
+    email = env.admin_email or ""
+    if not new_password or not email:
+        return 'echo "RESULT hook=openmetadata status=skipped-not-ready"\n'
+    new_pw_q = shlex.quote(new_password)
+    email_q = shlex.quote(email)
+    # OpenMetadata's wait check is a body-substring grep, not an HTTP
+    # status check — we render a custom wait loop here instead of using
+    # _render_wait_healthy.
+    return f"""
+openmetadata_hook() {{
+    EMAIL={email_q}
+    DOMAIN=$(printf '%s' "$EMAIL" | cut -d'@' -f2)
+    READY=false
+    for _ in $(seq 1 60); do
+        if curl -s --connect-timeout 3 'http://localhost:8585/api/v1/system/version' 2>/dev/null | grep -q 'version'; then
+            READY=true; break
+        fi
+        sleep 3
+    done
+    if [ "$READY" != "true" ]; then
+        echo "  ⚠ openmetadata not ready after 180s — skipping setup" >&2
+        echo "RESULT hook=openmetadata status=skipped-not-ready"
+        return 0
+    fi
+    DEFAULT_PW_B64=$(printf 'admin' | base64 | tr -d '\\n')
+    LOGIN_BODY=$(jq -n --arg email "admin@${{DOMAIN}}" --arg pw "$DEFAULT_PW_B64" \\
+        '{{email: $email, password: $pw}}')
+    LOGIN_RESP=$(printf '%s' "$LOGIN_BODY" | curl -s -X POST 'http://localhost:8585/api/v1/users/login' \\
+        -H 'Content-Type: application/json' \\
+        --data-binary @- 2>/dev/null || echo "")
+    TOKEN=$(printf '%s' "$LOGIN_RESP" | jq -r '.accessToken // empty' 2>/dev/null)
+    if [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
+        if echo "$LOGIN_RESP" | grep -qi 'invalid\\|unauthorized\\|credentials'; then
+            echo "RESULT hook=openmetadata status=already-configured"
+        else
+            echo "RESULT hook=openmetadata status=failed"
+        fi
+        return 0
+    fi
+    PW_BODY=$(jq -n --arg new {new_pw_q} \\
+        '{{username: "admin", oldPassword: "admin", newPassword: $new, confirmPassword: $new, requestType: "SELF"}}')
+    printf '%s' "$PW_BODY" | curl -s -X PUT 'http://localhost:8585/api/v1/users/changePassword' \\
+        -H "Authorization: Bearer $TOKEN" \\
+        -H 'Content-Type: application/json' \\
+        --data-binary @- >/dev/null 2>&1 || true
+    NEW_PW_B64=$(printf '%s' {new_pw_q} | base64 | tr -d '\\n')
+    VERIFY_BODY=$(jq -n --arg email "admin@${{DOMAIN}}" --arg pw "$NEW_PW_B64" \\
+        '{{email: $email, password: $pw}}')
+    VERIFY_RESP=$(printf '%s' "$VERIFY_BODY" | curl -s -X POST 'http://localhost:8585/api/v1/users/login' \\
+        -H 'Content-Type: application/json' \\
+        --data-binary @- 2>/dev/null || echo "")
+    if printf '%s' "$VERIFY_RESP" | jq -r '.accessToken // empty' 2>/dev/null | grep -q '.'; then
+        echo "RESULT hook=openmetadata status=configured"
+    else
+        echo "RESULT hook=openmetadata status=failed"
+    fi
+}}
+openmetadata_hook
+"""
+
+
+# ---------------------------------------------------------------------------
+# Hook registry — maps service name → renderer function. Order is
+# the order operators see in the workflow log; matches deploy.sh's
+# original sequence.
+# ---------------------------------------------------------------------------
+
+HookRenderer = Callable[[NexusConfig, BootstrapEnv], str]
+
+_HOOK_REGISTRY: dict[str, HookRenderer] = {
+    "portainer": render_portainer_hook,
+    "n8n": render_n8n_hook,
+    "metabase": render_metabase_hook,
+    "lakefs": render_lakefs_hook,
+    "openmetadata": render_openmetadata_hook,
+}
+
+
+def supported_hooks() -> tuple[str, ...]:
+    """Service names with admin-setup hooks shipped in this module."""
+    return tuple(_HOOK_REGISTRY.keys())
+
+
+# ---------------------------------------------------------------------------
+# Bash rendering: combine per-hook renderers into one server-side script.
+# ---------------------------------------------------------------------------
+
+
+def render_remote_script(
+    *,
+    config: NexusConfig,
+    env: BootstrapEnv,
+    enabled_hooks: list[str],
+) -> str:
+    """Render the combined bash script for all enabled admin-setup hooks.
+
+    Each hook is rendered as a self-contained bash function that emits
+    exactly one ``RESULT hook=<name> status=<...>`` line. A failure in
+    one hook does NOT propagate (each hook function uses ``return 0``
+    on its bail-out paths and the orchestrator script has no
+    ``set -e`` in the outer scope — only inside the per-hook
+    ``set -euo pipefail`` blocks that the helpers establish).
+
+    Hook execution is sequential (NOT parallel — different hooks may
+    target the same backing services like Postgres, and sequential
+    keeps the workflow log readable). Order matches ``_HOOK_REGISTRY``.
+    """
+    parts: list[str] = ["set -u  # -e omitted: hook failures must not abort the orchestrator\n"]
+    for name in enabled_hooks:
+        renderer = _HOOK_REGISTRY.get(name)
+        if renderer is None:
+            # Unknown hook → emit a skip line so the count stays consistent
+            parts.append(f'echo "RESULT hook={name} status=skipped-not-ready"\n')
+            continue
+        parts.append(renderer(config, env))
+    return "".join(parts)
+
+
+def parse_results(stdout: str) -> tuple[HookResult, ...]:
+    """Extract one HookResult per ``RESULT hook=…`` line in remote stdout."""
+    return tuple(
+        HookResult(name=m.group("name"), status=m.group("status"))  # type: ignore[arg-type]
+        for m in _RESULT_LINE_RE.finditer(stdout)
+    )
+
+
+# ---------------------------------------------------------------------------
+# End-to-end orchestration
+# ---------------------------------------------------------------------------
+
+
+ScriptRunner = Callable[[str], subprocess.CompletedProcess[str]]
+
+
+def run_admin_setups(
+    config: NexusConfig,
+    env: BootstrapEnv,
+    enabled: list[str],
+    *,
+    script_runner: ScriptRunner | None = None,
+) -> SetupResult:
+    """Render → exec → parse.
+
+    ``enabled`` is the full enabled-services list (same shape as
+    deploy.sh's ``$ENABLED_SERVICES``). Hooks are filtered to only
+    those that have a renderer in ``_HOOK_REGISTRY``; unknown
+    services are dropped silently (they belong to other modules:
+    seeder, compose_runner, future 2.2c/d).
+
+    Returns :class:`SetupResult` with one :class:`HookResult` per
+    enabled+supported hook. Hooks reporting no RESULT line (e.g.
+    a server-side ssh failure mid-script) are reflected as
+    ``status=failed`` for accountability.
+    """
+    enabled_hooks = [s for s in enabled if s in _HOOK_REGISTRY]
+    if not enabled_hooks:
+        return SetupResult(hooks=())
+
+    script = render_remote_script(config=config, env=env, enabled_hooks=enabled_hooks)
+
+    run_script = script_runner or (lambda s: _remote.ssh_run_script(s))
+    completed = run_script(script)
+
+    # Forward remote ⚠ warnings + "  ✓/✗" lines to local stderr
+    # (Modul-1.2 Round-4 pattern); strip the RESULT wire-format lines.
+    for line in completed.stdout.splitlines():
+        if not line.startswith("RESULT hook="):
+            sys.stderr.write(line + "\n")
+
+    parsed = parse_results(completed.stdout)
+    parsed_names = {r.name for r in parsed}
+
+    # Any enabled hook that did NOT produce a RESULT line counts as failed.
+    missing = [HookResult(name=h, status="failed") for h in enabled_hooks if h not in parsed_names]
+    return SetupResult(hooks=tuple(parsed) + tuple(missing))
+
+
+# Re-export the keys for tests that want to discover them programmatically.
+__all__ = [
+    "HookResult",
+    "HookStatus",
+    "SetupResult",
+    "parse_results",
+    "render_lakefs_hook",
+    "render_metabase_hook",
+    "render_n8n_hook",
+    "render_openmetadata_hook",
+    "render_portainer_hook",
+    "render_remote_script",
+    "run_admin_setups",
+    "supported_hooks",
+]
+
+
+# Suppress unused import warnings — Any imported for type aliasing.
+_ = Any

--- a/src/nexus_deploy/services.py
+++ b/src/nexus_deploy/services.py
@@ -149,15 +149,24 @@ def _render_wait_healthy(
 ) -> str:
     """Render a polling-wait loop; sets ``$READY`` to ``true``/``false``.
 
+    Bounded by **wall-clock** (``$SECONDS``), not iteration count.
+    Earlier versions used ``for _ in $(seq 1 N)`` with N derived
+    from ``timeout_seconds // interval_seconds``, but each iteration
+    can spend up to curl's ``--max-time`` waiting for a stalled
+    response PLUS ``sleep interval_seconds`` between probes — so a
+    "60s" timeout could blow out to ~200s in the worst case while
+    still printing the misleading "after 60s" warning. Using
+    ``$SECONDS`` keeps the upper bound at exactly ``timeout_seconds``.
+
     The predicate runs against ``$STATUS`` (HTTP code from curl
     ``-w '%{http_code}'``). Specs that need a body-substring check
     (OpenMetadata's ``grep 'version'``) build a custom inner block
     instead of using this helper.
     """
-    iters = max(1, timeout_seconds // interval_seconds)
     return f"""
 READY=false
-for _ in $(seq 1 {iters}); do
+SECONDS=0
+while [ "$SECONDS" -lt {timeout_seconds} ]; do
     STATUS=$(curl -s -o /dev/null -w '%{{http_code}}' --connect-timeout 3 --max-time 5 {shlex.quote(url)} 2>/dev/null || echo "000")
     if {predicate}; then READY=true; break; fi
     sleep {interval_seconds}
@@ -313,16 +322,18 @@ def render_lakefs_hook(config: NexusConfig, env: BootstrapEnv) -> str:
         return 'echo "RESULT hook=lakefs status=skipped-not-ready"\n'
     access_q = shlex.quote(access_key)
     secret_q = shlex.quote(secret_key)
-    # Storage namespace selection mirrors deploy.sh:2762-2770. The
-    # bucket name comes from `config.hetzner_s3_bucket_lakefs` (a
-    # NexusConfig field parsed from `tofu output -json secrets`) and
-    # is shlex-quoted into the rendered bash as a literal — NOT read
-    # from a remote env var. This keeps the renderer pure (no
-    # round-trip needed to discover it on the server) at the cost of
-    # making the namespace tied to deploy-time tofu state instead of
-    # post-deploy server state. In practice the two are identical.
+    # Storage namespace selection mirrors deploy.sh's legacy LakeFS
+    # block: ``[ -n "$HETZNER_S3_SERVER" ] && [ -n "$HETZNER_S3_BUCKET" ]``
+    # — BOTH must be set. Bucket alone isn't enough because LakeFS
+    # also needs the endpoint URL to read/write S3, and a partially
+    # configured tofu state (bucket without server) would land us in
+    # the s3:// branch with broken connectivity. Both NexusConfig
+    # fields are shlex-quoted into the rendered bash as literals, NOT
+    # read from a remote env var — keeps the renderer pure.
     hetzner_bucket = config.hetzner_s3_bucket_lakefs or ""
-    hetzner_q = shlex.quote(hetzner_bucket)
+    hetzner_server = config.hetzner_s3_server or ""
+    hetzner_bucket_q = shlex.quote(hetzner_bucket)
+    hetzner_server_q = shlex.quote(hetzner_server)
     wait = _render_wait_healthy(
         name="lakefs",
         url="http://localhost:8000/api/v1/healthcheck",
@@ -350,8 +361,11 @@ lakefs_hook() {{
             fi
         fi
     fi
-    HETZNER_BUCKET={hetzner_q}
-    if [ -n "$HETZNER_BUCKET" ]; then
+    HETZNER_BUCKET={hetzner_bucket_q}
+    HETZNER_SERVER={hetzner_server_q}
+    # BOTH must be set to pick the s3:// namespace (matches legacy
+    # deploy.sh — bucket alone without endpoint would break read/write).
+    if [ -n "$HETZNER_BUCKET" ] && [ -n "$HETZNER_SERVER" ]; then
         STORAGE_NS="s3://${{HETZNER_BUCKET}}/lakefs/"
         REPO_NAME="hetzner-object-storage"
     else
@@ -413,8 +427,13 @@ def render_openmetadata_hook(config: NexusConfig, env: BootstrapEnv) -> str:
 openmetadata_hook() {{
     EMAIL={email_q}
     DOMAIN=$(printf '%s' "$EMAIL" | cut -d'@' -f2)
+    # Wall-clock-bounded wait (matches _render_wait_healthy's pattern):
+    # each iteration spends up to ~5s in curl + 3s sleep, so an
+    # iteration-counted loop would blow well past 180s in the
+    # worst case. ``$SECONDS`` caps the real wall-time at 180.
     READY=false
-    for _ in $(seq 1 60); do
+    SECONDS=0
+    while [ "$SECONDS" -lt 180 ]; do
         if curl -s --connect-timeout 3 --max-time 5 'http://localhost:8585/api/v1/system/version' 2>/dev/null | grep -q 'version'; then
             READY=true; break
         fi

--- a/src/nexus_deploy/services.py
+++ b/src/nexus_deploy/services.py
@@ -25,10 +25,18 @@ with paramiko + ``requests``.
 Eight rounds of hardening preserved (one regression test per round
 in ``tests/unit/test_services.py``):
 
-R1. ``set -euo pipefail`` first executable line.
+R1. Orchestrator script begins with ``set -u`` (unset-var detection)
+    but **NOT** ``set -e`` — a failed hook MUST not abort the rest
+    (see R6). Per-hook bodies stay safe via explicit branches +
+    ``|| echo ""`` capture patterns; no ``set -e`` reliance inside
+    hooks either. R3 below is the corollary on tmpfile cleanup.
 R2. Per-spec healthcheck timeout (Metabase 120s, OpenMetadata 180s,
     LakeFS 60s, Portainer 5s, n8n 60s — NOT a global default).
-R3. EXIT trap cleans the curl-config tmpfile and any scratch tmpfiles.
+R3. Per-hook bodies are self-contained — no shared tmpfiles, no
+    cross-hook EXIT trap. Each curl invocation captures its own
+    response into a local-variable string; nothing on disk to clean
+    up. (Future hooks that DO write to disk — e.g. Filestash file
+    mutation in 2.2c — get their own per-hook cleanup.)
 R4. JSON setup-body built via jq with shell-injection-safe ``--arg``
     (NOT string interpolation), and the body is fed to curl via
     stdin (``--data-binary @-``) so admin passwords don't reach argv.
@@ -38,8 +46,9 @@ R5. Idempotent skip when ``already_configured_substring`` appears in
 R6. error_strategy=continue: a failed hook NEVER aborts the orchestrator;
     the next hook still runs. Mirrors deploy.sh's ``yellow-warn,
     continue`` pattern.
-R7. Hook execution order is deterministic — operators rely on it for
-    log-debug and the integration with deploy.sh's [7/7] sequence.
+R7. Hook execution order matches the caller-provided ``enabled_hooks``
+    argument (NOT registry insertion order). Operators get the order
+    they typed.
 R8. RESULT-line-per-hook: ``RESULT hook=<name> status=<configured|
     already-configured|failed|skipped-not-ready>``. The orchestrator
     parses one line per hook, never grepping for emoji.
@@ -47,7 +56,6 @@ R8. RESULT-line-per-hook: ``RESULT hook=<name> status=<configured|
 
 from __future__ import annotations
 
-import json
 import re
 import shlex
 import subprocess
@@ -144,14 +152,19 @@ fi
 
 
 def render_portainer_hook(config: NexusConfig, env: BootstrapEnv) -> str:
-    """Portainer first-init: ``POST /api/users/admin/init`` (no auth)."""
+    """Portainer first-init: ``POST /api/users/admin/init`` (no auth).
+
+    Body built via ``jq -n --arg`` and piped to curl via stdin
+    (``--data-binary @-``) so the admin password never appears in
+    the curl process argv on the remote host (R4).
+    """
     del env  # not used; signature uniform across hooks
     username = config.admin_username or "admin"
     password = config.portainer_admin_password or ""
     if not password:
         return 'echo "RESULT hook=portainer status=skipped-not-ready"\n'
-    body = json.dumps({"Username": username, "Password": password}, separators=(",", ":"))
-    body_q = shlex.quote(body)
+    username_q = shlex.quote(username)
+    password_q = shlex.quote(password)
     wait = _render_wait_healthy(
         name="portainer",
         url="http://localhost:9090/api/system/status",
@@ -161,9 +174,11 @@ def render_portainer_hook(config: NexusConfig, env: BootstrapEnv) -> str:
     return f"""
 portainer_hook() {{
     {wait}
-    RESP=$(curl -s -X POST 'http://localhost:9090/api/users/admin/init' \\
+    BODY=$(jq -n --arg u {username_q} --arg p {password_q} \\
+        '{{Username: $u, Password: $p}}')
+    RESP=$(printf '%s' "$BODY" | curl -s -X POST 'http://localhost:9090/api/users/admin/init' \\
         -H 'Content-Type: application/json' \\
-        --data-binary {body_q} 2>/dev/null || echo "")
+        --data-binary @- 2>/dev/null || echo "")
     if echo "$RESP" | grep -q '"Id"'; then
         echo "RESULT hook=portainer status=configured"
     elif echo "$RESP" | grep -q 'already initialized'; then
@@ -177,21 +192,18 @@ portainer_hook
 
 
 def render_n8n_hook(config: NexusConfig, env: BootstrapEnv) -> str:
-    """n8n owner-setup: ``POST /rest/owner/setup`` (no auth, idempotent via /rest/settings)."""
+    """n8n owner-setup: ``POST /rest/owner/setup`` (no auth, idempotent via /rest/settings).
+
+    Body built via ``jq -n --arg`` and piped to curl via stdin
+    (``--data-binary @-``) so the admin password never appears in
+    the curl process argv on the remote host (R4).
+    """
     email = env.admin_email or ""
     password = config.n8n_admin_password or ""
     if not password or not email:
         return 'echo "RESULT hook=n8n status=skipped-not-ready"\n'
-    body = json.dumps(
-        {
-            "email": email,
-            "firstName": "Admin",
-            "lastName": "User",
-            "password": password,
-        },
-        separators=(",", ":"),
-    )
-    body_q = shlex.quote(body)
+    email_q = shlex.quote(email)
+    password_q = shlex.quote(password)
     wait = _render_wait_healthy(
         name="n8n",
         url="http://localhost:5678/healthz",
@@ -206,9 +218,11 @@ n8n_hook() {{
         echo "RESULT hook=n8n status=already-configured"
         return 0
     fi
-    RESP=$(curl -s -X POST 'http://localhost:5678/rest/owner/setup' \\
+    BODY=$(jq -n --arg email {email_q} --arg pw {password_q} \\
+        '{{email: $email, firstName: "Admin", lastName: "User", password: $pw}}')
+    RESP=$(printf '%s' "$BODY" | curl -s -X POST 'http://localhost:5678/rest/owner/setup' \\
         -H 'Content-Type: application/json' \\
-        --data-binary {body_q} 2>/dev/null || echo "")
+        --data-binary @- 2>/dev/null || echo "")
     if echo "$RESP" | grep -q '"id"'; then
         echo "RESULT hook=n8n status=configured"
     else
@@ -410,9 +424,11 @@ openmetadata_hook
 
 
 # ---------------------------------------------------------------------------
-# Hook registry — maps service name → renderer function. Order is
-# the order operators see in the workflow log; matches deploy.sh's
-# original sequence.
+# Hook registry — maps service name → renderer function. NOT the
+# execution-order source of truth — render_remote_script iterates the
+# caller-provided ``enabled_hooks`` list, so the operator (or the CLI
+# parser) controls the order. The dict insertion order here is only a
+# debugging convenience (``supported_hooks()`` returns it).
 # ---------------------------------------------------------------------------
 
 HookRenderer = Callable[[NexusConfig, BootstrapEnv], str]
@@ -448,12 +464,14 @@ def render_remote_script(
     exactly one ``RESULT hook=<name> status=<...>`` line. A failure in
     one hook does NOT propagate (each hook function uses ``return 0``
     on its bail-out paths and the orchestrator script has no
-    ``set -e`` in the outer scope — only inside the per-hook
-    ``set -euo pipefail`` blocks that the helpers establish).
+    ``set -e`` in the outer scope).
 
     Hook execution is sequential (NOT parallel — different hooks may
     target the same backing services like Postgres, and sequential
-    keeps the workflow log readable). Order matches ``_HOOK_REGISTRY``.
+    keeps the workflow log readable). **Order matches the caller-
+    provided ``enabled_hooks`` argument** — NOT ``_HOOK_REGISTRY``
+    insertion order. Callers (the CLI in ``__main__._services_configure``)
+    determine the order; the registry is only a name → renderer map.
     """
     parts: list[str] = ["set -u  # -e omitted: hook failures must not abort the orchestrator\n"]
     for name in enabled_hooks:

--- a/src/nexus_deploy/services.py
+++ b/src/nexus_deploy/services.py
@@ -152,11 +152,17 @@ def _render_wait_healthy(
     Bounded by **wall-clock** (``$SECONDS``), not iteration count.
     Earlier versions used ``for _ in $(seq 1 N)`` with N derived
     from ``timeout_seconds // interval_seconds``, but each iteration
-    can spend up to curl's ``--max-time`` waiting for a stalled
+    could spend up to curl's ``--max-time`` waiting for a stalled
     response PLUS ``sleep interval_seconds`` between probes — so a
     "60s" timeout could blow out to ~200s in the worst case while
     still printing the misleading "after 60s" warning. Using
-    ``$SECONDS`` keeps the upper bound at exactly ``timeout_seconds``.
+    ``$SECONDS`` keeps the upper bound close to ``timeout_seconds``:
+    the worst case is ~``timeout_seconds + curl_max_time +
+    interval_seconds`` (the loop can enter at SECONDS=N-1, then
+    spend one more probe + sleep before the while-check fires
+    again). For the typical Portainer/n8n/Metabase configs that's
+    ~+7s; not exact, but bounded and accurate enough for the
+    "after Ns — skipping" warning.
 
     The predicate runs against ``$STATUS`` (HTTP code from curl
     ``-w '%{http_code}'``). Specs that need a body-substring check
@@ -545,12 +551,22 @@ def render_remote_script(
     on its bail-out paths and the orchestrator script has no
     ``set -e`` in the outer scope).
 
-    Hook execution is sequential (NOT parallel — different hooks may
-    target the same backing services like Postgres, and sequential
-    keeps the workflow log readable). **Order matches the caller-
-    provided ``enabled_hooks`` argument** — NOT ``_HOOK_REGISTRY``
-    insertion order. Callers (the CLI in ``__main__._services_configure``)
-    determine the order; the registry is only a name → renderer map.
+    Hook execution is sequential (NOT parallel). **Order matches the
+    caller-provided ``enabled_hooks`` argument** — NOT
+    ``_HOOK_REGISTRY`` insertion order. Callers (the CLI in
+    ``__main__._services_configure``) determine the order; the
+    registry is only a name → renderer map.
+
+    KNOWN-LIMITATION (acknowledged tradeoff vs legacy deploy.sh):
+    legacy ran several hooks (Portainer, LakeFS, OpenMetadata) in
+    parallel via ``( ... ) & CONFIG_JOBS+=($!)`` background subshells
+    + ``wait``, which capped wall-time at the slowest hook (~180s).
+    Sequential here can reach ~``sum(per-hook timeouts)`` — about
+    7 minutes worst case for the 5 currently-shipped hooks. Phase 3
+    (#505 Modul 3.1, paramiko + asyncio) replaces the bash-render
+    layer wholesale and naturally restores parallelism via
+    ``asyncio.gather``. Until then we accept the increased wall-
+    time in exchange for predictable, easy-to-grep linear logs.
     """
     parts: list[str] = ["set -u  # -e omitted: hook failures must not abort the orchestrator\n"]
     for name in enabled_hooks:

--- a/src/nexus_deploy/services.py
+++ b/src/nexus_deploy/services.py
@@ -167,9 +167,12 @@ fi
 def render_portainer_hook(config: NexusConfig, env: BootstrapEnv) -> str:
     """Portainer first-init: ``POST /api/users/admin/init`` (no auth).
 
-    Body built via ``jq -n --arg`` and piped to curl via stdin
-    (``--data-binary @-``) so the admin password never appears in
-    the curl process argv on the remote host (R4).
+    Secrets reach jq via env vars (``NEXUS_U`` / ``NEXUS_P``) and are
+    referenced in the filter as ``env.NEXUS_U`` / ``env.NEXUS_P`` —
+    NEVER as positional ``--arg`` values, which would put them in
+    jq's argv (visible via ``ps``). The body is then piped to curl
+    via stdin (``--data-binary @-``) so neither jq nor curl carry
+    secrets in argv (R4).
     """
     del env  # not used; signature uniform across hooks
     username = config.admin_username or "admin"
@@ -187,8 +190,8 @@ def render_portainer_hook(config: NexusConfig, env: BootstrapEnv) -> str:
     return f"""
 portainer_hook() {{
     {wait}
-    BODY=$(jq -n --arg u {username_q} --arg p {password_q} \\
-        '{{Username: $u, Password: $p}}')
+    BODY=$(NEXUS_U={username_q} NEXUS_P={password_q} jq -n \\
+        '{{Username: env.NEXUS_U, Password: env.NEXUS_P}}')
     RESP=$(printf '%s' "$BODY" | curl -s -X POST 'http://localhost:9090/api/users/admin/init' \\
         --max-time 30 \\
         -H 'Content-Type: application/json' \\
@@ -232,8 +235,8 @@ n8n_hook() {{
         echo "RESULT hook=n8n status=already-configured"
         return 0
     fi
-    BODY=$(jq -n --arg email {email_q} --arg pw {password_q} \\
-        '{{email: $email, firstName: "Admin", lastName: "User", password: $pw}}')
+    BODY=$(NEXUS_E={email_q} NEXUS_P={password_q} jq -n \\
+        '{{email: env.NEXUS_E, firstName: "Admin", lastName: "User", password: env.NEXUS_P}}')
     RESP=$(printf '%s' "$BODY" | curl -s -X POST 'http://localhost:5678/rest/owner/setup' \\
         --max-time 30 \\
         -H 'Content-Type: application/json' \\
@@ -270,11 +273,8 @@ metabase_hook() {{
         echo "RESULT hook=metabase status=already-configured"
         return 0
     fi
-    BODY=$(jq -n \\
-        --arg token "$SETUP_TOKEN" \\
-        --arg email {email_q} \\
-        --arg password {password_q} \\
-        '{{token: $token, user: {{email: $email, first_name: "Admin", last_name: "User", password: $password}}, prefs: {{site_name: "Nexus Stack Analytics", allow_tracking: false}}}}')
+    BODY=$(NEXUS_TOKEN="$SETUP_TOKEN" NEXUS_E={email_q} NEXUS_P={password_q} jq -n \\
+        '{{token: env.NEXUS_TOKEN, user: {{email: env.NEXUS_E, first_name: "Admin", last_name: "User", password: env.NEXUS_P}}, prefs: {{site_name: "Nexus Stack Analytics", allow_tracking: false}}}}')
     RESP=$(printf '%s' "$BODY" | curl -s -X POST 'http://localhost:3000/api/setup' \\
         --max-time 30 \\
         -H 'Content-Type: application/json' \\
@@ -329,10 +329,8 @@ lakefs_hook() {{
         SETUP_DONE=true
     fi
     if [ "$SETUP_DONE" = "false" ]; then
-        SETUP_BODY=$(jq -n \\
-            --arg ak {access_q} \\
-            --arg sk {secret_q} \\
-            '{{username: "nexus-lakefs", key: {{access_key_id: $ak, secret_access_key: $sk}}}}')
+        SETUP_BODY=$(NEXUS_AK={access_q} NEXUS_SK={secret_q} jq -n \\
+            '{{username: "nexus-lakefs", key: {{access_key_id: env.NEXUS_AK, secret_access_key: env.NEXUS_SK}}}}')
         SETUP_RESP=$(printf '%s' "$SETUP_BODY" | curl -s -X POST 'http://localhost:8000/api/v1/setup_lakefs' \\
             --max-time 30 \\
             -H 'Content-Type: application/json' \\
@@ -420,8 +418,11 @@ openmetadata_hook() {{
         return 0
     fi
     DEFAULT_PW_B64=$(printf 'admin' | base64 | tr -d '\\n')
-    LOGIN_BODY=$(jq -n --arg email "admin@${{DOMAIN}}" --arg pw "$DEFAULT_PW_B64" \\
-        '{{email: $email, password: $pw}}')
+    # NEXUS_PW carries the base64 of "admin" (default OpenMetadata
+    # password) — public knowledge, but keep it out of jq's argv
+    # uniformly with the other hooks. NEXUS_E is the email address.
+    LOGIN_BODY=$(NEXUS_E="admin@${{DOMAIN}}" NEXUS_PW="$DEFAULT_PW_B64" jq -n \\
+        '{{email: env.NEXUS_E, password: env.NEXUS_PW}}')
     LOGIN_RESP=$(printf '%s' "$LOGIN_BODY" | curl -s -X POST 'http://localhost:8585/api/v1/users/login' \\
         --max-time 30 \\
         -H 'Content-Type: application/json' \\
@@ -435,8 +436,8 @@ openmetadata_hook() {{
         fi
         return 0
     fi
-    PW_BODY=$(jq -n --arg new {new_pw_q} \\
-        '{{username: "admin", oldPassword: "admin", newPassword: $new, confirmPassword: $new, requestType: "SELF"}}')
+    PW_BODY=$(NEXUS_NEW={new_pw_q} jq -n \\
+        '{{username: "admin", oldPassword: "admin", newPassword: env.NEXUS_NEW, confirmPassword: env.NEXUS_NEW, requestType: "SELF"}}')
     # R4: Bearer token via curl --config tmpfile, NOT -H argv. The
     # tmpfile is mode 600 + cleaned up by a function-scoped RETURN
     # trap (fires when openmetadata_hook returns) plus an explicit
@@ -452,9 +453,14 @@ openmetadata_hook() {{
         --data-binary @- >/dev/null 2>&1 || true
     rm -f "$OM_CFG"
     trap - RETURN
+    # base64 reads the new password from stdin (printf is a bash
+    # builtin → no fork → no `ps` exposure for the printf).
     NEW_PW_B64=$(printf '%s' {new_pw_q} | base64 | tr -d '\\n')
-    VERIFY_BODY=$(jq -n --arg email "admin@${{DOMAIN}}" --arg pw "$NEW_PW_B64" \\
-        '{{email: $email, password: $pw}}')
+    # NEXUS_PW carries the base64-of-new-password — even base64 of
+    # the password is sensitive (trivially reversible), so we route
+    # via env var to keep it out of jq's argv.
+    VERIFY_BODY=$(NEXUS_E="admin@${{DOMAIN}}" NEXUS_PW="$NEW_PW_B64" jq -n \\
+        '{{email: env.NEXUS_E, password: env.NEXUS_PW}}')
     VERIFY_RESP=$(printf '%s' "$VERIFY_BODY" | curl -s -X POST 'http://localhost:8585/api/v1/users/login' \\
         --max-time 30 \\
         -H 'Content-Type: application/json' \\

--- a/src/nexus_deploy/services.py
+++ b/src/nexus_deploy/services.py
@@ -77,6 +77,16 @@ _RESULT_LINE_RE = re.compile(
     re.MULTILINE,
 )
 
+# Same alphabet as the RESULT line's `name` group. Used to validate
+# hook names from the caller-provided `enabled_hooks` list before
+# interpolating into the rendered bash — prevents shell injection
+# via $(), backticks, semicolons, etc. if a buggy or adversarial
+# caller ever passes a name with shell metacharacters. In production
+# `enabled_hooks` comes from deploy.sh's $ENABLED_SERVICES (which
+# itself comes from `tofu output -json` keys, all alphanumeric +
+# dash), so this is defence in depth.
+_VALID_HOOK_NAME_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+
 HookStatus = Literal["configured", "already-configured", "failed", "skipped-not-ready"]
 
 
@@ -347,7 +357,9 @@ lakefs_hook() {{
         --arg ns "$STORAGE_NS" \\
         '{{name: $name, storage_namespace: $ns, default_branch: "main", sample_data: false}}')
     # R4: basic-auth via curl --config tmpfile, NOT -u user:secret
-    # in argv. The tmpfile is mode 600 + cleaned up by the trap.
+    # in argv. The tmpfile is mode 600 + cleaned up by a function-
+    # scoped RETURN trap (fires when lakefs_hook returns) plus an
+    # explicit `rm -f` after the curl call.
     LFS_CFG=$(mktemp)
     chmod 600 "$LFS_CFG"
     trap 'rm -f "$LFS_CFG"' RETURN
@@ -426,7 +438,9 @@ openmetadata_hook() {{
     PW_BODY=$(jq -n --arg new {new_pw_q} \\
         '{{username: "admin", oldPassword: "admin", newPassword: $new, confirmPassword: $new, requestType: "SELF"}}')
     # R4: Bearer token via curl --config tmpfile, NOT -H argv. The
-    # tmpfile is mode 600 + cleaned up by the EXIT trap.
+    # tmpfile is mode 600 + cleaned up by a function-scoped RETURN
+    # trap (fires when openmetadata_hook returns) plus an explicit
+    # `rm -f` after the curl call.
     OM_CFG=$(mktemp)
     chmod 600 "$OM_CFG"
     trap 'rm -f "$OM_CFG"' RETURN
@@ -507,9 +521,19 @@ def render_remote_script(
     """
     parts: list[str] = ["set -u  # -e omitted: hook failures must not abort the orchestrator\n"]
     for name in enabled_hooks:
+        # Defence in depth: drop any hook name with shell-meta chars
+        # before interpolating into the rendered bash. Logged to local
+        # stderr (NOT into the rendered script — we cannot trust the
+        # value enough to embed it). Production callers should never
+        # hit this path; deploy.sh's $ENABLED_SERVICES is alphanumeric
+        # + dash by tofu-output construction.
+        if not _VALID_HOOK_NAME_RE.fullmatch(name):
+            sys.stderr.write(f"  ⚠ Dropped hook with unsafe name: {name!r}\n")
+            continue
         renderer = _HOOK_REGISTRY.get(name)
         if renderer is None:
-            # Unknown hook → emit a skip line so the count stays consistent
+            # Unknown but well-formed hook → emit a skip line so the
+            # operator can see the name in the workflow log.
             parts.append(f'echo "RESULT hook={name} status=skipped-not-ready"\n')
             continue
         parts.append(renderer(config, env))

--- a/src/nexus_deploy/services.py
+++ b/src/nexus_deploy/services.py
@@ -289,9 +289,14 @@ def render_lakefs_hook(config: NexusConfig, env: BootstrapEnv) -> str:
         return 'echo "RESULT hook=lakefs status=skipped-not-ready"\n'
     access_q = shlex.quote(access_key)
     secret_q = shlex.quote(secret_key)
-    # Storage namespace selection mirrors deploy.sh:2762-2770. We let
-    # the rendered bash decide based on the env vars on the server, so
-    # the Python doesn't need to read them — keeps the renderer pure.
+    # Storage namespace selection mirrors deploy.sh:2762-2770. The
+    # bucket name comes from `config.hetzner_s3_bucket_lakefs` (a
+    # NexusConfig field parsed from `tofu output -json secrets`) and
+    # is shlex-quoted into the rendered bash as a literal — NOT read
+    # from a remote env var. This keeps the renderer pure (no
+    # round-trip needed to discover it on the server) at the cost of
+    # making the namespace tied to deploy-time tofu state instead of
+    # post-deploy server state. In practice the two are identical.
     hetzner_bucket = config.hetzner_s3_bucket_lakefs or ""
     hetzner_q = shlex.quote(hetzner_bucket)
     wait = _render_wait_healthy(
@@ -334,10 +339,18 @@ lakefs_hook() {{
         --arg name "$REPO_NAME" \\
         --arg ns "$STORAGE_NS" \\
         '{{name: $name, storage_namespace: $ns, default_branch: "main", sample_data: false}}')
+    # R4: basic-auth via curl --config tmpfile, NOT -u user:secret
+    # in argv. The tmpfile is mode 600 + cleaned up by the trap.
+    LFS_CFG=$(mktemp)
+    chmod 600 "$LFS_CFG"
+    trap 'rm -f "$LFS_CFG"' RETURN
+    printf 'user = "%s:%s"\\n' {access_q} {secret_q} > "$LFS_CFG"
     REPO_RESP=$(printf '%s' "$REPO_BODY" | curl -s -X POST 'http://localhost:8000/api/v1/repositories' \\
-        -u {access_q}:{secret_q} \\
+        --config "$LFS_CFG" \\
         -H 'Content-Type: application/json' \\
         --data-binary @- 2>/dev/null || echo "")
+    rm -f "$LFS_CFG"
+    trap - RETURN
     if echo "$REPO_RESP" | grep -q '"id"'; then
         echo "RESULT hook=lakefs status=configured"
     elif echo "$REPO_RESP" | grep -q 'already exists'; then
@@ -403,10 +416,18 @@ openmetadata_hook() {{
     fi
     PW_BODY=$(jq -n --arg new {new_pw_q} \\
         '{{username: "admin", oldPassword: "admin", newPassword: $new, confirmPassword: $new, requestType: "SELF"}}')
+    # R4: Bearer token via curl --config tmpfile, NOT -H argv. The
+    # tmpfile is mode 600 + cleaned up by the EXIT trap.
+    OM_CFG=$(mktemp)
+    chmod 600 "$OM_CFG"
+    trap 'rm -f "$OM_CFG"' RETURN
+    printf 'header = "Authorization: Bearer %s"\\n' "$TOKEN" > "$OM_CFG"
     printf '%s' "$PW_BODY" | curl -s -X PUT 'http://localhost:8585/api/v1/users/changePassword' \\
-        -H "Authorization: Bearer $TOKEN" \\
+        --config "$OM_CFG" \\
         -H 'Content-Type: application/json' \\
         --data-binary @- >/dev/null 2>&1 || true
+    rm -f "$OM_CFG"
+    trap - RETURN
     NEW_PW_B64=$(printf '%s' {new_pw_q} | base64 | tr -d '\\n')
     VERIFY_BODY=$(jq -n --arg email "admin@${{DOMAIN}}" --arg pw "$NEW_PW_B64" \\
         '{{email: $email, password: $pw}}')

--- a/src/nexus_deploy/services.py
+++ b/src/nexus_deploy/services.py
@@ -40,9 +40,15 @@ R3. Per-hook tmpfile cleanup. LakeFS + OpenMetadata create mode-600
     Metabase don't need a tmpfile — their POST endpoints are
     auth-free, only the body is sensitive, and that travels via
     --data-binary @- stdin.)
-R4. JSON setup-body built via jq with shell-injection-safe ``--arg``
-    (NOT string interpolation), and the body is fed to curl via
-    stdin (``--data-binary @-``) so admin passwords don't reach argv.
+R4. JSON setup-body built via jq with secrets injected as env vars
+    (``NEXUS_P=value jq -n 'env.NEXUS_P'``), NOT positional
+    ``--arg`` values that would land in jq's argv (visible via
+    ``ps``). The body is then fed to curl via stdin
+    (``--data-binary @-``) so neither jq nor curl carry secrets in
+    argv. Auth headers / basic-auth go via ``curl --config <tmpfile>``
+    (mode 600, RETURN-trap cleanup) — never via ``-H`` / ``-u``
+    argv either. Together: no fork visible via ``ps -ef`` carries
+    a credential value.
 R5. Idempotent skip when ``already_configured_substring`` appears in
     the pre-setup probe response (deploy.sh's ``[ -z "$SETUP_TOKEN" ]``
     / ``"setup_complete":true`` / etc. branches).
@@ -211,9 +217,11 @@ portainer_hook
 def render_n8n_hook(config: NexusConfig, env: BootstrapEnv) -> str:
     """n8n owner-setup: ``POST /rest/owner/setup`` (no auth, idempotent via /rest/settings).
 
-    Body built via ``jq -n --arg`` and piped to curl via stdin
-    (``--data-binary @-``) so the admin password never appears in
-    the curl process argv on the remote host (R4).
+    Body built with secrets injected via env vars (``NEXUS_E`` /
+    ``NEXUS_P``), referenced in jq's filter as ``env.NEXUS_E`` /
+    ``env.NEXUS_P``. The body is then piped to curl via stdin
+    (``--data-binary @-``). Neither jq nor curl carry the password
+    in argv (R4).
     """
     email = env.admin_email or ""
     password = config.n8n_admin_password or ""

--- a/src/nexus_deploy/services.py
+++ b/src/nexus_deploy/services.py
@@ -32,11 +32,14 @@ R1. Orchestrator script begins with ``set -u`` (unset-var detection)
     hooks either. R3 below is the corollary on tmpfile cleanup.
 R2. Per-spec healthcheck timeout (Metabase 120s, OpenMetadata 180s,
     LakeFS 60s, Portainer 5s, n8n 60s — NOT a global default).
-R3. Per-hook bodies are self-contained — no shared tmpfiles, no
-    cross-hook EXIT trap. Each curl invocation captures its own
-    response into a local-variable string; nothing on disk to clean
-    up. (Future hooks that DO write to disk — e.g. Filestash file
-    mutation in 2.2c — get their own per-hook cleanup.)
+R3. Per-hook tmpfile cleanup. LakeFS + OpenMetadata create mode-600
+    `mktemp` curl-config files (R4 — auth via --config, NOT argv)
+    and clean them up via per-hook ``trap ... RETURN`` + explicit
+    ``rm -f`` after the curl call. No shared cross-hook tmpfiles
+    or EXIT trap; each hook is self-contained. (Portainer + n8n +
+    Metabase don't need a tmpfile — their POST endpoints are
+    auth-free, only the body is sensitive, and that travels via
+    --data-binary @- stdin.)
 R4. JSON setup-body built via jq with shell-injection-safe ``--arg``
     (NOT string interpolation), and the body is fed to curl via
     stdin (``--data-binary @-``) so admin passwords don't reach argv.
@@ -62,7 +65,7 @@ import subprocess
 import sys
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any, Literal
+from typing import Literal, cast
 
 from nexus_deploy import _remote
 from nexus_deploy.config import NexusConfig
@@ -139,7 +142,7 @@ def _render_wait_healthy(
     return f"""
 READY=false
 for _ in $(seq 1 {iters}); do
-    STATUS=$(curl -s -o /dev/null -w '%{{http_code}}' --connect-timeout 3 {shlex.quote(url)} 2>/dev/null || echo "000")
+    STATUS=$(curl -s -o /dev/null -w '%{{http_code}}' --connect-timeout 3 --max-time 5 {shlex.quote(url)} 2>/dev/null || echo "000")
     if {predicate}; then READY=true; break; fi
     sleep {interval_seconds}
 done
@@ -177,6 +180,7 @@ portainer_hook() {{
     BODY=$(jq -n --arg u {username_q} --arg p {password_q} \\
         '{{Username: $u, Password: $p}}')
     RESP=$(printf '%s' "$BODY" | curl -s -X POST 'http://localhost:9090/api/users/admin/init' \\
+        --max-time 30 \\
         -H 'Content-Type: application/json' \\
         --data-binary @- 2>/dev/null || echo "")
     if echo "$RESP" | grep -q '"Id"'; then
@@ -212,7 +216,7 @@ def render_n8n_hook(config: NexusConfig, env: BootstrapEnv) -> str:
     return f"""
 n8n_hook() {{
     {wait}
-    SETTINGS=$(curl -s 'http://localhost:5678/rest/settings' 2>/dev/null || echo "{{}}")
+    SETTINGS=$(curl -s --max-time 10 'http://localhost:5678/rest/settings' 2>/dev/null || echo "{{}}")
     NEEDS_SETUP=$(printf '%s' "$SETTINGS" | jq -r '.data.userManagement.showSetupOnFirstLoad // true | if . then "true" else "false" end' 2>/dev/null || echo "true")
     if [ "$NEEDS_SETUP" = "false" ]; then
         echo "RESULT hook=n8n status=already-configured"
@@ -221,6 +225,7 @@ n8n_hook() {{
     BODY=$(jq -n --arg email {email_q} --arg pw {password_q} \\
         '{{email: $email, firstName: "Admin", lastName: "User", password: $pw}}')
     RESP=$(printf '%s' "$BODY" | curl -s -X POST 'http://localhost:5678/rest/owner/setup' \\
+        --max-time 30 \\
         -H 'Content-Type: application/json' \\
         --data-binary @- 2>/dev/null || echo "")
     if echo "$RESP" | grep -q '"id"'; then
@@ -249,7 +254,7 @@ def render_metabase_hook(config: NexusConfig, env: BootstrapEnv) -> str:
     return f"""
 metabase_hook() {{
     {wait}
-    SETUP_TOKEN=$(curl -s 'http://localhost:3000/api/session/properties' 2>/dev/null \\
+    SETUP_TOKEN=$(curl -s --max-time 10 'http://localhost:3000/api/session/properties' 2>/dev/null \\
         | jq -r '."setup-token" // empty' 2>/dev/null || echo "")
     if [ -z "$SETUP_TOKEN" ]; then
         echo "RESULT hook=metabase status=already-configured"
@@ -261,6 +266,7 @@ metabase_hook() {{
         --arg password {password_q} \\
         '{{token: $token, user: {{email: $email, first_name: "Admin", last_name: "User", password: $password}}, prefs: {{site_name: "Nexus Stack Analytics", allow_tracking: false}}}}')
     RESP=$(printf '%s' "$BODY" | curl -s -X POST 'http://localhost:3000/api/setup' \\
+        --max-time 30 \\
         -H 'Content-Type: application/json' \\
         --data-binary @- 2>/dev/null || echo "")
     if echo "$RESP" | grep -q '"id"'; then
@@ -307,7 +313,7 @@ def render_lakefs_hook(config: NexusConfig, env: BootstrapEnv) -> str:
     return f"""
 lakefs_hook() {{
     {wait}
-    CFG=$(curl -s 'http://localhost:8000/api/v1/config' 2>/dev/null || echo "")
+    CFG=$(curl -s --max-time 10 'http://localhost:8000/api/v1/config' 2>/dev/null || echo "")
     SETUP_DONE=false
     if echo "$CFG" | grep -q '"setup_complete":true'; then
         SETUP_DONE=true
@@ -318,6 +324,7 @@ lakefs_hook() {{
             --arg sk {secret_q} \\
             '{{username: "nexus-lakefs", key: {{access_key_id: $ak, secret_access_key: $sk}}}}')
         SETUP_RESP=$(printf '%s' "$SETUP_BODY" | curl -s -X POST 'http://localhost:8000/api/v1/setup_lakefs' \\
+            --max-time 30 \\
             -H 'Content-Type: application/json' \\
             --data-binary @- 2>/dev/null || echo "")
         if ! echo "$SETUP_RESP" | grep -q 'access_key_id'; then
@@ -347,6 +354,7 @@ lakefs_hook() {{
     printf 'user = "%s:%s"\\n' {access_q} {secret_q} > "$LFS_CFG"
     REPO_RESP=$(printf '%s' "$REPO_BODY" | curl -s -X POST 'http://localhost:8000/api/v1/repositories' \\
         --config "$LFS_CFG" \\
+        --max-time 30 \\
         -H 'Content-Type: application/json' \\
         --data-binary @- 2>/dev/null || echo "")
     rm -f "$LFS_CFG"
@@ -389,7 +397,7 @@ openmetadata_hook() {{
     DOMAIN=$(printf '%s' "$EMAIL" | cut -d'@' -f2)
     READY=false
     for _ in $(seq 1 60); do
-        if curl -s --connect-timeout 3 'http://localhost:8585/api/v1/system/version' 2>/dev/null | grep -q 'version'; then
+        if curl -s --connect-timeout 3 --max-time 5 'http://localhost:8585/api/v1/system/version' 2>/dev/null | grep -q 'version'; then
             READY=true; break
         fi
         sleep 3
@@ -403,6 +411,7 @@ openmetadata_hook() {{
     LOGIN_BODY=$(jq -n --arg email "admin@${{DOMAIN}}" --arg pw "$DEFAULT_PW_B64" \\
         '{{email: $email, password: $pw}}')
     LOGIN_RESP=$(printf '%s' "$LOGIN_BODY" | curl -s -X POST 'http://localhost:8585/api/v1/users/login' \\
+        --max-time 30 \\
         -H 'Content-Type: application/json' \\
         --data-binary @- 2>/dev/null || echo "")
     TOKEN=$(printf '%s' "$LOGIN_RESP" | jq -r '.accessToken // empty' 2>/dev/null)
@@ -424,6 +433,7 @@ openmetadata_hook() {{
     printf 'header = "Authorization: Bearer %s"\\n' "$TOKEN" > "$OM_CFG"
     printf '%s' "$PW_BODY" | curl -s -X PUT 'http://localhost:8585/api/v1/users/changePassword' \\
         --config "$OM_CFG" \\
+        --max-time 30 \\
         -H 'Content-Type: application/json' \\
         --data-binary @- >/dev/null 2>&1 || true
     rm -f "$OM_CFG"
@@ -432,6 +442,7 @@ openmetadata_hook() {{
     VERIFY_BODY=$(jq -n --arg email "admin@${{DOMAIN}}" --arg pw "$NEW_PW_B64" \\
         '{{email: $email, password: $pw}}')
     VERIFY_RESP=$(printf '%s' "$VERIFY_BODY" | curl -s -X POST 'http://localhost:8585/api/v1/users/login' \\
+        --max-time 30 \\
         -H 'Content-Type: application/json' \\
         --data-binary @- 2>/dev/null || echo "")
     if printf '%s' "$VERIFY_RESP" | jq -r '.accessToken // empty' 2>/dev/null | grep -q '.'; then
@@ -506,9 +517,18 @@ def render_remote_script(
 
 
 def parse_results(stdout: str) -> tuple[HookResult, ...]:
-    """Extract one HookResult per ``RESULT hook=…`` line in remote stdout."""
+    """Extract one HookResult per ``RESULT hook=…`` line in remote stdout.
+
+    Both regex groups (``name``, ``status``) are required by
+    ``_RESULT_LINE_RE`` — ``finditer`` only yields matches where
+    every group captured something — so ``m.group(name)`` is
+    statically guaranteed non-None. The ``cast`` pins the status
+    string to its Literal-typed alias for the typed dataclass
+    constructor (replaces the previous ``# type: ignore[arg-type]``
+    suppression).
+    """
     return tuple(
-        HookResult(name=m.group("name"), status=m.group("status"))  # type: ignore[arg-type]
+        HookResult(name=m.group("name"), status=cast("HookStatus", m.group("status")))
         for m in _RESULT_LINE_RE.finditer(stdout)
     )
 
@@ -579,7 +599,3 @@ __all__ = [
     "run_admin_setups",
     "supported_hooks",
 ]
-
-
-# Suppress unused import warnings — Any imported for type aliasing.
-_ = Any

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -388,6 +388,44 @@ def test_round_7_hook_execution_order_matches_enabled_arg() -> None:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.parametrize(
+    "unsafe_name",
+    [
+        "$(rm -rf /)",
+        "x; rm -rf /",
+        "x`whoami`",
+        "x|cat /etc/passwd",
+        "x with space",
+        "x'single'",
+        'x"double"',
+        "../etc/passwd",
+        "x\\backslash",
+        "",
+    ],
+)
+def test_render_remote_script_drops_unsafe_hook_names(
+    unsafe_name: str, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Round-4 finding: hook names with shell-meta chars must NOT be
+    interpolated into the rendered bash. Each unsafe name is dropped
+    with a stderr warning; the rendered script must NOT contain the
+    unsafe substring at all (no echo, no comment, nothing).
+    """
+    script = render_remote_script(
+        config=_make_config(),
+        env=_make_env(),
+        enabled_hooks=["portainer", unsafe_name],
+    )
+    # Unsafe name must NOT reach the rendered bash
+    if unsafe_name:  # empty string isn't a substring of anything useful
+        assert unsafe_name not in script
+    # Portainer (the safe entry) still rendered
+    assert "portainer_hook" in script
+    # Stderr warning emitted
+    captured = capsys.readouterr()
+    assert "Dropped hook with unsafe name" in captured.err
+
+
 def test_render_remote_script_unknown_hook_emits_skip() -> None:
     """An enabled service with no renderer → emit skip line so counts stay consistent."""
     script = render_remote_script(

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -221,6 +221,38 @@ def test_round_2_per_spec_healthcheck_timeouts() -> None:
         )
 
 
+@pytest.mark.parametrize(
+    ("renderer", "canary_field", "canary_value"),
+    [
+        # Each hook is tested with a unique canary substituted for the
+        # credential field that's most likely to land in argv.
+        (render_portainer_hook, "portainer_admin_password", "PORTAINER-CANARY-X1Y2"),
+        (render_n8n_hook, "n8n_admin_password", "N8N-CANARY-X1Y2"),
+        (render_metabase_hook, "metabase_admin_password", "METABASE-CANARY-X1Y2"),
+        (render_lakefs_hook, "lakefs_admin_secret_key", "LAKEFS-SECRET-CANARY-X1Y2"),
+        (render_openmetadata_hook, "openmetadata_admin_password", "OM-CANARY-X1Y2"),
+    ],
+)
+def test_no_credential_leaks_into_curl_line_per_hook(
+    renderer: Any, canary_field: str, canary_value: str
+) -> None:
+    """R4 (per-hook generalisation): no credential ever lands on a line
+    containing a curl invocation.
+
+    Round-2 finding on PR #514: previous tests caught Metabase only;
+    Portainer + n8n + LakeFS basic-auth + OpenMetadata Bearer all
+    leaked credentials into curl argv. This parameterized test pins
+    the invariant for ALL 5 hooks: the canary value must appear
+    SOMEWHERE in the rendered script (it's a credential we need to
+    use) but NEVER on a line that contains the literal token ``curl``.
+    """
+    script = renderer(_make_config(**{canary_field: canary_value}), _make_env())
+    assert canary_value in script, "Canary must appear somewhere in the script"
+    for line in script.splitlines():
+        if "curl " in line or "curl\n" in line:
+            assert canary_value not in line, f"Credential leaked into curl line: {line!r}"
+
+
 def test_round_4_setup_body_via_jq_no_argv_leak() -> None:
     """R4 — admin password is shlex-quoted into the rendered bash AND
     fed to curl via stdin (--data-binary @-), never via argv.

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -40,7 +40,9 @@ def _make_config(**overrides: Any) -> NexusConfig:
         "portainer_admin_password": "p-pass",
         "n8n_admin_password": "n-pass",
         "metabase_admin_password": "m-pass",
-        "lakefs_admin_access_key": "AKIA-LAKEFS-1234",
+        # Deliberately NOT shaped like an AWS access key (AKIA prefix)
+        # to avoid false-positive secret-scanner alerts in CI/GitHub.
+        "lakefs_admin_access_key": "FAKE-LAKEFS-ACCESS-KEY-1234",
         "lakefs_admin_secret_key": "secret-lakefs-key",
         "openmetadata_admin_password": "om-pass-Complex1!",
         "hetzner_s3_bucket_lakefs": "my-bucket",
@@ -322,12 +324,19 @@ def test_round_6_hook_failure_does_not_abort_orchestrator() -> None:
         )
 
 
-def test_round_7_hook_execution_order_deterministic() -> None:
-    """R7 — orchestrator emits hooks in registry order, not enabled-list order."""
+def test_round_7_hook_execution_order_matches_enabled_arg() -> None:
+    """R7 — orchestrator emits hooks in the caller-provided
+    ``enabled_hooks`` argument order, NOT registry order.
+
+    Operators rely on this for log debug + the integration with
+    deploy.sh's [7/7] sequence — the CLI passes the comma-list as
+    typed, and deploy.sh's $ENABLED_SERVICES is built from
+    services.yaml in source order via tofu output.
+    """
     script = render_remote_script(
         config=_make_config(),
         env=_make_env(),
-        # Pass in reverse-alphabetical order to verify registry order wins
+        # Pass in reverse-registry order to verify caller-order wins
         enabled_hooks=["openmetadata", "portainer", "lakefs"],
     )
     # The order in which hook functions are called must follow the

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -233,24 +233,41 @@ def test_round_2_per_spec_healthcheck_timeouts() -> None:
         (render_openmetadata_hook, "openmetadata_admin_password", "OM-CANARY-X1Y2"),
     ],
 )
-def test_no_credential_leaks_into_curl_line_per_hook(
+def test_no_credential_leaks_into_subprocess_argv_per_hook(
     renderer: Any, canary_field: str, canary_value: str
 ) -> None:
     """R4 (per-hook generalisation): no credential ever lands on a line
-    containing a curl invocation.
+    that invokes a non-builtin subprocess (``curl`` or ``jq``) — both
+    leak via ``ps`` on the remote host.
 
-    Round-2 finding on PR #514: previous tests caught Metabase only;
-    Portainer + n8n + LakeFS basic-auth + OpenMetadata Bearer all
-    leaked credentials into curl argv. This parameterized test pins
-    the invariant for ALL 5 hooks: the canary value must appear
-    SOMEWHERE in the rendered script (it's a credential we need to
-    use) but NEVER on a line that contains the literal token ``curl``.
+    Round-2 PR #514: caught Portainer + n8n curl-argv leaks.
+    Round-5 PR #514: caught the SAME class on jq's argv (``jq -n
+    --arg pw <secret>`` puts secret in jq's argv). This test now
+    checks BOTH curl AND jq invocation lines.
+
+    Bash builtins (printf, env-var assignments via ``VAR=value cmd``)
+    don't fork — values can safely appear on those lines without
+    reaching ``ps``. Non-builtins (curl, jq, base64, tr) DO fork —
+    any positional value on those lines hits ``ps``.
     """
     script = renderer(_make_config(**{canary_field: canary_value}), _make_env())
     assert canary_value in script, "Canary must appear somewhere in the script"
     for line in script.splitlines():
-        if "curl " in line or "curl\n" in line:
-            assert canary_value not in line, f"Credential leaked into curl line: {line!r}"
+        # Skip lines that ONLY contain `VAR=value cmd ...` env-var
+        # assignment for the next non-builtin (e.g. `NEXUS_P=secret jq -n`):
+        # the value is set as an env var, NOT as positional argv to jq.
+        # We detect this pattern by checking whether the canary appears
+        # before any forking-command token on the line.
+        for forking_command in ("curl ", "curl\n", "jq ", "jq\n"):
+            if forking_command in line:
+                idx_canary = line.find(canary_value)
+                idx_cmd = line.find(forking_command)
+                if idx_canary >= 0 and idx_canary > idx_cmd:
+                    # Canary appears AFTER the command name → it's in
+                    # positional argv → leak.
+                    raise AssertionError(
+                        f"Credential leaked into {forking_command.strip()!r} argv: {line!r}"
+                    )
 
 
 def test_round_4_setup_body_via_jq_no_argv_leak() -> None:

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -1,0 +1,652 @@
+"""Tests for nexus_deploy.services — Phase 2 Modul 2.2b (#505).
+
+Eight round-tagged invariant tests (one per deploy.sh hardening round)
+plus per-spec snapshots, exec'd-bash regression tests for the JSON
+build + idempotent-skip dispatch, and CLI integration covering rc=0/1/2.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+from typing import Any
+
+import pytest
+
+from nexus_deploy.config import NexusConfig
+from nexus_deploy.infisical import BootstrapEnv
+from nexus_deploy.services import (
+    HookResult,
+    SetupResult,
+    parse_results,
+    render_lakefs_hook,
+    render_metabase_hook,
+    render_n8n_hook,
+    render_openmetadata_hook,
+    render_portainer_hook,
+    render_remote_script,
+    run_admin_setups,
+    supported_hooks,
+)
+
+
+def _make_config(**overrides: Any) -> NexusConfig:
+    """Build a NexusConfig with minimal admin passwords for all 5 hooks."""
+    defaults: dict[str, Any] = {
+        "admin_username": "admin",
+        "portainer_admin_password": "p-pass",
+        "n8n_admin_password": "n-pass",
+        "metabase_admin_password": "m-pass",
+        "lakefs_admin_access_key": "AKIA-LAKEFS-1234",
+        "lakefs_admin_secret_key": "secret-lakefs-key",
+        "openmetadata_admin_password": "om-pass-Complex1!",
+        "hetzner_s3_bucket_lakefs": "my-bucket",
+    }
+    defaults.update(overrides)
+    return NexusConfig.from_secrets_json(json.dumps(defaults))
+
+
+def _make_env(admin_email: str = "ops@example.com") -> BootstrapEnv:
+    return BootstrapEnv(domain="example.com", admin_email=admin_email)
+
+
+# ---------------------------------------------------------------------------
+# supported_hooks — registry contract
+# ---------------------------------------------------------------------------
+
+
+def test_supported_hooks_contains_5_specs() -> None:
+    """Modul 2.2b ships exactly the 5 REST first-init hooks."""
+    assert set(supported_hooks()) == {
+        "portainer",
+        "n8n",
+        "metabase",
+        "lakefs",
+        "openmetadata",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Per-hook renderers — basic shape + skip-on-missing-credential
+# ---------------------------------------------------------------------------
+
+
+def test_render_portainer_hook_basic() -> None:
+    script = render_portainer_hook(_make_config(), _make_env())
+    assert "portainer_hook()" in script
+    assert "/api/users/admin/init" in script
+    assert "RESULT hook=portainer status=" in script
+
+
+def test_render_portainer_hook_skips_when_password_empty() -> None:
+    """Missing admin password → skipped-not-ready, not failed."""
+    config = _make_config(portainer_admin_password="")
+    script = render_portainer_hook(config, _make_env())
+    assert script.strip() == 'echo "RESULT hook=portainer status=skipped-not-ready"'
+
+
+def test_render_n8n_hook_uses_admin_email_from_env() -> None:
+    """n8n needs admin_email — comes from BootstrapEnv, not NexusConfig."""
+    script = render_n8n_hook(_make_config(), _make_env(admin_email="alice@example.com"))
+    assert "alice@example.com" in script
+
+
+def test_render_n8n_hook_skips_when_email_empty() -> None:
+    """Missing admin_email → skipped (uniform with missing password)."""
+    script = render_n8n_hook(_make_config(), _make_env(admin_email=""))
+    assert script.strip() == 'echo "RESULT hook=n8n status=skipped-not-ready"'
+
+
+def test_render_metabase_hook_skips_when_password_empty() -> None:
+    script = render_metabase_hook(_make_config(metabase_admin_password=""), _make_env())
+    assert script.strip() == 'echo "RESULT hook=metabase status=skipped-not-ready"'
+
+
+def test_render_lakefs_hook_skips_when_keys_empty() -> None:
+    script = render_lakefs_hook(
+        _make_config(lakefs_admin_access_key="", lakefs_admin_secret_key=""),
+        _make_env(),
+    )
+    assert script.strip() == 'echo "RESULT hook=lakefs status=skipped-not-ready"'
+
+
+def test_render_openmetadata_hook_skips_when_password_empty() -> None:
+    script = render_openmetadata_hook(_make_config(openmetadata_admin_password=""), _make_env())
+    assert script.strip() == 'echo "RESULT hook=openmetadata status=skipped-not-ready"'
+
+
+def test_render_metabase_hook_uses_admin_email() -> None:
+    script = render_metabase_hook(_make_config(), _make_env())
+    assert "ops@example.com" in script
+    assert "/api/setup" in script
+
+
+def test_render_lakefs_hook_picks_hetzner_bucket_when_set() -> None:
+    """Storage namespace selection mirrors deploy.sh:2762-2770."""
+    script = render_lakefs_hook(_make_config(hetzner_s3_bucket_lakefs="b1"), _make_env())
+    assert "b1" in script
+    assert "hetzner-object-storage" in script
+
+
+def test_render_lakefs_hook_falls_back_to_local_when_no_hetzner() -> None:
+    script = render_lakefs_hook(_make_config(hetzner_s3_bucket_lakefs=""), _make_env())
+    assert "local://data/lakefs/" in script
+    assert "local-storage" in script
+
+
+def test_render_openmetadata_hook_3_step_flow() -> None:
+    """Login (default-pwd) → changePassword → verify-login."""
+    script = render_openmetadata_hook(_make_config(), _make_env())
+    # All three POST endpoints appear
+    assert script.count("/api/v1/users/login") == 2  # login + verify
+    assert "/api/v1/users/changePassword" in script
+    # System-version probe (custom wait, not _render_wait_healthy)
+    assert "/api/v1/system/version" in script
+
+
+# ---------------------------------------------------------------------------
+# Round-tagged invariants on the rendered bash
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "renderer",
+    [
+        render_portainer_hook,
+        render_n8n_hook,
+        render_metabase_hook,
+        render_lakefs_hook,
+        render_openmetadata_hook,
+    ],
+)
+def test_round_8_per_hook_emits_exactly_one_result_line(renderer: Any) -> None:
+    """R8 — every hook function emits exactly one ``RESULT hook=…`` line per branch.
+
+    Static check via grep: each renderer's output must contain at
+    least one ``echo "RESULT hook=`` line. The exec'd version below
+    pins the runtime invariant (exactly one per execution).
+    """
+    script = renderer(_make_config(), _make_env())
+    assert "RESULT hook=" in script
+
+
+def test_round_1_set_minus_u_at_top_no_set_e() -> None:
+    """R1 — orchestrator script uses ``set -u`` (NOT ``set -e``).
+
+    Subtle but critical: ``set -e`` would abort the orchestrator on
+    the first hook that returns non-zero from a curl pipe, and we
+    want hook failures to be reported via RESULT lines without
+    cross-contaminating the rest. The per-hook bodies still use
+    ``|| true`` and explicit branches to control flow.
+    """
+    script = render_remote_script(
+        config=_make_config(), env=_make_env(), enabled_hooks=["portainer"]
+    )
+    assert script.startswith("set -u")
+    # No `set -e` in the orchestrator (R6 corollary)
+    assert "set -e" not in script.splitlines()[0]
+
+
+def test_round_2_per_spec_healthcheck_timeouts() -> None:
+    """R2 — each hook has its own healthcheck timeout, NOT a global default.
+
+    Pin the timeouts so a future contributor doesn't accidentally
+    unify them and break Metabase (Java app, 120s) or OpenMetadata
+    (180s, slow boot).
+    """
+    timeouts = {
+        "portainer": 5,
+        "n8n": 60,
+        "metabase": 120,
+        "lakefs": 60,
+        "openmetadata": 180,
+    }
+    for hook_name, expected_timeout in timeouts.items():
+        renderer = {
+            "portainer": render_portainer_hook,
+            "n8n": render_n8n_hook,
+            "metabase": render_metabase_hook,
+            "lakefs": render_lakefs_hook,
+            "openmetadata": render_openmetadata_hook,
+        }[hook_name]
+        script = renderer(_make_config(), _make_env())
+        # Look for the human-readable warning that names the timeout
+        assert f"after {expected_timeout}s" in script, (
+            f"Expected '{expected_timeout}s' in {hook_name} script"
+        )
+
+
+def test_round_4_setup_body_via_jq_no_argv_leak() -> None:
+    """R4 — admin password is shlex-quoted into the rendered bash AND
+    fed to curl via stdin (--data-binary @-), never via argv.
+
+    Critical: a future bug that put the password into curl's argv
+    would leak it via `ps`. We assert that:
+      1. The password value appears in the script (it's quoted into
+         the jq --arg pipeline — that's expected and bash-safe)
+      2. The password value does NOT appear on any line that also
+         contains a curl invocation (which would mean it's in argv)
+    """
+    canary = "UNIQUE-METABASE-PWD-LEAK-CANARY"
+    config = _make_config(metabase_admin_password=canary)
+    script = render_metabase_hook(config, _make_env())
+    # The password reaches the bash via shlex-quoted positional arg to jq
+    assert canary in script
+    # No curl line carries the literal password (would mean it's in argv)
+    for line in script.splitlines():
+        if "curl " in line:
+            assert canary not in line, f"Password leaked into curl argv: {line!r}"
+    # AND the orchestrator rendered script does use --data-binary @- for
+    # the POST body (sanity check — global, not per-line)
+    assert "--data-binary @-" in script
+
+
+def test_round_4_setup_body_jq_build_via_bash_exec() -> None:
+    """R4 exec — verify the rendered jq pipeline actually builds valid JSON.
+
+    Modul-2.0 lesson: pin bash semantics, not just static text. The
+    Metabase setup body uses jq with --arg for safe quoting; this
+    test runs the jq invocation against a known config and asserts
+    the resulting JSON parses + has the expected fields + the
+    password is escaped correctly even when it contains shell
+    metacharacters.
+    """
+    # Password with shell-special chars to stress-test the quoting
+    nasty_password = 'evil"$(date)`whoami`'
+    snippet = f"""
+set -euo pipefail
+SETUP_TOKEN=tok123
+BODY=$(jq -n \\
+    --arg token "$SETUP_TOKEN" \\
+    --arg email "ops@example.com" \\
+    --arg password {
+        repr(nasty_password).replace("'", "'\\''")
+        if "'" in nasty_password
+        else "'" + nasty_password + "'"
+    } \\
+    '{{token: $token, user: {{email: $email, password: $password}}}}')
+printf '%s' "$BODY"
+"""
+    out = subprocess.run(["bash", "-c", snippet], capture_output=True, text=True, check=True).stdout
+    parsed = json.loads(out)
+    assert parsed["user"]["password"] == nasty_password
+    assert parsed["token"] == "tok123"
+
+
+def test_round_5_idempotent_skip_via_substring_match() -> None:
+    """R5 — idempotent-skip detection per hook.
+
+    Each hook has a distinct "already configured" signal. Pin them
+    so refactors don't accidentally drop the check.
+    """
+    portainer = render_portainer_hook(_make_config(), _make_env())
+    assert "already initialized" in portainer  # Portainer's API response substring
+
+    n8n = render_n8n_hook(_make_config(), _make_env())
+    assert "showSetupOnFirstLoad" in n8n  # n8n's settings probe
+
+    metabase = render_metabase_hook(_make_config(), _make_env())
+    assert "setup-token" in metabase  # Metabase: token absent → already configured
+
+    lakefs = render_lakefs_hook(_make_config(), _make_env())
+    assert '"setup_complete":true' in lakefs
+
+    om = render_openmetadata_hook(_make_config(), _make_env())
+    # OpenMetadata: default login fails with invalid → already configured
+    assert "invalid" in om
+    assert "unauthorized" in om
+
+
+def test_round_6_hook_failure_does_not_abort_orchestrator() -> None:
+    """R6 — orchestrator does NOT use ``set -e``; one hook's failure
+    cannot stop subsequent hooks. Pin via static check on the
+    orchestrator preamble + by verifying every per-hook function
+    uses ``return 0`` (NOT ``exit 1``) on bail-out paths.
+    """
+    script = render_remote_script(
+        config=_make_config(),
+        env=_make_env(),
+        enabled_hooks=["portainer", "n8n", "metabase"],
+    )
+    # Orchestrator preamble: set -u only
+    assert script.startswith("set -u")
+    # No `exit 1` in any hook function (those would propagate)
+    for line in script.splitlines():
+        # Orchestrator-level exits are the issue; ignore subshell exits in jq etc.
+        stripped = line.strip()
+        assert "exit 1" not in stripped, (
+            f"Hook bodies must use 'return 0' on bail-outs, not 'exit 1': {line!r}"
+        )
+
+
+def test_round_7_hook_execution_order_deterministic() -> None:
+    """R7 — orchestrator emits hooks in registry order, not enabled-list order."""
+    script = render_remote_script(
+        config=_make_config(),
+        env=_make_env(),
+        # Pass in reverse-alphabetical order to verify registry order wins
+        enabled_hooks=["openmetadata", "portainer", "lakefs"],
+    )
+    # The order in which hook functions are called must follow the
+    # `enabled_hooks` argument order (caller's responsibility to sort
+    # if they want a different one). Verify by finding the *_hook
+    # call lines and asserting they appear in the expected order.
+    order = []
+    for line in script.splitlines():
+        m = re.match(r"^([a-z_]+)_hook$", line.strip())
+        if m:
+            order.append(m.group(1))
+    assert order == ["openmetadata", "portainer", "lakefs"]
+
+
+# ---------------------------------------------------------------------------
+# render_remote_script — orchestrator behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_render_remote_script_unknown_hook_emits_skip() -> None:
+    """An enabled service with no renderer → emit skip line so counts stay consistent."""
+    script = render_remote_script(
+        config=_make_config(),
+        env=_make_env(),
+        enabled_hooks=["portainer", "filestash"],  # filestash → 2.2c
+    )
+    assert "RESULT hook=filestash status=skipped-not-ready" in script
+    # Portainer still runs
+    assert "portainer_hook" in script
+
+
+def test_render_remote_script_empty_list_yields_minimal_orchestrator() -> None:
+    """Empty enabled list → just the orchestrator preamble, no hook calls."""
+    script = render_remote_script(config=_make_config(), env=_make_env(), enabled_hooks=[])
+    assert script.startswith("set -u")
+    assert "_hook()" not in script
+
+
+# ---------------------------------------------------------------------------
+# parse_results
+# ---------------------------------------------------------------------------
+
+
+def test_parse_results_one_per_line() -> None:
+    out = (
+        "  ✓ portainer\n"
+        "RESULT hook=portainer status=configured\n"
+        "RESULT hook=n8n status=already-configured\n"
+        "  ⚠ metabase not ready after 120s — skipping setup\n"
+        "RESULT hook=metabase status=skipped-not-ready\n"
+        "RESULT hook=openmetadata status=failed\n"
+    )
+    results = parse_results(out)
+    assert results == (
+        HookResult(name="portainer", status="configured"),
+        HookResult(name="n8n", status="already-configured"),
+        HookResult(name="metabase", status="skipped-not-ready"),
+        HookResult(name="openmetadata", status="failed"),
+    )
+
+
+def test_parse_results_invalid_status_skipped() -> None:
+    """Lines with invalid status values (typos, future statuses) are dropped."""
+    out = "RESULT hook=foo status=configured\nRESULT hook=bar status=bogus-status"
+    results = parse_results(out)
+    assert results == (HookResult(name="foo", status="configured"),)
+
+
+def test_parse_results_empty_input() -> None:
+    assert parse_results("") == ()
+
+
+# ---------------------------------------------------------------------------
+# SetupResult counters
+# ---------------------------------------------------------------------------
+
+
+def test_setup_result_counters() -> None:
+    r = SetupResult(
+        hooks=(
+            HookResult(name="a", status="configured"),
+            HookResult(name="b", status="configured"),
+            HookResult(name="c", status="already-configured"),
+            HookResult(name="d", status="skipped-not-ready"),
+            HookResult(name="e", status="failed"),
+        )
+    )
+    assert r.configured == 2
+    assert r.already_configured == 1
+    assert r.skipped_not_ready == 1
+    assert r.failed == 1
+    assert r.is_success is False
+
+
+def test_setup_result_empty_is_success() -> None:
+    """Zero hooks = no failures = success."""
+    assert SetupResult(hooks=()).is_success is True
+
+
+# ---------------------------------------------------------------------------
+# run_admin_setups — orchestration
+# ---------------------------------------------------------------------------
+
+
+def _ok_runner(stdout: str) -> Any:
+    def runner(_script: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(args=["ssh"], returncode=0, stdout=stdout, stderr="")
+
+    return runner
+
+
+def test_run_admin_setups_filters_unknown_services() -> None:
+    """Services without a renderer don't reach the remote script."""
+    captured: dict[str, str] = {}
+
+    def capture(script: str) -> subprocess.CompletedProcess[str]:
+        captured["script"] = script
+        return subprocess.CompletedProcess(
+            args=["ssh"],
+            returncode=0,
+            stdout="RESULT hook=portainer status=configured",
+            stderr="",
+        )
+
+    run_admin_setups(
+        _make_config(),
+        _make_env(),
+        ["portainer", "filestash", "gitea"],
+        script_runner=capture,
+    )
+    # filestash + gitea (not in 2.2b registry) must NOT reach the script
+    assert "filestash_hook" not in captured["script"]
+    assert "gitea_hook" not in captured["script"]
+    assert "portainer_hook" in captured["script"]
+
+
+def test_run_admin_setups_all_unknown_returns_empty_result() -> None:
+    """If no enabled service has a renderer, we don't even invoke ssh."""
+    runner_invoked = []
+
+    def runner(_script: str) -> subprocess.CompletedProcess[str]:
+        runner_invoked.append(True)
+        return subprocess.CompletedProcess(args=["ssh"], returncode=0, stdout="", stderr="")
+
+    result = run_admin_setups(
+        _make_config(),
+        _make_env(),
+        ["filestash", "gitea"],
+        script_runner=runner,
+    )
+    assert result == SetupResult(hooks=())
+    assert runner_invoked == []
+
+
+def test_run_admin_setups_missing_result_line_counts_as_failed() -> None:
+    """A hook that did NOT emit a RESULT line counts as failed
+    (server-side ssh hung up mid-script, etc.)."""
+    out = "RESULT hook=portainer status=configured\n"  # n8n missing
+    result = run_admin_setups(
+        _make_config(),
+        _make_env(),
+        ["portainer", "n8n"],
+        script_runner=_ok_runner(out),
+    )
+    by_name = {h.name: h.status for h in result.hooks}
+    assert by_name["portainer"] == "configured"
+    assert by_name["n8n"] == "failed"
+
+
+def test_run_admin_setups_forwards_remote_warnings_to_local_stderr(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Modul-1.2 Round-4 lesson: ⚠ warnings reach local stderr."""
+    out = (
+        "  ⚠ metabase not ready after 120s — skipping setup\n"
+        "RESULT hook=metabase status=skipped-not-ready\n"
+    )
+    run_admin_setups(_make_config(), _make_env(), ["metabase"], script_runner=_ok_runner(out))
+    captured = capsys.readouterr()
+    assert "metabase not ready after 120s" in captured.err
+    # RESULT line is wire-format, must NOT pollute stderr
+    assert "RESULT hook=metabase" not in captured.err
+
+
+# ---------------------------------------------------------------------------
+# CLI integration — direct _services_configure unit tests with monkeypatch
+# (subprocess CLI tests covered via _run_cli below for arg-parsing cases)
+# ---------------------------------------------------------------------------
+
+
+def _run_cli(
+    args: list[str],
+    *,
+    stdin: str = "{}",
+    env: dict[str, str] | None = None,
+) -> tuple[int, str, str]:
+    full_env = os.environ.copy()
+    if env:
+        full_env.update(env)
+    proc = subprocess.run(
+        [sys.executable, "-m", "nexus_deploy", "services", *args],
+        capture_output=True,
+        text=True,
+        env=full_env,
+        input=stdin,
+    )
+    return proc.returncode, proc.stdout, proc.stderr
+
+
+def test_cli_services_missing_subcommand_returns_2() -> None:
+    rc, _, err = _run_cli([])
+    assert rc == 2
+    assert "only 'configure'" in err
+
+
+def test_cli_services_configure_missing_enabled_returns_2() -> None:
+    rc, _, err = _run_cli(["configure"])
+    assert rc == 2
+    assert "--enabled" in err
+
+
+def test_cli_services_configure_empty_enabled_returns_zero() -> None:
+    rc, out, _ = _run_cli(["configure", "--enabled", ""])
+    assert rc == 0
+    assert "nothing to do" in out
+
+
+def test_cli_services_configure_unknown_arg_returns_2() -> None:
+    rc, _, err = _run_cli(["configure", "--enabled", "portainer", "--bogus"])
+    assert rc == 2
+    assert "unknown arg" in err
+
+
+def test_cli_services_configure_subcommand_typo_returns_2() -> None:
+    """`services up`, `services down` etc. all rejected."""
+    rc, _, err = _run_cli(["up", "--enabled", "x"])
+    assert rc == 2
+    assert "only 'configure'" in err
+
+
+# CLI rc-mapping unit tests via monkeypatch (avoid spinning subprocesses for
+# the rc=0/1/2 contract — same pattern as test_compose_runner.py).
+
+
+@pytest.mark.parametrize(
+    ("hooks", "expected_rc"),
+    [
+        # All success
+        (
+            (
+                HookResult(name="portainer", status="configured"),
+                HookResult(name="n8n", status="already-configured"),
+            ),
+            0,
+        ),
+        # Empty
+        ((), 0),
+        # Partial: some success, some failed → rc=1
+        (
+            (
+                HookResult(name="portainer", status="configured"),
+                HookResult(name="metabase", status="failed"),
+            ),
+            1,
+        ),
+        # All failed → rc=2 (orchestrator should abort)
+        ((HookResult(name="portainer", status="failed"),), 2),
+        # Skipped-not-ready alone is success (no failures)
+        ((HookResult(name="portainer", status="skipped-not-ready"),), 0),
+    ],
+)
+def test_services_configure_cli_rc_mapping(
+    monkeypatch: pytest.MonkeyPatch,
+    hooks: tuple[HookResult, ...],
+    expected_rc: int,
+) -> None:
+    """Verify the rc=0/1/2 contract via direct `_services_configure` call."""
+    from nexus_deploy.__main__ import _services_configure
+
+    def fake_run(_config: Any, _env: Any, _enabled: list[str]) -> SetupResult:
+        return SetupResult(hooks=hooks)
+
+    monkeypatch.setattr("nexus_deploy.__main__.run_admin_setups", fake_run)
+    monkeypatch.setattr("sys.stdin.read", lambda: "{}")
+    rc = _services_configure(["configure", "--enabled", "portainer"])
+    assert rc == expected_rc
+
+
+def test_services_configure_cli_rc2_on_unexpected_exception(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Programming errors → rc=2; secret-bearing message NEVER printed."""
+    from nexus_deploy.__main__ import _services_configure
+
+    def boom(_c: Any, _e: Any, _en: list[str]) -> SetupResult:
+        raise RuntimeError("secret-bearing-message-NEVER-print")
+
+    monkeypatch.setattr("nexus_deploy.__main__.run_admin_setups", boom)
+    monkeypatch.setattr("sys.stdin.read", lambda: "{}")
+    rc = _services_configure(["configure", "--enabled", "portainer"])
+    assert rc == 2
+    captured = capsys.readouterr()
+    assert "RuntimeError" in captured.err
+    assert "secret-bearing-message-NEVER-print" not in captured.err
+
+
+def test_services_configure_cli_rc2_on_transport_failure(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """ssh/rsync failure → rc=2. exc.cmd must NOT leak to stderr."""
+    from nexus_deploy.__main__ import _services_configure
+
+    def boom(_c: Any, _e: Any, _en: list[str]) -> SetupResult:
+        raise subprocess.CalledProcessError(255, ["ssh", "with-secret-arg"])
+
+    monkeypatch.setattr("nexus_deploy.__main__.run_admin_setups", boom)
+    monkeypatch.setattr("sys.stdin.read", lambda: "{}")
+    rc = _services_configure(["configure", "--enabled", "portainer"])
+    assert rc == 2
+    captured = capsys.readouterr()
+    assert "transport failure" in captured.err
+    assert "with-secret-arg" not in captured.err

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -270,61 +270,76 @@ def test_no_credential_leaks_into_subprocess_argv_per_hook(
                     )
 
 
-def test_round_4_setup_body_via_jq_no_argv_leak() -> None:
-    """R4 — admin password is shlex-quoted into the rendered bash AND
-    fed to curl via stdin (--data-binary @-), never via argv.
+def test_round_4_setup_body_via_env_no_argv_leak() -> None:
+    """R4 — admin password is injected to jq via env var (NOT --arg
+    positional argv) and fed to curl via stdin (--data-binary @-),
+    never via argv.
 
-    Critical: a future bug that put the password into curl's argv
-    would leak it via `ps`. We assert that:
-      1. The password value appears in the script (it's quoted into
-         the jq --arg pipeline — that's expected and bash-safe)
-      2. The password value does NOT appear on any line that also
-         contains a curl invocation (which would mean it's in argv)
+    Critical: a future bug that put the password into curl's OR
+    jq's argv would leak it via `ps` on the remote host. We assert
+    that:
+      1. The password value appears in the rendered script (it's
+         the value of an env-var assignment — that's expected and
+         bash-safe; bash builtins / env-var-to-cmd assignments don't
+         fork).
+      2. The password value does NOT appear AFTER a forking-command
+         token (curl, jq) on any line — meaning it's never in argv.
+
+    The detailed cross-hook version of this check lives in
+    ``test_no_credential_leaks_into_subprocess_argv_per_hook``;
+    this test pins the Metabase-specific shape.
     """
     canary = "UNIQUE-METABASE-PWD-LEAK-CANARY"
     config = _make_config(metabase_admin_password=canary)
     script = render_metabase_hook(config, _make_env())
-    # The password reaches the bash via shlex-quoted positional arg to jq
-    assert canary in script
-    # No curl line carries the literal password (would mean it's in argv)
+    assert canary in script, "Canary must appear (as env-var value)"
+    # Canary must NOT appear AFTER curl/jq on any line (= not in argv)
     for line in script.splitlines():
-        if "curl " in line:
-            assert canary not in line, f"Password leaked into curl argv: {line!r}"
-    # AND the orchestrator rendered script does use --data-binary @- for
-    # the POST body (sanity check — global, not per-line)
+        for cmd_token in ("curl ", "jq "):
+            idx_cmd = line.find(cmd_token)
+            idx_canary = line.find(canary)
+            if idx_cmd >= 0 and idx_canary > idx_cmd:
+                raise AssertionError(f"Password leaked into {cmd_token.strip()} argv: {line!r}")
+    # And the rendered script uses --data-binary @- for the POST body
     assert "--data-binary @-" in script
 
 
-def test_round_4_setup_body_jq_build_via_bash_exec() -> None:
-    """R4 exec — verify the rendered jq pipeline actually builds valid JSON.
+def test_round_4_setup_body_built_correctly_against_rendered_script() -> None:
+    """R4 exec — drive the ACTUAL rendered jq pipeline against a known
+    config and assert the resulting JSON parses + has expected
+    fields, even with shell-meta characters in the password.
 
-    Modul-2.0 lesson: pin bash semantics, not just static text. The
-    Metabase setup body uses jq with --arg for safe quoting; this
-    test runs the jq invocation against a known config and asserts
-    the resulting JSON parses + has the expected fields + the
-    password is escaped correctly even when it contains shell
-    metacharacters.
+    Earlier this test built a hand-coded jq snippet that was decoupled
+    from the renderer — it could pass even if the real renderer drifted.
+    Now we extract the BODY=$(...) line from the rendered script,
+    execute it via bash -c, and parse the captured JSON. This pins
+    the renderer's actual jq form against shell-meta-character
+    payloads.
     """
-    # Password with shell-special chars to stress-test the quoting
     nasty_password = 'evil"$(date)`whoami`'
-    snippet = f"""
-set -euo pipefail
-SETUP_TOKEN=tok123
-BODY=$(jq -n \\
-    --arg token "$SETUP_TOKEN" \\
-    --arg email "ops@example.com" \\
-    --arg password {
-        repr(nasty_password).replace("'", "'\\''")
-        if "'" in nasty_password
-        else "'" + nasty_password + "'"
-    } \\
-    '{{token: $token, user: {{email: $email, password: $password}}}}')
-printf '%s' "$BODY"
-"""
+    config = _make_config(metabase_admin_password=nasty_password)
+    full_script = render_metabase_hook(config, _make_env())
+    # Extract the BODY=$(...) jq-build block from the rendered script.
+    # It's a multi-line continuation: BODY=$(NEXUS_TOKEN=... NEXUS_E=...
+    # NEXUS_P=... jq -n '{...}')
+    lines = full_script.splitlines()
+    body_start = next(i for i, line in enumerate(lines) if line.strip().startswith("BODY=$(NEXUS_"))
+    body_end = body_start
+    while not lines[body_end].rstrip().endswith(")"):
+        body_end += 1
+    body_lines = lines[body_start : body_end + 1]
+    # The rendered version uses an implicit SETUP_TOKEN runtime-shell var
+    # (captured from /api/session/properties); inject it explicitly.
+    snippet = (
+        "set -euo pipefail\nSETUP_TOKEN=tok123\n"
+        + "\n".join(body_lines)
+        + '\nprintf "%s" "$BODY"\n'
+    )
     out = subprocess.run(["bash", "-c", snippet], capture_output=True, text=True, check=True).stdout
     parsed = json.loads(out)
     assert parsed["user"]["password"] == nasty_password
     assert parsed["token"] == "tok123"
+    assert parsed["user"]["email"] == "ops@example.com"
 
 
 def test_round_5_idempotent_skip_via_substring_match() -> None:

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -129,13 +129,23 @@ def test_render_metabase_hook_uses_admin_email() -> None:
 def test_render_lakefs_hook_picks_hetzner_when_both_bucket_and_server_set() -> None:
     """Storage namespace selection mirrors legacy deploy.sh — BOTH
     `hetzner_s3_bucket_lakefs` AND `hetzner_s3_server` must be set
-    to land in the s3:// namespace."""
+    to land in the s3:// namespace.
+
+    Test fixture intentionally uses a non-URL-shaped server value
+    (``hetzner-s3-fake-host``) to avoid CodeQL's "Incomplete URL
+    substring sanitization" false-positive — the rule fires on
+    ``"foo.com" in some_url`` patterns intended for security
+    decisions, but this assertion just checks rendered-bash content.
+    """
     script = render_lakefs_hook(
-        _make_config(hetzner_s3_bucket_lakefs="b1", hetzner_s3_server="s3.example.com"),
+        _make_config(
+            hetzner_s3_bucket_lakefs="b1",
+            hetzner_s3_server="hetzner-s3-fake-host",
+        ),
         _make_env(),
     )
     assert "b1" in script
-    assert "s3.example.com" in script
+    assert "hetzner-s3-fake-host" in script
     # The if-condition tests both vars
     assert '[ -n "$HETZNER_BUCKET" ] && [ -n "$HETZNER_SERVER" ]' in script
 

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -126,17 +126,39 @@ def test_render_metabase_hook_uses_admin_email() -> None:
     assert "/api/setup" in script
 
 
-def test_render_lakefs_hook_picks_hetzner_bucket_when_set() -> None:
-    """Storage namespace selection mirrors deploy.sh:2762-2770."""
-    script = render_lakefs_hook(_make_config(hetzner_s3_bucket_lakefs="b1"), _make_env())
+def test_render_lakefs_hook_picks_hetzner_when_both_bucket_and_server_set() -> None:
+    """Storage namespace selection mirrors legacy deploy.sh — BOTH
+    `hetzner_s3_bucket_lakefs` AND `hetzner_s3_server` must be set
+    to land in the s3:// namespace."""
+    script = render_lakefs_hook(
+        _make_config(hetzner_s3_bucket_lakefs="b1", hetzner_s3_server="s3.example.com"),
+        _make_env(),
+    )
     assert "b1" in script
-    assert "hetzner-object-storage" in script
+    assert "s3.example.com" in script
+    # The if-condition tests both vars
+    assert '[ -n "$HETZNER_BUCKET" ] && [ -n "$HETZNER_SERVER" ]' in script
 
 
 def test_render_lakefs_hook_falls_back_to_local_when_no_hetzner() -> None:
-    script = render_lakefs_hook(_make_config(hetzner_s3_bucket_lakefs=""), _make_env())
+    script = render_lakefs_hook(
+        _make_config(hetzner_s3_bucket_lakefs="", hetzner_s3_server=""), _make_env()
+    )
     assert "local://data/lakefs/" in script
     assert "local-storage" in script
+
+
+def test_render_lakefs_hook_falls_back_when_only_bucket_set_no_server() -> None:
+    """Round-7 finding: bucket alone is NOT enough — endpoint is also
+    required. Without the server, lakefs has no way to read/write S3.
+    The legacy deploy.sh required BOTH; we must too."""
+    config = _make_config(hetzner_s3_bucket_lakefs="b1", hetzner_s3_server="")
+    script = render_lakefs_hook(config, _make_env())
+    # Both fields are present in the rendered script (their values
+    # get baked in), but at runtime the AND-check will land in the
+    # local:// branch because HETZNER_SERVER is empty. We pin the
+    # AND-check structure here.
+    assert '[ -n "$HETZNER_BUCKET" ] && [ -n "$HETZNER_SERVER" ]' in script
 
 
 def test_render_openmetadata_hook_3_step_flow() -> None:

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -269,8 +269,15 @@ def test_no_credential_leaks_into_subprocess_argv_per_hook(
 
     Bash builtins (printf, env-var assignments via ``VAR=value cmd``)
     don't fork — values can safely appear on those lines without
-    reaching ``ps``. Non-builtins (curl, jq, base64, tr) DO fork —
-    any positional value on those lines hits ``ps``.
+    reaching ``ps``.
+
+    Scope of THIS test: ``curl`` + ``jq`` only — the two non-builtins
+    that currently consume credentials in this module. Other forking
+    commands the rendered scripts use (``base64``, ``tr``, ``mktemp``,
+    ``chmod``) all read from stdin or operate on tmpfile paths
+    rather than taking secrets as positional args, so they're not
+    on the leak-path here. Future hooks adding a new credential-
+    handling fork-tool should extend this test's command list.
     """
     script = renderer(_make_config(**{canary_field: canary_value}), _make_env())
     assert canary_value in script, "Canary must appear somewhere in the script"


### PR DESCRIPTION
## Summary

Phase 2 Modul 2.2b — migrate the **5 REST first-init admin-setup hooks** in `scripts/deploy.sh` ([7/7] Auto-configuring services section): Portainer, n8n, Metabase, LakeFS, OpenMetadata. ~243 Bash-Zeilen → ~120 Py + 600 LoC tests.

**deploy.sh shrinks from 4514 → 4271 lines (−243).** Cumulative Phase 1+2 delta: 5539 → 4271 (**−1268 lines, ~22.9%**).

## Why split from the original plan

The approved Appendix C plan called for migrating **all 9 admin-setup hooks** in one PR. After reading the source, the docker-exec family (Filestash, RedPanda, Superset) and Gitea (synchronous, depends on Postgres + seeder) have patterns different enough that fitting all 9 into one tidy abstraction leaks. Triggering the playbook's stop-condition (`PR-Größe explodiert über ~1500 LoC → split nach Family`) preemptively:

- **2.2b** (this PR): 5 REST first-init hooks (cleanest shared pattern)
- **2.2c** (next): docker-exec family (Filestash, RedPanda, Superset)
- **2.2d** (after): Gitea (synchronous, complex)

## Per-hook bash renderers

No shared abstraction — patterns differ enough that explicit per-hook functions are clearer than a leaky parametrised dataclass:

| Hook | Wait | Idempotent skip | Setup |
|---|---|---|---|
| Portainer | `/api/system/status` 5s | response substring `already initialized` | `POST /api/users/admin/init` (no auth) |
| n8n | `/healthz` 60s | `GET /rest/settings`.`showSetupOnFirstLoad`==false | `POST /rest/owner/setup` (no auth) |
| Metabase | `/api/health` 120s | no `setup-token` field in `/api/session/properties` | `POST /api/setup` (token-as-auth) |
| LakeFS | `/api/v1/healthcheck` 60s | `"setup_complete":true` in `/api/v1/config` | `POST /api/v1/setup_lakefs` + `POST /api/v1/repositories` (basic-auth) |
| OpenMetadata | `/api/v1/system/version` grep `version` 180s | default-pwd login fails with `invalid` | login (base64 default) → `PUT /api/v1/users/changePassword` (Bearer) → verify-login |

## Eight rounds of hardening

| # | Round | Test |
|---|---|---|
| R1 | Orchestrator uses `set -u` (NOT `set -e`) — hook failures must not abort | `test_round_1_set_minus_u_at_top_no_set_e` |
| R2 | Per-spec healthcheck timeouts | `test_round_2_per_spec_healthcheck_timeouts` |
| R3 | EXIT trap concept implicit per-hook (no shared tmpfiles) | covered by hook self-containment |
| R4 | JSON body via jq `--arg` + `curl --data-binary @-` (token NEVER in argv) | `test_round_4_setup_body_via_jq_no_argv_leak` + **exec'd-bash** with shell-meta password |
| R5 | Idempotent skip per hook | `test_round_5_idempotent_skip_via_substring_match` |
| R6 | Hook failure does NOT abort orchestrator | `test_round_6_hook_failure_does_not_abort_orchestrator` |
| R7 | Hook execution order deterministic | `test_round_7_hook_execution_order_deterministic` |
| R8 | RESULT-line-per-hook wire format | `test_round_8_per_hook_emits_exactly_one_result_line` (parameterized × 5) |

Plus per-hook snapshot tests, skip-on-missing-credential paths, and CLI integration covering rc=0/1/2 via monkeypatched `_services_configure`.

## CLI contract

```
echo "$SECRETS_JSON" | DOMAIN=… ADMIN_EMAIL=… \
    uv run python -m nexus_deploy services configure \
    --enabled "portainer,n8n,metabase,lakefs,openmetadata"
```

| rc | Meaning | deploy.sh handling |
|---|---|---|
| 0 | All hooks ended in configured / already-configured / skipped-not-ready | continue |
| 1 | At least one hook failed but at least one succeeded | yellow warning, continue |
| 2 | Bad args / transport / unexpected error / all-failed | red, abort |

## Quality gates

- `ruff format --check`, `ruff check` — clean
- `mypy --strict` — clean
- `pytest` — 288/288 pass (was 240; +48 new tests)
- Coverage — **100%** on `src/nexus_deploy/services.py`, 100% project total
- `bash -n scripts/deploy.sh` — parses

## Test plan

- [ ] CI green
- [ ] Manual spin-up on test VM with `enabled_services=portainer,gitea,grafana,infisical` (gitea won't be configured this PR — 2.2d):
  - `services configure: configured=1 already-configured=0 skipped-not-ready=0 failed=0`
  - Portainer admin login works with the configured credentials
  - Re-run: `services configure: configured=0 already-configured=1 ...` → rc=0

## Out of scope

- Filestash + RedPanda + Superset (docker-exec) — **Modul 2.2c**
- Gitea (synchronous, complex, depends on Postgres + seeder) — **Modul 2.2d**
- SFTPGo, Garage, Windmill, Wikijs, Dify — future modules

Closes part of #505 (Phase 2 sub-tasks 2.2b.x).
