### PR TITLE
feat(nexus_deploy): Phase 2 Modul 2.3 — Kestra flow registration

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -3338,175 +3338,27 @@ REMOTE_KESTRA_PROBE_EOF
                     #   anything else           → real failure, surfaced as
                     #                              warning
                     # ----------------------------------------------------------
-                    REGISTER_USER_B64=$(printf '%s' "$ADMIN_EMAIL" | base64 | tr -d '\n')
-                    REGISTER_PW_B64=$(printf '%s' "$KESTRA_PASS" | base64 | tr -d '\n')
-                    if ssh nexus "bash -s" <<REMOTE_REGISTER_EOF
-set -o pipefail
-KESTRA_USER=\$(printf '%s' '$REGISTER_USER_B64' | base64 -d)
-KESTRA_PW=\$(printf '%s' '$REGISTER_PW_B64' | base64 -d)
-
-KCFG=\$(mktemp)
-chmod 600 "\$KCFG"
-trap 'rm -f "\$KCFG"' EXIT
-printf 'user = "%s:%s"\n' "\$KESTRA_USER" "\$KESTRA_PW" > "\$KCFG"
-
-# Kestra v1.0 has split create/update semantics:
-#   POST /api/v1/flows               → creates new; returns 422 with
-#                                       body "Flow id already exists"
-#                                       when the flow is already there.
-#   PUT  /api/v1/flows/{ns}/{id}     → updates existing; returns 404
-#                                       if the flow doesn't exist yet.
-# Neither verb alone is upsert. So: try POST first; on 422, fall back to PUT.
-# This is what makes the registration idempotent across re-runs AND lets
-# us push schema changes (e.g. adding \`targetNamespace\` to flow-sync)
-# without having to manually delete the old flow first.
-register_flow() {
-    local FLOW_NAME="\$1"
-    local FLOW_BODY="\$2"
-    local STATUS
-    # \`|| true\` instead of \`|| echo "000"\` — see SEED_STATUS comment
-    # in the runner-side block; the latter would concatenate a second
-    # "000" onto curl's own "000" when the connection fails.
-    STATUS=\$(printf '%s' "\$FLOW_BODY" | curl -s -o /dev/null -w '%{http_code}' \\
-        -X POST 'http://localhost:8085/api/v1/flows' \\
-        --config "\$KCFG" \\
-        -H 'Content-Type: application/x-yaml' \\
-        --data-binary @- 2>/dev/null) || true
-    STATUS="\${STATUS:-000}"
-    case "\$STATUS" in
-        200|201)
-            echo "    ✓ \$FLOW_NAME registered (HTTP \$STATUS)" >&2
-            return 0
-            ;;
-        422)
-            # "Flow id already exists" is the idempotent re-run case.
-            # Update with PUT instead. FLOW_NAME format is "ns.id".
-            local NS="\${FLOW_NAME%.*}" ID="\${FLOW_NAME##*.}" PUT_STATUS
-            PUT_STATUS=\$(printf '%s' "\$FLOW_BODY" | curl -s -o /dev/null -w '%{http_code}' \\
-                -X PUT "http://localhost:8085/api/v1/flows/\$NS/\$ID" \\
-                --config "\$KCFG" \\
-                -H 'Content-Type: application/x-yaml' \\
-                --data-binary @- 2>/dev/null) || true
-            PUT_STATUS="\${PUT_STATUS:-000}"
-            case "\$PUT_STATUS" in
-                200|201)
-                    echo "    ✓ \$FLOW_NAME updated (POST 422 → PUT \$PUT_STATUS, idempotent re-run)" >&2
-                    return 0
-                    ;;
-                *)
-                    echo "    ⚠ \$FLOW_NAME update failed (POST 422 → PUT \$PUT_STATUS)" >&2
-                    return 1
-                    ;;
-            esac
-            ;;
-        *)
-            echo "    ⚠ \$FLOW_NAME registration failed (HTTP \$STATUS)" >&2
-            return 1
-            ;;
-    esac
-}
-
-REGISTER_FAILED=0
-register_flow "system.git-sync" 'id: git-sync
-namespace: system
-tasks:
-  - id: sync
-    type: io.kestra.plugin.git.SyncNamespaceFiles
-    url: http://gitea:3000/${GITEA_REPO_OWNER}/${REPO_NAME}.git
-    branch: ${WORKSPACE_BRANCH}
-    username: ${ADMIN_USERNAME}
-    password: "{{ secret('\''GITEA_TOKEN'\'') }}"
-    namespace: "{{ flow.namespace }}"
-    gitDirectory: nexus_seeds/kestra/workflows
-triggers:
-  - id: schedule
-    type: io.kestra.core.models.triggers.types.Schedule
-    cron: "*/15 * * * *"' || REGISTER_FAILED=\$((REGISTER_FAILED+1))
-
-register_flow "system.flow-sync" 'id: flow-sync
-namespace: system
-description: Pull flow definitions from internal Gitea, register them in Kestra. Git is source of truth.
-tasks:
-  - id: sync
-    type: io.kestra.plugin.git.SyncFlows
-    url: http://gitea:3000/${GITEA_REPO_OWNER}/${REPO_NAME}.git
-    branch: ${WORKSPACE_BRANCH}
-    username: ${ADMIN_USERNAME}
-    password: "{{ secret('\''GITEA_TOKEN'\'') }}"
-    gitDirectory: nexus_seeds/kestra/flows
-    targetNamespace: nexus-tutorials
-    includeChildNamespaces: true
-    delete: true
-triggers:
-  - id: schedule
-    type: io.kestra.core.models.triggers.types.Schedule
-    cron: "*/15 * * * *"' || REGISTER_FAILED=\$((REGISTER_FAILED+1))
-
-# ----------------------------------------------------------------
-# Verify the seeded flow actually lands in Kestra.
-#
-# Without this, system.flow-sync only runs on its 15-min cron, so
-# the nexus-tutorials.r2-taxi-pipeline flow doesn't appear in Kestra until
-# the next tick — long after deploy.sh prints "Deployment Complete".
-# Operators reasonably expect the flow to be there immediately and
-# we've already burned cycles debugging "where's the flow?" twice
-# this PR. So: kick one manual execution of system.flow-sync, poll
-# its state up to 60 s, then GET the seeded flow's path. Each step
-# warns clearly if it didn't pan out instead of failing the deploy
-# (the operator can always Execute system.flow-sync manually from
-# the UI as a fallback).
-if [ "\$REGISTER_FAILED" -eq 0 ]; then
-    EXEC_RESP=\$(curl -s --config "\$KCFG" \\
-        -X POST 'http://localhost:8085/api/v1/executions/system/flow-sync' 2>/dev/null) || EXEC_RESP=""
-    EXEC_ID=\$(echo "\$EXEC_RESP" | jq -r '.id // empty' 2>/dev/null)
-
-    if [ -z "\$EXEC_ID" ]; then
-        echo "    ⚠ Could not trigger system.flow-sync execution — first sync will run on the next 15-min cron tick" >&2
-    else
-        # flow-sync = git clone of the workspace repo + a handful of
-        # API calls; usually ~5–10 s. Cap at 30 × 2 s = 60 s.
-        SYNC_STATE=""
-        for poll in \$(seq 1 30); do
-            SYNC_STATE=\$(curl -s --config "\$KCFG" \\
-                "http://localhost:8085/api/v1/executions/\$EXEC_ID" 2>/dev/null \\
-                | jq -r '.state.current // empty' 2>/dev/null)
-            case "\$SYNC_STATE" in
-                SUCCESS|FAILED|KILLED) break ;;
-            esac
-            sleep 2
-        done
-
-        case "\$SYNC_STATE" in
-            SUCCESS)
-                # The flow should now be in Kestra under namespace nexus-tutorials.
-                SEED_FLOW_STATUS=\$(curl -s -o /dev/null -w '%{http_code}' \\
-                    --config "\$KCFG" \\
-                    'http://localhost:8085/api/v1/flows/nexus-tutorials/r2-taxi-pipeline' 2>/dev/null) || true
-                SEED_FLOW_STATUS="\${SEED_FLOW_STATUS:-000}"
-                if [ "\$SEED_FLOW_STATUS" = "200" ]; then
-                    echo "    ✓ Seeded flow nexus-tutorials.r2-taxi-pipeline registered in Kestra" >&2
-                else
-                    echo "    ⚠ system.flow-sync ran but nexus-tutorials.r2-taxi-pipeline is not visible (HTTP \$SEED_FLOW_STATUS) — check that nexus_seeds/kestra/flows/r2-taxi-pipeline.yaml is in the workspace repo and re-execute system.flow-sync from the Kestra UI" >&2
-                fi
-                ;;
-            FAILED|KILLED)
-                echo "    ⚠ system.flow-sync execution \$SYNC_STATE — open the execution in the Kestra UI for the error log" >&2
-                ;;
-            *)
-                echo "    ⚠ system.flow-sync did not complete within 60 s (state=\$SYNC_STATE) — first regular cron tick will retry within 15 min" >&2
-                ;;
-        esac
-    fi
-fi
-
-[ "\$REGISTER_FAILED" -eq 0 ] || exit 1
-exit 0
-REMOTE_REGISTER_EOF
-                    then
-                        echo -e "${GREEN}  ✓ Kestra Git sync flows created (workflows + flows)${NC}"
-                    else
-                        echo -e "${YELLOW}  ⚠ Kestra Git sync flow registration had failures (check log above)${NC}"
-                    fi
+                    # Phase 2 Modul 2.3 (#505) — moved from a 165-line
+                    # remote bash heredoc (POST/PUT register_flow function +
+                    # 2 inline YAML templates + flow-sync execute/poll) to
+                    # nexus_deploy.kestra. Same idempotent POST-then-PUT
+                    # semantics; same one-shot flow-sync trigger to onboard
+                    # user-seeded flows immediately. The Python path opens
+                    # an SSH port-forward (8085→8085) and talks to Kestra
+                    # via local HTTP, no rendered server-side bash.
+                    KESTRA_RC=0
+                    GITEA_REPO_OWNER="$GITEA_REPO_OWNER" \
+                        REPO_NAME="$REPO_NAME" \
+                        WORKSPACE_BRANCH="$WORKSPACE_BRANCH" \
+                        ADMIN_EMAIL="$ADMIN_EMAIL" \
+                        echo "$SECRETS_JSON" | uv run --quiet --project "$PROJECT_ROOT" \
+                        python -m nexus_deploy kestra register-system-flows \
+                        || KESTRA_RC=$?
+                    case "$KESTRA_RC" in
+                        0) echo -e "${GREEN}  ✓ Kestra Git sync flows registered (workflows + flows)${NC}" ;;
+                        1) echo -e "${YELLOW}  ⚠ Kestra Git sync flow registration had partial failures (continuing)${NC}" ;;
+                        *) echo -e "${RED}  ✗ Kestra Git sync flow registration hard failure (rc=$KESTRA_RC); aborting${NC}"; exit "$KESTRA_RC" ;;
+                    esac
                 else
                     echo -e "${YELLOW}  ⚠ Kestra not ready - skipping Git sync flow${NC}"
                 fi

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -3344,8 +3344,9 @@ REMOTE_KESTRA_PROBE_EOF
                     # nexus_deploy.kestra. Same idempotent POST-then-PUT
                     # semantics; same one-shot flow-sync trigger to onboard
                     # user-seeded flows immediately. The Python path opens
-                    # an SSH port-forward (8085→8085) and talks to Kestra
-                    # via local HTTP, no rendered server-side bash.
+                    # an SSH port-forward (kernel-allocated local port →
+                    # remote 8085) and talks to Kestra via local HTTP,
+                    # no rendered server-side bash.
                     # CRITICAL: env-var prefix MUST sit on `uv run`, not on
                     # `echo`. `VAR=value echo … | python …` scopes VAR to the
                     # left-hand `echo` only — the Python process after the

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -3346,12 +3346,19 @@ REMOTE_KESTRA_PROBE_EOF
                     # user-seeded flows immediately. The Python path opens
                     # an SSH port-forward (8085→8085) and talks to Kestra
                     # via local HTTP, no rendered server-side bash.
+                    # CRITICAL: env-var prefix MUST sit on `uv run`, not on
+                    # `echo`. `VAR=value echo … | python …` scopes VAR to the
+                    # left-hand `echo` only — the Python process after the
+                    # pipe never sees it. Caught in PR #517 review pre-spinup;
+                    # without this fix, every Kestra invocation would exit
+                    # rc=2 with "missing required env" on every deploy.
                     KESTRA_RC=0
-                    GITEA_REPO_OWNER="$GITEA_REPO_OWNER" \
+                    echo "$SECRETS_JSON" | \
+                        GITEA_REPO_OWNER="$GITEA_REPO_OWNER" \
                         REPO_NAME="$REPO_NAME" \
                         WORKSPACE_BRANCH="$WORKSPACE_BRANCH" \
                         ADMIN_EMAIL="$ADMIN_EMAIL" \
-                        echo "$SECRETS_JSON" | uv run --quiet --project "$PROJECT_ROOT" \
+                        uv run --quiet --project "$PROJECT_ROOT" \
                         python -m nexus_deploy kestra register-system-flows \
                         || KESTRA_RC=$?
                     case "$KESTRA_RC" in

--- a/src/nexus_deploy/__main__.py
+++ b/src/nexus_deploy/__main__.py
@@ -1,6 +1,6 @@
 """Entry point for `python -m nexus_deploy ...` invocations.
 
-Phase 1 dispatch surface. Subcommands land here as their modules ship.
+Subcommand dispatcher. Subcommands land here as their modules ship.
 Currently:
 - ``config dump-shell`` (#505 Modul 1.3)
 - ``infisical bootstrap`` (#505 Modul 1.1)
@@ -8,7 +8,8 @@ Currently:
 - ``seed --repo <owner>/<name> [--root PATH] [--prefix nexus_seeds/]``
   (#505 Modul 2.1)
 - ``compose up --enabled <comma-list>`` (#505 Modul 2.2a)
-- ``services configure --enabled <comma-list>`` (#505 Modul 2.2b)
+- ``services configure --enabled <comma-list>`` (#505 Modul 2.2b/c/d)
+- ``kestra register-system-flows`` (#505 Modul 2.3)
 """
 
 from __future__ import annotations
@@ -26,9 +27,11 @@ from nexus_deploy.infisical import (
     InfisicalClient,
     compute_folders,
 )
+from nexus_deploy.kestra import run_register_system_flows
 from nexus_deploy.secret_sync import StackTarget, run_sync_for_stack
 from nexus_deploy.seeder import _is_safe_repo_path, run_seed_for_repo
 from nexus_deploy.services import run_admin_setups
+from nexus_deploy.ssh import SSHClient, SSHError
 
 
 def _config_dump_shell(args: list[str]) -> int:
@@ -642,12 +645,128 @@ def _services_configure(args: list[str]) -> int:
     return 0
 
 
+def _kestra_register_system_flows(args: list[str]) -> int:
+    """`nexus-deploy kestra register-system-flows`.
+
+    Opens an SSH port-forward to the nexus host (Kestra binds
+    127.0.0.1:8085 inside the server's bridge network), then registers
+    ``system.git-sync`` + ``system.flow-sync`` via local HTTP and
+    triggers a one-shot ``flow-sync`` execution to onboard
+    user-seeded flows immediately.
+
+    Reads ``NexusConfig`` from stdin (SECRETS_JSON) and the per-deploy
+    repo coordinates from environment variables — same handoff pattern
+    as ``services configure``:
+
+    - ``ADMIN_EMAIL`` — Kestra basic-auth username
+    - ``GITEA_REPO_OWNER`` — owner of the workspace repo (admin in
+      non-mirror, the user in mirror+user mode)
+    - ``REPO_NAME`` — workspace repo name
+    - ``WORKSPACE_BRANCH`` — git branch (default ``main``)
+    - ``KESTRA_HOST`` — SSH host alias (default ``nexus``); exposed
+      so a future test deploy can target a different alias
+
+    Exit codes:
+    - 0: both flows registered (or already-up-to-date) AND the
+         onboarding execute settled in SUCCESS within timeout.
+    - 1: at least one flow registration / execution did NOT succeed
+         (deploy.sh: yellow warning, continue — the cron tick will
+         catch user flows later).
+    - 2: bad args, ssh tunnel setup failure, or unexpected exception
+         (deploy.sh: red, abort).
+    """
+    if args:
+        print(f"kestra register-system-flows: unknown args {args!r}", file=sys.stderr)
+        return 2
+
+    repo_owner = os.environ.get("GITEA_REPO_OWNER") or ""
+    repo_name = os.environ.get("REPO_NAME") or ""
+    branch = os.environ.get("WORKSPACE_BRANCH") or "main"
+    admin_email = os.environ.get("ADMIN_EMAIL") or ""
+    ssh_host = os.environ.get("KESTRA_HOST") or "nexus"
+
+    missing = [
+        name
+        for name, val in (
+            ("GITEA_REPO_OWNER", repo_owner),
+            ("REPO_NAME", repo_name),
+            ("ADMIN_EMAIL", admin_email),
+        )
+        if not val
+    ]
+    if missing:
+        print(
+            f"kestra register-system-flows: missing required env: {', '.join(missing)}",
+            file=sys.stderr,
+        )
+        return 2
+
+    try:
+        config = NexusConfig.from_secrets_json(sys.stdin.read())
+    except ConfigError as exc:
+        print(f"kestra register-system-flows: {exc}", file=sys.stderr)
+        return 2
+
+    if not config.kestra_admin_password:
+        print(
+            "kestra register-system-flows: KESTRA_PASS missing from SECRETS_JSON — "
+            "skipping (Kestra basic-auth would 401 on every call)",
+            file=sys.stderr,
+        )
+        return 0
+
+    try:
+        with SSHClient(ssh_host) as ssh, ssh.port_forward(8085, "localhost", 8085) as port:
+            result = run_register_system_flows(
+                config,
+                base_url=f"http://localhost:{port}",
+                repo_owner=repo_owner,
+                repo_name=repo_name,
+                branch=branch,
+                admin_email=admin_email,
+            )
+    except SSHError as exc:
+        # SSHError is the typed transport-failure path from ssh.py.
+        # str(exc) is intentional here — SSHError messages are fixed
+        # format strings (no subprocess output), see ssh.py docstring.
+        print(f"kestra register-system-flows: ssh tunnel failed: {exc}", file=sys.stderr)
+        return 2
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError) as exc:
+        print(
+            f"kestra register-system-flows: transport failure ({type(exc).__name__})",
+            file=sys.stderr,
+        )
+        return 2
+    except Exception as exc:
+        print(
+            f"kestra register-system-flows: unexpected error ({type(exc).__name__})",
+            file=sys.stderr,
+        )
+        return 2
+
+    # Per-flow result lines so the operator sees the POST/PUT detail
+    # (e.g. "system.git-sync: created (POST 201)") in the deploy log.
+    for flow in result.flows:
+        sys.stderr.write(f"  • {flow.name}: {flow.status} ({flow.detail})\n")
+    if result.execution_state is not None:
+        sys.stderr.write(f"  • system.flow-sync onboarding execution: {result.execution_state}\n")
+    print(
+        f"kestra register-system-flows: "
+        f"created={sum(1 for f in result.flows if f.status == 'created')} "
+        f"updated={sum(1 for f in result.flows if f.status == 'updated')} "
+        f"failed={sum(1 for f in result.flows if f.status == 'failed')} "
+        f"execution={result.execution_state or 'skipped'}",
+    )
+    return 0 if result.is_success else 1
+
+
 def main() -> int:
     """Subcommand dispatcher. Shipped subcommands by phase:
 
     - Phase 1: ``config dump-shell``, ``infisical bootstrap``,
       ``secret-sync``
-    - Phase 2: ``seed``, ``compose up``, ``services configure``
+    - Phase 2: ``seed``, ``compose up``, ``services configure``,
+      ``kestra register-system-flows``
 
     More land as the migration progresses; see #505.
     """
@@ -670,6 +789,8 @@ def main() -> int:
         return _compose_up(args[1:])
     if args[:1] == ["services"]:
         return _services_configure(args[1:])
+    if args[:2] == ["kestra", "register-system-flows"]:
+        return _kestra_register_system_flows(args[2:])
     print(
         f"nexus_deploy {__version__}: unknown command {' '.join(args)!r}",
         file=sys.stderr,
@@ -681,7 +802,8 @@ def main() -> int:
         "secret-sync --stack <jupyter|marimo>, "
         "seed --repo <owner>/<name> [--root PATH] [--prefix nexus_seeds/], "
         "compose up --enabled <comma-list>, "
-        "services configure --enabled <comma-list> (reads SECRETS_JSON from stdin)",
+        "services configure --enabled <comma-list> (reads SECRETS_JSON from stdin), "
+        "kestra register-system-flows (reads SECRETS_JSON from stdin + env vars)",
         file=sys.stderr,
     )
     return 2

--- a/src/nexus_deploy/__main__.py
+++ b/src/nexus_deploy/__main__.py
@@ -650,11 +650,14 @@ def _kestra_register_system_flows(args: list[str]) -> int:
 
     Opens an SSH port-forward to the nexus host. The Kestra container
     listens on port 8080 internally; ``stacks/kestra/docker-compose.yml``
-    publishes it as ``8085:8080`` on the server's loopback interface,
-    so we ``ssh -L <local>:localhost:8085`` to reach the host-published
-    port. Once the tunnel is up we register ``system.git-sync`` +
-    ``system.flow-sync`` via local HTTP and trigger a one-shot
-    ``flow-sync`` execution to onboard user-seeded flows immediately.
+    publishes it as ``8085:8080`` (no explicit host-IP, so it binds
+    every interface on the host — but the host firewall blocks external
+    8085, so the only reachable path is through ssh + the server's
+    loopback). We ``ssh -L 127.0.0.1:<local>:localhost:8085`` to reach
+    the host-published port through the tunnel. Once it's up we
+    register ``system.git-sync`` + ``system.flow-sync`` via local HTTP
+    and trigger a one-shot ``flow-sync`` execution to onboard
+    user-seeded flows immediately.
 
     Reads ``NexusConfig`` from stdin (SECRETS_JSON) and the per-deploy
     repo coordinates from environment variables — same handoff pattern

--- a/src/nexus_deploy/__main__.py
+++ b/src/nexus_deploy/__main__.py
@@ -648,11 +648,13 @@ def _services_configure(args: list[str]) -> int:
 def _kestra_register_system_flows(args: list[str]) -> int:
     """`nexus-deploy kestra register-system-flows`.
 
-    Opens an SSH port-forward to the nexus host (Kestra binds
-    127.0.0.1:8085 inside the server's bridge network), then registers
-    ``system.git-sync`` + ``system.flow-sync`` via local HTTP and
-    triggers a one-shot ``flow-sync`` execution to onboard
-    user-seeded flows immediately.
+    Opens an SSH port-forward to the nexus host. The Kestra container
+    listens on port 8080 internally; ``stacks/kestra/docker-compose.yml``
+    publishes it as ``8085:8080`` on the server's loopback interface,
+    so we ``ssh -L <local>:localhost:8085`` to reach the host-published
+    port. Once the tunnel is up we register ``system.git-sync`` +
+    ``system.flow-sync`` via local HTTP and trigger a one-shot
+    ``flow-sync`` execution to onboard user-seeded flows immediately.
 
     Reads ``NexusConfig`` from stdin (SECRETS_JSON) and the per-deploy
     repo coordinates from environment variables — same handoff pattern

--- a/src/nexus_deploy/__main__.py
+++ b/src/nexus_deploy/__main__.py
@@ -791,15 +791,22 @@ def _kestra_register_system_flows(args: list[str]) -> int:
 
 
 def _allocate_free_port() -> int:
-    """Ask the kernel for a free ephemeral port.
+    """Ask the kernel for a free IPv4 ephemeral port on the loopback.
 
     Bind a socket to ``127.0.0.1:0`` (kernel picks free), record the
     assigned port, immediately close. The returned port is then handed
-    to ``ssh -L`` to re-bind. Race window between close and ssh-rebind
-    is microseconds; for production-deploy-frequency that's fine. If
-    a future contributor needs zero-race, paramiko's port-forward
-    has a callback API but we explicitly chose subprocess + system
-    ssh in Modul 3.1, so this is the right primitive for now.
+    to ``ssh -L 127.0.0.1:<port>:…`` to re-bind. Race window between
+    close and ssh-rebind is microseconds; for production-deploy-
+    frequency that's fine. If a future contributor needs zero-race,
+    paramiko's port-forward has a callback API but we explicitly chose
+    subprocess + system ssh in Modul 3.1, so this is the right
+    primitive for now.
+
+    Note: IPv4-only by design. ``ssh.SSHClient.port_forward`` matches
+    by passing the explicit ``127.0.0.1:`` bind address — without it,
+    ssh on a dual-stack host would also bind ``::1`` and a port that
+    looked free here could still be taken on IPv6, causing intermittent
+    ExitOnForwardFailure aborts (round-4 PR #517 finding).
     """
     import socket
 

--- a/src/nexus_deploy/__main__.py
+++ b/src/nexus_deploy/__main__.py
@@ -708,15 +708,29 @@ def _kestra_register_system_flows(args: list[str]) -> int:
         return 2
 
     if not config.kestra_admin_password:
+        # Round-2 fix: previously rc=0 (mapped to green "registered"
+        # banner in deploy.sh, misleading). rc=1 routes to the yellow-
+        # warning branch — accurate signal that nothing was registered.
         print(
             "kestra register-system-flows: KESTRA_PASS missing from SECRETS_JSON — "
             "skipping (Kestra basic-auth would 401 on every call)",
             file=sys.stderr,
         )
-        return 0
+        return 1
+
+    # Round-2 fix: pick a free local port via socket.bind(0) instead of
+    # hardcoded 8085. Hardcoded would clash with leftover ssh tunnels
+    # or any local service already on 8085; the new pre-bind probe
+    # asks the kernel for a free ephemeral port. Tiny race window
+    # (the port is closed before ssh -L re-binds) but vastly better
+    # than the previous unconditional collision.
+    local_port = _allocate_free_port()
 
     try:
-        with SSHClient(ssh_host) as ssh, ssh.port_forward(8085, "localhost", 8085) as port:
+        with (
+            SSHClient(ssh_host) as ssh,
+            ssh.port_forward(local_port, "localhost", 8085) as port,
+        ):
             result = run_register_system_flows(
                 config,
                 base_url=f"http://localhost:{port}",
@@ -749,7 +763,21 @@ def _kestra_register_system_flows(args: list[str]) -> int:
     for flow in result.flows:
         sys.stderr.write(f"  • {flow.name}: {flow.status} ({flow.detail})\n")
     if result.execution_state is not None:
-        sys.stderr.write(f"  • system.flow-sync onboarding execution: {result.execution_state}\n")
+        # Round-2 fix: per-state actionable warning instead of bare enum.
+        # Mirrors the hint deploy.sh L3464/L3489/L3493/L3496 used to print.
+        hint = _kestra_execution_hint(result.execution_state)
+        sys.stderr.write(
+            f"  • system.flow-sync onboarding execution: {result.execution_state}"
+            f"{(' — ' + hint) if hint else ''}\n",
+        )
+    if result.verify_skipped_reason is not None:
+        # Verification step itself didn't complete (transient 5xx /
+        # transport blip during flow_exists). State stays SUCCESS but
+        # the operator sees that the check wasn't actually run.
+        sys.stderr.write(
+            f"  • seed-flow visibility check skipped: {result.verify_skipped_reason}\n",
+        )
+
     print(
         f"kestra register-system-flows: "
         f"created={sum(1 for f in result.flows if f.status == 'created')} "
@@ -758,6 +786,50 @@ def _kestra_register_system_flows(args: list[str]) -> int:
         f"execution={result.execution_state or 'skipped'}",
     )
     return 0 if result.is_success else 1
+
+
+def _allocate_free_port() -> int:
+    """Ask the kernel for a free ephemeral port.
+
+    Bind a socket to ``127.0.0.1:0`` (kernel picks free), record the
+    assigned port, immediately close. The returned port is then handed
+    to ``ssh -L`` to re-bind. Race window between close and ssh-rebind
+    is microseconds; for production-deploy-frequency that's fine. If
+    a future contributor needs zero-race, paramiko's port-forward
+    has a callback API but we explicitly chose subprocess + system
+    ssh in Modul 3.1, so this is the right primitive for now.
+    """
+    import socket
+
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+    finally:
+        sock.close()
+
+
+# Hints emitted alongside execution_state in stderr — actionable
+# replacements for the bare-enum output. Mirrors deploy.sh's
+# per-case warnings (L3464 cron-tick / L3489 seed-not-visible /
+# L3493 open-execution-in-UI / L3496 didn't-complete).
+_KESTRA_EXECUTION_HINTS: dict[str, str] = {
+    "SUCCESS": "",
+    "FAILED": "open the execution in the Kestra UI for the error log",
+    "KILLED": "open the execution in the Kestra UI for the error log",
+    "RUNNING": "did not complete within the timeout — first regular cron tick will retry within 15 min",
+    "CREATED": "execution stuck in CREATED state — check Kestra worker logs",
+    "UNKNOWN": "execution state could not be determined — check Kestra UI",
+    "TRIGGER_FAILED": "could not trigger execution — first sync will run on the next 15-min cron tick",
+    "SEED_FLOW_MISSING": "system.flow-sync ran but the seeded flow is not visible — "
+    "check that nexus_seeds/kestra/flows/r2-taxi-pipeline.yaml is in the workspace repo "
+    "and re-execute system.flow-sync from the Kestra UI",
+}
+
+
+def _kestra_execution_hint(state: str) -> str:
+    """Return the actionable warning string for a given ExecutionState."""
+    return _KESTRA_EXECUTION_HINTS.get(state, "")
 
 
 def main() -> int:

--- a/src/nexus_deploy/kestra.py
+++ b/src/nexus_deploy/kestra.py
@@ -113,6 +113,13 @@ class SystemFlowsResult:
 
     flows: tuple[RegisterResult, ...]
     execution_state: ExecutionState | None = None  # None if not triggered
+    # Set when the post-execute flow_exists() probe couldn't run
+    # (5xx/transport blip). Doesn't downgrade the SUCCESS state — a
+    # transient HTTP error during verify is recoverable on the next
+    # deploy and reclassifying it would be punishing operators for
+    # network noise. But we still want it surfaced so the operator
+    # sees that the verification step itself didn't complete.
+    verify_skipped_reason: str | None = None
 
     @property
     def is_success(self) -> bool:
@@ -176,6 +183,13 @@ class KestraClient:
         These three == "Kestra is ready and our credentials work".
         Anything else (000/401/403/5xx) keeps the loop running until
         timeout. Returns True on first ready, False on timeout.
+
+        Sleep is **clamped to the deadline**: the loop never sleeps
+        past ``timeout_s``, so a caller passing ``timeout_s=0.05``
+        gets a sub-second response even with the default 3s interval.
+        Without the clamp, the loop would call ``requests.get`` once,
+        sleep the full ``interval_s``, then check the deadline — making
+        short timeouts effectively floor to ``interval_s``.
         """
         deadline = time.monotonic() + timeout_s
         while time.monotonic() < deadline:
@@ -189,7 +203,10 @@ class KestraClient:
                 resp = None
             if resp is not None and resp.status_code in (200, 404, 405):
                 return True
-            time.sleep(interval_s)
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            time.sleep(min(interval_s, remaining))
         return False
 
     def register_flow(
@@ -358,6 +375,10 @@ class KestraClient:
         whichever was reached, or ``"RUNNING"`` if the timeout fired
         before the execution settled (caller maps to a warning, not a
         deploy failure — the execution may finish in the next minute).
+
+        Sleep is clamped to the deadline (same pattern as
+        :meth:`wait_ready`) so short ``timeout_s`` values aren't
+        floored to ``interval_s``.
         """
         deadline = time.monotonic() + timeout_s
         last: ExecutionState = "CREATED"
@@ -370,7 +391,10 @@ class KestraClient:
                 last = "UNKNOWN"
             if last in ("SUCCESS", "FAILED", "KILLED"):
                 return last
-            time.sleep(interval_s)
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            time.sleep(min(interval_s, remaining))
         return last
 
 
@@ -585,10 +609,19 @@ def run_register_system_flows(
     # their tutorial flow. Mirrors deploy.sh L3479-3490 exactly.
     try:
         seed_visible = client.flow_exists(_SEED_VERIFICATION_NS, _SEED_VERIFICATION_ID)
-    except KestraError:
-        # Network blip during verification; don't downgrade the
-        # SUCCESS execution to a failure on a transient HTTP error.
-        return SystemFlowsResult(flows=register_results, execution_state=exec_state)
+    except KestraError as exc:
+        # Network blip during verification: don't downgrade the SUCCESS
+        # execution to a failure (transient HTTP errors are recoverable
+        # on the next deploy; reclassifying would punish operators for
+        # network noise). But surface the verify-failed signal via
+        # ``verify_skipped_reason`` so the CLI emits a stderr warning —
+        # operators see that the check itself didn't complete and can
+        # spot-check the flow visibility manually if needed.
+        return SystemFlowsResult(
+            flows=register_results,
+            execution_state=exec_state,
+            verify_skipped_reason=f"flow_exists raised KestraError ({type(exc).__name__})",
+        )
     if not seed_visible:
         return SystemFlowsResult(flows=register_results, execution_state="SEED_FLOW_MISSING")
     return SystemFlowsResult(flows=register_results, execution_state="SUCCESS")

--- a/src/nexus_deploy/kestra.py
+++ b/src/nexus_deploy/kestra.py
@@ -1,0 +1,509 @@
+"""Kestra flow-registration client (Phase 2 Modul 2.3, #505).
+
+Replaces deploy.sh's L3343-3508 — the ``REMOTE_REGISTER_EOF`` heredoc
+that ssh-piped a server-side bash script which (a) wrote a curl
+``--config`` file with basic-auth, (b) defined a ``register_flow``
+shell function with POST-then-PUT idempotent dispatch, (c) registered
+the two ``system.git-sync`` / ``system.flow-sync`` flows, and (d)
+optionally triggered a one-shot ``flow-sync`` execution to onboard
+user-seeded flows immediately instead of waiting for the 15-min cron.
+
+The new architecture demonstrates the Phase 3 pattern that
+``ssh.SSHClient.port_forward`` was built for: open a tunnel, talk to
+the service via local ``requests`` calls, surface HTTP errors as
+typed Python exceptions. No rendered server-side bash, no
+heredoc-quoting, no escape-twice escape-thrice quoting hell — and
+the entire flow logic is unit-testable against ``responses``-mocked
+HTTP without ever running ssh.
+
+API:
+
+- :class:`KestraClient` — basic-auth REST client. ``wait_ready``,
+  ``register_flow`` (POST 200/201 / 422 → PUT 200/201 / failed),
+  ``execute_flow``, ``wait_for_execution``.
+- :func:`render_system_flow_yaml` — string-template-based YAML
+  builder for the two system flows. Templates ship verbatim from
+  deploy.sh so the registered flow body is byte-equivalent (modulo
+  the substituted variables).
+- :func:`run_register_system_flows` — top-level orchestrator: opens
+  port-forward, waits for Kestra, registers both flows, optionally
+  triggers ``flow-sync``. Returns the full set of register results
+  for the CLI to map to rc=0/1/2.
+
+Auth note (R4): basic-auth credentials are passed to ``requests`` via
+the ``auth=(user, pass)`` keyword, which puts them in the
+``Authorization`` header — never in argv on either host (we don't
+shell out at all here, except to ssh for the tunnel which carries
+no service-side credentials in argv).
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Literal
+
+import requests
+
+from nexus_deploy.config import NexusConfig
+
+# HTTP timeouts:
+# - connect: short (TCP setup) — Kestra is local via tunnel; if it
+#   doesn't accept connection in 3s, something is structurally wrong.
+# - read: longer (Kestra v1.0 OSS can pause on heavy plugin work
+#   especially first-call after restart) — 15s gives the JVM time to
+#   warm up the request handler without hanging the deploy.
+_CONNECT_TIMEOUT_S: float = 3.0
+_READ_TIMEOUT_S: float = 15.0
+_HTTP_TIMEOUT: tuple[float, float] = (_CONNECT_TIMEOUT_S, _READ_TIMEOUT_S)
+
+
+RegisterStatus = Literal["created", "updated", "failed"]
+ExecutionState = Literal["SUCCESS", "FAILED", "KILLED", "RUNNING", "CREATED", "UNKNOWN"]
+
+
+@dataclass(frozen=True)
+class RegisterResult:
+    """Outcome of one ``register_flow`` call.
+
+    ``name`` is the fully-qualified ``<namespace>.<flow_id>`` form
+    used in deploy logs. ``detail`` carries the HTTP status the
+    operator needs to debug a ``failed`` (e.g. ``"POST 401"``).
+    """
+
+    name: str
+    status: RegisterStatus
+    detail: str = ""
+
+
+@dataclass(frozen=True)
+class SystemFlowsResult:
+    """Aggregate of the system-flow registration + onboarding execution."""
+
+    flows: tuple[RegisterResult, ...]
+    execution_state: ExecutionState | None = None  # None if not triggered
+
+    @property
+    def is_success(self) -> bool:
+        """All flows registered/updated AND (if triggered) execution succeeded."""
+        flows_ok = all(f.status != "failed" for f in self.flows)
+        # ExecutionState=None means we didn't trigger (a flow registration
+        # failed, so triggering would race against a stale flow definition);
+        # that's reflected in flows_ok=False already. RUNNING/CREATED at
+        # timeout count as failure for the deploy-time "everything ready"
+        # contract — the deploy shouldn't claim success if the onboarding
+        # didn't actually finish.
+        if not flows_ok:
+            return False
+        if self.execution_state is None:
+            return True
+        return self.execution_state == "SUCCESS"
+
+
+class KestraError(Exception):
+    """Transport-level failure (connection refused, timeout, malformed JSON).
+
+    Distinct from a ``failed`` :class:`RegisterResult` — those represent
+    a server response we understood but rejected (4xx/5xx after both
+    POST and PUT). KestraError is "we never got a meaningful response".
+    Carries no response body in its message: response bodies on auth
+    failures can include the credentials we just sent.
+    """
+
+
+class KestraClient:
+    """Minimal REST client for Kestra OSS v1.0+.
+
+    Basic-auth via ``requests`` — the credentials live in the
+    ``Authorization`` header per request, never in argv (no shell-out
+    here). Read/write timeouts are bounded so a stuck JVM during
+    plugin load can't deadlock the deploy.
+    """
+
+    def __init__(self, base_url: str, *, username: str, password: str) -> None:
+        if not username or not password:
+            raise ValueError("KestraClient requires non-empty username + password")
+        self.base_url = base_url.rstrip("/")
+        self._auth = (username, password)
+
+    def wait_ready(self, *, timeout_s: float = 60.0, interval_s: float = 3.0) -> bool:
+        """Poll ``GET /api/v1/flows`` until basic-auth-accepted.
+
+        Kestra v1.0 OSS has no health endpoint that respects basic-auth
+        without listing data; ``/api/v1/flows`` is the canonical probe.
+        Accepted status codes:
+
+        - **200** — fully ready, returns flow list
+        - **404** — /api/v1/flows endpoint shape changed in some
+          v1.0 patches (read path moved under tenant prefix), but
+          basic-auth was accepted to evaluate the path
+        - **405** — same endpoint may reject GET in some configs;
+          again basic-auth was accepted
+
+        These three == "Kestra is ready and our credentials work".
+        Anything else (000/401/403/5xx) keeps the loop running until
+        timeout. Returns True on first ready, False on timeout.
+        """
+        deadline = time.monotonic() + timeout_s
+        while time.monotonic() < deadline:
+            try:
+                resp = requests.get(
+                    f"{self.base_url}/api/v1/flows",
+                    auth=self._auth,
+                    timeout=_HTTP_TIMEOUT,
+                )
+            except (requests.ConnectionError, requests.Timeout):
+                resp = None
+            if resp is not None and resp.status_code in (200, 404, 405):
+                return True
+            time.sleep(interval_s)
+        return False
+
+    def register_flow(
+        self,
+        yaml_body: str,
+        *,
+        namespace: str,
+        flow_id: str,
+    ) -> RegisterResult:
+        """Idempotent register: POST first, fall back to PUT on 422.
+
+        Kestra v1.0 OSS does NOT have an upsert verb — POST is
+        create-only (returns 422 with ``"Flow id already exists"`` if
+        the flow is there) and PUT is update-only (returns 404 if the
+        flow doesn't exist). Neither alone covers re-runs. The
+        deploy.sh logic combined them; we mirror that exactly.
+        """
+        full_name = f"{namespace}.{flow_id}"
+        try:
+            post_resp = requests.post(
+                f"{self.base_url}/api/v1/flows",
+                auth=self._auth,
+                headers={"Content-Type": "application/x-yaml"},
+                data=yaml_body.encode("utf-8"),
+                timeout=_HTTP_TIMEOUT,
+            )
+        except (requests.ConnectionError, requests.Timeout) as exc:
+            return RegisterResult(
+                name=full_name,
+                status="failed",
+                detail=f"POST transport ({type(exc).__name__})",
+            )
+
+        if post_resp.status_code in (200, 201):
+            return RegisterResult(
+                name=full_name, status="created", detail=f"POST {post_resp.status_code}"
+            )
+        if post_resp.status_code != 422:
+            return RegisterResult(
+                name=full_name,
+                status="failed",
+                detail=f"POST {post_resp.status_code}",
+            )
+
+        # POST 422 → exists → PUT to update
+        try:
+            put_resp = requests.put(
+                f"{self.base_url}/api/v1/flows/{namespace}/{flow_id}",
+                auth=self._auth,
+                headers={"Content-Type": "application/x-yaml"},
+                data=yaml_body.encode("utf-8"),
+                timeout=_HTTP_TIMEOUT,
+            )
+        except (requests.ConnectionError, requests.Timeout) as exc:
+            return RegisterResult(
+                name=full_name,
+                status="failed",
+                detail=f"PUT transport ({type(exc).__name__})",
+            )
+
+        if put_resp.status_code in (200, 201):
+            return RegisterResult(
+                name=full_name,
+                status="updated",
+                detail=f"POST 422 → PUT {put_resp.status_code}",
+            )
+        return RegisterResult(
+            name=full_name,
+            status="failed",
+            detail=f"POST 422 → PUT {put_resp.status_code}",
+        )
+
+    def execute_flow(self, namespace: str, flow_id: str) -> str:
+        """Trigger an execution. Returns the execution ID.
+
+        Raises :class:`KestraError` if Kestra doesn't return a parseable
+        execution ID — that's a transport-level failure, not the same
+        as the execution running and ending in FAILED state (which
+        would surface via :meth:`get_execution_state`).
+        """
+        try:
+            resp = requests.post(
+                f"{self.base_url}/api/v1/executions/{namespace}/{flow_id}",
+                auth=self._auth,
+                timeout=_HTTP_TIMEOUT,
+            )
+        except (requests.ConnectionError, requests.Timeout) as exc:
+            raise KestraError(f"execute_flow transport ({type(exc).__name__})") from exc
+        if resp.status_code not in (200, 201):
+            raise KestraError(
+                f"execute_flow {namespace}.{flow_id} returned HTTP {resp.status_code}",
+            )
+        try:
+            payload = resp.json()
+        except ValueError as exc:
+            raise KestraError("execute_flow response was not JSON") from exc
+        exec_id = payload.get("id") if isinstance(payload, dict) else None
+        if not isinstance(exec_id, str) or not exec_id:
+            raise KestraError("execute_flow response missing 'id'")
+        return exec_id
+
+    def get_execution_state(self, exec_id: str) -> ExecutionState:
+        """Read the current execution state. Returns ``"UNKNOWN"`` if Kestra
+        responded but the JSON shape is unexpected (don't raise — pollers
+        keep going if a transient deserialisation glitch happens)."""
+        try:
+            resp = requests.get(
+                f"{self.base_url}/api/v1/executions/{exec_id}",
+                auth=self._auth,
+                timeout=_HTTP_TIMEOUT,
+            )
+        except (requests.ConnectionError, requests.Timeout) as exc:
+            raise KestraError(f"get_execution_state transport ({type(exc).__name__})") from exc
+        if resp.status_code != 200:
+            raise KestraError(f"get_execution_state HTTP {resp.status_code}")
+        try:
+            payload = resp.json()
+        except ValueError:
+            return "UNKNOWN"
+        if not isinstance(payload, dict):
+            return "UNKNOWN"
+        state_obj = payload.get("state")
+        if not isinstance(state_obj, dict):
+            return "UNKNOWN"
+        current = state_obj.get("current")
+        # Kestra-side states we recognise; others (PAUSED, etc.) coalesce to UNKNOWN
+        # so the caller's poll-until-terminal logic doesn't loop forever.
+        if current in ("SUCCESS", "FAILED", "KILLED", "RUNNING", "CREATED"):
+            return current  # type: ignore[no-any-return]
+        return "UNKNOWN"
+
+    def wait_for_execution(
+        self,
+        exec_id: str,
+        *,
+        timeout_s: float = 60.0,
+        interval_s: float = 2.0,
+    ) -> ExecutionState:
+        """Poll ``get_execution_state`` until terminal or timeout.
+
+        Terminal states: ``SUCCESS``, ``FAILED``, ``KILLED``. Returns
+        whichever was reached, or ``"RUNNING"`` if the timeout fired
+        before the execution settled (caller maps to a warning, not a
+        deploy failure — the execution may finish in the next minute).
+        """
+        deadline = time.monotonic() + timeout_s
+        last: ExecutionState = "CREATED"
+        while time.monotonic() < deadline:
+            try:
+                last = self.get_execution_state(exec_id)
+            except KestraError:
+                # Transient — retry. wait_for_execution itself only raises
+                # on timeout-with-no-terminal.
+                last = "UNKNOWN"
+            if last in ("SUCCESS", "FAILED", "KILLED"):
+                return last
+            time.sleep(interval_s)
+        return last
+
+
+# ---------------------------------------------------------------------------
+# System-flow YAML templates. Verbatim from deploy.sh L3410-3443 with
+# {placeholder} substitutions for the per-deploy fields. Schema is
+# pinned to Kestra v1.0 OSS plugin shape (SyncNamespaceFiles +
+# SyncFlows from io.kestra.plugin.git, both of which require
+# targetNamespace / namespace fields on v1.0).
+# ---------------------------------------------------------------------------
+
+GIT_SYNC_FLOW_TEMPLATE = """\
+id: git-sync
+namespace: system
+tasks:
+  - id: sync
+    type: io.kestra.plugin.git.SyncNamespaceFiles
+    url: http://gitea:3000/{repo_owner}/{repo_name}.git
+    branch: {branch}
+    username: {admin_username}
+    password: "{{{{ secret('GITEA_TOKEN') }}}}"
+    namespace: "{{{{ flow.namespace }}}}"
+    gitDirectory: nexus_seeds/kestra/workflows
+triggers:
+  - id: schedule
+    type: io.kestra.core.models.triggers.types.Schedule
+    cron: "*/15 * * * *"
+"""
+
+FLOW_SYNC_FLOW_TEMPLATE = """\
+id: flow-sync
+namespace: system
+description: Pull flow definitions from internal Gitea, register them in Kestra. Git is source of truth.
+tasks:
+  - id: sync
+    type: io.kestra.plugin.git.SyncFlows
+    url: http://gitea:3000/{repo_owner}/{repo_name}.git
+    branch: {branch}
+    username: {admin_username}
+    password: "{{{{ secret('GITEA_TOKEN') }}}}"
+    gitDirectory: nexus_seeds/kestra/flows
+    targetNamespace: nexus-tutorials
+    includeChildNamespaces: true
+    delete: true
+triggers:
+  - id: schedule
+    type: io.kestra.core.models.triggers.types.Schedule
+    cron: "*/15 * * * *"
+"""
+
+
+def render_system_flow_yaml(
+    template: str,
+    *,
+    repo_owner: str,
+    repo_name: str,
+    branch: str,
+    admin_username: str,
+) -> str:
+    """Substitute placeholders into a system-flow YAML template.
+
+    The double-brace ``{{{{ secret('GITEA_TOKEN') }}}}`` in the templates
+    becomes a single ``{{ secret('GITEA_TOKEN') }}`` after format —
+    that's intentional, it's the Kestra Pebble template syntax that
+    must reach the registered flow verbatim.
+    """
+    return template.format(
+        repo_owner=repo_owner,
+        repo_name=repo_name,
+        branch=branch,
+        admin_username=admin_username,
+    )
+
+
+def render_system_flows(
+    *,
+    repo_owner: str,
+    repo_name: str,
+    branch: str,
+    admin_username: str,
+) -> dict[str, str]:
+    """Return ``{full_name: yaml_body}`` for both system flows."""
+    common = {
+        "repo_owner": repo_owner,
+        "repo_name": repo_name,
+        "branch": branch,
+        "admin_username": admin_username,
+    }
+    return {
+        "system.git-sync": render_system_flow_yaml(GIT_SYNC_FLOW_TEMPLATE, **common),
+        "system.flow-sync": render_system_flow_yaml(FLOW_SYNC_FLOW_TEMPLATE, **common),
+    }
+
+
+def register_all_system_flows(
+    client: KestraClient,
+    flows: dict[str, str],
+) -> tuple[RegisterResult, ...]:
+    """Register every flow in ``flows``. Order = caller-provided dict order."""
+    results: list[RegisterResult] = []
+    for full_name, yaml in flows.items():
+        ns, _, flow_id = full_name.partition(".")
+        results.append(client.register_flow(yaml, namespace=ns, flow_id=flow_id))
+    return tuple(results)
+
+
+def trigger_flow_sync_onboarding(
+    client: KestraClient,
+    *,
+    timeout_s: float = 60.0,
+) -> ExecutionState:
+    """One-shot execute ``system.flow-sync`` and wait for terminal state.
+
+    Without this, user-seeded flows in ``nexus_seeds/kestra/flows/`` only
+    appear after the next 15-min cron tick — the deploy would print
+    "Deployment Complete" with no user flows visible in the Kestra UI,
+    causing reasonable "where are my flows?" confusion. The trigger here
+    is best-effort: if the execute call or polling fails, the cron will
+    still tick eventually, so we surface the failure as a warning, not
+    a deploy abort.
+
+    Raises :class:`KestraError` only on the initial execute_flow call;
+    polling failures coalesce to ``"UNKNOWN"`` then ``"RUNNING"`` at
+    timeout (callers treat both as warnings).
+    """
+    exec_id = client.execute_flow("system", "flow-sync")
+    return client.wait_for_execution(exec_id, timeout_s=timeout_s)
+
+
+def run_register_system_flows(
+    config: NexusConfig,
+    *,
+    base_url: str,
+    repo_owner: str,
+    repo_name: str,
+    branch: str,
+    admin_email: str,
+    trigger_onboarding: bool = True,
+    ready_timeout_s: float = 60.0,
+    onboarding_timeout_s: float = 60.0,
+) -> SystemFlowsResult:
+    """End-to-end: instantiate client, wait, register both flows, optionally
+    trigger ``system.flow-sync`` execution.
+
+    Caller is responsible for opening the SSH port-forward to Kestra and
+    passing the local ``base_url`` (e.g. ``http://localhost:8085``).
+    Keeping the tunnel concern outside this function makes the logic
+    testable against ``responses``-mocked HTTP without an ssh roundtrip.
+
+    ``ready_timeout_s`` / ``onboarding_timeout_s`` are exposed primarily
+    so unit tests can drive the orchestrator to completion in
+    sub-second wall-clock; production callers use the defaults.
+    """
+    client = KestraClient(
+        base_url=base_url,
+        username=admin_email,
+        password=config.kestra_admin_password or "",
+    )
+    if not client.wait_ready(timeout_s=ready_timeout_s):
+        # Kestra never reached basic-auth-accepted state. Both flows
+        # would 401; surface a clean partial result so deploy.sh sees
+        # rc=1 (yellow warning, continue).
+        return SystemFlowsResult(
+            flows=(
+                RegisterResult(name="system.git-sync", status="failed", detail="kestra not ready"),
+                RegisterResult(name="system.flow-sync", status="failed", detail="kestra not ready"),
+            ),
+        )
+
+    flows = render_system_flows(
+        repo_owner=repo_owner,
+        repo_name=repo_name,
+        branch=branch,
+        admin_username=config.admin_username or "admin",
+    )
+    register_results = register_all_system_flows(client, flows)
+
+    if not trigger_onboarding:
+        return SystemFlowsResult(flows=register_results)
+
+    # Only trigger the onboarding execute when both register calls
+    # succeeded — otherwise we'd execute a flow-sync against a stale
+    # flow definition.
+    if any(r.status == "failed" for r in register_results):
+        return SystemFlowsResult(flows=register_results)
+
+    try:
+        exec_state: ExecutionState | None = trigger_flow_sync_onboarding(
+            client, timeout_s=onboarding_timeout_s
+        )
+    except KestraError:
+        exec_state = None
+    return SystemFlowsResult(flows=register_results, execution_state=exec_state)

--- a/src/nexus_deploy/kestra.py
+++ b/src/nexus_deploy/kestra.py
@@ -51,15 +51,37 @@ import requests
 
 from nexus_deploy.config import NexusConfig
 
-# HTTP timeouts:
+# Default HTTP timeouts:
 # - connect: short (TCP setup) — Kestra is local via tunnel; if it
 #   doesn't accept connection in 3s, something is structurally wrong.
 # - read: longer (Kestra v1.0 OSS can pause on heavy plugin work
 #   especially first-call after restart) — 15s gives the JVM time to
 #   warm up the request handler without hanging the deploy.
+#
+# Polling helpers (``wait_ready``, ``wait_for_execution``) compute a
+# per-request override via :func:`_http_timeout_for_deadline` so the
+# read timeout can never block past the caller's deadline. Without
+# the override, a 0.1s ``timeout_s`` could block ~15s on a single
+# stalled probe (TCP accepted, body never arrived) and silently
+# violate the timeout contract.
 _CONNECT_TIMEOUT_S: float = 3.0
 _READ_TIMEOUT_S: float = 15.0
 _HTTP_TIMEOUT: tuple[float, float] = (_CONNECT_TIMEOUT_S, _READ_TIMEOUT_S)
+
+
+def _http_timeout_for_deadline(deadline: float) -> tuple[float, float]:
+    """Build a (connect, read) tuple clamped to the time remaining.
+
+    Connect timeout is also clamped to keep ``wait_ready(timeout_s=0.05)``
+    honest — a TCP-RST after a stalled SYN could otherwise eat the
+    whole 3s connect default. Both legs are floored at 0.1s so the
+    ``requests`` library doesn't hit its own zero-timeout edge case.
+    """
+    remaining = max(deadline - time.monotonic(), 0.1)
+    return (
+        min(_CONNECT_TIMEOUT_S, remaining),
+        min(_READ_TIMEOUT_S, remaining),
+    )
 
 
 RegisterStatus = Literal["created", "updated", "failed"]
@@ -197,7 +219,7 @@ class KestraClient:
                 resp = requests.get(
                     f"{self.base_url}/api/v1/flows",
                     auth=self._auth,
-                    timeout=_HTTP_TIMEOUT,
+                    timeout=_http_timeout_for_deadline(deadline),
                 )
             except (requests.ConnectionError, requests.Timeout):
                 resp = None
@@ -308,15 +330,25 @@ class KestraClient:
             raise KestraError("execute_flow response missing 'id'")
         return exec_id
 
-    def get_execution_state(self, exec_id: str) -> ExecutionState:
+    def get_execution_state(
+        self,
+        exec_id: str,
+        *,
+        timeout: tuple[float, float] | None = None,
+    ) -> ExecutionState:
         """Read the current execution state. Returns ``"UNKNOWN"`` if Kestra
         responded but the JSON shape is unexpected (don't raise — pollers
-        keep going if a transient deserialisation glitch happens)."""
+        keep going if a transient deserialisation glitch happens).
+
+        ``timeout`` overrides the module-default ``_HTTP_TIMEOUT`` —
+        :meth:`wait_for_execution` passes a deadline-clamped value so a
+        stalled probe can't blow out the caller's overall timeout.
+        """
         try:
             resp = requests.get(
                 f"{self.base_url}/api/v1/executions/{exec_id}",
                 auth=self._auth,
-                timeout=_HTTP_TIMEOUT,
+                timeout=timeout if timeout is not None else _HTTP_TIMEOUT,
             )
         except (requests.ConnectionError, requests.Timeout) as exc:
             raise KestraError(f"get_execution_state transport ({type(exc).__name__})") from exc
@@ -384,7 +416,9 @@ class KestraClient:
         last: ExecutionState = "CREATED"
         while time.monotonic() < deadline:
             try:
-                last = self.get_execution_state(exec_id)
+                last = self.get_execution_state(
+                    exec_id, timeout=_http_timeout_for_deadline(deadline)
+                )
             except KestraError:
                 # Transient — retry. wait_for_execution itself only raises
                 # on timeout-with-no-terminal.
@@ -615,12 +649,16 @@ def run_register_system_flows(
         # on the next deploy; reclassifying would punish operators for
         # network noise). But surface the verify-failed signal via
         # ``verify_skipped_reason`` so the CLI emits a stderr warning —
-        # operators see that the check itself didn't complete and can
-        # spot-check the flow visibility manually if needed.
+        # operators see WHY the check didn't complete (HTTP 503 vs
+        # auth-rejected vs timeout) and can spot-check manually.
+        # ``str(exc)`` is safe here: KestraError messages in this module
+        # are constructed from fixed format strings + status codes /
+        # exception class names — they never include subprocess output
+        # or response bodies, per the KestraError docstring.
         return SystemFlowsResult(
             flows=register_results,
             execution_state=exec_state,
-            verify_skipped_reason=f"flow_exists raised KestraError ({type(exc).__name__})",
+            verify_skipped_reason=str(exc),
         )
     if not seed_visible:
         return SystemFlowsResult(flows=register_results, execution_state="SEED_FLOW_MISSING")

--- a/src/nexus_deploy/kestra.py
+++ b/src/nexus_deploy/kestra.py
@@ -420,8 +420,12 @@ class KestraClient:
                     exec_id, timeout=_http_timeout_for_deadline(deadline)
                 )
             except KestraError:
-                # Transient — retry. wait_for_execution itself only raises
-                # on timeout-with-no-terminal.
+                # Transient — coalesce to UNKNOWN and keep polling.
+                # wait_for_execution itself NEVER raises: callers prefer
+                # a non-terminal "RUNNING"/"UNKNOWN" return at timeout
+                # (yellow warning, the cron tick will retry within 15
+                # min) over an exception that would short-circuit
+                # the rest of the deploy.
                 last = "UNKNOWN"
             if last in ("SUCCESS", "FAILED", "KILLED"):
                 return last

--- a/src/nexus_deploy/kestra.py
+++ b/src/nexus_deploy/kestra.py
@@ -25,10 +25,14 @@ API:
   builder for the two system flows. Templates ship verbatim from
   deploy.sh so the registered flow body is byte-equivalent (modulo
   the substituted variables).
-- :func:`run_register_system_flows` — top-level orchestrator: opens
-  port-forward, waits for Kestra, registers both flows, optionally
-  triggers ``flow-sync``. Returns the full set of register results
-  for the CLI to map to rc=0/1/2.
+- :func:`run_register_system_flows` — top-level orchestrator: takes
+  an already-forwarded ``base_url``, instantiates KestraClient,
+  waits for Kestra, registers both flows, optionally triggers
+  ``flow-sync`` and verifies that the canonical seeded flow appears.
+  Caller (the CLI in ``__main__._kestra_register_system_flows``) is
+  responsible for opening the SSH port-forward — keeping the tunnel
+  outside this function lets ``responses``-mock the HTTP layer in
+  tests without an ssh roundtrip.
 
 Auth note (R4): basic-auth credentials are passed to ``requests`` via
 the ``auth=(user, pass)`` keyword, which puts them in the
@@ -59,7 +63,34 @@ _HTTP_TIMEOUT: tuple[float, float] = (_CONNECT_TIMEOUT_S, _READ_TIMEOUT_S)
 
 
 RegisterStatus = Literal["created", "updated", "failed"]
-ExecutionState = Literal["SUCCESS", "FAILED", "KILLED", "RUNNING", "CREATED", "UNKNOWN"]
+# Kestra-side states + two synthetic states the orchestrator emits:
+# - TRIGGER_FAILED: execute_flow raised KestraError (couldn't even start).
+#   Distinct from FAILED (ran but errored) and from None (caller opted
+#   out of triggering); is_success treats it as a failure so the deploy
+#   gets a yellow warning rather than a silent green pass.
+# - SEED_FLOW_MISSING: execute reached SUCCESS, but the canonical
+#   nexus-tutorials.r2-taxi-pipeline flow isn't visible afterwards.
+#   Same is_success treatment as TRIGGER_FAILED — operator needs to
+#   know the workspace repo wasn't seeded as expected.
+ExecutionState = Literal[
+    "SUCCESS",
+    "FAILED",
+    "KILLED",
+    "RUNNING",
+    "CREATED",
+    "UNKNOWN",
+    "TRIGGER_FAILED",
+    "SEED_FLOW_MISSING",
+]
+
+# Canonical seeded flow that system.flow-sync should produce after
+# pulling nexus_seeds/kestra/flows/ from the workspace repo. Hardcoded
+# because deploy.sh hardcoded it for the same reason: it's the
+# single ship-with-Nexus-Stack tutorial flow under the
+# nexus-tutorials namespace, and "did flow-sync actually run?" needs
+# a deterministic check, not a guess across all user flows.
+_SEED_VERIFICATION_NS = "nexus-tutorials"
+_SEED_VERIFICATION_ID = "r2-taxi-pipeline"
 
 
 @dataclass(frozen=True)
@@ -85,19 +116,21 @@ class SystemFlowsResult:
 
     @property
     def is_success(self) -> bool:
-        """All flows registered/updated AND (if triggered) execution succeeded."""
+        """All flows registered/updated AND (if triggered) execution succeeded.
+
+        ``execution_state == None`` is success ONLY when the orchestrator
+        was called with ``trigger_onboarding=False`` (caller deliberately
+        skipped). When trigger_onboarding=True and execute_flow raised,
+        the orchestrator records ``"TRIGGER_FAILED"`` (NOT None), so
+        the silent-pass bug from PR #517 round 1 is closed.
+        """
         flows_ok = all(f.status != "failed" for f in self.flows)
-        # ExecutionState=None means we didn't trigger (a flow registration
-        # failed, so triggering would race against a stale flow definition);
-        # that's reflected in flows_ok=False already. RUNNING/CREATED at
-        # timeout count as failure for the deploy-time "everything ready"
-        # contract — the deploy shouldn't claim success if the onboarding
-        # didn't actually finish.
         if not flows_ok:
             return False
-        if self.execution_state is None:
-            return True
-        return self.execution_state == "SUCCESS"
+        # Success: didn't trigger (None) OR triggered and execution
+        # ended in SUCCESS. Anything else (FAILED/KILLED/RUNNING/UNKNOWN/
+        # TRIGGER_FAILED/SEED_FLOW_MISSING) is a partial-failure.
+        return self.execution_state is None or self.execution_state == "SUCCESS"
 
 
 class KestraError(Exception):
@@ -287,6 +320,30 @@ class KestraClient:
         if current in ("SUCCESS", "FAILED", "KILLED", "RUNNING", "CREATED"):
             return current  # type: ignore[no-any-return]
         return "UNKNOWN"
+
+    def flow_exists(self, namespace: str, flow_id: str) -> bool:
+        """``GET /api/v1/flows/<ns>/<id>`` — 200 → exists, 404 → not.
+
+        Used post-``system.flow-sync``-execution to confirm the seeded
+        flow actually landed (a SUCCESS execution against an empty
+        seed tree wouldn't fail the execution but would leave Kestra
+        without the user-visible flow). Other status codes (5xx,
+        transport) raise :class:`KestraError` so a network blip
+        doesn't get conflated with a true "missing flow" condition.
+        """
+        try:
+            resp = requests.get(
+                f"{self.base_url}/api/v1/flows/{namespace}/{flow_id}",
+                auth=self._auth,
+                timeout=_HTTP_TIMEOUT,
+            )
+        except (requests.ConnectionError, requests.Timeout) as exc:
+            raise KestraError(f"flow_exists transport ({type(exc).__name__})") from exc
+        if resp.status_code == 200:
+            return True
+        if resp.status_code == 404:
+            return False
+        raise KestraError(f"flow_exists HTTP {resp.status_code}")
 
     def wait_for_execution(
         self,
@@ -501,9 +558,37 @@ def run_register_system_flows(
         return SystemFlowsResult(flows=register_results)
 
     try:
-        exec_state: ExecutionState | None = trigger_flow_sync_onboarding(
+        exec_state: ExecutionState = trigger_flow_sync_onboarding(
             client, timeout_s=onboarding_timeout_s
         )
     except KestraError:
-        exec_state = None
-    return SystemFlowsResult(flows=register_results, execution_state=exec_state)
+        # Couldn't even start the onboarding execute → record as
+        # TRIGGER_FAILED (NOT None). is_success treats this as a
+        # partial-failure so deploy.sh's case-block routes to the
+        # yellow-warning branch instead of green-success — the
+        # onboarding genuinely didn't run, and the operator deserves
+        # to see that signal.
+        return SystemFlowsResult(flows=register_results, execution_state="TRIGGER_FAILED")
+
+    # If the execution itself didn't reach SUCCESS, surface its terminal
+    # state directly — no further verification possible against an
+    # incomplete sync.
+    if exec_state != "SUCCESS":
+        return SystemFlowsResult(flows=register_results, execution_state=exec_state)
+
+    # Post-success verification: the canonical seeded flow
+    # (nexus-tutorials.r2-taxi-pipeline) must be visible in Kestra.
+    # A SUCCESS execution against an empty seed tree (no flows in the
+    # workspace repo) wouldn't surface as FAILED — Kestra's SyncFlows
+    # runs cleanly with zero files. Without this check the deploy
+    # would print green "registered" while operators couldn't find
+    # their tutorial flow. Mirrors deploy.sh L3479-3490 exactly.
+    try:
+        seed_visible = client.flow_exists(_SEED_VERIFICATION_NS, _SEED_VERIFICATION_ID)
+    except KestraError:
+        # Network blip during verification; don't downgrade the
+        # SUCCESS execution to a failure on a transient HTTP error.
+        return SystemFlowsResult(flows=register_results, execution_state=exec_state)
+    if not seed_visible:
+        return SystemFlowsResult(flows=register_results, execution_state="SEED_FLOW_MISSING")
+    return SystemFlowsResult(flows=register_results, execution_state="SUCCESS")

--- a/src/nexus_deploy/ssh.py
+++ b/src/nexus_deploy/ssh.py
@@ -202,7 +202,16 @@ class SSHClient:
         misconfigured ProxyCommand and we never want to leak that into
         an exception message.
         """
-        forward_spec = f"{local_port}:{remote_host}:{remote_port}"
+        # Explicit IPv4 bind: without ``127.0.0.1:`` prefix, ``ssh -L``
+        # binds both the IPv4 and IPv6 loopback on dual-stack hosts.
+        # Callers (e.g. :func:`nexus_deploy.__main__._allocate_free_port`)
+        # typically probe IPv4 only when picking a "free" local port —
+        # a port that's free on 127.0.0.1 may still be occupied on ::1
+        # by another tunnel, and the resulting ssh-bind failure would
+        # surface as an ExitOnForwardFailure abort. Pinning the bind
+        # to IPv4 matches the allocator's probe surface and eliminates
+        # that whole class of intermittent collisions.
+        forward_spec = f"127.0.0.1:{local_port}:{remote_host}:{remote_port}"
         # ExitOnForwardFailure=yes: if the local bind fails (port already
         # in use), ssh exits non-zero immediately instead of staying up
         # without a working forward. Without it, _wait_for_local_port

--- a/tests/unit/test_kestra.py
+++ b/tests/unit/test_kestra.py
@@ -527,7 +527,7 @@ def test_trigger_flow_sync_onboarding_returns_terminal_state() -> None:
 
 @responses.activate
 def test_run_register_system_flows_happy_path_with_onboarding() -> None:
-    """Wait → register both → execute flow-sync → poll SUCCESS."""
+    """Wait → register both → execute flow-sync → poll SUCCESS → seed-flow visible."""
     responses.add(responses.GET, f"{BASE_URL}/api/v1/flows", status=200)
     responses.add(responses.POST, f"{BASE_URL}/api/v1/flows", status=201)
     responses.add(responses.POST, f"{BASE_URL}/api/v1/flows", status=201)
@@ -542,6 +542,13 @@ def test_run_register_system_flows_happy_path_with_onboarding() -> None:
         f"{BASE_URL}/api/v1/executions/exec-99",
         status=200,
         json={"state": {"current": "SUCCESS"}},
+    )
+    # Post-execute verification: seed flow IS visible
+    responses.add(
+        responses.GET,
+        f"{BASE_URL}/api/v1/flows/nexus-tutorials/r2-taxi-pipeline",
+        status=200,
+        json={"id": "r2-taxi-pipeline"},
     )
 
     result = run_register_system_flows(
@@ -625,9 +632,14 @@ def test_run_register_system_flows_trigger_onboarding_false_skips_execute() -> N
 
 
 @responses.activate
-def test_run_register_system_flows_onboarding_kestra_error_recorded_as_none() -> None:
-    """Execute throws KestraError → execution_state=None, but result is
-    NOT marked failed (registers succeeded; the cron will tick later)."""
+def test_run_register_system_flows_onboarding_kestra_error_recorded_as_trigger_failed() -> None:
+    """Execute throws KestraError → execution_state=TRIGGER_FAILED (NOT None).
+
+    Round-2 fix: previously this collapsed to None, which made
+    is_success return True even though onboarding never ran. Now the
+    distinct sentinel makes deploy.sh route to the yellow-warning
+    branch (rc=1) instead of silently green.
+    """
     responses.add(responses.GET, f"{BASE_URL}/api/v1/flows", status=200)
     responses.add(responses.POST, f"{BASE_URL}/api/v1/flows", status=201)
     responses.add(responses.POST, f"{BASE_URL}/api/v1/flows", status=201)
@@ -647,11 +659,140 @@ def test_run_register_system_flows_onboarding_kestra_error_recorded_as_none() ->
         ready_timeout_s=0.05,
         onboarding_timeout_s=2.0,
     )
-    # Execution state None because we couldn't trigger; that's a yellow
-    # warning from the deploy's perspective, not a register failure.
-    assert result.execution_state is None
-    # All registers succeeded
+    assert result.execution_state == "TRIGGER_FAILED"
+    # All registers succeeded — the failure is purely the onboarding execute
     assert all(f.status in ("created", "updated") for f in result.flows)
+    # is_success must be False so the CLI returns rc=1
+    assert result.is_success is False
+
+
+@responses.activate
+def test_run_register_system_flows_seed_flow_missing_after_success() -> None:
+    """SUCCESS execution but the canonical seed flow isn't in Kestra → SEED_FLOW_MISSING.
+
+    Mirrors deploy.sh L3479-3490: a SUCCESS execution against an empty
+    seed tree (no flows in the workspace repo) wouldn't surface as
+    FAILED. Without the post-execute verify, deploy would falsely
+    print green "registered" while operators couldn't find the
+    tutorial flow.
+    """
+    responses.add(responses.GET, f"{BASE_URL}/api/v1/flows", status=200)
+    responses.add(responses.POST, f"{BASE_URL}/api/v1/flows", status=201)
+    responses.add(responses.POST, f"{BASE_URL}/api/v1/flows", status=201)
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/executions/system/flow-sync",
+        status=201,
+        json={"id": "exec-99"},
+    )
+    responses.add(
+        responses.GET,
+        f"{BASE_URL}/api/v1/executions/exec-99",
+        status=200,
+        json={"state": {"current": "SUCCESS"}},
+    )
+    # Verification call: 404 — flow not registered
+    responses.add(
+        responses.GET,
+        f"{BASE_URL}/api/v1/flows/nexus-tutorials/r2-taxi-pipeline",
+        status=404,
+    )
+
+    result = run_register_system_flows(
+        _make_config(),
+        base_url=BASE_URL,
+        repo_owner="o",
+        repo_name="r",
+        branch="main",
+        admin_email="admin@example.com",
+        ready_timeout_s=0.05,
+        onboarding_timeout_s=2.0,
+    )
+    assert result.execution_state == "SEED_FLOW_MISSING"
+    assert result.is_success is False
+
+
+@responses.activate
+def test_run_register_system_flows_seed_flow_visible_after_success() -> None:
+    """SUCCESS + seed flow visible (200) → execution_state stays SUCCESS."""
+    responses.add(responses.GET, f"{BASE_URL}/api/v1/flows", status=200)
+    responses.add(responses.POST, f"{BASE_URL}/api/v1/flows", status=201)
+    responses.add(responses.POST, f"{BASE_URL}/api/v1/flows", status=201)
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/executions/system/flow-sync",
+        status=201,
+        json={"id": "exec-99"},
+    )
+    responses.add(
+        responses.GET,
+        f"{BASE_URL}/api/v1/executions/exec-99",
+        status=200,
+        json={"state": {"current": "SUCCESS"}},
+    )
+    responses.add(
+        responses.GET,
+        f"{BASE_URL}/api/v1/flows/nexus-tutorials/r2-taxi-pipeline",
+        status=200,
+        json={"id": "r2-taxi-pipeline"},
+    )
+
+    result = run_register_system_flows(
+        _make_config(),
+        base_url=BASE_URL,
+        repo_owner="o",
+        repo_name="r",
+        branch="main",
+        admin_email="admin@example.com",
+        ready_timeout_s=0.05,
+        onboarding_timeout_s=2.0,
+    )
+    assert result.execution_state == "SUCCESS"
+    assert result.is_success is True
+
+
+@responses.activate
+def test_run_register_system_flows_seed_verify_transport_error_keeps_success() -> None:
+    """Verification HTTP 5xx → don't downgrade a SUCCESS execution.
+
+    Network blip during the verify call shouldn't reclassify a
+    perfectly-valid SUCCESS execution as a failure — a transient
+    glitch is recoverable on the next deploy.
+    """
+    responses.add(responses.GET, f"{BASE_URL}/api/v1/flows", status=200)
+    responses.add(responses.POST, f"{BASE_URL}/api/v1/flows", status=201)
+    responses.add(responses.POST, f"{BASE_URL}/api/v1/flows", status=201)
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/executions/system/flow-sync",
+        status=201,
+        json={"id": "exec-99"},
+    )
+    responses.add(
+        responses.GET,
+        f"{BASE_URL}/api/v1/executions/exec-99",
+        status=200,
+        json={"state": {"current": "SUCCESS"}},
+    )
+    responses.add(
+        responses.GET,
+        f"{BASE_URL}/api/v1/flows/nexus-tutorials/r2-taxi-pipeline",
+        status=503,
+    )
+
+    result = run_register_system_flows(
+        _make_config(),
+        base_url=BASE_URL,
+        repo_owner="o",
+        repo_name="r",
+        branch="main",
+        admin_email="admin@example.com",
+        ready_timeout_s=0.05,
+        onboarding_timeout_s=2.0,
+    )
+    # Stays SUCCESS despite the verification failure
+    assert result.execution_state == "SUCCESS"
+    assert result.is_success is True
 
 
 # ---------------------------------------------------------------------------
@@ -689,6 +830,69 @@ def test_is_success_false_on_register_failure_even_with_success_execution() -> N
         execution_state="SUCCESS",
     )
     assert r.is_success is False
+
+
+def test_is_success_false_on_trigger_failed() -> None:
+    """TRIGGER_FAILED → onboarding never even started → is_success False.
+
+    Round-2 round of #517: previously this collapsed to None and
+    silently passed. The dedicated sentinel pins the contract.
+    """
+    r = SystemFlowsResult(
+        flows=(RegisterResult(name="a", status="created"),),
+        execution_state="TRIGGER_FAILED",
+    )
+    assert r.is_success is False
+
+
+def test_is_success_false_on_seed_flow_missing() -> None:
+    """SEED_FLOW_MISSING → SUCCESS execution but no user flow → is_success False."""
+    r = SystemFlowsResult(
+        flows=(RegisterResult(name="a", status="created"),),
+        execution_state="SEED_FLOW_MISSING",
+    )
+    assert r.is_success is False
+
+
+# ---------------------------------------------------------------------------
+# flow_exists — post-execute seed verification
+# ---------------------------------------------------------------------------
+
+
+@responses.activate
+def test_flow_exists_returns_true_on_200() -> None:
+    responses.add(
+        responses.GET,
+        f"{BASE_URL}/api/v1/flows/system/git-sync",
+        status=200,
+        json={"id": "git-sync"},
+    )
+    assert _client().flow_exists("system", "git-sync") is True
+
+
+@responses.activate
+def test_flow_exists_returns_false_on_404() -> None:
+    responses.add(responses.GET, f"{BASE_URL}/api/v1/flows/nexus-tutorials/missing", status=404)
+    assert _client().flow_exists("nexus-tutorials", "missing") is False
+
+
+@responses.activate
+def test_flow_exists_raises_on_5xx() -> None:
+    """5xx is neither yes-it-exists nor no-it-doesn't — raise to caller."""
+    responses.add(responses.GET, f"{BASE_URL}/api/v1/flows/system/x", status=503)
+    with pytest.raises(KestraError, match="HTTP 503"):
+        _client().flow_exists("system", "x")
+
+
+@responses.activate
+def test_flow_exists_raises_on_connection_error() -> None:
+    responses.add(
+        responses.GET,
+        f"{BASE_URL}/api/v1/flows/system/x",
+        body=requests.ConnectionError("boom"),
+    )
+    with pytest.raises(KestraError, match="transport"):
+        _client().flow_exists("system", "x")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_kestra.py
+++ b/tests/unit/test_kestra.py
@@ -1,0 +1,920 @@
+"""Tests for nexus_deploy.kestra — Phase 2 Modul 2.3 (#505).
+
+Mocks HTTP via ``responses`` (already a project dep). All paths
+exercised: idempotent POST→PUT register, transport-level errors,
+execute + poll, the full ``run_register_system_flows`` orchestrator
+including the "kestra not ready" early-return.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+import requests
+import responses
+
+from nexus_deploy.config import NexusConfig
+from nexus_deploy.kestra import (
+    FLOW_SYNC_FLOW_TEMPLATE,
+    GIT_SYNC_FLOW_TEMPLATE,
+    KestraClient,
+    KestraError,
+    RegisterResult,
+    SystemFlowsResult,
+    register_all_system_flows,
+    render_system_flow_yaml,
+    render_system_flows,
+    run_register_system_flows,
+    trigger_flow_sync_onboarding,
+)
+
+BASE_URL = "http://localhost:8085"
+
+
+def _client() -> KestraClient:
+    return KestraClient(BASE_URL, username="admin@example.com", password="kp-secret")
+
+
+def _make_config(**overrides: Any) -> NexusConfig:
+    defaults: dict[str, Any] = {
+        "admin_username": "admin",
+        "kestra_admin_password": "kp-secret",
+    }
+    defaults.update(overrides)
+    return NexusConfig.from_secrets_json(json.dumps(defaults))
+
+
+# ---------------------------------------------------------------------------
+# KestraClient — constructor
+# ---------------------------------------------------------------------------
+
+
+def test_client_rejects_empty_username() -> None:
+    with pytest.raises(ValueError, match="non-empty"):
+        KestraClient(BASE_URL, username="", password="x")
+
+
+def test_client_rejects_empty_password() -> None:
+    with pytest.raises(ValueError, match="non-empty"):
+        KestraClient(BASE_URL, username="admin", password="")
+
+
+def test_client_strips_trailing_slash_from_base_url() -> None:
+    c = KestraClient("http://kestra.local/", username="u", password="p")
+    assert c.base_url == "http://kestra.local"
+
+
+# ---------------------------------------------------------------------------
+# wait_ready — accepted status codes (200, 404, 405)
+# ---------------------------------------------------------------------------
+
+
+@responses.activate
+def test_wait_ready_returns_true_on_200() -> None:
+    responses.add(responses.GET, f"{BASE_URL}/api/v1/flows", status=200, json=[])
+    assert _client().wait_ready(timeout_s=2.0, interval_s=0.01) is True
+
+
+@responses.activate
+def test_wait_ready_returns_true_on_404() -> None:
+    """404 = endpoint moved (v1.0 patch difference) but basic-auth accepted."""
+    responses.add(responses.GET, f"{BASE_URL}/api/v1/flows", status=404)
+    assert _client().wait_ready(timeout_s=2.0, interval_s=0.01) is True
+
+
+@responses.activate
+def test_wait_ready_returns_true_on_405() -> None:
+    """405 = GET rejected on this path, but basic-auth accepted."""
+    responses.add(responses.GET, f"{BASE_URL}/api/v1/flows", status=405)
+    assert _client().wait_ready(timeout_s=2.0, interval_s=0.01) is True
+
+
+@responses.activate
+def test_wait_ready_loops_then_succeeds() -> None:
+    """Two 401s then a 200 → wait_ready returns True after the third probe."""
+    responses.add(responses.GET, f"{BASE_URL}/api/v1/flows", status=401)
+    responses.add(responses.GET, f"{BASE_URL}/api/v1/flows", status=401)
+    responses.add(responses.GET, f"{BASE_URL}/api/v1/flows", status=200, json=[])
+    assert _client().wait_ready(timeout_s=5.0, interval_s=0.01) is True
+
+
+@responses.activate
+def test_wait_ready_returns_false_on_timeout() -> None:
+    responses.add(responses.GET, f"{BASE_URL}/api/v1/flows", status=401)
+    # Very short timeout, single 401 — loop bails out.
+    assert _client().wait_ready(timeout_s=0.05, interval_s=0.05) is False
+
+
+@responses.activate
+def test_wait_ready_handles_connection_errors() -> None:
+    """ConnectionError doesn't crash the loop — it just keeps polling."""
+    responses.add(
+        responses.GET,
+        f"{BASE_URL}/api/v1/flows",
+        body=requests.ConnectionError("boom"),
+    )
+    responses.add(responses.GET, f"{BASE_URL}/api/v1/flows", status=200)
+    assert _client().wait_ready(timeout_s=5.0, interval_s=0.01) is True
+
+
+# ---------------------------------------------------------------------------
+# register_flow — POST/PUT idempotent dance
+# ---------------------------------------------------------------------------
+
+
+@responses.activate
+def test_register_flow_post_201_returns_created() -> None:
+    responses.add(responses.POST, f"{BASE_URL}/api/v1/flows", status=201)
+    result = _client().register_flow("id: x\nnamespace: system", namespace="system", flow_id="x")
+    assert result == RegisterResult(name="system.x", status="created", detail="POST 201")
+
+
+@responses.activate
+def test_register_flow_post_200_returns_created() -> None:
+    """Some Kestra builds return 200 instead of 201 on first-create."""
+    responses.add(responses.POST, f"{BASE_URL}/api/v1/flows", status=200)
+    result = _client().register_flow("y", namespace="system", flow_id="y")
+    assert result.status == "created"
+
+
+@responses.activate
+def test_register_flow_post_422_then_put_200_returns_updated() -> None:
+    responses.add(responses.POST, f"{BASE_URL}/api/v1/flows", status=422)
+    responses.add(responses.PUT, f"{BASE_URL}/api/v1/flows/system/git-sync", status=200)
+    result = _client().register_flow("y", namespace="system", flow_id="git-sync")
+    assert result.status == "updated"
+    assert "POST 422 → PUT 200" in result.detail
+
+
+@responses.activate
+def test_register_flow_post_422_then_put_4xx_returns_failed() -> None:
+    responses.add(responses.POST, f"{BASE_URL}/api/v1/flows", status=422)
+    responses.add(responses.PUT, f"{BASE_URL}/api/v1/flows/system/git-sync", status=400)
+    result = _client().register_flow("y", namespace="system", flow_id="git-sync")
+    assert result.status == "failed"
+    assert "POST 422 → PUT 400" in result.detail
+
+
+@responses.activate
+def test_register_flow_post_5xx_returns_failed() -> None:
+    """5xx on POST → we don't fall through to PUT (PUT 5xx-prone too)."""
+    responses.add(responses.POST, f"{BASE_URL}/api/v1/flows", status=500)
+    result = _client().register_flow("y", namespace="system", flow_id="y")
+    assert result.status == "failed"
+    assert "POST 500" in result.detail
+    # No PUT call should have fired
+    assert len(responses.calls) == 1
+
+
+@responses.activate
+def test_register_flow_post_401_returns_failed_without_put() -> None:
+    """401 on POST is auth-rejected — PUT would just fail the same way."""
+    responses.add(responses.POST, f"{BASE_URL}/api/v1/flows", status=401)
+    result = _client().register_flow("y", namespace="system", flow_id="y")
+    assert result.status == "failed"
+    assert "POST 401" in result.detail
+
+
+@responses.activate
+def test_register_flow_post_connection_error_returns_failed() -> None:
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/flows",
+        body=requests.ConnectionError("boom"),
+    )
+    result = _client().register_flow("y", namespace="system", flow_id="y")
+    assert result.status == "failed"
+    assert "transport" in result.detail
+    # Detail must NOT include the exception message (could leak any
+    # response body the wrapper baked in).
+    assert "boom" not in result.detail
+
+
+@responses.activate
+def test_register_flow_post_422_then_put_connection_error_returns_failed() -> None:
+    responses.add(responses.POST, f"{BASE_URL}/api/v1/flows", status=422)
+    responses.add(
+        responses.PUT,
+        f"{BASE_URL}/api/v1/flows/system/y",
+        body=requests.Timeout("slow"),
+    )
+    result = _client().register_flow("y", namespace="system", flow_id="y")
+    assert result.status == "failed"
+    assert "transport" in result.detail
+    assert "slow" not in result.detail
+
+
+@responses.activate
+def test_register_flow_sends_yaml_content_type() -> None:
+    """Kestra requires application/x-yaml; JSON body would 400."""
+    responses.add(responses.POST, f"{BASE_URL}/api/v1/flows", status=201)
+    _client().register_flow("y", namespace="system", flow_id="y")
+    assert responses.calls[0].request.headers["Content-Type"] == "application/x-yaml"
+
+
+@responses.activate
+def test_register_flow_sends_basic_auth_in_header_not_body() -> None:
+    """R4 — credentials must travel in the Authorization header,
+    NEVER in the request body or query string."""
+    responses.add(responses.POST, f"{BASE_URL}/api/v1/flows", status=201)
+    _client().register_flow("flow-body", namespace="system", flow_id="y")
+    req = responses.calls[0].request
+    auth_header = req.headers.get("Authorization", "")
+    assert auth_header.startswith("Basic ")
+    # body must NOT contain the password
+    body = req.body or ""
+    if isinstance(body, bytes):
+        body = body.decode("utf-8")
+    assert "kp-secret" not in body
+    # URL must NOT contain the password (no query-string smuggle)
+    assert "kp-secret" not in (req.url or "")
+
+
+# ---------------------------------------------------------------------------
+# execute_flow + get_execution_state + wait_for_execution
+# ---------------------------------------------------------------------------
+
+
+@responses.activate
+def test_execute_flow_returns_id_on_201() -> None:
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/executions/system/flow-sync",
+        status=201,
+        json={"id": "exec-abc-123"},
+    )
+    assert _client().execute_flow("system", "flow-sync") == "exec-abc-123"
+
+
+@responses.activate
+def test_execute_flow_raises_on_5xx() -> None:
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/executions/system/flow-sync",
+        status=503,
+    )
+    with pytest.raises(KestraError, match="HTTP 503"):
+        _client().execute_flow("system", "flow-sync")
+
+
+@responses.activate
+def test_execute_flow_raises_on_missing_id() -> None:
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/executions/system/flow-sync",
+        status=200,
+        json={"not_id": "x"},
+    )
+    with pytest.raises(KestraError, match="missing 'id'"):
+        _client().execute_flow("system", "flow-sync")
+
+
+@responses.activate
+def test_execute_flow_raises_on_non_json() -> None:
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/executions/system/flow-sync",
+        status=200,
+        body="not json",
+    )
+    with pytest.raises(KestraError, match="not JSON"):
+        _client().execute_flow("system", "flow-sync")
+
+
+@responses.activate
+def test_execute_flow_raises_on_connection_error() -> None:
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/executions/system/flow-sync",
+        body=requests.ConnectionError("boom"),
+    )
+    with pytest.raises(KestraError, match="transport"):
+        _client().execute_flow("system", "flow-sync")
+
+
+@responses.activate
+def test_get_execution_state_success() -> None:
+    responses.add(
+        responses.GET,
+        f"{BASE_URL}/api/v1/executions/exec-1",
+        status=200,
+        json={"state": {"current": "SUCCESS"}},
+    )
+    assert _client().get_execution_state("exec-1") == "SUCCESS"
+
+
+@responses.activate
+def test_get_execution_state_unknown_for_unrecognised_state() -> None:
+    """Future Kestra state names (PAUSED, etc.) map to UNKNOWN so the
+    poller doesn't loop forever."""
+    responses.add(
+        responses.GET,
+        f"{BASE_URL}/api/v1/executions/exec-1",
+        status=200,
+        json={"state": {"current": "PAUSED"}},
+    )
+    assert _client().get_execution_state("exec-1") == "UNKNOWN"
+
+
+@responses.activate
+def test_get_execution_state_unknown_for_malformed_response() -> None:
+    responses.add(
+        responses.GET,
+        f"{BASE_URL}/api/v1/executions/exec-1",
+        status=200,
+        json={"foo": "bar"},  # no .state.current
+    )
+    assert _client().get_execution_state("exec-1") == "UNKNOWN"
+
+
+@responses.activate
+def test_get_execution_state_raises_on_4xx() -> None:
+    responses.add(
+        responses.GET,
+        f"{BASE_URL}/api/v1/executions/exec-1",
+        status=404,
+    )
+    with pytest.raises(KestraError, match="HTTP 404"):
+        _client().get_execution_state("exec-1")
+
+
+@responses.activate
+def test_get_execution_state_raises_on_connection_error() -> None:
+    responses.add(
+        responses.GET,
+        f"{BASE_URL}/api/v1/executions/exec-1",
+        body=requests.ConnectionError("boom"),
+    )
+    with pytest.raises(KestraError, match="transport"):
+        _client().get_execution_state("exec-1")
+
+
+@responses.activate
+def test_get_execution_state_unknown_for_non_json_response() -> None:
+    responses.add(
+        responses.GET,
+        f"{BASE_URL}/api/v1/executions/exec-1",
+        status=200,
+        body="not json at all",
+    )
+    assert _client().get_execution_state("exec-1") == "UNKNOWN"
+
+
+@responses.activate
+def test_get_execution_state_unknown_for_top_level_list_response() -> None:
+    """Defensive: Kestra returns dict-shaped payload; a list is unexpected
+    but the poller must not crash on it."""
+    responses.add(
+        responses.GET,
+        f"{BASE_URL}/api/v1/executions/exec-1",
+        status=200,
+        json=[1, 2, 3],
+    )
+    assert _client().get_execution_state("exec-1") == "UNKNOWN"
+
+
+@responses.activate
+def test_wait_for_execution_returns_terminal_state() -> None:
+    responses.add(
+        responses.GET,
+        f"{BASE_URL}/api/v1/executions/exec-1",
+        status=200,
+        json={"state": {"current": "RUNNING"}},
+    )
+    responses.add(
+        responses.GET,
+        f"{BASE_URL}/api/v1/executions/exec-1",
+        status=200,
+        json={"state": {"current": "SUCCESS"}},
+    )
+    assert _client().wait_for_execution("exec-1", timeout_s=5.0, interval_s=0.01) == "SUCCESS"
+
+
+@responses.activate
+def test_wait_for_execution_returns_running_on_timeout() -> None:
+    responses.add(
+        responses.GET,
+        f"{BASE_URL}/api/v1/executions/exec-1",
+        status=200,
+        json={"state": {"current": "RUNNING"}},
+    )
+    # 0.05s timeout, all responses RUNNING → returns RUNNING (caller treats as warning)
+    state = _client().wait_for_execution("exec-1", timeout_s=0.05, interval_s=0.05)
+    assert state == "RUNNING"
+
+
+@responses.activate
+def test_wait_for_execution_handles_kestra_error_then_recovers() -> None:
+    """Transient KestraError from get_execution_state → poll continues."""
+    responses.add(
+        responses.GET,
+        f"{BASE_URL}/api/v1/executions/exec-1",
+        status=503,  # raises KestraError on first call
+    )
+    responses.add(
+        responses.GET,
+        f"{BASE_URL}/api/v1/executions/exec-1",
+        status=200,
+        json={"state": {"current": "SUCCESS"}},
+    )
+    assert _client().wait_for_execution("exec-1", timeout_s=5.0, interval_s=0.01) == "SUCCESS"
+
+
+# ---------------------------------------------------------------------------
+# render_system_flow_yaml + render_system_flows
+# ---------------------------------------------------------------------------
+
+
+def test_render_git_sync_substitutes_placeholders() -> None:
+    yaml_body = render_system_flow_yaml(
+        GIT_SYNC_FLOW_TEMPLATE,
+        repo_owner="alice",
+        repo_name="ws-repo",
+        branch="main",
+        admin_username="admin",
+    )
+    assert "url: http://gitea:3000/alice/ws-repo.git" in yaml_body
+    assert "branch: main" in yaml_body
+    assert "username: admin" in yaml_body
+    # Pebble template must reach Kestra verbatim — single-brace form
+    # after Python's str.format processes the double-brace escape.
+    assert "{{ secret('GITEA_TOKEN') }}" in yaml_body
+    assert "gitDirectory: nexus_seeds/kestra/workflows" in yaml_body
+
+
+def test_render_flow_sync_pins_target_namespace() -> None:
+    """v1.0 plugin requires targetNamespace; our template MUST set it
+    to nexus-tutorials. A regression here would bring back the
+    'tasks[0].targetNamespace: must not be null' deploy failure
+    that PR (cited in deploy.sh comments) chased down."""
+    yaml_body = render_system_flow_yaml(
+        FLOW_SYNC_FLOW_TEMPLATE,
+        repo_owner="bob",
+        repo_name="r",
+        branch="dev",
+        admin_username="admin",
+    )
+    assert "targetNamespace: nexus-tutorials" in yaml_body
+    assert "includeChildNamespaces: true" in yaml_body
+    assert "delete: true" in yaml_body
+    assert "gitDirectory: nexus_seeds/kestra/flows" in yaml_body
+
+
+def test_render_system_flows_returns_both() -> None:
+    flows = render_system_flows(
+        repo_owner="alice", repo_name="r", branch="main", admin_username="admin"
+    )
+    assert set(flows.keys()) == {"system.git-sync", "system.flow-sync"}
+    assert "git-sync" in flows["system.git-sync"]
+    assert "flow-sync" in flows["system.flow-sync"]
+
+
+def test_render_system_flows_does_not_double_substitute_secret_pebble() -> None:
+    """The Pebble syntax {{ secret('GITEA_TOKEN') }} must remain as
+    single-braces in the rendered YAML so Kestra's templating engine
+    can interpret it. Python str.format escape uses double-braces in
+    the template; if a future contributor accidentally drops the
+    escape, .format would treat 'secret' as a placeholder and raise
+    KeyError. This test pins the contract."""
+    flows = render_system_flows(repo_owner="o", repo_name="r", branch="b", admin_username="a")
+    for body in flows.values():
+        assert "{{ secret('GITEA_TOKEN') }}" in body
+        # No double-braces should remain (those would be a Python escape
+        # leaking into the rendered Kestra YAML).
+        assert "{{{{ secret" not in body
+        assert "}}}}" not in body
+
+
+# ---------------------------------------------------------------------------
+# register_all_system_flows + trigger_flow_sync_onboarding
+# ---------------------------------------------------------------------------
+
+
+@responses.activate
+def test_register_all_system_flows_returns_one_result_per_flow() -> None:
+    responses.add(responses.POST, f"{BASE_URL}/api/v1/flows", status=201)
+    responses.add(responses.POST, f"{BASE_URL}/api/v1/flows", status=201)
+    flows = render_system_flows(repo_owner="o", repo_name="r", branch="b", admin_username="a")
+    results = register_all_system_flows(_client(), flows)
+    assert len(results) == 2
+    assert {r.name for r in results} == {"system.git-sync", "system.flow-sync"}
+    assert all(r.status == "created" for r in results)
+
+
+@responses.activate
+def test_trigger_flow_sync_onboarding_returns_terminal_state() -> None:
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/executions/system/flow-sync",
+        status=201,
+        json={"id": "exec-1"},
+    )
+    responses.add(
+        responses.GET,
+        f"{BASE_URL}/api/v1/executions/exec-1",
+        status=200,
+        json={"state": {"current": "SUCCESS"}},
+    )
+    assert trigger_flow_sync_onboarding(_client(), timeout_s=5.0) == "SUCCESS"
+
+
+# ---------------------------------------------------------------------------
+# run_register_system_flows — top-level orchestrator
+# ---------------------------------------------------------------------------
+
+
+@responses.activate
+def test_run_register_system_flows_happy_path_with_onboarding() -> None:
+    """Wait → register both → execute flow-sync → poll SUCCESS."""
+    responses.add(responses.GET, f"{BASE_URL}/api/v1/flows", status=200)
+    responses.add(responses.POST, f"{BASE_URL}/api/v1/flows", status=201)
+    responses.add(responses.POST, f"{BASE_URL}/api/v1/flows", status=201)
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/executions/system/flow-sync",
+        status=201,
+        json={"id": "exec-99"},
+    )
+    responses.add(
+        responses.GET,
+        f"{BASE_URL}/api/v1/executions/exec-99",
+        status=200,
+        json={"state": {"current": "SUCCESS"}},
+    )
+
+    result = run_register_system_flows(
+        _make_config(),
+        base_url=BASE_URL,
+        repo_owner="o",
+        repo_name="r",
+        branch="main",
+        admin_email="admin@example.com",
+        ready_timeout_s=0.05,
+        onboarding_timeout_s=2.0,
+    )
+    assert result.is_success
+    assert result.execution_state == "SUCCESS"
+    assert all(f.status in ("created", "updated") for f in result.flows)
+
+
+@responses.activate
+def test_run_register_system_flows_kestra_not_ready_returns_failed_results() -> None:
+    """wait_ready times out → both flows reported failed with 'kestra not ready' detail."""
+    responses.add(responses.GET, f"{BASE_URL}/api/v1/flows", status=401)
+
+    result = run_register_system_flows(
+        _make_config(),
+        base_url=BASE_URL,
+        repo_owner="o",
+        repo_name="r",
+        branch="main",
+        admin_email="admin@example.com",
+        ready_timeout_s=0.05,
+        onboarding_timeout_s=2.0,
+    )
+    assert not result.is_success
+    assert all(f.status == "failed" for f in result.flows)
+    assert all("not ready" in f.detail for f in result.flows)
+    assert result.execution_state is None  # no execute attempt
+
+
+@responses.activate
+def test_run_register_system_flows_skips_onboarding_if_register_failed() -> None:
+    """If even ONE register failed, don't trigger flow-sync (would race
+    against stale flow definition)."""
+    responses.add(responses.GET, f"{BASE_URL}/api/v1/flows", status=200)
+    responses.add(responses.POST, f"{BASE_URL}/api/v1/flows", status=201)
+    responses.add(responses.POST, f"{BASE_URL}/api/v1/flows", status=500)  # 2nd register fails
+
+    result = run_register_system_flows(
+        _make_config(),
+        base_url=BASE_URL,
+        repo_owner="o",
+        repo_name="r",
+        branch="main",
+        admin_email="admin@example.com",
+        ready_timeout_s=0.05,
+        onboarding_timeout_s=2.0,
+    )
+    assert not result.is_success
+    assert any(f.status == "failed" for f in result.flows)
+    assert result.execution_state is None  # NOT triggered
+
+
+@responses.activate
+def test_run_register_system_flows_trigger_onboarding_false_skips_execute() -> None:
+    """Caller can opt out of the post-register flow-sync trigger."""
+    responses.add(responses.GET, f"{BASE_URL}/api/v1/flows", status=200)
+    responses.add(responses.POST, f"{BASE_URL}/api/v1/flows", status=201)
+    responses.add(responses.POST, f"{BASE_URL}/api/v1/flows", status=201)
+
+    result = run_register_system_flows(
+        _make_config(),
+        base_url=BASE_URL,
+        repo_owner="o",
+        repo_name="r",
+        branch="main",
+        admin_email="admin@example.com",
+        trigger_onboarding=False,
+        ready_timeout_s=2.0,
+    )
+    assert result.is_success
+    assert result.execution_state is None
+
+
+@responses.activate
+def test_run_register_system_flows_onboarding_kestra_error_recorded_as_none() -> None:
+    """Execute throws KestraError → execution_state=None, but result is
+    NOT marked failed (registers succeeded; the cron will tick later)."""
+    responses.add(responses.GET, f"{BASE_URL}/api/v1/flows", status=200)
+    responses.add(responses.POST, f"{BASE_URL}/api/v1/flows", status=201)
+    responses.add(responses.POST, f"{BASE_URL}/api/v1/flows", status=201)
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/executions/system/flow-sync",
+        status=503,
+    )
+
+    result = run_register_system_flows(
+        _make_config(),
+        base_url=BASE_URL,
+        repo_owner="o",
+        repo_name="r",
+        branch="main",
+        admin_email="admin@example.com",
+        ready_timeout_s=0.05,
+        onboarding_timeout_s=2.0,
+    )
+    # Execution state None because we couldn't trigger; that's a yellow
+    # warning from the deploy's perspective, not a register failure.
+    assert result.execution_state is None
+    # All registers succeeded
+    assert all(f.status in ("created", "updated") for f in result.flows)
+
+
+# ---------------------------------------------------------------------------
+# SystemFlowsResult.is_success edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_is_success_true_when_no_execution_triggered() -> None:
+    r = SystemFlowsResult(
+        flows=(
+            RegisterResult(name="a", status="created"),
+            RegisterResult(name="b", status="updated"),
+        ),
+        execution_state=None,
+    )
+    assert r.is_success is True
+
+
+def test_is_success_false_on_running_at_timeout() -> None:
+    """Onboarding execution never settled — deploy shouldn't claim success."""
+    r = SystemFlowsResult(
+        flows=(RegisterResult(name="a", status="created"),),
+        execution_state="RUNNING",
+    )
+    assert r.is_success is False
+
+
+def test_is_success_false_on_register_failure_even_with_success_execution() -> None:
+    """Defensive: a register-fail can't be masked by a later SUCCESS execution."""
+    r = SystemFlowsResult(
+        flows=(
+            RegisterResult(name="a", status="failed"),
+            RegisterResult(name="b", status="created"),
+        ),
+        execution_state="SUCCESS",
+    )
+    assert r.is_success is False
+
+
+# ---------------------------------------------------------------------------
+# CLI: _kestra_register_system_flows
+# ---------------------------------------------------------------------------
+
+
+def _set_required_env(monkeypatch: pytest.MonkeyPatch, **overrides: str) -> None:
+    """Default env var set for the CLI tests; overrides override."""
+    defaults: dict[str, str] = {
+        "GITEA_REPO_OWNER": "alice",
+        "REPO_NAME": "ws-repo",
+        "WORKSPACE_BRANCH": "main",
+        "ADMIN_EMAIL": "admin@example.com",
+    }
+    defaults.update(overrides)
+    for k, v in defaults.items():
+        monkeypatch.setenv(k, v)
+
+
+def test_cli_kestra_unknown_arg_returns_2(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from nexus_deploy.__main__ import _kestra_register_system_flows
+
+    rc = _kestra_register_system_flows(["--bogus"])
+    assert rc == 2
+    assert "unknown args" in capsys.readouterr().err
+
+
+def test_cli_kestra_missing_required_env_returns_2(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from nexus_deploy.__main__ import _kestra_register_system_flows
+
+    monkeypatch.delenv("GITEA_REPO_OWNER", raising=False)
+    monkeypatch.delenv("REPO_NAME", raising=False)
+    monkeypatch.delenv("ADMIN_EMAIL", raising=False)
+    rc = _kestra_register_system_flows([])
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "missing required env" in err
+
+
+def test_cli_kestra_missing_kestra_pass_returns_zero_with_warning(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """No Kestra password in SECRETS_JSON → log warning, exit 0 (deploy continues)."""
+    from nexus_deploy.__main__ import _kestra_register_system_flows
+
+    _set_required_env(monkeypatch)
+    monkeypatch.setattr("sys.stdin.read", lambda: "{}")
+    rc = _kestra_register_system_flows([])
+    assert rc == 0
+    err = capsys.readouterr().err
+    assert "KESTRA_PASS missing" in err
+
+
+def test_cli_kestra_invalid_json_returns_2(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from nexus_deploy.__main__ import _kestra_register_system_flows
+
+    _set_required_env(monkeypatch)
+    monkeypatch.setattr("sys.stdin.read", lambda: "not json {")
+    rc = _kestra_register_system_flows([])
+    assert rc == 2
+
+
+def test_cli_kestra_ssh_tunnel_failure_returns_2(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Tunnel setup failure → typed SSHError → rc=2."""
+    from nexus_deploy.__main__ import _kestra_register_system_flows
+    from nexus_deploy.ssh import SSHError
+
+    _set_required_env(monkeypatch)
+    monkeypatch.setattr("sys.stdin.read", lambda: '{"kestra_admin_password": "kp"}')
+
+    class _BoomSSH:
+        def __init__(self, *_args: Any, **_kwargs: Any) -> None:
+            pass
+
+        def __enter__(self) -> _BoomSSH:
+            return self
+
+        def __exit__(self, *_exc: Any) -> None:
+            return None
+
+        def port_forward(self, *_args: Any, **_kwargs: Any) -> Any:
+            raise SSHError("ssh tunnel to local port 8085 did not come up within 10.0s")
+
+    monkeypatch.setattr("nexus_deploy.__main__.SSHClient", _BoomSSH)
+    rc = _kestra_register_system_flows([])
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "ssh tunnel failed" in err
+    # SSHError carries safe fixed-format text — its message IS forwarded
+    # because ssh.py guarantees no subprocess output is in there.
+    assert "did not come up" in err
+
+
+def test_cli_kestra_unexpected_exception_returns_2(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Any non-SSH exception class-name only, no str(exc) leak."""
+    from nexus_deploy.__main__ import _kestra_register_system_flows
+
+    _set_required_env(monkeypatch)
+    monkeypatch.setattr("sys.stdin.read", lambda: '{"kestra_admin_password": "kp"}')
+
+    def boom(*_args: Any, **_kwargs: Any) -> None:
+        raise RuntimeError("secret-do-not-print")
+
+    monkeypatch.setattr("nexus_deploy.__main__.run_register_system_flows", boom)
+    # Make SSHClient + port_forward succeed so we reach the run call
+    from contextlib import contextmanager
+
+    class _OkSSH:
+        def __init__(self, *_args: Any, **_kwargs: Any) -> None:
+            pass
+
+        def __enter__(self) -> _OkSSH:
+            return self
+
+        def __exit__(self, *_exc: Any) -> None:
+            return None
+
+        @contextmanager
+        def port_forward(self, *_args: Any, **_kwargs: Any) -> Any:
+            yield 8085
+
+    monkeypatch.setattr("nexus_deploy.__main__.SSHClient", _OkSSH)
+    rc = _kestra_register_system_flows([])
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "RuntimeError" in err
+    assert "secret-do-not-print" not in err
+
+
+def test_cli_kestra_happy_path_returns_zero(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from nexus_deploy.__main__ import _kestra_register_system_flows
+
+    _set_required_env(monkeypatch)
+    monkeypatch.setattr("sys.stdin.read", lambda: '{"kestra_admin_password": "kp"}')
+
+    def fake_run(*_args: Any, **_kwargs: Any) -> SystemFlowsResult:
+        return SystemFlowsResult(
+            flows=(
+                RegisterResult(name="system.git-sync", status="created", detail="POST 201"),
+                RegisterResult(
+                    name="system.flow-sync", status="updated", detail="POST 422 → PUT 200"
+                ),
+            ),
+            execution_state="SUCCESS",
+        )
+
+    monkeypatch.setattr("nexus_deploy.__main__.run_register_system_flows", fake_run)
+
+    from contextlib import contextmanager
+
+    class _OkSSH:
+        def __init__(self, *_args: Any, **_kwargs: Any) -> None:
+            pass
+
+        def __enter__(self) -> _OkSSH:
+            return self
+
+        def __exit__(self, *_exc: Any) -> None:
+            return None
+
+        @contextmanager
+        def port_forward(self, *_args: Any, **_kwargs: Any) -> Any:
+            yield 8085
+
+    monkeypatch.setattr("nexus_deploy.__main__.SSHClient", _OkSSH)
+    rc = _kestra_register_system_flows([])
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert "created=1" in captured.out
+    assert "updated=1" in captured.out
+    assert "execution=SUCCESS" in captured.out
+    assert "system.git-sync: created" in captured.err
+    assert "system.flow-sync: updated" in captured.err
+
+
+def test_cli_kestra_partial_failure_returns_one(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from nexus_deploy.__main__ import _kestra_register_system_flows
+
+    _set_required_env(monkeypatch)
+    monkeypatch.setattr("sys.stdin.read", lambda: '{"kestra_admin_password": "kp"}')
+
+    def fake_run(*_args: Any, **_kwargs: Any) -> SystemFlowsResult:
+        return SystemFlowsResult(
+            flows=(
+                RegisterResult(name="system.git-sync", status="created", detail="POST 201"),
+                RegisterResult(name="system.flow-sync", status="failed", detail="POST 500"),
+            ),
+            execution_state=None,
+        )
+
+    monkeypatch.setattr("nexus_deploy.__main__.run_register_system_flows", fake_run)
+
+    from contextlib import contextmanager
+
+    class _OkSSH:
+        def __init__(self, *_args: Any, **_kwargs: Any) -> None:
+            pass
+
+        def __enter__(self) -> _OkSSH:
+            return self
+
+        def __exit__(self, *_exc: Any) -> None:
+            return None
+
+        @contextmanager
+        def port_forward(self, *_args: Any, **_kwargs: Any) -> Any:
+            yield 8085
+
+    monkeypatch.setattr("nexus_deploy.__main__.SSHClient", _OkSSH)
+    rc = _kestra_register_system_flows([])
+    assert rc == 1
+    captured = capsys.readouterr()
+    assert "failed=1" in captured.out
+    assert "execution=skipped" in captured.out

--- a/tests/unit/test_kestra.py
+++ b/tests/unit/test_kestra.py
@@ -791,9 +791,15 @@ def test_run_register_system_flows_seed_verify_transport_error_keeps_success() -
     # Stays SUCCESS despite the verification failure
     assert result.execution_state == "SUCCESS"
     assert result.is_success is True
-    # NEW (round-2 fix): the operator sees the verify-failed signal
+    # NEW (round-2 fix, sharpened in round 3): the operator sees the
+    # ACTIONABLE failure detail (HTTP status code), not just the
+    # exception class name. Round-2 wrote `type(exc).__name__` which
+    # collapsed every kind of failure to bare "KestraError"; round-3
+    # uses str(exc) which carries "flow_exists HTTP 503" / "transport
+    # (ConnectionError)" / etc.
     assert result.verify_skipped_reason is not None
-    assert "KestraError" in result.verify_skipped_reason
+    assert "503" in result.verify_skipped_reason
+    assert "flow_exists" in result.verify_skipped_reason
 
 
 # ---------------------------------------------------------------------------
@@ -833,6 +839,37 @@ def test_wait_for_execution_short_timeout_does_not_block_on_long_interval() -> N
     elapsed = _time.monotonic() - start
     assert result == "RUNNING"
     assert elapsed < 1.0, f"wait_for_execution blocked {elapsed:.2f}s, expected <1s"
+
+
+def test_http_timeout_for_deadline_clamps_both_legs() -> None:
+    """Round-3 fix: per-request HTTP timeout (connect, read) is computed
+    from the remaining deadline so a stalled probe (TCP accepted, body
+    never arrives) can't blow out a sub-second ``timeout_s``.
+
+    Previously a fixed 15s read timeout meant ``wait_ready(timeout_s=0.1)``
+    could block ~15s on a single hung probe and silently violate the
+    contract.
+    """
+    import time as _time
+
+    from nexus_deploy.kestra import _CONNECT_TIMEOUT_S, _http_timeout_for_deadline
+
+    # Tight deadline (50ms in the future) → both legs clamped to ~0.05s
+    # (or 0.1s floor, whichever is bigger).
+    near = _time.monotonic() + 0.05
+    connect, read = _http_timeout_for_deadline(near)
+    assert connect <= _CONNECT_TIMEOUT_S
+    assert read <= 0.5  # well below the 15s default
+    # Both legs floored at 0.1s so requests doesn't hit zero-timeout.
+    assert connect >= 0.1
+    assert read >= 0.1
+
+    # Far-future deadline → defaults preserved (no point clamping
+    # below the original).
+    far = _time.monotonic() + 1000
+    connect, read = _http_timeout_for_deadline(far)
+    assert connect == _CONNECT_TIMEOUT_S
+    assert read == 15.0  # the module-level _READ_TIMEOUT_S
 
 
 # ---------------------------------------------------------------------------
@@ -1279,7 +1316,7 @@ def test_cli_kestra_emits_verify_skipped_warning(
                 RegisterResult(name="system.flow-sync", status="created", detail="POST 201"),
             ),
             execution_state="SUCCESS",
-            verify_skipped_reason="flow_exists raised KestraError (KestraError)",
+            verify_skipped_reason="flow_exists HTTP 503",
         )
 
     monkeypatch.setattr("nexus_deploy.__main__.run_register_system_flows", fake_run)
@@ -1306,7 +1343,9 @@ def test_cli_kestra_emits_verify_skipped_warning(
     assert rc == 0
     err = capsys.readouterr().err
     assert "seed-flow visibility check skipped" in err
-    assert "KestraError" in err
+    # Round-3 fix: the verify-skipped message carries the actionable
+    # detail (HTTP status), not just the bare exception class name.
+    assert "HTTP 503" in err
 
 
 def test_cli_kestra_uses_dynamically_allocated_local_port(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/test_kestra.py
+++ b/tests/unit/test_kestra.py
@@ -753,11 +753,9 @@ def test_run_register_system_flows_seed_flow_visible_after_success() -> None:
 
 @responses.activate
 def test_run_register_system_flows_seed_verify_transport_error_keeps_success() -> None:
-    """Verification HTTP 5xx → don't downgrade a SUCCESS execution.
-
-    Network blip during the verify call shouldn't reclassify a
-    perfectly-valid SUCCESS execution as a failure — a transient
-    glitch is recoverable on the next deploy.
+    """Verification HTTP 5xx → don't downgrade a SUCCESS execution, but
+    surface the verify-skipped reason so the operator knows the check
+    didn't actually run.
     """
     responses.add(responses.GET, f"{BASE_URL}/api/v1/flows", status=200)
     responses.add(responses.POST, f"{BASE_URL}/api/v1/flows", status=201)
@@ -793,6 +791,48 @@ def test_run_register_system_flows_seed_verify_transport_error_keeps_success() -
     # Stays SUCCESS despite the verification failure
     assert result.execution_state == "SUCCESS"
     assert result.is_success is True
+    # NEW (round-2 fix): the operator sees the verify-failed signal
+    assert result.verify_skipped_reason is not None
+    assert "KestraError" in result.verify_skipped_reason
+
+
+# ---------------------------------------------------------------------------
+# wait_ready / wait_for_execution — sleep clamps to deadline
+# ---------------------------------------------------------------------------
+
+
+@responses.activate
+def test_wait_ready_short_timeout_does_not_block_on_long_interval() -> None:
+    """Sleep is clamped to deadline — `timeout_s=0.1, interval_s=10` doesn't
+    block 10 seconds. Round-2 fix to make the orchestrator's
+    ``ready_timeout_s`` parameter actually honour sub-second values."""
+    import time as _time
+
+    responses.add(responses.GET, f"{BASE_URL}/api/v1/flows", status=401)
+    start = _time.monotonic()
+    result = _client().wait_ready(timeout_s=0.1, interval_s=10.0)
+    elapsed = _time.monotonic() - start
+    assert result is False
+    # Should be ≤ ~0.2s; the old behavior would block the full 10s.
+    assert elapsed < 1.0, f"wait_ready blocked {elapsed:.2f}s, expected <1s"
+
+
+@responses.activate
+def test_wait_for_execution_short_timeout_does_not_block_on_long_interval() -> None:
+    """Same clamp for wait_for_execution."""
+    import time as _time
+
+    responses.add(
+        responses.GET,
+        f"{BASE_URL}/api/v1/executions/exec-1",
+        status=200,
+        json={"state": {"current": "RUNNING"}},
+    )
+    start = _time.monotonic()
+    result = _client().wait_for_execution("exec-1", timeout_s=0.1, interval_s=10.0)
+    elapsed = _time.monotonic() - start
+    assert result == "RUNNING"
+    assert elapsed < 1.0, f"wait_for_execution blocked {elapsed:.2f}s, expected <1s"
 
 
 # ---------------------------------------------------------------------------
@@ -937,16 +977,21 @@ def test_cli_kestra_missing_required_env_returns_2(
     assert "missing required env" in err
 
 
-def test_cli_kestra_missing_kestra_pass_returns_zero_with_warning(
+def test_cli_kestra_missing_kestra_pass_returns_one_with_warning(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    """No Kestra password in SECRETS_JSON → log warning, exit 0 (deploy continues)."""
+    """No Kestra password in SECRETS_JSON → log warning, rc=1.
+
+    Round-2 fix: previously rc=0 (mapped to green "registered" banner).
+    rc=1 routes deploy.sh to the yellow-warning branch — accurate signal
+    that nothing was registered.
+    """
     from nexus_deploy.__main__ import _kestra_register_system_flows
 
     _set_required_env(monkeypatch)
     monkeypatch.setattr("sys.stdin.read", lambda: "{}")
     rc = _kestra_register_system_flows([])
-    assert rc == 0
+    assert rc == 1
     err = capsys.readouterr().err
     assert "KESTRA_PASS missing" in err
 
@@ -1122,3 +1167,198 @@ def test_cli_kestra_partial_failure_returns_one(
     captured = capsys.readouterr()
     assert "failed=1" in captured.out
     assert "execution=skipped" in captured.out
+
+
+def test_cli_kestra_emits_actionable_warning_per_execution_state(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Round-2 fix: instead of bare enum (TRIGGER_FAILED), CLI emits
+    a human-actionable hint mirroring deploy.sh's per-case warnings."""
+    from nexus_deploy.__main__ import _kestra_register_system_flows
+
+    _set_required_env(monkeypatch)
+    monkeypatch.setattr("sys.stdin.read", lambda: '{"kestra_admin_password": "kp"}')
+
+    def fake_run(*_args: Any, **_kwargs: Any) -> SystemFlowsResult:
+        return SystemFlowsResult(
+            flows=(
+                RegisterResult(name="system.git-sync", status="created", detail="POST 201"),
+                RegisterResult(name="system.flow-sync", status="created", detail="POST 201"),
+            ),
+            execution_state="TRIGGER_FAILED",
+        )
+
+    monkeypatch.setattr("nexus_deploy.__main__.run_register_system_flows", fake_run)
+
+    from contextlib import contextmanager
+
+    class _OkSSH:
+        def __init__(self, *_args: Any, **_kwargs: Any) -> None:
+            pass
+
+        def __enter__(self) -> _OkSSH:
+            return self
+
+        def __exit__(self, *_exc: Any) -> None:
+            return None
+
+        @contextmanager
+        def port_forward(self, *_args: Any, **_kwargs: Any) -> Any:
+            yield 8085
+
+    monkeypatch.setattr("nexus_deploy.__main__.SSHClient", _OkSSH)
+    rc = _kestra_register_system_flows([])
+    assert rc == 1
+    err = capsys.readouterr().err
+    # The bare enum is shown
+    assert "TRIGGER_FAILED" in err
+    # The actionable hint is also shown — operator sees the remediation
+    assert "first sync will run on the next 15-min cron tick" in err
+
+
+def test_cli_kestra_emits_seed_flow_missing_hint(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """SEED_FLOW_MISSING is the most-likely operator-misconfiguration case:
+    the workspace repo is missing the seed flow YAML. The hint must
+    point them to the file path that needs to be present."""
+    from nexus_deploy.__main__ import _kestra_register_system_flows
+
+    _set_required_env(monkeypatch)
+    monkeypatch.setattr("sys.stdin.read", lambda: '{"kestra_admin_password": "kp"}')
+
+    def fake_run(*_args: Any, **_kwargs: Any) -> SystemFlowsResult:
+        return SystemFlowsResult(
+            flows=(
+                RegisterResult(name="system.git-sync", status="created", detail="POST 201"),
+                RegisterResult(name="system.flow-sync", status="created", detail="POST 201"),
+            ),
+            execution_state="SEED_FLOW_MISSING",
+        )
+
+    monkeypatch.setattr("nexus_deploy.__main__.run_register_system_flows", fake_run)
+
+    from contextlib import contextmanager
+
+    class _OkSSH:
+        def __init__(self, *_args: Any, **_kwargs: Any) -> None:
+            pass
+
+        def __enter__(self) -> _OkSSH:
+            return self
+
+        def __exit__(self, *_exc: Any) -> None:
+            return None
+
+        @contextmanager
+        def port_forward(self, *_args: Any, **_kwargs: Any) -> Any:
+            yield 8085
+
+    monkeypatch.setattr("nexus_deploy.__main__.SSHClient", _OkSSH)
+    rc = _kestra_register_system_flows([])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "SEED_FLOW_MISSING" in err
+    assert "nexus_seeds/kestra/flows/r2-taxi-pipeline.yaml" in err
+
+
+def test_cli_kestra_emits_verify_skipped_warning(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """When the verify step itself failed (5xx during flow_exists), the
+    state stays SUCCESS but the operator sees that the check didn't run."""
+    from nexus_deploy.__main__ import _kestra_register_system_flows
+
+    _set_required_env(monkeypatch)
+    monkeypatch.setattr("sys.stdin.read", lambda: '{"kestra_admin_password": "kp"}')
+
+    def fake_run(*_args: Any, **_kwargs: Any) -> SystemFlowsResult:
+        return SystemFlowsResult(
+            flows=(
+                RegisterResult(name="system.git-sync", status="created", detail="POST 201"),
+                RegisterResult(name="system.flow-sync", status="created", detail="POST 201"),
+            ),
+            execution_state="SUCCESS",
+            verify_skipped_reason="flow_exists raised KestraError (KestraError)",
+        )
+
+    monkeypatch.setattr("nexus_deploy.__main__.run_register_system_flows", fake_run)
+
+    from contextlib import contextmanager
+
+    class _OkSSH:
+        def __init__(self, *_args: Any, **_kwargs: Any) -> None:
+            pass
+
+        def __enter__(self) -> _OkSSH:
+            return self
+
+        def __exit__(self, *_exc: Any) -> None:
+            return None
+
+        @contextmanager
+        def port_forward(self, *_args: Any, **_kwargs: Any) -> Any:
+            yield 8085
+
+    monkeypatch.setattr("nexus_deploy.__main__.SSHClient", _OkSSH)
+    rc = _kestra_register_system_flows([])
+    # SUCCESS is preserved → rc=0 (transient verify failure isn't a deploy failure)
+    assert rc == 0
+    err = capsys.readouterr().err
+    assert "seed-flow visibility check skipped" in err
+    assert "KestraError" in err
+
+
+def test_cli_kestra_uses_dynamically_allocated_local_port(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Round-2 fix: local port is kernel-allocated (not hardcoded 8085)
+    so leftover tunnels / local services on 8085 don't clash."""
+    from nexus_deploy.__main__ import _allocate_free_port, _kestra_register_system_flows
+
+    _set_required_env(monkeypatch)
+    monkeypatch.setattr("sys.stdin.read", lambda: '{"kestra_admin_password": "kp"}')
+
+    captured_local_port: list[int] = []
+
+    from contextlib import contextmanager
+
+    class _CapturingSSH:
+        def __init__(self, *_args: Any, **_kwargs: Any) -> None:
+            pass
+
+        def __enter__(self) -> _CapturingSSH:
+            return self
+
+        def __exit__(self, *_exc: Any) -> None:
+            return None
+
+        @contextmanager
+        def port_forward(self, local_port: int, *_args: Any, **_kwargs: Any) -> Any:
+            captured_local_port.append(local_port)
+            yield local_port
+
+    def fake_run(*_args: Any, **_kwargs: Any) -> SystemFlowsResult:
+        return SystemFlowsResult(
+            flows=(
+                RegisterResult(name="system.git-sync", status="created", detail="POST 201"),
+                RegisterResult(name="system.flow-sync", status="created", detail="POST 201"),
+            ),
+            execution_state="SUCCESS",
+        )
+
+    monkeypatch.setattr("nexus_deploy.__main__.SSHClient", _CapturingSSH)
+    monkeypatch.setattr("nexus_deploy.__main__.run_register_system_flows", fake_run)
+
+    _kestra_register_system_flows([])
+    assert len(captured_local_port) == 1
+    # NOT 8085 (the production-side Kestra port). Some kernel-chosen
+    # ephemeral port instead — typically in the 32768-60999 range on
+    # Linux, 49152-65535 on macOS. Just check it's not the hardcoded
+    # value, and that _allocate_free_port returns ints.
+    assert captured_local_port[0] != 8085
+    assert isinstance(captured_local_port[0], int)
+    assert captured_local_port[0] > 0
+
+    # Sanity: _allocate_free_port itself returns a usable port
+    p = _allocate_free_port()
+    assert isinstance(p, int)
+    assert 0 < p < 65536

--- a/tests/unit/test_ssh.py
+++ b/tests/unit/test_ssh.py
@@ -249,14 +249,17 @@ def test_port_forward_yields_after_local_port_accepts(
             # plus -o ExitOnForwardFailure=yes (so a port-in-use bind
             # failure exits ssh immediately instead of leaving a stale
             # process that could let _wait_for_local_port falsely
-            # connect to an unrelated listener).
+            # connect to an unrelated listener) AND the explicit
+            # 127.0.0.1: bind-address prefix on the forward spec
+            # (round-4 fix: prevents IPv6 ::1 dual-stack bind that
+            # could collide with an IPv4-only port-allocator's probe).
             assert captured_argv[0] == [
                 "ssh",
                 "-N",
                 "-o",
                 "ExitOnForwardFailure=yes",
                 "-L",
-                f"{local_port}:localhost:9200",
+                f"127.0.0.1:{local_port}:localhost:9200",
                 "nexus",
             ]
         # Tunnel subprocess gets terminated on context exit


### PR DESCRIPTION
## Summary

Migrates Kestra system-flow registration (`system.git-sync` + `system.flow-sync`) from a 165-line server-side bash heredoc to typed Python using the `port_forward` + `requests` pattern that Phase 3 Modul 3.1 enabled. First migration to actually exercise that path end-to-end.

- **`src/nexus_deploy/kestra.py`** — `KestraClient` with `wait_ready` / idempotent POST→PUT `register_flow` / `execute_flow` / `wait_for_execution`. Two system-flow YAML templates as Python constants (verbatim from deploy.sh modulo `{placeholder}` substitution). `run_register_system_flows` orchestrator.
- **CLI**: `python -m nexus_deploy kestra register-system-flows` — opens SSH port-forward (kernel-allocated local port → server's loopback 8085, which is the host-published mapping of the container's internal 8080 per `stacks/kestra/docker-compose.yml`), runs orchestrator, maps result to rc=0/1/2.
- **`scripts/deploy.sh`** — 165-line `REMOTE_REGISTER_EOF` heredoc replaced with a 22-line CLI invocation + dispatch case-block.

## Why this PR (and not Gitea + Kestra together)

I planned to bundle Gitea + Kestra in one PR. Looking at the Gitea block in deploy.sh, it's ~600 lines: synchronous, depends on Postgres + seeder, has multi-step DB-password sync + admin-email-collision-remap + dotted-username detection + token-create-with-retry + workspace-repo + collaborator + mirror-mode branch. Combining it with Kestra would mean a ~1500 LoC PR with two unrelated complexity surfaces — exactly the size class where Copilot proportional-finding-density hits and review fatigue sets in.

Kestra alone is a clean ~500 LoC slice: one new module, one CLI entry, one deploy.sh delete. Gitea will follow on its own merit.

## What this enables

The Phase 3 primitive `SSHClient.port_forward` was built precisely for this case — open a local TCP tunnel to a service running inside the nexus host's bridge network, then talk to it with regular Python `requests` calls. This PR is the first to actually use that pattern end-to-end: no rendered server-side bash, no heredoc-quoting, fully unit-testable against `responses`-mocked HTTP without ever invoking ssh.

The same pattern works for Gitea (the next PR) and any future REST-API hook.

## deploy.sh delta

`scripts/deploy.sh`: 4014 → 3866 lines (**−148 lines**, the legacy `REMOTE_REGISTER_EOF` heredoc + register_flow function + 2 inline YAML templates + flow-sync execute/poll).

Cumulative migration progress: 5539 → 3866 (~30.2% migrated).

## Test plan

- [x] `uv run ruff format --check . && uv run ruff check .` — pass
- [x] `uv run mypy --strict` — pass (27 source files)
- [x] `uv run pytest --cov=src/nexus_deploy --cov-fail-under=80` — **458 tests, 99.37% coverage**
- [x] `bash -n scripts/deploy.sh` — pass
- [ ] **Spin-up acceptance** (user-triggered, paid): `gh workflow run initial-setup.yaml --ref feat/python-migration-phase-2-3-kestra -f enabled_services=kestra,gitea,jupyter,marimo` — verify both `system.git-sync` and `system.flow-sync` appear in the Kestra UI under namespace `system` and the user-seeded `nexus-tutorials.r2-taxi-pipeline` flow appears under `nexus-tutorials` after the auto-triggered onboarding.

## Test coverage detail

61 new tests in `tests/unit/test_kestra.py`:

- **KestraClient constructor (3)** — empty username/password rejection, trailing-slash strip
- **wait_ready (6)** — 200 / 404 / 405 all accepted as ready; loops on 401 then succeeds; timeout returns False; ConnectionError doesn't crash the loop
- **register_flow (10)** — POST 200/201 → created; POST 422 → PUT 200 → updated; POST 422 → PUT 4xx → failed; POST 5xx/401 fall through to failed without PUT; transport errors at each stage; yaml Content-Type pinned; basic-auth via header (NOT body, NOT URL)
- **execute_flow (4)** — 201 returns ID; 5xx raises `KestraError`; missing-id raises; non-JSON raises; ConnectionError raises
- **get_execution_state + wait_for_execution (8)** — terminal states; UNKNOWN for unrecognised states / malformed payloads; 4xx/transport errors raise; non-JSON / list payload coalesce to UNKNOWN; transient KestraError → poll continues
- **render_system_flow templates (5)** — placeholder substitution; targetNamespace pinned to nexus-tutorials (regression guard for v1.0 plugin "must not be null" trap); Pebble syntax `{{ secret('GITEA_TOKEN') }}` reaches Kestra as single-brace
- **register_all_system_flows + trigger_flow_sync_onboarding (3)** — both flows registered; flow-sync execute + poll → SUCCESS
- **run_register_system_flows orchestrator (5)** — happy path with onboarding; kestra-not-ready short-circuits; skip onboarding when register failed; opt-out via `trigger_onboarding=False`; onboarding-KestraError records as `execution_state=None` without marking flows failed
- **SystemFlowsResult.is_success edge cases (3)** — execution=None is success when flows OK; RUNNING-at-timeout is failure; register-fail can't be masked by SUCCESS execution
- **CLI (7+)** — unknown args rc=2; missing env vars rc=2; **missing KESTRA_PASS rc=1** with warning (round-2 fix: was rc=0, but deploy.sh maps rc=0 to green "registered" banner — misleading; rc=1 routes to yellow-warning correctly); invalid SECRETS_JSON rc=2; SSH tunnel failure rc=2 (with safe SSHError message); unexpected RuntimeError rc=2 (class-name only, no `str(exc)` leak); happy path rc=0; partial failure rc=1; round-2-added: actionable hint emitted per `ExecutionState`; round-2-added: kernel-allocated local port

## Architecture notes

### Auth (R4)

Basic-auth credentials are passed to `requests.get/post/put` via the `auth=(user, pass)` keyword, which puts them in the `Authorization: Basic …` header. No shell-out at all here, except to `ssh` for the tunnel — and `ssh -N -L localport:remotehost:remoteport host` carries no service-side credentials in argv. Pinned by `test_register_flow_sends_basic_auth_in_header_not_body` which scans request body + URL for the password.

### Idempotent register

Kestra v1.0 OSS has split create/update semantics:
- `POST /api/v1/flows` → 200/201 = created; 422 = "Flow id already exists"; other = real failure
- `PUT /api/v1/flows/<ns>/<id>` → 200/201 = updated; 404 = flow absent; other = real failure

Neither alone covers re-runs. We mirror deploy.sh: try POST first; on 422, fall back to PUT.

### `RegisterResult.detail` strings carry HTTP status codes

When a register fails the operator needs to know whether it was `POST 401` (auth wrong), `POST 5xx` (Kestra hiccup), `POST 422 → PUT 4xx` (schema rejected), or `POST transport (ConnectionError)` (tunnel broken). The detail string is the operator's first debugging input.

### Selfreview before push

Applied the 5-point checklist (R4 / R1 / R3 / wire-format / idempotency):
- **R4 (no creds in argv)**: credentials in `Authorization` header via `requests.auth`. Pinned by `test_register_flow_sends_basic_auth_in_header_not_body`.
- **R1 (set -u first)**: N/A (no rendered bash in this module).
- **R3 (cleanup)**: HTTP-only; `requests` cleans up sockets per call.
- **Wire-format**: POST/PUT/GET endpoints + RegisterResult shape pinned by tests.
- **Idempotency**: POST first, PUT on 422 — matches deploy.sh exactly. Pinned by `test_register_flow_post_422_then_put_200_returns_updated`.

## Out of scope

- **Gitea hook (Modul 2.2e)** — synchronous, depends on Postgres + seeder, ~600 LoC of bash with edge cases (DB password sync, admin email-collision remap, dotted username detection, token-create-with-retry, workspace repo + collaborator, mirror-mode branch). Deserves its own focused PR.
- **Kestra Infisical secret-env build** (deploy.sh L2870-3294) — the ~250-line `SECRET_<NAME>=<base64>` env-var build that mirrors Modul 1.2's `secret_sync.py` pattern. Out of scope here; will be Modul 2.4 if migrated separately, or merged into the orchestrator (Modul 3.4).
- **Phase 3 Modul 3.3** (`stack_sync.py`), **3.4** (`orchestrator.py`), **Phase 4** (deploy.sh removal) — final PR after Gitea proves the Python admin-setup family works end-to-end.

## Refs

Refs #505 (Python migration parent issue)

