### PR TITLE
feat(nexus_deploy): Migrate Gitea synchronous core (Modul 2.2e, #505)

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -2483,7 +2483,16 @@ fi
 # depend on the Gitea repo being created before they can be configured.
 if echo "$ENABLED_SERVICES" | grep -qw "gitea" && [ -n "$GITEA_ADMIN_PASS" ]; then
     echo "  Configuring Gitea..."
+    # Tempfile holds the eval-able `GITEA_TOKEN=<sha1>` line. chmod
+    # 600 explicitly (mktemp's mode is umask-dependent — CI runners
+    # often run with umask 022 → 644 by default, which would let
+    # any other process on the runner read the token). Register
+    # with the global RUNNER_CLEANUP_PATHS list so an interrupt
+    # between mktemp and the explicit `rm -f` below still triggers
+    # removal via the script's EXIT trap (see L324-331).
     GITEA_OUT=$(mktemp)
+    chmod 600 "$GITEA_OUT"
+    echo "$GITEA_OUT" >> "$RUNNER_CLEANUP_PATHS"
     GITEA_RC=0
     # Pass env vars via the `uv run` line, NOT via the leading `echo` —
     # otherwise the assignments are scoped only to `echo` and the python

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -2534,31 +2534,36 @@ if echo "$ENABLED_SERVICES" | grep -qw "gitea" && [ -n "$GITEA_ADMIN_PASS" ]; th
     # --- Workspace seed + service restart (post-token, non-mirror only) ---
     if [ -n "${GITEA_TOKEN:-}" ]; then
 
+        # Seed examples/workspace-seeds/ → Gitea repo via the migrated
+        # nexus_deploy.seeder CLI (Phase 2 Modul 2.1, #512). Defined
+        # UNCONDITIONALLY (outside the GH_MIRROR_REPOS branch) so the
+        # mirror-mode block later in this script can call it for
+        # per-user forks too — Modul 2.2f will migrate that block.
+        # Args default to $GITEA_REPO_OWNER/$REPO_NAME (matches the
+        # legacy no-arg call site at L3403). Pass explicit owner/repo
+        # when looping over multiple repos (e.g. mirror forks).
+        seed_workspace_files() {
+            local owner="${1:-$GITEA_REPO_OWNER}" repo="${2:-$REPO_NAME}"
+            local SEED_DIR="$PROJECT_ROOT/examples/workspace-seeds"
+            if [ ! -d "$SEED_DIR" ] || [ -z "$GITEA_TOKEN" ] || [ -z "$repo" ] || [ -z "$owner" ]; then
+                return 0
+            fi
+            echo "  Seeding workspace files into ${owner}/${repo}..."
+            local SEED_RC=0
+            GITEA_TOKEN="$GITEA_TOKEN" \
+                uv run --quiet --project "$PROJECT_ROOT" \
+                python -m nexus_deploy seed \
+                --repo "$owner/$repo" \
+                --root "$SEED_DIR" \
+                || SEED_RC=$?
+            case "$SEED_RC" in
+                0) ;;
+                1) echo -e "${YELLOW}  ⚠ Workspace seed had partial failures (continuing)${NC}" ;;
+                *) echo -e "${RED}  ✗ Workspace seed transport failure (rc=$SEED_RC); aborting${NC}"; exit 1 ;;
+            esac
+        }
+
         if [ -z "${GH_MIRROR_REPOS:-}" ]; then
-            # Seed examples/workspace-seeds/ → workspace repo via the migrated
-            # nexus_deploy.seeder CLI (Phase 2 Modul 2.1, #512). Kept as a
-            # function so mirror-mode can call it for forks too (still
-            # in deploy.sh — separate Modul 2.2f migration).
-            seed_workspace_files() {
-                local owner="$1" repo="$2"
-                local SEED_DIR="$PROJECT_ROOT/examples/workspace-seeds"
-                if [ ! -d "$SEED_DIR" ] || [ -z "$GITEA_TOKEN" ] || [ -z "$repo" ] || [ -z "$owner" ]; then
-                    return 0
-                fi
-                echo "  Seeding workspace files into ${owner}/${repo}..."
-                local SEED_RC=0
-                GITEA_TOKEN="$GITEA_TOKEN" \
-                    uv run --quiet --project "$PROJECT_ROOT" \
-                    python -m nexus_deploy seed \
-                    --repo "$owner/$repo" \
-                    --root "$SEED_DIR" \
-                    || SEED_RC=$?
-                case "$SEED_RC" in
-                    0) ;;
-                    1) echo -e "${YELLOW}  ⚠ Workspace seed had partial failures (continuing)${NC}" ;;
-                    *) echo -e "${RED}  ✗ Workspace seed transport failure (rc=$SEED_RC); aborting${NC}"; exit 1 ;;
-                esac
-            }
             seed_workspace_files "$GITEA_REPO_OWNER" "$REPO_NAME"
 
             # Restart git-integrated services. Python emitted a CSV via

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -2463,350 +2463,107 @@ fi
 
 
 # Configure Gitea admin account and shared workspace repo
+# Phase 2 Modul 2.2e (#505) — moved from a 346-line synchronous block
+# (DB pw sync + admin/user create-or-sync + legacy email PATCH +
+# token retry-via-delete + workspace repo + collaborator) to
+# nexus_deploy.gitea. Same idempotent behavior; same column-exact
+# user-existence checks (PR #464 bug fix preserved); same
+# legacy-email-collision PATCH (Stage 3, v0.51.9 fix preserved).
+# Token comes back via stdout `GITEA_TOKEN=...` line and is captured
+# via eval so seed_workspace_files (already migrated, #512) +
+# downstream Kestra (#517) can use it. RESTART_SERVICES is also
+# emitted on stdout so the post-token restart loop knows which
+# git-integrated services need a recreate.
+#
+# NOT migrated in this PR (separate Modul 2.2f):
+#   - mirror-mode (GH_MIRROR_REPOS block at L3443+)
+#   - Woodpecker OAuth registration (L3373+)
+#
 # NOTE: This runs synchronously (not in background) because other services
 # depend on the Gitea repo being created before they can be configured.
 if echo "$ENABLED_SERVICES" | grep -qw "gitea" && [ -n "$GITEA_ADMIN_PASS" ]; then
     echo "  Configuring Gitea..."
-
-    # Sync DB password with the current OpenTofu-generated value.
-    # This handles persistent volume scenarios where the DB was initialized with
-    # a different password (e.g., after OpenTofu state recreation).
-    # Uses socket auth (peer) inside the container - no password required for the ALTER.
-    if [ -n "$GITEA_DB_PASS" ]; then
-        echo "  Syncing Gitea DB password..."
-        # Escape password for safe use in SQL string literal
-        GITEA_DB_PASS_ESC=$GITEA_DB_PASS
-        GITEA_DB_PASS_ESC=${GITEA_DB_PASS_ESC//\\/\\\\}
-        GITEA_DB_PASS_ESC=${GITEA_DB_PASS_ESC//\'/\'\'}
-        GITEA_DB_SYNCED=false
-        for i in $(seq 1 15); do
-            if ssh nexus "docker exec gitea-db psql -U nexus-gitea -d gitea \
-                -c \"ALTER USER \\\"nexus-gitea\\\" WITH PASSWORD '$GITEA_DB_PASS_ESC'\" \
-                >/dev/null 2>&1"; then
-                echo -e "${GREEN}  ✓ Gitea DB password synced${NC}"
-                GITEA_DB_SYNCED=true
-                break
+    GITEA_OUT=$(mktemp)
+    GITEA_RC=0
+    # Pass env vars via the `uv run` line, NOT via the leading `echo` —
+    # otherwise the assignments are scoped only to `echo` and the python
+    # subprocess sees them empty (the env-var-precedence-pipe-bug from
+    # PR #517 round 1).
+    echo "$SECRETS_JSON" | \
+        ADMIN_EMAIL="$ADMIN_EMAIL" \
+        REPO_NAME="$REPO_NAME" \
+        GITEA_REPO_OWNER="$GITEA_REPO_OWNER" \
+        GITEA_USER_EMAIL="${GITEA_USER_EMAIL:-}" \
+        GITEA_USER_PASS="${GITEA_USER_PASS:-}" \
+        GH_MIRROR_REPOS="${GH_MIRROR_REPOS:-}" \
+        ENABLED_SERVICES="$ENABLED_SERVICES" \
+        uv run --quiet --project "$PROJECT_ROOT" \
+        python -m nexus_deploy gitea configure > "$GITEA_OUT" \
+        || GITEA_RC=$?
+    case "$GITEA_RC" in
+        0|1)
+            # Even on partial-failure rc=1, the token (if minted) is in
+            # stdout — eval to capture it so downstream blocks
+            # (Kestra Git sync, mirror-mode forks) still work.
+            if [ -s "$GITEA_OUT" ]; then
+                eval "$(cat "$GITEA_OUT")"
             fi
-            sleep 2
-        done
-        if [ "$GITEA_DB_SYNCED" != "true" ]; then
-            echo -e "${YELLOW}  ⚠ Failed to sync Gitea DB password after 15 attempts${NC}"
-        fi
-    fi
-
-    # Wait for Gitea to be ready
-    GITEA_READY=false
-    for i in $(seq 1 30); do
-        if ssh nexus "curl -sf http://localhost:3200/api/healthz" >/dev/null 2>&1; then
-            GITEA_READY=true
-            break
-        fi
-        sleep 2
-    done
-
-    if [ "$GITEA_READY" = "true" ]; then
-        # Check if admin user already exists.
-        # awk-column-exact on the Username column ($2), NOT grep-substring on
-        # the whole line. grep -c '$NAME' falsely matches when the name appears
-        # anywhere in the output — e.g. as a substring of another user's email
-        # address. For the admin block this is only latent (the admin almost
-        # always exists, so a true or false positive both route to the SYNC
-        # branch which was going to run anyway), but the same pattern on the
-        # USER_EXISTS check below is a confirmed bug (see v0.51.7 stderr: on
-        # stacks where the admin email contains the user's username substring,
-        # USER_EXISTS=1 wrongly, CREATE is skipped, the user never exists,
-        # SYNC then fails). Fix the detection in both places for consistency.
-        #
-        # Two-step form (fetch → parse) instead of a one-line remote pipeline
-        # so the remote fetch isn't coupled to a downstream parser whose exit
-        # status could mask an upstream failure. The local code path here is
-        # a single command with an `||` fallback (not a pipeline), so
-        # set -o pipefail doesn't apply — ssh/docker failures are explicitly
-        # folded into an empty list via `|| echo ""` and the downstream awk
-        # then prints 0, routing to the CREATE branch (where PR #464's
-        # stderr capture surfaces any genuine connectivity problem). Same
-        # soft-fallback pattern this section uses elsewhere for transient-
-        # Gitea resilience during deploy — not a crash-on-error design.
-        # If stricter failure handling is wanted later, capture ssh's exit
-        # status in a separate variable and warn explicitly.
-        #
-        # printf '%s\n' instead of echo because bash's echo treats a leading
-        # '-n'/'-e'/'-E' in $ADMIN_LIST as options (not data). Gitea's list
-        # starts with "ID  Username  Email ..." in practice so the collision
-        # doesn't happen today, but printf is the idiomatic safe form.
-        ADMIN_LIST=$(ssh nexus "docker exec -u git gitea gitea admin user list --admin 2>/dev/null" || echo "")
-        ADMIN_EXISTS=$(printf '%s\n' "$ADMIN_LIST" | awk -v name="$ADMIN_USERNAME" 'NR>1 && $2==name {c++} END{print c+0}')
-
-        # Legacy-volume remediation: if admin was previously created with
-        # email == USER_EMAIL (every stack deployed with a pre-v0.51.9
-        # deploy.sh where the caller set both emails equal), the user-create
-        # below will fail with "e-mail already in use". Patch admin's email
-        # to the now-synthesised ADMIN_EMAIL via the Gitea admin API before
-        # the user-create runs. Idempotent: on subsequent spin-ups
-        # CURRENT_ADMIN_EMAIL no longer equals USER_EMAIL and this block
-        # short-circuits. No-op on fresh stacks (admin row doesn't exist
-        # yet) and on stacks where ADMIN_EMAIL and USER_EMAIL were already
-        # distinct (the normal template case).
-        #
-        # The PATCH body requires source_id and login_name even for an
-        # email-only update — Gitea's admin-users schema rejects partial
-        # bodies without them. source_id:0 = local auth provider.
-        if [ "$ADMIN_EXISTS" -gt 0 ] && [ -n "$GITEA_USER_EMAIL" ]; then
-            CURRENT_ADMIN_EMAIL=$(printf '%s\n' "$ADMIN_LIST" | awk -v name="$ADMIN_USERNAME" 'NR>1 && $2==name {print $3; exit}')
-            # Compare against GITEA_USER_EMAIL (single address). The admin
-            # row's email column is always a single address; if USER_EMAIL
-            # is a comma-list, a raw equality check would never match and
-            # this remap (Stage 3, v0.51.9) would silently not fire for
-            # upgraded stacks, leaving the legacy collision in place.
-            if [ "$CURRENT_ADMIN_EMAIL" = "$GITEA_USER_EMAIL" ]; then
-                echo "  Admin has legacy email conflicting with user — remapping to $ADMIN_EMAIL..."
-                # --fail-with-body so curl exits non-zero on HTTP 4xx/5xx while
-                # still printing the response body — without it, a Gitea
-                # validation error would be reported as "✓ remapped".
-                PATCH_OUTPUT=$(ssh nexus "curl -sS --fail-with-body -X PATCH 'http://localhost:3200/api/v1/admin/users/$ADMIN_USERNAME' \
-                    -u '$ADMIN_USERNAME:$GITEA_ADMIN_PASS' \
-                    -H 'Content-Type: application/json' \
-                    -d '{\"email\":\"$ADMIN_EMAIL\",\"source_id\":0,\"login_name\":\"$ADMIN_USERNAME\"}'" 2>&1) \
-                    && echo -e "${GREEN}  ✓ Admin email remapped${NC}" \
-                    || printf "${YELLOW}  ⚠ Could not remap admin email: %s${NC}\n" "$PATCH_OUTPUT"
-            fi
-        fi
-
-        if [ "$ADMIN_EXISTS" -gt 0 ]; then
-            # Sync password to match current OpenTofu state (persistent volume may have old password).
-            # Capture stderr so when the sync fails we see WHY. Previously this block
-            # used `>/dev/null 2>&1` and silently discarded the error, making diagnosis
-            # impossible for the dotted-username and similar failure classes. Matches
-            # the 2>&1 → RESULT var pattern the CREATE path below already uses.
-            # The failure branch uses printf so CHANGE_OUTPUT is printed verbatim —
-            # echo -e would interpret backslash sequences in the captured stderr
-            # (e.g. Gitea errors mentioning `\w+` or embedded escape codes).
-            echo "  Syncing Gitea admin password..."
-            CHANGE_OUTPUT=$(ssh nexus "docker exec -u git gitea gitea admin user change-password \
-                --username '$ADMIN_USERNAME' \
-                --password '$GITEA_ADMIN_PASS' \
-                --must-change-password=false" 2>&1) \
-                && echo -e "${GREEN}  ✓ Gitea admin password synced${NC}" \
-                || printf "${YELLOW}  ⚠ Could not sync Gitea admin password: %s${NC}\n" "$CHANGE_OUTPUT"
-        else
-            # Create admin user via CLI
-            GITEA_RESULT=$(ssh nexus "docker exec -u git gitea gitea admin user create \
-                --admin \
-                --username '$ADMIN_USERNAME' \
-                --password '$GITEA_ADMIN_PASS' \
-                --email '$ADMIN_EMAIL' \
-                --must-change-password=false" 2>&1 || echo "")
-
-            if echo "$GITEA_RESULT" | grep -qi "created\|success\|New user"; then
-                echo -e "${GREEN}  ✓ Gitea admin created (user: $ADMIN_USERNAME)${NC}"
+            if [ "$GITEA_RC" = "1" ]; then
+                echo -e "${YELLOW}  ⚠ Gitea config had partial failures (continuing)${NC}"
             else
-                # Print the captured result so the Gitea error is visible, not
-                # swallowed. printf (not echo -e) so any backslash sequences in
-                # the captured output are rendered verbatim — same rationale
-                # as the change-password failure branches above.
-                printf "${YELLOW}  ⚠ Gitea admin setup needs manual configuration: %s${NC}\n" "$GITEA_RESULT"
-                echo -e "${YELLOW}    Credentials available in Infisical${NC}"
+                echo -e "${GREEN}  ✓ Gitea configured${NC}"
             fi
-        fi
+            ;;
+        *)
+            rm -f "$GITEA_OUT"
+            echo -e "${RED}  ✗ Gitea hard failure (rc=$GITEA_RC); aborting${NC}"
+            exit "$GITEA_RC"
+            ;;
+    esac
+    rm -f "$GITEA_OUT"
 
-        # --- Create regular user account (for students/user_email) ---
-        # Extract username from the single-address GITEA_USER_EMAIL (see ~line 85).
-        # Gate on GITEA_USER_EMAIL (not raw USER_EMAIL) — empty-after-trim
-        # means no valid single address, so CREATE/SYNC both skip cleanly.
-        GITEA_USER_USERNAME="${GITEA_USER_EMAIL%%@*}"
-        if [ -n "$GITEA_USER_EMAIL" ] && [ -n "$GITEA_USER_PASS" ]; then
-            # Same column-exact awk pattern as the admin block above, with the
-            # same two-step fetch-then-parse structure. Note that the current
-            # `|| echo ""` fallback collapses ssh/list failures into an empty
-            # result, so failures are treated the same as the "no match" case
-            # (awk prints 0 → CREATE path fires, where PR #464's stderr capture
-            # surfaces the genuine error). This is the block where the
-            # grep-substring form actively broke things: GITEA_USER_USERNAME
-            # is derived from USER_EMAIL prefix (e.g. stefan.koch from
-            # stefan.koch@hslu.ch). If ADMIN_EMAIL also ends in @hslu.ch (or
-            # otherwise contains the user's username as a substring),
-            # `grep -c 'stefan.koch'` matches the admin's email column —
-            # USER_EXISTS=1, CREATE never runs, user is never created,
-            # subsequent SYNC fails because the target doesn't exist.
-            # printf '%s\n' instead of echo — see admin block above for rationale.
-            USER_LIST=$(ssh nexus "docker exec -u git gitea gitea admin user list 2>/dev/null" || echo "")
-            USER_EXISTS=$(printf '%s\n' "$USER_LIST" | awk -v name="$GITEA_USER_USERNAME" 'NR>1 && $2==name {c++} END{print c+0}')
+    # --- Workspace seed + service restart (post-token, non-mirror only) ---
+    if [ -n "${GITEA_TOKEN:-}" ]; then
 
-            if [ "$USER_EXISTS" -gt 0 ]; then
-                # Sync password to match current OpenTofu state (persistent volume may have old password).
-                # Capture stderr — see admin block above for rationale. Currently chasing
-                # a failure class where user stacks whose email prefix contains a dot
-                # (e.g. stefan.koch@hslu.ch → username stefan.koch) silently fail this
-                # sync on every second-or-later Spin Up. Template stack (sk@…) works.
-                # Without the output here we can't tell whether it's a CLI limitation,
-                # a sanitized-name mismatch, or something else — so make it vocal.
-                # Failure branch uses printf (not echo -e) so CHANGE_OUTPUT is printed
-                # verbatim — see admin block above.
-                echo "  Syncing Gitea user password..."
-                CHANGE_OUTPUT=$(ssh nexus "docker exec -u git gitea gitea admin user change-password \
-                    --username '$GITEA_USER_USERNAME' \
-                    --password '$GITEA_USER_PASS' \
-                    --must-change-password=false" 2>&1) \
-                    && echo -e "${GREEN}  ✓ Gitea user password synced${NC}" \
-                    || printf "${YELLOW}  ⚠ Could not sync Gitea user password: %s${NC}\n" "$CHANGE_OUTPUT"
-            else
-                GITEA_USER_RESULT=$(ssh nexus "docker exec -u git gitea gitea admin user create \
-                    --username '$GITEA_USER_USERNAME' \
-                    --password '$GITEA_USER_PASS' \
-                    --email '$GITEA_USER_EMAIL' \
-                    --must-change-password=false" 2>&1 || echo "")
-
-                if echo "$GITEA_USER_RESULT" | grep -qi "created\|success\|New user"; then
-                    echo -e "${GREEN}  ✓ Gitea user created (user: $GITEA_USER_USERNAME)${NC}"
-                else
-                    # Print the captured result — see admin CREATE branch above.
-                    printf "${YELLOW}  ⚠ Gitea user setup needs manual configuration: %s${NC}\n" "$GITEA_USER_RESULT"
+        if [ -z "${GH_MIRROR_REPOS:-}" ]; then
+            # Seed examples/workspace-seeds/ → workspace repo via the migrated
+            # nexus_deploy.seeder CLI (Phase 2 Modul 2.1, #512). Kept as a
+            # function so mirror-mode can call it for forks too (still
+            # in deploy.sh — separate Modul 2.2f migration).
+            seed_workspace_files() {
+                local owner="$1" repo="$2"
+                local SEED_DIR="$PROJECT_ROOT/examples/workspace-seeds"
+                if [ ! -d "$SEED_DIR" ] || [ -z "$GITEA_TOKEN" ] || [ -z "$repo" ] || [ -z "$owner" ]; then
+                    return 0
                 fi
-            fi
-        fi
+                echo "  Seeding workspace files into ${owner}/${repo}..."
+                local SEED_RC=0
+                GITEA_TOKEN="$GITEA_TOKEN" \
+                    uv run --quiet --project "$PROJECT_ROOT" \
+                    python -m nexus_deploy seed \
+                    --repo "$owner/$repo" \
+                    --root "$SEED_DIR" \
+                    || SEED_RC=$?
+                case "$SEED_RC" in
+                    0) ;;
+                    1) echo -e "${YELLOW}  ⚠ Workspace seed had partial failures (continuing)${NC}" ;;
+                    *) echo -e "${RED}  ✗ Workspace seed transport failure (rc=$SEED_RC); aborting${NC}"; exit 1 ;;
+                esac
+            }
+            seed_workspace_files "$GITEA_REPO_OWNER" "$REPO_NAME"
 
-        # --- Create shared workspace repo ---
-        # Create admin API token for automation (reuse existing if present)
-        # Use curl -s (not -sf) to avoid exit code 22 on HTTP errors with set -e
-        GITEA_TOKEN=$(ssh nexus "curl -s -X POST 'http://localhost:3200/api/v1/users/$ADMIN_USERNAME/tokens' \
-            -u '$ADMIN_USERNAME:$GITEA_ADMIN_PASS' \
-            -H 'Content-Type: application/json' \
-            -d '{\"name\":\"nexus-automation\",\"scopes\":[\"all\"]}'" 2>/dev/null | jq -r '.sha1 // empty')
-
-        if [ -z "$GITEA_TOKEN" ]; then
-            # Token may already exist, try to delete and recreate
-            ssh nexus "curl -s -X DELETE 'http://localhost:3200/api/v1/users/$ADMIN_USERNAME/tokens/nexus-automation' \
-                -u '$ADMIN_USERNAME:$GITEA_ADMIN_PASS'" >/dev/null 2>&1 || true
-            GITEA_TOKEN=$(ssh nexus "curl -s -X POST 'http://localhost:3200/api/v1/users/$ADMIN_USERNAME/tokens' \
-                -u '$ADMIN_USERNAME:$GITEA_ADMIN_PASS' \
-                -H 'Content-Type: application/json' \
-                -d '{\"name\":\"nexus-automation\",\"scopes\":[\"all\"]}'" 2>/dev/null | jq -r '.sha1 // empty')
-        fi
-
-        # ---------------------------------------------------------------
-        # seed_workspace_files — POST every file under
-        # `examples/workspace-seeds/` into the workspace Gitea repo at
-        # the same relative path. POST returns 422 ("already exists")
-        # for files the user has already touched, which we count as
-        # SKIPPED so user edits persist across re-deploys.
-        #
-        # Called from BOTH branches of the workspace-repo-creation flow:
-        # the non-mirror branch seeds the default `nexus-<slug>-gitea`
-        # repo, the mirror branch seeds each user's fork after it has
-        # been created. The repo PATH owner comes from
-        # `$GITEA_REPO_OWNER` (set per-mode at the top of this script):
-        # admin in non-mirror / mirror-readonly mode, the user's Gitea
-        # username in mirror+user mode. The auth still goes through the
-        # admin token (`$GITEA_TOKEN`) — admin has API access to write
-        # to user forks too.
-        #
-        # Token transits via a curl `--config` file rather than `-H
-        # 'Authorization: token <TOK>'` per request: the latter would
-        # leak the token into the remote `ps` listing for every
-        # iteration of the loop.
-        # ---------------------------------------------------------------
-        # Migrated from a 113-line bash function (Phase 2 Modul 2.1, #505)
-        # to nexus_deploy.seeder. Both call-sites (non-mirror and
-        # mirror+user mode) keep using this thin wrapper to preserve
-        # control flow + the global $REPO_NAME / $GITEA_REPO_OWNER
-        # convention.
-        # Exit-code contract enforced by the Python CLI:
-        #   0 = all files created or correctly skipped (HTTP 422 = exists)
-        #   1 = partial — some files failed but at least one succeeded
-        #   2 = transport / unexpected error → abort the deploy
-        seed_workspace_files() {
-            local SEED_DIR="$PROJECT_ROOT/examples/workspace-seeds"
-            if [ ! -d "$SEED_DIR" ] || [ -z "$GITEA_TOKEN" ] || [ -z "$REPO_NAME" ] || [ -z "$GITEA_REPO_OWNER" ]; then
-                return 0
-            fi
-            echo "  Seeding workspace files into ${GITEA_REPO_OWNER}/${REPO_NAME}..."
-            local SEED_RC=0
-            GITEA_TOKEN="$GITEA_TOKEN" \
-                uv run --quiet --project "$PROJECT_ROOT" \
-                python -m nexus_deploy seed \
-                --repo "$GITEA_REPO_OWNER/$REPO_NAME" \
-                --root "$SEED_DIR" \
-                || SEED_RC=$?
-            case "$SEED_RC" in
-                0) ;;
-                1) echo -e "${YELLOW}  ⚠ Workspace seed had partial failures (continuing)${NC}" ;;
-                *) echo -e "${RED}  ✗ Workspace seed transport failure (rc=$SEED_RC); aborting${NC}"; exit 1 ;;
-            esac
-        }
-
-        if [ -n "$GITEA_TOKEN" ]; then
-            GITEA_USER_USERNAME="${GITEA_USER_EMAIL%%@*}"
-
-            if [ -z "${GH_MIRROR_REPOS:-}" ]; then
-                # --- Create default empty workspace repo ---
-                # (When GH_MIRROR_REPOS is set, the fork is created after the mirror is ready)
-                REPO_NAME="nexus-${DOMAIN//./-}-gitea"
-                echo "  Creating shared workspace repo: $REPO_NAME..."
-
-                # Create private repo (requires auth for clone and push)
-                # Use curl -s (not -sf) - repo may already exist (409), which is fine
-                REPO_RESULT=$(ssh nexus "curl -s -X POST 'http://localhost:3200/api/v1/user/repos' \
-                    -H 'Authorization: token $GITEA_TOKEN' \
-                    -H 'Content-Type: application/json' \
-                    -d '{
-                        \"name\": \"$REPO_NAME\",
-                        \"description\": \"Shared workspace for notebooks, workflows, and pipelines\",
-                        \"private\": true,
-                        \"auto_init\": true,
-                        \"default_branch\": \"main\"
-                    }'" 2>/dev/null || echo "")
-
-                if echo "$REPO_RESULT" | jq -e '.id' >/dev/null 2>&1; then
-                    echo -e "${GREEN}  ✓ Shared repo '$REPO_NAME' created (private)${NC}"
-                elif echo "$REPO_RESULT" | grep -q "already exists"; then
-                    echo -e "${YELLOW}  ⚠ Repo '$REPO_NAME' already exists${NC}"
-                    # Ensure existing repo is set to private
-                    ssh nexus "curl -s -X PATCH 'http://localhost:3200/api/v1/repos/$ADMIN_USERNAME/$REPO_NAME' \
-                        -H 'Authorization: token $GITEA_TOKEN' \
-                        -H 'Content-Type: application/json' \
-                        -d '{\"private\": true}'" >/dev/null 2>&1 || true
-                else
-                    echo -e "${YELLOW}  ⚠ Repo creation returned unexpected response${NC}"
-                fi
-
-                # --- Add user as collaborator to the repo ---
-                if [ -n "$GITEA_USER_USERNAME" ] && [ -n "$GITEA_USER_PASS" ]; then
-                    ssh nexus "curl -s -X PUT 'http://localhost:3200/api/v1/repos/$ADMIN_USERNAME/$REPO_NAME/collaborators/$GITEA_USER_USERNAME' \
-                        -H 'Authorization: token $GITEA_TOKEN' \
-                        -H 'Content-Type: application/json' \
-                        -d '{\"permission\": \"write\"}'" >/dev/null 2>&1 || true
-                    echo -e "${GREEN}  ✓ User '$GITEA_USER_USERNAME' added as collaborator${NC}"
-                fi
-
-                # Seed example workspace files via shared function (also
-                # called from the GH_MIRROR_REPOS branch later in this script
-                # so mirror users get the same starter material). See the
-                # function definition for the full mapping rationale.
-                seed_workspace_files
-            fi
-
-            # --- Restart services that have Git integration (to pick up .env vars) ---
-            # Services had their Git .env vars generated in Step 3 but Gitea wasn't
-            # ready yet. Now that the repo exists, restart them to trigger git clone.
-            # When GH_MIRROR_REPOS is set, the fork doesn't exist yet at this point -
-            # services are restarted later in the mirror setup block after fork creation.
-            if [ -z "${GH_MIRROR_REPOS:-}" ]; then
-                RESTART_SERVICES=""
-                for SERVICE in jupyter marimo code-server meltano prefect; do
-                    if echo "$ENABLED_SERVICES" | grep -qw "$SERVICE"; then
-                        RESTART_SERVICES="$RESTART_SERVICES $SERVICE"
-                    fi
+            # Restart git-integrated services. Python emitted a CSV via
+            # RESTART_SERVICES=, captured by eval above. Empty CSV → noop.
+            if [ -n "${RESTART_SERVICES:-}" ]; then
+                echo "  Restarting services with Git integration..."
+                IFS=',' read -ra _RS <<< "$RESTART_SERVICES"
+                for SERVICE in "${_RS[@]}"; do
+                    ssh nexus "cd $REMOTE_STACKS_DIR/$SERVICE && docker compose restart" >/dev/null 2>&1 || true
+                    echo "    Restarted $SERVICE"
                 done
-
-                if [ -n "$RESTART_SERVICES" ]; then
-                    echo "  Restarting services with Git integration..."
-                    for SERVICE in $RESTART_SERVICES; do
-                        ssh nexus "cd $REMOTE_STACKS_DIR/$SERVICE && docker compose restart" >/dev/null 2>&1 || true
-                        echo "    Restarted $SERVICE"
-                    done
-                    echo -e "${GREEN}  ✓ Git-integrated services restarted${NC}"
-                fi
+                echo -e "${GREEN}  ✓ Git-integrated services restarted${NC}"
             fi
+        fi
 
             # --- Configure Kestra Git sync flow ---
             if echo "$ENABLED_SERVICES" | grep -qw "kestra"; then
@@ -3423,12 +3180,9 @@ WPEOF
                 fi
             fi
 
-            echo -e "${GREEN}  ✓ Gitea workspace setup complete${NC}"
-        else
-            echo -e "${YELLOW}  ⚠ Could not create Gitea API token - skipping repo setup${NC}"
-        fi
+        echo -e "${GREEN}  ✓ Gitea workspace setup complete${NC}"
     else
-        echo -e "${YELLOW}  ⚠ Gitea not ready after 60s - skipping admin setup${NC}"
+        echo -e "${YELLOW}  ⚠ Gitea token not minted — skipping seed/Kestra/Woodpecker${NC}"
         echo -e "${YELLOW}    Credentials available in Infisical${NC}"
     fi
 fi

--- a/src/nexus_deploy/__main__.py
+++ b/src/nexus_deploy/__main__.py
@@ -821,10 +821,13 @@ def _gitea_configure(args: list[str]) -> int:
     coordinates from environment variables:
 
     - ``ADMIN_EMAIL`` — admin's email
-    - ``GITEA_USER_EMAIL`` (optional) — regular user's email; if set,
-      the user will be created/synced. Also drives the legacy
-      email-collision PATCH check on the admin row.
-    - ``GITEA_USER_PASS`` (optional) — required iff GITEA_USER_EMAIL set
+    - ``GITEA_USER_EMAIL`` (optional) — regular user's email. Drives the
+      legacy email-collision PATCH check on the admin row. The user is
+      created/synced ONLY when both this AND ``GITEA_USER_PASS`` are set
+      — if either is missing the user-create/sync branch is silently
+      skipped (mirrors deploy.sh L2617's `[ -n "$GITEA_USER_EMAIL" ] &&
+      [ -n "$GITEA_USER_PASS" ]` guard).
+    - ``GITEA_USER_PASS`` (optional) — see ``GITEA_USER_EMAIL`` above
     - ``REPO_NAME`` — workspace repo name (e.g. nexus-<slug>-gitea)
     - ``GITEA_REPO_OWNER`` — owner of the workspace repo
     - ``ENABLED_SERVICES`` — comma-or-space list driving the

--- a/src/nexus_deploy/__main__.py
+++ b/src/nexus_deploy/__main__.py
@@ -10,6 +10,7 @@ Currently:
 - ``compose up --enabled <comma-list>`` (#505 Modul 2.2a)
 - ``services configure --enabled <comma-list>`` (#505 Modul 2.2b/c/d)
 - ``kestra register-system-flows`` (#505 Modul 2.3)
+- ``gitea configure`` (#505 Modul 2.2e)
 """
 
 from __future__ import annotations
@@ -22,6 +23,7 @@ from pathlib import Path
 from nexus_deploy import __version__, hello
 from nexus_deploy.compose_runner import run_compose_up
 from nexus_deploy.config import ConfigError, NexusConfig
+from nexus_deploy.gitea import run_configure_gitea
 from nexus_deploy.infisical import (
     BootstrapEnv,
     InfisicalClient,
@@ -793,6 +795,173 @@ def _kestra_register_system_flows(args: list[str]) -> int:
     return 0 if result.is_success else 1
 
 
+def _gitea_configure(args: list[str]) -> int:
+    """`nexus-deploy gitea configure`.
+
+    Opens an SSH port-forward to nexus, runs the synchronous Gitea
+    configure flow (DB password sync, admin/user create-or-sync with
+    legacy email-collision PATCH, API token create with retry-via-
+    delete, workspace repo + collaborator), emits stdout in
+    eval-able shell form so deploy.sh can capture the token via:
+
+    .. code-block:: bash
+
+        GITEA_OUT=$(mktemp); python -m nexus_deploy gitea configure > "$GITEA_OUT"
+        eval "$(cat "$GITEA_OUT")"  # GITEA_TOKEN=...; RESTART_SERVICES=...
+        rm -f "$GITEA_OUT"
+
+    **stdout** (eval-able):
+    - ``GITEA_TOKEN=<sha1>`` — only if token was successfully minted
+    - ``RESTART_SERVICES=<csv>`` — git-integrated services intersected
+      with ``$ENABLED_SERVICES`` (always emitted, may be empty string)
+
+    **stderr**: per-step status lines for the deploy log.
+
+    Reads ``NexusConfig`` from stdin (SECRETS_JSON) and per-deploy
+    coordinates from environment variables:
+
+    - ``ADMIN_EMAIL`` — admin's email
+    - ``GITEA_USER_EMAIL`` (optional) — regular user's email; if set,
+      the user will be created/synced. Also drives the legacy
+      email-collision PATCH check on the admin row.
+    - ``GITEA_USER_PASS`` (optional) — required iff GITEA_USER_EMAIL set
+    - ``REPO_NAME`` — workspace repo name (e.g. nexus-<slug>-gitea)
+    - ``GITEA_REPO_OWNER`` — owner of the workspace repo
+    - ``ENABLED_SERVICES`` — comma-or-space list driving the
+      RESTART_SERVICES intersection
+    - ``GH_MIRROR_REPOS`` (optional) — if non-empty, skip repo+collab
+      (deferred to Modul 2.2f mirror-mode)
+    - ``GITEA_HOST`` — SSH host alias (default ``nexus``)
+
+    Exit codes:
+    - 0: success — admin configured, token minted, repo state OK
+    - 1: partial — at least one step failed but token may be in stdout
+    - 2: bad args / ssh / unexpected — NO token in stdout
+    """
+    if args:
+        print(f"gitea configure: unknown args {args!r}", file=sys.stderr)
+        return 2
+
+    admin_email = os.environ.get("ADMIN_EMAIL") or ""
+    repo_name = os.environ.get("REPO_NAME") or ""
+    gitea_repo_owner = os.environ.get("GITEA_REPO_OWNER") or ""
+    enabled_str = os.environ.get("ENABLED_SERVICES") or ""
+    ssh_host = os.environ.get("GITEA_HOST") or "nexus"
+    gitea_user_email = os.environ.get("GITEA_USER_EMAIL") or None
+    gitea_user_password = os.environ.get("GITEA_USER_PASS") or None
+    is_mirror_mode = bool(os.environ.get("GH_MIRROR_REPOS") or "")
+
+    missing = [
+        name
+        for name, val in (
+            ("ADMIN_EMAIL", admin_email),
+            ("REPO_NAME", repo_name),
+            ("GITEA_REPO_OWNER", gitea_repo_owner),
+        )
+        if not val
+    ]
+    if missing:
+        print(
+            f"gitea configure: missing required env: {', '.join(missing)}",
+            file=sys.stderr,
+        )
+        return 2
+
+    enabled = [s.strip() for s in enabled_str.replace(",", " ").split() if s.strip()]
+
+    try:
+        config = NexusConfig.from_secrets_json(sys.stdin.read())
+    except ConfigError as exc:
+        print(f"gitea configure: {exc}", file=sys.stderr)
+        return 2
+
+    if not config.gitea_admin_password:
+        # Required for both the CLI sync_password and REST basic-auth
+        # paths. Without it everything 401s; emit rc=1 so deploy.sh
+        # routes to yellow warning, NOT rc=0 (which would be a silent
+        # green pass — same bug class as kestra round-2).
+        print(
+            "gitea configure: GITEA_ADMIN_PASS missing from SECRETS_JSON — "
+            "skipping (basic-auth would 401 on every call)",
+            file=sys.stderr,
+        )
+        # Still emit empty RESTART_SERVICES line so eval doesn't
+        # leave a stale value from a previous deploy.
+        print('RESTART_SERVICES=""')
+        return 1
+
+    local_port = _allocate_free_port()
+
+    try:
+        with (
+            SSHClient(ssh_host) as ssh,
+            ssh.port_forward(local_port, "localhost", 3200) as port,
+        ):
+            result = run_configure_gitea(
+                config,
+                base_url=f"http://localhost:{port}",
+                ssh=ssh,
+                admin_email=admin_email,
+                gitea_user_email=gitea_user_email,
+                gitea_user_password=gitea_user_password,
+                repo_name=repo_name,
+                gitea_repo_owner=gitea_repo_owner,
+                is_mirror_mode=is_mirror_mode,
+                enabled_services=enabled,
+            )
+    except SSHError as exc:
+        print(f"gitea configure: ssh tunnel failed: {exc}", file=sys.stderr)
+        return 2
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError) as exc:
+        print(
+            f"gitea configure: transport failure ({type(exc).__name__})",
+            file=sys.stderr,
+        )
+        return 2
+    except Exception as exc:
+        print(
+            f"gitea configure: unexpected error ({type(exc).__name__})",
+            file=sys.stderr,
+        )
+        return 2
+
+    # Per-step status lines on stderr for the deploy log.
+    if result.db_pw_synced:
+        sys.stderr.write("  • gitea-db password synced\n")
+    sys.stderr.write(
+        f"  • admin: {result.admin.status}"
+        f"{(' — ' + result.admin.detail) if result.admin.detail else ''}\n"
+    )
+    if result.user is not None:
+        sys.stderr.write(
+            f"  • user: {result.user.status}"
+            f"{(' — ' + result.user.detail) if result.user.detail else ''}\n"
+        )
+    if result.repo is not None:
+        sys.stderr.write(
+            f"  • repo: {result.repo.status}"
+            f"{(' — ' + result.repo.detail) if result.repo.detail else ''}\n"
+        )
+    if result.collaborator_added:
+        sys.stderr.write("  • collaborator added\n")
+    if result.token is None:
+        sys.stderr.write("  • token: NOT minted (REST will 401 downstream)\n")
+
+    # Eval-able stdout. RESTART_SERVICES is always emitted (even
+    # empty) so deploy.sh's ``eval`` doesn't leave a stale value
+    # from a previous run in the variable. ``shlex.quote`` on every
+    # value — Gitea sha1 tokens are 40 hex chars in practice (no
+    # special chars), but the explicit quote contract makes
+    # injection-safety unambiguous, same as config dump-shell (#508).
+    import shlex as _shlex
+
+    if result.token is not None:
+        sys.stdout.write(f"GITEA_TOKEN={_shlex.quote(result.token)}\n")
+    sys.stdout.write(f"RESTART_SERVICES={_shlex.quote(','.join(result.restart_services))}\n")
+
+    return 0 if result.is_success else 1
+
+
 def _allocate_free_port() -> int:
     """Ask the kernel for a free IPv4 ephemeral port on the loopback.
 
@@ -875,6 +1044,8 @@ def main() -> int:
         return _services_configure(args[1:])
     if args[:2] == ["kestra", "register-system-flows"]:
         return _kestra_register_system_flows(args[2:])
+    if args[:2] == ["gitea", "configure"]:
+        return _gitea_configure(args[2:])
     print(
         f"nexus_deploy {__version__}: unknown command {' '.join(args)!r}",
         file=sys.stderr,
@@ -887,7 +1058,8 @@ def main() -> int:
         "seed --repo <owner>/<name> [--root PATH] [--prefix nexus_seeds/], "
         "compose up --enabled <comma-list>, "
         "services configure --enabled <comma-list> (reads SECRETS_JSON from stdin), "
-        "kestra register-system-flows (reads SECRETS_JSON from stdin + env vars)",
+        "kestra register-system-flows (reads SECRETS_JSON from stdin + env vars), "
+        "gitea configure (reads SECRETS_JSON from stdin + env vars; emits eval-able stdout)",
         file=sys.stderr,
     )
     return 2

--- a/src/nexus_deploy/gitea.py
+++ b/src/nexus_deploy/gitea.py
@@ -763,7 +763,11 @@ def run_configure_gitea(
     if not rest.wait_ready(timeout_s=ready_timeout_s):
         return GiteaResult(
             db_pw_synced=db_pw_synced,
-            admin=CreateUserResult(name="admin", status="failed", detail="gitea not ready"),
+            # Use the configured admin_username (Copilot round 2) — not
+            # the literal "admin" — so CreateUserResult.name carries
+            # the same value across all paths regardless of how the
+            # operator named the admin user.
+            admin=CreateUserResult(name=admin_username, status="failed", detail="gitea not ready"),
             user=None,
             token=None,
             repo=None,

--- a/src/nexus_deploy/gitea.py
+++ b/src/nexus_deploy/gitea.py
@@ -1,0 +1,830 @@
+"""Gitea admin/user/repo configuration client (Phase 2 Modul 2.2e, #505).
+
+Replaces deploy.sh's L2465-2810 — the synchronous Gitea-configure block
+covering DB password sync, admin user lifecycle (create or sync, with
+legacy email-collision PATCH for stacks deployed pre-v0.51.9), regular
+user lifecycle, API token creation with retry-via-delete on conflict,
+workspace repo creation with private-PATCH fallback, and collaborator
+add. Mirror-mode (``GH_MIRROR_REPOS``) and Woodpecker OAuth
+registration are deferred to Modul 2.2f.
+
+Two transports — by design, mirroring deploy.sh's split:
+
+- **CLI via ssh.run_script** for admin/user CRUD (list, create,
+  change-password). Inside the gitea container the ``gitea admin user``
+  CLI authenticates via peer auth (``-u git``) and DOES NOT need a
+  working REST password — which matters because the whole point of
+  the SYNC step is to make basic-auth work after persistent-volume
+  password drift. Using REST for these would chicken-egg.
+
+- **REST via port-forward + requests** for token, email PATCH, repo
+  CRUD, collaborator add. By the time the token is minted, the admin
+  password has already been synced via CLI, so basic-auth works.
+
+R7 (token-not-in-argv): all REST calls use ``requests`` with
+``auth=(user, pw)`` or ``headers={"Authorization": f"token {tok}"}``
+— credentials live in the Authorization header, never in argv. The
+DB-password sync is the only exception by necessity (psql wants the
+password as a SQL string literal): we use ``ssh.run_script`` so the
+script (and the password inside it) is fed via stdin to the remote
+shell, not argv.
+
+R5 (path safety): all user/repo path segments are validated against
+``^[a-zA-Z0-9._-]+$`` before URL interpolation OR shell-quoting.
+Username/repo-name with shell metacharacters are rejected up front.
+"""
+
+from __future__ import annotations
+
+import re
+import shlex
+import time
+from dataclasses import dataclass
+from typing import Literal
+
+import requests
+
+from nexus_deploy.config import NexusConfig
+from nexus_deploy.ssh import SSHClient
+
+_CONNECT_TIMEOUT_S: float = 3.0
+_READ_TIMEOUT_S: float = 15.0
+_HTTP_TIMEOUT: tuple[float, float] = (_CONNECT_TIMEOUT_S, _READ_TIMEOUT_S)
+
+_PATH_SAFE_RE: re.Pattern[str] = re.compile(r"^[a-zA-Z0-9._-]+$")
+
+# Services that have Git integration (clone the workspace repo on start).
+# Order matters for stable RESTART_SERVICES output → CLI emits the list
+# in this order, intersected with `enabled_services`. Must match
+# deploy.sh L2795 exactly so the strangler-fig handoff doesn't drift.
+_GIT_INTEGRATED_SERVICES: tuple[str, ...] = (
+    "jupyter",
+    "marimo",
+    "code-server",
+    "meltano",
+    "prefect",
+)
+
+
+def _http_timeout_for_deadline(deadline: float) -> tuple[float, float]:
+    """Build a (connect, read) tuple clamped to time remaining.
+
+    Same pattern as kestra.py — keeps ``wait_ready(timeout_s=0.05)``
+    honest. Both legs are floored at 0.1s so requests doesn't hit its
+    own zero-timeout edge case.
+    """
+    remaining = max(deadline - time.monotonic(), 0.1)
+    return (
+        min(_CONNECT_TIMEOUT_S, remaining),
+        min(_READ_TIMEOUT_S, remaining),
+    )
+
+
+def _validate_path_segment(value: str, *, kind: str) -> None:
+    """Reject shell-meta / URL-traversal in user/repo identifiers (R5).
+
+    Allowed: ``[a-zA-Z0-9._-]+`` — but explicitly NOT ``.`` or ``..``
+    (which match the regex but are URL-traversal in path context).
+    Dotted usernames like ``stefan.koch`` are allowed (Gitea permits
+    them — that's the dotted-username class from PR #464).
+    """
+    if not _PATH_SAFE_RE.fullmatch(value):
+        raise GiteaError(f"unsafe {kind}: {value!r}")
+    if value in (".", ".."):
+        raise GiteaError(f"unsafe {kind}: {value!r}")
+
+
+def _escape_sql_string_literal(value: str) -> str:
+    """Escape a value for safe inclusion in a single-quoted SQL string.
+
+    Mirrors deploy.sh L2479-2480: ``\\`` → ``\\\\`` first, then
+    ``'`` → ``''``. Order matters — escape backslashes before quotes
+    so a literal backslash in the password doesn't end up doubling
+    the quote escape.
+    """
+    return value.replace("\\", "\\\\").replace("'", "''")
+
+
+def _parse_admin_list_for_user(text: str, username: str) -> tuple[bool, str | None]:
+    """Column-exact awk-equivalent on ``gitea admin user list`` output (R1).
+
+    Gitea CLI output:
+
+    .. code-block:: text
+
+        ID    Username    Email                FullName    IsActive
+        1     admin       admin@example.com    Admin       true
+        2     stefan      stefan@example.com   Stefan      true
+
+    Returns ``(exists, email)``: column-2 (Username) must equal
+    ``username`` exactly. NEVER substring match — the dotted-username
+    bug from PR #464 was: ``grep -c 'stefan.koch'`` matched admin's
+    email column ``stefan.koch@hslu.ch`` even though no user with
+    that username existed, so CREATE was skipped, SYNC then failed.
+
+    Empty / malformed output → ``(False, None)``. Headers (``NR==1``)
+    are skipped.
+    """
+    for line_no, raw_line in enumerate(text.splitlines()):
+        if line_no == 0:
+            continue  # header
+        parts = raw_line.split()
+        if len(parts) < 2:
+            continue
+        if parts[1] == username:
+            email = parts[2] if len(parts) >= 3 else None
+            return True, email
+    return False, None
+
+
+def _render_db_pw_sync_script(
+    escaped_pw: str,
+    *,
+    attempts: int,
+    interval_s: float,
+) -> str:
+    """Render bash to retry psql ALTER USER inside the gitea-db container.
+
+    Peer auth via ``-U nexus-gitea`` (no ``-W``), so no PGPASSWORD env
+    var is needed and the password value only enters the SQL string
+    literal. The SQL is built locally so the escaped password is in
+    the SCRIPT body (which we feed via stdin, not argv) — never in
+    ``ps`` on either host.
+
+    Mirrors deploy.sh L2477-2491. RESULT line emitted on success so
+    the caller can disambiguate "succeeded after N tries" from "all
+    N tries failed".
+    """
+    sql = f"ALTER USER \"nexus-gitea\" WITH PASSWORD '{escaped_pw}'"
+    quoted_sql = shlex.quote(sql)
+    return (
+        "set -euo pipefail\n"
+        f"for i in $(seq 1 {attempts}); do\n"
+        f"  if docker exec gitea-db psql -U nexus-gitea -d gitea "
+        f"-c {quoted_sql} >/dev/null 2>&1; then\n"
+        '    echo "RESULT db_pw=synced"\n'
+        "    exit 0\n"
+        "  fi\n"
+        f"  sleep {interval_s}\n"
+        "done\n"
+        'echo "RESULT db_pw=failed"\n'
+        "exit 1\n"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Result dataclasses
+# ---------------------------------------------------------------------------
+
+
+CreateUserStatus = Literal["created", "already_exists", "synced", "failed"]
+CreateRepoStatus = Literal["created", "already_exists", "failed"]
+
+
+@dataclass(frozen=True)
+class CreateUserResult:
+    name: str
+    status: CreateUserStatus
+    detail: str = ""
+
+
+@dataclass(frozen=True)
+class CreateRepoResult:
+    name: str
+    status: CreateRepoStatus
+    detail: str = ""
+
+
+@dataclass(frozen=True)
+class GiteaResult:
+    """Aggregate of all Gitea-config sub-steps.
+
+    ``token`` is None until :meth:`GiteaClient.create_token_with_retry`
+    succeeds. The CLI emits ``GITEA_TOKEN=<token>`` to stdout iff
+    token is non-None — eval-able by deploy.sh.
+    """
+
+    db_pw_synced: bool
+    admin: CreateUserResult
+    user: CreateUserResult | None
+    token: str | None
+    repo: CreateRepoResult | None
+    collaborator_added: bool
+    restart_services: tuple[str, ...]
+
+    @property
+    def is_success(self) -> bool:
+        """Strict success: every step that ran must have succeeded.
+
+        - admin status must be ``created``, ``already_exists``, or ``synced``
+          (NOT ``failed``)
+        - user (if present) same
+        - token must exist (if expected — i.e. core happy path)
+        - repo (if present) must be ``created`` or ``already_exists``
+
+        deploy.sh maps False → rc=1 (yellow warn, continue). The token
+        IS in stdout regardless so downstream seed/kestra still work.
+        """
+        if self.admin.status == "failed":
+            return False
+        if self.user is not None and self.user.status == "failed":
+            return False
+        if self.token is None:
+            return False
+        return not (self.repo is not None and self.repo.status == "failed")
+
+
+class GiteaError(Exception):
+    """Transport/validation failure surfaced to the caller.
+
+    Carries no response body — Gitea error responses on auth-failure
+    paths can echo back the credentials we just sent. Constructed
+    from fixed format strings + status codes / type names only.
+    """
+
+
+class TokenExistsError(GiteaError):
+    """Raised by ``create_token`` when Gitea reports the token name is taken.
+
+    The orchestrator catches this and falls back to delete-then-retry
+    (``create_token_with_retry``). Keeping the exception class
+    distinct lets tests pin the retry behaviour without grepping
+    error messages.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Hybrid client: SSH-CLI for admin/user CRUD, REST for token/repo/email
+# ---------------------------------------------------------------------------
+
+
+class GiteaCli:
+    """SSH-driven ``docker exec gitea`` CLI wrapper.
+
+    Used for admin/user CRUD where peer auth (``-u git`` inside the
+    container) bypasses the chicken-egg of "we need to sync the
+    password before basic-auth works". Output is parsed locally so
+    the typed dispatch (``created`` / ``already_exists`` / ``synced``
+    / ``failed``) matches the rest of the module.
+
+    All commands fed via ``ssh.run_script`` so passwords land in
+    stdin to the remote shell, not argv on either host.
+    """
+
+    def __init__(self, ssh: SSHClient) -> None:
+        self.ssh = ssh
+
+    def sync_db_password(
+        self,
+        password: str,
+        *,
+        attempts: int = 15,
+        interval_s: float = 2.0,
+    ) -> bool:
+        """Retry ``ALTER USER`` until psql accepts the connection.
+
+        On first start, gitea-db can take ~10-30s to accept connections.
+        Bounded retry loop renders bash that exits 0 on first success
+        or non-zero after exhausting attempts.
+        """
+        if not password:
+            return False
+        escaped = _escape_sql_string_literal(password)
+        script = _render_db_pw_sync_script(escaped, attempts=attempts, interval_s=interval_s)
+        # Generous overall timeout: attempts * interval_s + a safety
+        # margin for ssh + docker exec setup per iteration. Never
+        # raises — this is best-effort and we map a non-zero rc to
+        # ``False`` so the caller can route to a yellow warning.
+        timeout = float(attempts) * float(interval_s) + 30.0
+        result = self.ssh.run_script(script, check=False, timeout=timeout)
+        return result.returncode == 0 and "RESULT db_pw=synced" in result.stdout
+
+    def list_admin_users(self) -> str:
+        """Run ``gitea admin user list --admin`` and return raw output.
+
+        Empty string if ssh/docker fails — caller routes empty list
+        to the CREATE branch (deploy.sh L2620-2630 pattern: any
+        unexpected error surfaces on the next CLI call rather than
+        spinning here).
+        """
+        # ``2>/dev/null`` mirrors deploy.sh — the CLI sometimes warns
+        # on stderr about deprecated flags; we don't want that noise
+        # mixed into the parsed output. ``|| echo ""`` swallows non-zero
+        # exit (transient docker/gitea startup race).
+        result = self.ssh.run_script(
+            "docker exec -u git gitea gitea admin user list --admin 2>/dev/null || echo ''",
+            check=False,
+            timeout=30.0,
+        )
+        return result.stdout if result.returncode == 0 else ""
+
+    def list_users(self) -> str:
+        """Run ``gitea admin user list`` (non-admin scope)."""
+        result = self.ssh.run_script(
+            "docker exec -u git gitea gitea admin user list 2>/dev/null || echo ''",
+            check=False,
+            timeout=30.0,
+        )
+        return result.stdout if result.returncode == 0 else ""
+
+    def create_admin(self, username: str, password: str, email: str) -> CreateUserResult:
+        return self._create_user(username, password, email, is_admin=True, label="admin")
+
+    def create_user(self, username: str, password: str, email: str) -> CreateUserResult:
+        return self._create_user(username, password, email, is_admin=False, label="user")
+
+    def _create_user(
+        self,
+        username: str,
+        password: str,
+        email: str,
+        *,
+        is_admin: bool,
+        label: str,
+    ) -> CreateUserResult:
+        _validate_path_segment(username, kind="username")
+        # email is not a URL segment but still feed via shlex.quote
+        # since it lands in argv after rendering. The container's
+        # `gitea admin user create` accepts it directly.
+        admin_flag = "--admin " if is_admin else ""
+        script = (
+            "set -euo pipefail\n"
+            f"docker exec -u git gitea gitea admin user create {admin_flag}"
+            f"--username {shlex.quote(username)} "
+            f"--password {shlex.quote(password)} "
+            f"--email {shlex.quote(email)} "
+            "--must-change-password=false 2>&1\n"
+        )
+        result = self.ssh.run_script(script, check=False, timeout=30.0)
+        text = result.stdout
+        # deploy.sh L2600 / L2659: success substrings.
+        text_lc = text.lower()
+        if any(kw in text_lc for kw in ("created", "success", "new user")):
+            return CreateUserResult(name=label, status="created")
+        # Gitea returns "user already exists" / "email already in use" on
+        # collision — both route to ``already_exists`` so the caller can
+        # follow up with a sync_password (which is idempotent) instead of
+        # treating it as a failure.
+        if "already" in text_lc:
+            return CreateUserResult(name=label, status="already_exists")
+        return CreateUserResult(
+            name=label,
+            status="failed",
+            detail=text.strip()[:200] if text else "(no output)",
+        )
+
+    def sync_password(self, username: str, password: str) -> CreateUserResult:
+        """``gitea admin user change-password`` — peer-auth, no old password.
+
+        Gitea's CLI command takes the username + new password and
+        updates the credential without requiring the previous one.
+        Idempotent: running twice on the same password is a no-op.
+        """
+        _validate_path_segment(username, kind="username")
+        script = (
+            "set -euo pipefail\n"
+            "docker exec -u git gitea gitea admin user change-password "
+            f"--username {shlex.quote(username)} "
+            f"--password {shlex.quote(password)} "
+            "--must-change-password=false 2>&1\n"
+        )
+        result = self.ssh.run_script(script, check=False, timeout=30.0)
+        if result.returncode == 0:
+            return CreateUserResult(name=username, status="synced")
+        return CreateUserResult(
+            name=username,
+            status="failed",
+            detail=result.stdout.strip()[:200] if result.stdout else "(no output)",
+        )
+
+
+class GiteaClient:
+    """REST client for Gitea. Basic-auth pre-token, token-auth post-token.
+
+    Path components in URL interpolation are validated against the
+    R5 path-safety regex before the f-string runs. Credentials in
+    Authorization header only — ``with_token`` returns a new client
+    instance so the pre/post-token modes don't share mutable state.
+    """
+
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        admin_username: str,
+        admin_password: str,
+    ) -> None:
+        if not admin_username or not admin_password:
+            raise ValueError("GiteaClient requires non-empty admin credentials")
+        _validate_path_segment(admin_username, kind="admin_username")
+        self.base_url = base_url.rstrip("/")
+        self.admin_username = admin_username
+        self._auth: tuple[str, str] | None = (admin_username, admin_password)
+        self._token: str | None = None
+
+    def with_token(self, token: str) -> GiteaClient:
+        """Return a NEW client that uses token-auth instead of basic-auth.
+
+        Token must be non-empty. Returns a separate instance so callers
+        can't accidentally fall back to basic-auth on a client that's
+        meant to be token-only.
+        """
+        if not token:
+            raise ValueError("with_token requires a non-empty token")
+        # New instance — copy URL + admin_username, drop basic-auth,
+        # set token. Bypass __init__'s admin_password requirement.
+        new = GiteaClient.__new__(GiteaClient)
+        new.base_url = self.base_url
+        new.admin_username = self.admin_username
+        new._auth = None
+        new._token = token
+        return new
+
+    def _request_kwargs(self) -> dict[str, object]:
+        """Build auth kwargs (headers OR auth tuple, never both)."""
+        if self._token is not None:
+            return {"headers": {"Authorization": f"token {self._token}"}}
+        if self._auth is not None:
+            return {"auth": self._auth}
+        raise GiteaError("client has no auth configured")  # pragma: no cover
+
+    def wait_ready(self, *, timeout_s: float = 60.0, interval_s: float = 2.0) -> bool:
+        """Poll ``GET /api/healthz`` until 200. Public endpoint, no auth.
+
+        Sleep clamped to deadline (kestra.py pattern).
+        """
+        deadline = time.monotonic() + timeout_s
+        while time.monotonic() < deadline:
+            try:
+                resp = requests.get(
+                    f"{self.base_url}/api/healthz",
+                    timeout=_http_timeout_for_deadline(deadline),
+                )
+            except (requests.ConnectionError, requests.Timeout):
+                resp = None
+            if resp is not None and resp.status_code == 200:
+                return True
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            time.sleep(min(interval_s, remaining))
+        return False
+
+    def patch_user_email(self, username: str, email: str, *, login_name: str) -> bool:
+        """``PATCH /api/v1/admin/users/<u>`` — email-only update (R2).
+
+        Gitea's admin-users schema rejects partial bodies, so the
+        full ``{email, source_id, login_name}`` triple is required
+        even though we only want to change email. ``source_id: 0`` =
+        local auth provider. Returns True on 200, False on any other
+        status (including auth failures — caller handles non-fatal
+        path).
+        """
+        _validate_path_segment(username, kind="username")
+        body = {"email": email, "source_id": 0, "login_name": login_name}
+        try:
+            resp = requests.patch(
+                f"{self.base_url}/api/v1/admin/users/{username}",
+                json=body,
+                timeout=_HTTP_TIMEOUT,
+                **self._request_kwargs(),  # type: ignore[arg-type]
+            )
+        except (requests.ConnectionError, requests.Timeout):
+            return False
+        return resp.status_code == 200
+
+    def create_token(self, username: str, name: str, scopes: list[str]) -> str:
+        """``POST /api/v1/users/<u>/tokens`` — basic-auth.
+
+        Returns the sha1. Raises :class:`TokenExistsError` on 409 (or
+        when the response body indicates the name is taken — Gitea
+        sometimes returns 422 with ``"name already exists"``).
+        Raises :class:`GiteaError` on other non-success status / transport.
+        """
+        _validate_path_segment(username, kind="username")
+        body = {"name": name, "scopes": scopes}
+        try:
+            resp = requests.post(
+                f"{self.base_url}/api/v1/users/{username}/tokens",
+                json=body,
+                timeout=_HTTP_TIMEOUT,
+                **self._request_kwargs(),  # type: ignore[arg-type]
+            )
+        except (requests.ConnectionError, requests.Timeout) as exc:
+            raise GiteaError(f"create_token transport ({type(exc).__name__})") from exc
+        if resp.status_code in (200, 201):
+            try:
+                payload = resp.json()
+            except ValueError as exc:
+                raise GiteaError("create_token response was not JSON") from exc
+            sha1 = payload.get("sha1") if isinstance(payload, dict) else None
+            if not isinstance(sha1, str) or not sha1:
+                raise GiteaError("create_token response missing 'sha1'")
+            return sha1
+        if resp.status_code == 409:
+            raise TokenExistsError(f"token {name!r} already exists")
+        # Some Gitea versions return 422 with "name already exists"
+        # in the message body. Match conservatively to avoid masking
+        # real validation errors.
+        if resp.status_code == 422:
+            try:
+                msg = resp.json().get("message", "") if resp.content else ""
+            except ValueError:
+                msg = ""
+            if isinstance(msg, str) and "already exists" in msg.lower():
+                raise TokenExistsError(f"token {name!r} already exists")
+        raise GiteaError(f"create_token HTTP {resp.status_code}")
+
+    def delete_token(self, username: str, name: str) -> bool:
+        """``DELETE /api/v1/users/<u>/tokens/<name>``. 204+404 → True."""
+        _validate_path_segment(username, kind="username")
+        # Token name may contain ``-`` and ``_`` but no path-traversal —
+        # validate against the same regex.
+        _validate_path_segment(name, kind="token_name")
+        try:
+            resp = requests.delete(
+                f"{self.base_url}/api/v1/users/{username}/tokens/{name}",
+                timeout=_HTTP_TIMEOUT,
+                **self._request_kwargs(),  # type: ignore[arg-type]
+            )
+        except (requests.ConnectionError, requests.Timeout):
+            return False
+        return resp.status_code in (204, 404)
+
+    def create_token_with_retry(self, username: str, name: str, scopes: list[str]) -> str:
+        """Idempotent: try create, on TokenExistsError → delete + retry once.
+
+        Mirrors deploy.sh L2671-2683. The second create returns the
+        new sha1 (Gitea always returns a new value on re-create — the
+        old token is invalidated by the delete).
+        """
+        try:
+            return self.create_token(username, name, scopes)
+        except TokenExistsError:
+            self.delete_token(username, name)
+            return self.create_token(username, name, scopes)
+
+    def repo_exists(self, owner: str, name: str) -> bool:
+        _validate_path_segment(owner, kind="owner")
+        _validate_path_segment(name, kind="repo_name")
+        try:
+            resp = requests.get(
+                f"{self.base_url}/api/v1/repos/{owner}/{name}",
+                timeout=_HTTP_TIMEOUT,
+                **self._request_kwargs(),  # type: ignore[arg-type]
+            )
+        except (requests.ConnectionError, requests.Timeout) as exc:
+            raise GiteaError(f"repo_exists transport ({type(exc).__name__})") from exc
+        if resp.status_code == 200:
+            return True
+        if resp.status_code == 404:
+            return False
+        raise GiteaError(f"repo_exists HTTP {resp.status_code}")
+
+    def create_repo(
+        self,
+        name: str,
+        *,
+        private: bool = True,
+        auto_init: bool = True,
+        default_branch: str = "main",
+        description: str = "",
+    ) -> CreateRepoResult:
+        """``POST /api/v1/user/repos`` — creates under the authenticated user.
+
+        409 → ``already_exists``. ``patch_repo_private`` is the
+        recommended fallback to ensure the existing repo is private.
+        """
+        _validate_path_segment(name, kind="repo_name")
+        body = {
+            "name": name,
+            "description": description,
+            "private": private,
+            "auto_init": auto_init,
+            "default_branch": default_branch,
+        }
+        try:
+            resp = requests.post(
+                f"{self.base_url}/api/v1/user/repos",
+                json=body,
+                timeout=_HTTP_TIMEOUT,
+                **self._request_kwargs(),  # type: ignore[arg-type]
+            )
+        except (requests.ConnectionError, requests.Timeout) as exc:
+            return CreateRepoResult(
+                name=name, status="failed", detail=f"transport ({type(exc).__name__})"
+            )
+        if resp.status_code in (200, 201):
+            return CreateRepoResult(name=name, status="created", detail="POST 201")
+        if resp.status_code == 409:
+            return CreateRepoResult(name=name, status="already_exists", detail="POST 409")
+        # Gitea also returns 422 with "already exists" for some modes
+        # (CE vs EE differ). Match conservatively.
+        if resp.status_code == 422:
+            try:
+                msg = resp.json().get("message", "") if resp.content else ""
+            except ValueError:
+                msg = ""
+            if isinstance(msg, str) and "already exists" in msg.lower():
+                return CreateRepoResult(
+                    name=name, status="already_exists", detail="POST 422 already exists"
+                )
+        return CreateRepoResult(name=name, status="failed", detail=f"POST {resp.status_code}")
+
+    def patch_repo_private(self, owner: str, name: str, *, private: bool = True) -> bool:
+        """``PATCH /api/v1/repos/<o>/<n>`` — ensure repo is/isn't private."""
+        _validate_path_segment(owner, kind="owner")
+        _validate_path_segment(name, kind="repo_name")
+        try:
+            resp = requests.patch(
+                f"{self.base_url}/api/v1/repos/{owner}/{name}",
+                json={"private": private},
+                timeout=_HTTP_TIMEOUT,
+                **self._request_kwargs(),  # type: ignore[arg-type]
+            )
+        except (requests.ConnectionError, requests.Timeout):
+            return False
+        return resp.status_code == 200
+
+    def add_collaborator(
+        self,
+        owner: str,
+        name: str,
+        collaborator: str,
+        *,
+        permission: str = "write",
+    ) -> bool:
+        """``PUT /api/v1/repos/<o>/<n>/collaborators/<c>`` — idempotent.
+
+        204 (added) and 422 ("already a collaborator") both → True.
+        """
+        _validate_path_segment(owner, kind="owner")
+        _validate_path_segment(name, kind="repo_name")
+        _validate_path_segment(collaborator, kind="collaborator")
+        try:
+            resp = requests.put(
+                f"{self.base_url}/api/v1/repos/{owner}/{name}/collaborators/{collaborator}",
+                json={"permission": permission},
+                timeout=_HTTP_TIMEOUT,
+                **self._request_kwargs(),  # type: ignore[arg-type]
+            )
+        except (requests.ConnectionError, requests.Timeout):
+            return False
+        return resp.status_code in (204, 422)
+
+
+# ---------------------------------------------------------------------------
+# Top-level orchestrator
+# ---------------------------------------------------------------------------
+
+
+def _compute_restart_services(enabled: list[str]) -> tuple[str, ...]:
+    """Intersection of ``_GIT_INTEGRATED_SERVICES`` and ``enabled``.
+
+    Order preserved from ``_GIT_INTEGRATED_SERVICES`` so the CLI
+    output is deterministic across runs.
+    """
+    enabled_set = set(enabled)
+    return tuple(s for s in _GIT_INTEGRATED_SERVICES if s in enabled_set)
+
+
+def run_configure_gitea(
+    config: NexusConfig,
+    *,
+    base_url: str,
+    ssh: SSHClient,
+    admin_email: str,
+    gitea_user_email: str | None,
+    gitea_user_password: str | None,
+    repo_name: str,
+    gitea_repo_owner: str,
+    is_mirror_mode: bool,
+    enabled_services: list[str],
+    ready_timeout_s: float = 60.0,
+    db_sync_attempts: int = 15,
+    db_sync_interval_s: float = 2.0,
+) -> GiteaResult:
+    """End-to-end Gitea configure (deploy.sh L2465-2810 equivalent).
+
+    Steps:
+
+    1. Sync gitea-db postgres password (peer-auth psql ALTER USER)
+    2. Wait for ``/api/healthz``
+    3. Admin: list via CLI → exists?
+       - yes + legacy email collision → REST PATCH email
+       - yes → CLI sync_password
+       - no  → CLI create_admin
+    4. User (if ``gitea_user_email``): list → exists?
+       - yes → CLI sync_password
+       - no  → CLI create_user
+    5. Token: REST create_token_with_retry
+    6. (non-mirror) repo: create → on already_exists → patch_repo_private
+    7. (non-mirror, with user) collaborator add
+    8. Build restart_services list (intersection with enabled)
+
+    Returns :class:`GiteaResult` with token in stdout-eval-able form
+    via the CLI handoff. Even on partial failures (e.g. legacy email
+    PATCH failed but token created), the token IS in the result so
+    deploy.sh can capture it via eval.
+    """
+    admin_username = config.admin_username or "admin"
+    admin_password = config.gitea_admin_password or ""
+    db_password = config.gitea_db_password or ""
+
+    cli = GiteaCli(ssh)
+    rest = GiteaClient(
+        base_url=base_url,
+        admin_username=admin_username,
+        admin_password=admin_password,
+    )
+
+    # 1. DB password sync
+    db_pw_synced = (
+        cli.sync_db_password(
+            db_password,
+            attempts=db_sync_attempts,
+            interval_s=db_sync_interval_s,
+        )
+        if db_password
+        else False
+    )
+
+    # 2. Wait for Gitea HTTP ready
+    if not rest.wait_ready(timeout_s=ready_timeout_s):
+        return GiteaResult(
+            db_pw_synced=db_pw_synced,
+            admin=CreateUserResult(name="admin", status="failed", detail="gitea not ready"),
+            user=None,
+            token=None,
+            repo=None,
+            collaborator_added=False,
+            restart_services=_compute_restart_services(enabled_services),
+        )
+
+    # 3. Admin: CLI list → parse → exists check → branch
+    admin_list = cli.list_admin_users()
+    admin_exists, current_admin_email = _parse_admin_list_for_user(admin_list, admin_username)
+
+    # 3a. Legacy email-collision PATCH (before sync_password — if PATCH
+    # fails because of password drift, sync_password later will fix
+    # the password and the next deploy's PATCH will succeed).
+    if admin_exists and gitea_user_email and current_admin_email == gitea_user_email:
+        # Best-effort. If it fails, the sync_password below still runs;
+        # next deploy will retry the PATCH.
+        rest.patch_user_email(admin_username, admin_email, login_name=admin_username)
+
+    if admin_exists:
+        admin_result = cli.sync_password(admin_username, admin_password)
+    else:
+        admin_result = cli.create_admin(admin_username, admin_password, admin_email)
+
+    # 4. Regular user (only if email + password provided)
+    user_result: CreateUserResult | None = None
+    user_username: str | None = None
+    if gitea_user_email and gitea_user_password:
+        user_username = gitea_user_email.split("@", 1)[0]
+        user_list = cli.list_users()
+        user_exists, _ = _parse_admin_list_for_user(user_list, user_username)
+        if user_exists:
+            user_result = cli.sync_password(user_username, gitea_user_password)
+        else:
+            user_result = cli.create_user(user_username, gitea_user_password, gitea_user_email)
+
+    # 5. Token (REST, basic-auth)
+    token: str | None = None
+    try:
+        token = rest.create_token_with_retry(admin_username, "nexus-automation", ["all"])
+    except GiteaError:
+        # Token couldn't be minted even with retry — surface as
+        # token=None; is_success will return False (rc=1 → yellow).
+        token = None
+
+    # 6+7. Repo + collaborator (skip in mirror mode)
+    repo_result: CreateRepoResult | None = None
+    collaborator_added = False
+    if not is_mirror_mode and token is not None:
+        rest_token = rest.with_token(token)
+        repo_result = rest_token.create_repo(
+            repo_name,
+            private=True,
+            auto_init=True,
+            default_branch="main",
+            description="Shared workspace for notebooks, workflows, and pipelines",
+        )
+        if repo_result.status == "already_exists":
+            # Belt-and-suspenders: ensure existing repo is private.
+            rest_token.patch_repo_private(gitea_repo_owner, repo_name, private=True)
+        if repo_result.status != "failed" and user_username is not None and gitea_user_password:
+            collaborator_added = rest_token.add_collaborator(
+                gitea_repo_owner, repo_name, user_username, permission="write"
+            )
+
+    return GiteaResult(
+        db_pw_synced=db_pw_synced,
+        admin=admin_result,
+        user=user_result,
+        token=token,
+        repo=repo_result,
+        collaborator_added=collaborator_added,
+        restart_services=_compute_restart_services(enabled_services),
+    )

--- a/src/nexus_deploy/gitea.py
+++ b/src/nexus_deploy/gitea.py
@@ -222,8 +222,15 @@ class GiteaResult:
         - token must exist (if expected — i.e. core happy path)
         - repo (if present) must be ``created`` or ``already_exists``
 
-        deploy.sh maps False → rc=1 (yellow warn, continue). The token
-        IS in stdout regardless so downstream seed/kestra still work.
+        deploy.sh maps False → rc=1 (yellow warn, continue). The CLI
+        only emits ``GITEA_TOKEN=`` to stdout when ``token is not None``
+        — so on partial-failure paths where the token DID get minted
+        (e.g. legacy email PATCH failed but token + repo OK), deploy.sh
+        captures the token via ``eval`` and downstream seed/kestra
+        still work; on paths where token is None (token-mint failed)
+        is_success is False AND no token line is emitted, so deploy.sh
+        sees rc=1 but no `$GITEA_TOKEN`, and the seed/kestra blocks
+        skip themselves on the empty-token guard.
         """
         if self.admin.status == "failed":
             return False
@@ -328,10 +335,10 @@ class GiteaCli:
         return result.stdout if result.returncode == 0 else ""
 
     def create_admin(self, username: str, password: str, email: str) -> CreateUserResult:
-        return self._create_user(username, password, email, is_admin=True, label="admin")
+        return self._create_user(username, password, email, is_admin=True)
 
     def create_user(self, username: str, password: str, email: str) -> CreateUserResult:
-        return self._create_user(username, password, email, is_admin=False, label="user")
+        return self._create_user(username, password, email, is_admin=False)
 
     def _create_user(
         self,
@@ -340,7 +347,6 @@ class GiteaCli:
         email: str,
         *,
         is_admin: bool,
-        label: str,
     ) -> CreateUserResult:
         _validate_path_segment(username, kind="username")
         # email is not a URL segment but still feed via shlex.quote
@@ -358,17 +364,21 @@ class GiteaCli:
         result = self.ssh.run_script(script, check=False, timeout=30.0)
         text = result.stdout
         # deploy.sh L2600 / L2659: success substrings.
+        # ``CreateUserResult.name`` is always the real username (Copilot
+        # round 1) — using a role label ("admin"/"user") here while
+        # ``sync_password`` returns the actual username made the field
+        # semantics inconsistent and confused downstream reporting.
         text_lc = text.lower()
         if any(kw in text_lc for kw in ("created", "success", "new user")):
-            return CreateUserResult(name=label, status="created")
+            return CreateUserResult(name=username, status="created")
         # Gitea returns "user already exists" / "email already in use" on
         # collision — both route to ``already_exists`` so the caller can
         # follow up with a sync_password (which is idempotent) instead of
         # treating it as a failure.
         if "already" in text_lc:
-            return CreateUserResult(name=label, status="already_exists")
+            return CreateUserResult(name=username, status="already_exists")
         return CreateUserResult(
-            name=label,
+            name=username,
             status="failed",
             detail=text.strip()[:200] if text else "(no output)",
         )
@@ -777,6 +787,16 @@ def run_configure_gitea(
         admin_result = cli.sync_password(admin_username, admin_password)
     else:
         admin_result = cli.create_admin(admin_username, admin_password, admin_email)
+        # CREATE returns ``already_exists`` when the existence check was a
+        # false negative (e.g. ssh+docker exec failed → empty list → CREATE
+        # path → "user already exists"). Without a follow-up sync, the
+        # admin password drift stays — the subsequent REST token mint
+        # uses basic-auth with the OpenTofu-generated password and 401s.
+        # Fall back to sync_password so we converge on the desired state.
+        # Same defence-in-depth pattern as deploy.sh's rerun-tolerance,
+        # but tightened (Copilot round 1).
+        if admin_result.status == "already_exists":
+            admin_result = cli.sync_password(admin_username, admin_password)
 
     # 4. Regular user (only if email + password provided)
     user_result: CreateUserResult | None = None
@@ -789,6 +809,9 @@ def run_configure_gitea(
             user_result = cli.sync_password(user_username, gitea_user_password)
         else:
             user_result = cli.create_user(user_username, gitea_user_password, gitea_user_email)
+            # Same already_exists → sync_password fallback as for admin.
+            if user_result.status == "already_exists":
+                user_result = cli.sync_password(user_username, gitea_user_password)
 
     # 5. Token (REST, basic-auth)
     token: str | None = None

--- a/src/nexus_deploy/gitea.py
+++ b/src/nexus_deploy/gitea.py
@@ -21,13 +21,28 @@ Two transports — by design, mirroring deploy.sh's split:
   CRUD, collaborator add. By the time the token is minted, the admin
   password has already been synced via CLI, so basic-auth works.
 
-R7 (token-not-in-argv): all REST calls use ``requests`` with
+R7 (token-not-in-LOCAL-argv): all REST calls use ``requests`` with
 ``auth=(user, pw)`` or ``headers={"Authorization": f"token {tok}"}``
-— credentials live in the Authorization header, never in argv. The
-DB-password sync is the only exception by necessity (psql wants the
-password as a SQL string literal): we use ``ssh.run_script`` so the
-script (and the password inside it) is fed via stdin to the remote
-shell, not argv.
+— credentials live in the Authorization header, never in argv on
+the deploy host (no shell-out for these calls).
+
+What we DON'T claim — for the SSH/CLI paths, secrets DO transit
+the remote container's argv for the brief duration of the docker-
+exec call: ``gitea admin user create --password '<pw>'`` and
+``psql -c "ALTER USER ... PASSWORD '<pw>'"`` are visible in
+``ps -ef`` inside the relevant container while running. We feed
+the rendered bash via ``ssh.run_script`` (stdin, not argv) so the
+secret never lands in:
+  - LOCAL ``ps`` on the deploy host
+  - LOCAL CI logs (workflow argv-echoes the bash invocation only)
+  - ``CalledProcessError.cmd`` / ``TimeoutExpired.cmd`` exception
+    payloads
+
+This matches the exposure profile of the legacy deploy.sh block
+exactly — same security boundary, no regression. Tightening
+further (e.g. piping the password into ``gitea admin user create``
+via stdin or ``--password-stdin``) is upstream-tooling-dependent
+and out of scope for this migration.
 
 R5 (path safety): all user/repo path segments are validated against
 ``^[a-zA-Z0-9._-]+$`` before URL interpolation OR shell-quoting.
@@ -147,9 +162,21 @@ def _render_db_pw_sync_script(
 
     Peer auth via ``-U nexus-gitea`` (no ``-W``), so no PGPASSWORD env
     var is needed and the password value only enters the SQL string
-    literal. The SQL is built locally so the escaped password is in
-    the SCRIPT body (which we feed via stdin, not argv) — never in
-    ``ps`` on either host.
+    literal. The SCRIPT body (containing the SQL) is fed via stdin
+    by the caller (``ssh.run_script``), so the password does NOT
+    appear in:
+      - LOCAL ``ps`` on the deploy host
+      - LOCAL CI logs / ``CalledProcessError.cmd`` payloads
+      - SSH argv on the deploy host
+
+    The password DOES appear in the gitea-db container's ``ps -ef``
+    for the brief duration of the ``psql -c "ALTER USER … PASSWORD
+    '<pw>'"`` call (since psql takes the SQL via argv). This matches
+    deploy.sh L2483-2485's exposure profile exactly — no regression.
+    Tightening would require either ``\\password`` (interactive) or
+    a server-side script feeding the SQL via stdin to psql, both of
+    which add complexity for marginal gain on a runner-isolated
+    container.
 
     Mirrors deploy.sh L2477-2491. RESULT line emitted on success so
     the caller can disambiguate "succeeded after N tries" from "all

--- a/tests/unit/test_gitea.py
+++ b/tests/unit/test_gitea.py
@@ -1097,20 +1097,26 @@ def test_run_configure_gitea_mirror_mode_skips_repo_and_collaborator() -> None:
 
 @responses.activate
 def test_run_configure_gitea_not_ready_returns_failed_admin() -> None:
-    """Health endpoint never 200 → admin.status=='failed', no token."""
+    """Health endpoint never 200 → admin.status=='failed', no token.
+
+    Uses a non-default admin_username so the regression test catches
+    the Copilot-round-2 finding: the early-return path on health-check
+    timeout previously hardcoded ``name="admin"`` even when the
+    operator configured a different admin username.
+    """
     responses.add(responses.GET, f"{BASE_URL}/api/healthz", status=503)
 
     ssh = _make_ssh([(0, "RESULT db_pw=synced\n")])
 
     result = run_configure_gitea(
-        _make_config(),
+        _make_config(admin_username="custom-admin-name"),
         base_url=BASE_URL,
         ssh=ssh,
         admin_email="a@b.c",
         gitea_user_email=None,
         gitea_user_password=None,
         repo_name="nexus-foo",
-        gitea_repo_owner="admin",
+        gitea_repo_owner="custom-admin-name",
         is_mirror_mode=False,
         enabled_services=["jupyter"],
         ready_timeout_s=0.2,
@@ -1120,6 +1126,9 @@ def test_run_configure_gitea_not_ready_returns_failed_admin() -> None:
 
     assert result.is_success is False
     assert result.admin.status == "failed"
+    # Round-2 regression: name must be the configured admin_username,
+    # not the literal "admin".
+    assert result.admin.name == "custom-admin-name"
     assert result.token is None
     assert result.restart_services == ("jupyter",)
 

--- a/tests/unit/test_gitea.py
+++ b/tests/unit/test_gitea.py
@@ -1,0 +1,1419 @@
+"""Tests for nexus_deploy.gitea — Phase 2 Modul 2.2e (#505).
+
+Covers the 8 named regression tests (R1-R8) per Appendix D plus
+orthogonal CLI/branch tests:
+
+- R1 column-exact awk match on user existence (PR #464 bug class)
+- R2 legacy email-collision PATCH
+- R3 DB password sync retry loop
+- R4 token retry-via-delete on conflict
+- R5 path-safety regex on URL segments
+- R6 repo-create-409 → patch_repo_private fallback
+- R7 token never in argv / URL (only in Authorization header)
+- R8 stdout emits eval-able GITEA_TOKEN= and RESTART_SERVICES=
+
+Mocks: ``responses`` for REST, ``unittest.mock.MagicMock`` for SSH.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+import responses
+
+from nexus_deploy.config import NexusConfig
+from nexus_deploy.gitea import (
+    CreateRepoResult,
+    CreateUserResult,
+    GiteaCli,
+    GiteaClient,
+    GiteaError,
+    GiteaResult,
+    TokenExistsError,
+    _compute_restart_services,
+    _escape_sql_string_literal,
+    _parse_admin_list_for_user,
+    _render_db_pw_sync_script,
+    _validate_path_segment,
+    run_configure_gitea,
+)
+
+BASE_URL = "http://localhost:3300"
+ADMIN = "admin"
+ADMIN_PASSWORD = "p@ss-w0rd!"
+
+
+def _make_config(**overrides: Any) -> NexusConfig:
+    defaults: dict[str, Any] = {
+        "admin_username": ADMIN,
+        "gitea_admin_password": ADMIN_PASSWORD,
+        "gitea_db_password": "db-secret",
+    }
+    defaults.update(overrides)
+    return NexusConfig.from_secrets_json(json.dumps(defaults))
+
+
+def _make_ssh(stdouts: list[str | tuple[int, str]] | None = None) -> MagicMock:
+    """Build a MagicMock SSH that returns the given stdouts in order.
+
+    Each stdout entry is either a string (rc=0) or (rc, stdout).
+    Once exhausted, returns rc=0 with empty stdout.
+    """
+    queue: list[tuple[int, str]] = []
+    for entry in stdouts or []:
+        if isinstance(entry, tuple):
+            queue.append(entry)
+        else:
+            queue.append((0, entry))
+
+    def run_script(
+        _script: str, *, check: bool = False, timeout: float | None = None
+    ) -> subprocess.CompletedProcess[str]:
+        if queue:
+            rc, out = queue.pop(0)
+        else:
+            rc, out = 0, ""
+        return subprocess.CompletedProcess(args=["ssh"], returncode=rc, stdout=out, stderr="")
+
+    ssh = MagicMock()
+    ssh.run_script.side_effect = run_script
+    return ssh
+
+
+# ---------------------------------------------------------------------------
+# R5 — path safety regex (CRITICAL — directory-traversal class)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "admin",
+        "stefan.koch",  # dotted username — Gitea allows
+        "user_42",
+        "a-b-c",
+        "Stefan",
+    ],
+)
+def test_round_5_path_safety_accepts_valid(value: str) -> None:
+    _validate_path_segment(value, kind="username")  # no raise
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "",  # empty
+        "..",  # traversal
+        "../etc/passwd",
+        "user/admin",  # slash
+        "user;rm -rf",  # shell meta
+        "user`whoami`",
+        "user$VAR",
+        "user with space",
+        "user'quote",
+        'user"quote',
+        "user\nnewline",
+        "user@host",  # @ not allowed (emails go elsewhere)
+    ],
+)
+def test_round_5_path_safety_rejects_unsafe(value: str) -> None:
+    with pytest.raises(GiteaError, match="unsafe"):
+        _validate_path_segment(value, kind="username")
+
+
+# ---------------------------------------------------------------------------
+# R1 — column-exact admin-list parser (PR #464 bug class)
+# ---------------------------------------------------------------------------
+
+
+_ADMIN_LIST_FIXTURE = (
+    "ID    Username       Email                          FullName\n"
+    "1     admin          admin@example.com              Admin\n"
+    "2     stefan.koch    stefan.koch@hslu.ch            Stefan\n"
+)
+
+
+def test_round_1_column_exact_match_finds_user() -> None:
+    exists, email = _parse_admin_list_for_user(_ADMIN_LIST_FIXTURE, "stefan.koch")
+    assert exists is True
+    assert email == "stefan.koch@hslu.ch"
+
+
+def test_round_1_column_exact_does_not_substring_match_email_column() -> None:
+    """The PR #464 bug: substring-grep matched 'koch' in admin's email column.
+
+    With column-exact awk equivalent, a username 'koch' must NOT
+    match 'stefan.koch' (column 2) and must NOT match 'stefan.koch@hslu.ch'
+    (column 3, even though it contains the substring).
+    """
+    exists, _ = _parse_admin_list_for_user(_ADMIN_LIST_FIXTURE, "koch")
+    assert exists is False
+
+
+def test_round_1_column_exact_does_not_substring_match_other_username() -> None:
+    """'admi' must not match 'admin'."""
+    exists, _ = _parse_admin_list_for_user(_ADMIN_LIST_FIXTURE, "admi")
+    assert exists is False
+
+
+def test_parse_empty_list_returns_false() -> None:
+    assert _parse_admin_list_for_user("", "admin") == (False, None)
+
+
+def test_parse_only_header_returns_false() -> None:
+    assert _parse_admin_list_for_user("ID Username Email\n", "admin") == (False, None)
+
+
+def test_parse_handles_short_lines_gracefully() -> None:
+    """Malformed lines (whitespace-only, <2 columns) must not crash the parser.
+
+    Line shapes:
+    - ``  `` (whitespace only) → split() = [] → skipped
+    - ``5 someuser`` (2 cols, no email) → matches by column 2,
+      email returned as None
+    """
+    text = "ID Username Email\n  \n5 someuser\n"
+    exists, email = _parse_admin_list_for_user(text, "someuser")
+    assert exists is True
+    # email column missing → None
+    assert email is None
+
+
+# ---------------------------------------------------------------------------
+# SQL escape
+# ---------------------------------------------------------------------------
+
+
+def test_sql_escape_handles_backslash_first() -> None:
+    """Backslash MUST be doubled BEFORE single-quote — order matters."""
+    assert _escape_sql_string_literal("a\\b") == "a\\\\b"
+    assert _escape_sql_string_literal("a'b") == "a''b"
+    # Combination: \' should NOT become \\\\\\' (which would close+open) —
+    # it should become \\\\\'\' i.e. backslash doubled then quote doubled.
+    # Result: a\\\\\'\'b   (4 chars source → "a", "\\\\", "''", "b")
+    assert _escape_sql_string_literal("a\\'b") == "a\\\\''b"
+
+
+def test_sql_escape_passthrough_safe_chars() -> None:
+    assert _escape_sql_string_literal("simple-pw_42") == "simple-pw_42"
+
+
+# ---------------------------------------------------------------------------
+# DB sync render + R3 retry loop
+# ---------------------------------------------------------------------------
+
+
+def test_render_db_sync_script_contains_set_euo_pipefail() -> None:
+    script = _render_db_pw_sync_script("escaped", attempts=3, interval_s=1.0)
+    assert script.splitlines()[0] == "set -euo pipefail"
+
+
+def test_render_db_sync_script_uses_peer_auth() -> None:
+    """No -W, no PGPASSWORD — peer auth via -U nexus-gitea inside container."""
+    script = _render_db_pw_sync_script("xx", attempts=3, interval_s=1.0)
+    assert "-U nexus-gitea" in script
+    assert "PGPASSWORD" not in script
+    assert " -W " not in script
+
+
+def test_render_db_sync_script_parses_as_valid_bash() -> None:
+    """``bash -n`` must accept the rendered script (R1 defence-in-depth).
+
+    Static-text tests caught the Modul-2.0 multi-line skip bug only
+    because we also exec'd bash. For the DB-sync script the surface
+    is small enough that ``bash -n`` (parse-only) is sufficient.
+    """
+    script = _render_db_pw_sync_script("p''q\\\\quoted", attempts=15, interval_s=2.0)
+    result = subprocess.run(
+        ["bash", "-n"], input=script, text=True, capture_output=True, check=False
+    )
+    assert result.returncode == 0, f"bash -n failed: {result.stderr}"
+
+
+def test_render_db_sync_script_shlex_protects_against_password_with_quotes() -> None:
+    """The SQL string MUST be shlex-quoted for the bash command.
+
+    A password containing a single quote (post-SQL-escape: ``''``)
+    must not break out of bash quoting. shlex.quote wraps the whole
+    SQL string in single quotes and escapes any internal single
+    quote as ``'\\''`` — so the literal ``''`` is transformed by
+    shlex but the bash-quoted form remains a single argument.
+
+    Verification: the rendered script must NOT contain an unbalanced
+    quoting pattern like ``'p''q'`` (which bash would parse as
+    ``'p' '' 'q'`` — three separate args, breaking psql's ``-c``).
+    """
+    escaped = _escape_sql_string_literal("p'q")  # → "p''q"
+    script = _render_db_pw_sync_script(escaped, attempts=3, interval_s=1.0)
+    # Should contain the SHLEX-escaped form, not the raw '' literal.
+    # shlex.quote of a string with single quotes uses '"'"' (or '\'') to
+    # escape, so the unsafe `'p''q'` form must NOT appear.
+    assert "'p''q'" not in script
+    # Must contain the unique substrings once shlex unwraps it.
+    assert "p" in script
+    assert "q" in script
+
+
+def test_round_3_db_sync_succeeds_after_retries() -> None:
+    """rc=0 + RESULT line on first or later attempt → True."""
+    ssh = _make_ssh([(0, "RESULT db_pw=synced\n")])
+    cli = GiteaCli(ssh)
+    assert cli.sync_db_password("secret", attempts=3, interval_s=0.01) is True
+    ssh.run_script.assert_called_once()
+
+
+def test_round_3_db_sync_fails_after_all_retries() -> None:
+    """rc=1 after exhausting attempts → False, no exception."""
+    ssh = _make_ssh([(1, "RESULT db_pw=failed\n")])
+    cli = GiteaCli(ssh)
+    assert cli.sync_db_password("secret", attempts=3, interval_s=0.01) is False
+
+
+def test_db_sync_skips_when_password_empty() -> None:
+    """Empty password → no ssh call, returns False."""
+    ssh = _make_ssh()
+    cli = GiteaCli(ssh)
+    assert cli.sync_db_password("", attempts=3, interval_s=0.01) is False
+    ssh.run_script.assert_not_called()
+
+
+def test_db_sync_password_never_in_argv_only_in_script_stdin() -> None:
+    """R7 / defence-in-depth — password must reach SSH via run_script
+    (stdin), not via run (argv). Verify by asserting `run` is never called.
+    """
+    ssh = _make_ssh([(0, "RESULT db_pw=synced\n")])
+    cli = GiteaCli(ssh)
+    cli.sync_db_password("supersecret-do-not-leak", attempts=2, interval_s=0.01)
+    # MagicMock.run is NOT called
+    ssh.run.assert_not_called()
+    # The script (which contains the password) was passed as the first
+    # positional arg to run_script.
+    call_script = ssh.run_script.call_args[0][0]
+    assert "supersecret-do-not-leak" in call_script
+
+
+# ---------------------------------------------------------------------------
+# GiteaCli — admin list + create + sync
+# ---------------------------------------------------------------------------
+
+
+def test_list_admin_users_returns_stdout_on_success() -> None:
+    ssh = _make_ssh([(0, _ADMIN_LIST_FIXTURE)])
+    assert GiteaCli(ssh).list_admin_users() == _ADMIN_LIST_FIXTURE
+
+
+def test_list_admin_users_returns_empty_on_ssh_failure() -> None:
+    """Non-zero rc → empty string (caller routes to CREATE branch)."""
+    ssh = _make_ssh([(1, "boom\n")])
+    assert GiteaCli(ssh).list_admin_users() == ""
+
+
+def test_create_admin_returns_created_on_success_keyword() -> None:
+    ssh = _make_ssh([(0, "New user 'admin' has been created\n")])
+    result = GiteaCli(ssh).create_admin("admin", "pw", "a@b.c")
+    assert result.status == "created"
+
+
+def test_create_admin_returns_already_exists_on_collision() -> None:
+    ssh = _make_ssh([(1, "user already exists\n")])
+    result = GiteaCli(ssh).create_admin("admin", "pw", "a@b.c")
+    assert result.status == "already_exists"
+
+
+def test_create_admin_returns_failed_on_other_error() -> None:
+    ssh = _make_ssh([(1, "Some other validation error\n")])
+    result = GiteaCli(ssh).create_admin("admin", "pw", "a@b.c")
+    assert result.status == "failed"
+    assert "Some other validation error" in result.detail
+
+
+def test_create_admin_path_safety() -> None:
+    ssh = _make_ssh([(0, "")])
+    with pytest.raises(GiteaError, match="unsafe"):
+        GiteaCli(ssh).create_admin("ad;min", "pw", "a@b.c")
+    ssh.run_script.assert_not_called()
+
+
+def test_sync_password_returns_synced_on_rc_zero() -> None:
+    ssh = _make_ssh([(0, "")])
+    assert GiteaCli(ssh).sync_password("admin", "newpw").status == "synced"
+
+
+def test_sync_password_returns_failed_on_rc_nonzero() -> None:
+    ssh = _make_ssh([(1, "user not found")])
+    result = GiteaCli(ssh).sync_password("admin", "newpw")
+    assert result.status == "failed"
+
+
+def test_sync_password_uses_run_script_not_run() -> None:
+    """R7 — password is in the rendered script, fed via stdin."""
+    ssh = _make_ssh([(0, "")])
+    GiteaCli(ssh).sync_password("admin", "leakable-pw")
+    ssh.run.assert_not_called()
+    assert "leakable-pw" in ssh.run_script.call_args[0][0]
+
+
+# ---------------------------------------------------------------------------
+# GiteaClient (REST) — basic-auth + token-auth
+# ---------------------------------------------------------------------------
+
+
+def _client(token: str | None = None) -> GiteaClient:
+    base = GiteaClient(BASE_URL, admin_username=ADMIN, admin_password=ADMIN_PASSWORD)
+    return base.with_token(token) if token else base
+
+
+def test_client_rejects_empty_admin_username() -> None:
+    with pytest.raises(ValueError, match="non-empty"):
+        GiteaClient(BASE_URL, admin_username="", admin_password="pw")
+
+
+def test_client_rejects_empty_admin_password() -> None:
+    with pytest.raises(ValueError, match="non-empty"):
+        GiteaClient(BASE_URL, admin_username="admin", admin_password="")
+
+
+def test_client_rejects_unsafe_admin_username() -> None:
+    with pytest.raises(GiteaError, match="unsafe"):
+        GiteaClient(BASE_URL, admin_username="adm;in", admin_password="pw")
+
+
+def test_with_token_rejects_empty_token() -> None:
+    with pytest.raises(ValueError, match="non-empty"):
+        _client().with_token("")
+
+
+@responses.activate
+def test_wait_ready_returns_true_on_200() -> None:
+    responses.add(responses.GET, f"{BASE_URL}/api/healthz", status=200)
+    assert _client().wait_ready(timeout_s=1.0, interval_s=0.05) is True
+
+
+@responses.activate
+def test_wait_ready_times_out() -> None:
+    responses.add(responses.GET, f"{BASE_URL}/api/healthz", status=503)
+    assert _client().wait_ready(timeout_s=0.2, interval_s=0.05) is False
+
+
+# ---------------------------------------------------------------------------
+# R2 — legacy email-collision PATCH
+# ---------------------------------------------------------------------------
+
+
+@responses.activate
+def test_round_2_patch_user_email_returns_true_on_200() -> None:
+    responses.add(
+        responses.PATCH,
+        f"{BASE_URL}/api/v1/admin/users/admin",
+        status=200,
+        json={"id": 1},
+    )
+    assert _client().patch_user_email("admin", "new@e.com", login_name="admin") is True
+    body = json.loads(responses.calls[0].request.body)  # type: ignore[arg-type]
+    assert body == {"email": "new@e.com", "source_id": 0, "login_name": "admin"}
+
+
+@responses.activate
+def test_round_2_patch_user_email_includes_required_full_body() -> None:
+    """Schema requires source_id + login_name even for email-only update."""
+    responses.add(responses.PATCH, f"{BASE_URL}/api/v1/admin/users/admin", status=200)
+    _client().patch_user_email("admin", "x@y.z", login_name="admin")
+    body = json.loads(responses.calls[0].request.body)  # type: ignore[arg-type]
+    assert "source_id" in body
+    assert "login_name" in body
+
+
+@responses.activate
+def test_patch_user_email_returns_false_on_4xx() -> None:
+    responses.add(responses.PATCH, f"{BASE_URL}/api/v1/admin/users/admin", status=403)
+    assert _client().patch_user_email("admin", "x@y.z", login_name="admin") is False
+
+
+def test_patch_user_email_path_safety() -> None:
+    with pytest.raises(GiteaError, match="unsafe"):
+        _client().patch_user_email("admi;n", "x@y.z", login_name="admin")
+
+
+# ---------------------------------------------------------------------------
+# R4 — token create / retry-via-delete
+# ---------------------------------------------------------------------------
+
+
+@responses.activate
+def test_create_token_returns_sha1_on_201() -> None:
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/users/admin/tokens",
+        status=201,
+        json={"id": 1, "name": "nexus-automation", "sha1": "abc123"},
+    )
+    assert _client().create_token("admin", "nexus-automation", ["all"]) == "abc123"
+
+
+@responses.activate
+def test_create_token_raises_token_exists_on_409() -> None:
+    responses.add(responses.POST, f"{BASE_URL}/api/v1/users/admin/tokens", status=409)
+    with pytest.raises(TokenExistsError):
+        _client().create_token("admin", "nexus-automation", ["all"])
+
+
+@responses.activate
+def test_create_token_raises_token_exists_on_422_with_message() -> None:
+    """Some Gitea versions return 422 with 'already exists' body."""
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/users/admin/tokens",
+        status=422,
+        json={"message": "token name already exists"},
+    )
+    with pytest.raises(TokenExistsError):
+        _client().create_token("admin", "nexus-automation", ["all"])
+
+
+@responses.activate
+def test_create_token_raises_gitea_error_on_other_422() -> None:
+    """Non-existence 422 (validation failure) is NOT a retry signal."""
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/users/admin/tokens",
+        status=422,
+        json={"message": "scopes invalid"},
+    )
+    with pytest.raises(GiteaError) as exc_info:
+        _client().create_token("admin", "nexus-automation", ["all"])
+    assert not isinstance(exc_info.value, TokenExistsError)
+
+
+@responses.activate
+def test_create_token_raises_gitea_error_on_5xx() -> None:
+    responses.add(responses.POST, f"{BASE_URL}/api/v1/users/admin/tokens", status=500)
+    with pytest.raises(GiteaError):
+        _client().create_token("admin", "nexus-automation", ["all"])
+
+
+@responses.activate
+def test_create_token_raises_on_missing_sha1() -> None:
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/users/admin/tokens",
+        status=201,
+        json={"id": 1, "name": "nexus-automation"},  # no sha1
+    )
+    with pytest.raises(GiteaError, match="sha1"):
+        _client().create_token("admin", "nexus-automation", ["all"])
+
+
+@responses.activate
+def test_round_4_create_token_with_retry_409_then_delete_then_201() -> None:
+    """The full retry-via-delete flow on a 409."""
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/users/admin/tokens",
+        status=409,
+    )
+    responses.add(
+        responses.DELETE,
+        f"{BASE_URL}/api/v1/users/admin/tokens/nexus-automation",
+        status=204,
+    )
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/users/admin/tokens",
+        status=201,
+        json={"sha1": "deadbeef"},
+    )
+    assert _client().create_token_with_retry("admin", "nexus-automation", ["all"]) == "deadbeef"
+    # Three calls: POST 409, DELETE 204, POST 201
+    assert len(responses.calls) == 3
+
+
+@responses.activate
+def test_delete_token_treats_404_as_success() -> None:
+    """Idempotent — 404 means already gone, equivalent to 204."""
+    responses.add(
+        responses.DELETE,
+        f"{BASE_URL}/api/v1/users/admin/tokens/nexus-automation",
+        status=404,
+    )
+    assert _client().delete_token("admin", "nexus-automation") is True
+
+
+def test_delete_token_path_safety_on_token_name() -> None:
+    with pytest.raises(GiteaError, match="unsafe"):
+        _client().delete_token("admin", "name;rm -rf /")
+
+
+def test_create_token_path_safety() -> None:
+    with pytest.raises(GiteaError, match="unsafe"):
+        _client().create_token("a;b", "nexus-automation", ["all"])
+
+
+# ---------------------------------------------------------------------------
+# R7 — token never in argv / URL, only Authorization header
+# ---------------------------------------------------------------------------
+
+
+@responses.activate
+def test_round_7_token_in_authorization_header_not_argv_or_url() -> None:
+    """After ``with_token``, every request carries
+    ``Authorization: token <sha>`` and the token MUST NOT appear in
+    the URL or in the request body.
+    """
+    secret_token = "do-not-leak-this-token-anywhere-please"
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/user/repos",
+        status=201,
+        json={"id": 1},
+    )
+    client = _client(token=secret_token)
+    client.create_repo("nexus-test-gitea", description="Hello")
+
+    call = responses.calls[0]
+    # URL: token NOT present
+    assert secret_token not in (call.request.url or "")
+    # Body: token NOT present
+    raw_body = call.request.body
+    if isinstance(raw_body, bytes):
+        body_text = raw_body.decode("utf-8")
+    elif isinstance(raw_body, str):
+        body_text = raw_body
+    else:
+        body_text = ""
+    assert secret_token not in body_text
+    # Authorization header: token IS present in `token <sha>` form
+    auth = call.request.headers.get("Authorization", "")
+    assert auth == f"token {secret_token}"
+
+
+@responses.activate
+def test_round_7_token_not_in_basic_auth_after_with_token() -> None:
+    """After ``with_token``, the basic-auth credentials MUST be gone."""
+    responses.add(responses.GET, f"{BASE_URL}/api/v1/repos/admin/foo", status=200)
+    client = _client(token="some-token")
+    client.repo_exists("admin", "foo")
+    auth_header = responses.calls[0].request.headers.get("Authorization", "")
+    # Must NOT be Basic ... (would be base64 of admin:password)
+    assert auth_header.startswith("token ")
+
+
+# ---------------------------------------------------------------------------
+# R6 — repo create 409 → patch_repo_private fallback
+# ---------------------------------------------------------------------------
+
+
+@responses.activate
+def test_create_repo_returns_created_on_201() -> None:
+    responses.add(responses.POST, f"{BASE_URL}/api/v1/user/repos", status=201, json={"id": 1})
+    result = _client(token="t").create_repo("nexus-test", description="x")
+    assert result.status == "created"
+
+
+@responses.activate
+def test_round_6_create_repo_409_returns_already_exists() -> None:
+    responses.add(responses.POST, f"{BASE_URL}/api/v1/user/repos", status=409)
+    result = _client(token="t").create_repo("nexus-test")
+    assert result.status == "already_exists"
+
+
+@responses.activate
+def test_round_6_create_repo_422_already_exists_returns_already_exists() -> None:
+    """Some Gitea modes return 422 with 'already exists' body."""
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/user/repos",
+        status=422,
+        json={"message": "repository already exists"},
+    )
+    result = _client(token="t").create_repo("nexus-test")
+    assert result.status == "already_exists"
+
+
+@responses.activate
+def test_create_repo_422_validation_returns_failed() -> None:
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/user/repos",
+        status=422,
+        json={"message": "invalid name"},
+    )
+    result = _client(token="t").create_repo("nexus-test")
+    assert result.status == "failed"
+
+
+@responses.activate
+def test_round_6_patch_repo_private_idempotent_204_or_200() -> None:
+    """Used after 409 to ensure the existing repo is private."""
+    responses.add(
+        responses.PATCH,
+        f"{BASE_URL}/api/v1/repos/admin/nexus-test",
+        status=200,
+    )
+    assert _client(token="t").patch_repo_private("admin", "nexus-test", private=True)
+    body = json.loads(responses.calls[0].request.body)  # type: ignore[arg-type]
+    assert body == {"private": True}
+
+
+# ---------------------------------------------------------------------------
+# Collaborator add — idempotent
+# ---------------------------------------------------------------------------
+
+
+@responses.activate
+def test_add_collaborator_returns_true_on_204() -> None:
+    responses.add(
+        responses.PUT,
+        f"{BASE_URL}/api/v1/repos/admin/nexus-test/collaborators/user",
+        status=204,
+    )
+    assert _client(token="t").add_collaborator("admin", "nexus-test", "user")
+
+
+@responses.activate
+def test_add_collaborator_returns_true_on_422_already_collaborator() -> None:
+    """Idempotent: 422 ('already a collaborator') counted as success."""
+    responses.add(
+        responses.PUT,
+        f"{BASE_URL}/api/v1/repos/admin/nexus-test/collaborators/user",
+        status=422,
+    )
+    assert _client(token="t").add_collaborator("admin", "nexus-test", "user")
+
+
+@responses.activate
+def test_add_collaborator_returns_false_on_403() -> None:
+    responses.add(
+        responses.PUT,
+        f"{BASE_URL}/api/v1/repos/admin/nexus-test/collaborators/user",
+        status=403,
+    )
+    assert _client(token="t").add_collaborator("admin", "nexus-test", "user") is False
+
+
+def test_add_collaborator_path_safety() -> None:
+    with pytest.raises(GiteaError, match="unsafe"):
+        _client(token="t").add_collaborator("admin", "nexus-test", "user;rm")
+
+
+# ---------------------------------------------------------------------------
+# repo_exists
+# ---------------------------------------------------------------------------
+
+
+@responses.activate
+def test_repo_exists_200() -> None:
+    responses.add(responses.GET, f"{BASE_URL}/api/v1/repos/a/b", status=200)
+    assert _client(token="t").repo_exists("a", "b") is True
+
+
+@responses.activate
+def test_repo_exists_404() -> None:
+    responses.add(responses.GET, f"{BASE_URL}/api/v1/repos/a/b", status=404)
+    assert _client(token="t").repo_exists("a", "b") is False
+
+
+@responses.activate
+def test_repo_exists_500_raises() -> None:
+    responses.add(responses.GET, f"{BASE_URL}/api/v1/repos/a/b", status=500)
+    with pytest.raises(GiteaError):
+        _client(token="t").repo_exists("a", "b")
+
+
+# ---------------------------------------------------------------------------
+# RESTART_SERVICES intersection
+# ---------------------------------------------------------------------------
+
+
+def test_compute_restart_services_preserves_order() -> None:
+    """Output order must be the canonical order (jupyter, marimo, code-server, ...)."""
+    enabled = ["redpanda", "code-server", "jupyter", "marimo"]
+    assert _compute_restart_services(enabled) == ("jupyter", "marimo", "code-server")
+
+
+def test_compute_restart_services_empty_when_none_enabled() -> None:
+    assert _compute_restart_services(["postgres", "redis"]) == ()
+
+
+def test_compute_restart_services_empty_input() -> None:
+    assert _compute_restart_services([]) == ()
+
+
+# ---------------------------------------------------------------------------
+# Top-level orchestrator — happy path + key branches
+# ---------------------------------------------------------------------------
+
+
+@responses.activate
+def test_run_configure_gitea_full_happy_path_admin_already_exists() -> None:
+    """Admin exists, password sync, token mint, repo+collaborator add."""
+    # Healthcheck OK
+    responses.add(responses.GET, f"{BASE_URL}/api/healthz", status=200)
+    # Token mint
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/users/admin/tokens",
+        status=201,
+        json={"sha1": "tok123"},
+    )
+    # Repo create
+    responses.add(responses.POST, f"{BASE_URL}/api/v1/user/repos", status=201, json={"id": 1})
+    # Collaborator add
+    responses.add(
+        responses.PUT,
+        f"{BASE_URL}/api/v1/repos/admin/nexus-foo/collaborators/stefan.koch",
+        status=204,
+    )
+
+    ssh = _make_ssh(
+        [
+            (0, "RESULT db_pw=synced\n"),  # DB pw sync
+            (0, _ADMIN_LIST_FIXTURE),  # admin user list
+            (0, ""),  # admin sync_password
+            (0, _ADMIN_LIST_FIXTURE),  # user list (same fixture, has stefan.koch)
+            (0, ""),  # user sync_password
+        ]
+    )
+
+    result = run_configure_gitea(
+        _make_config(),
+        base_url=BASE_URL,
+        ssh=ssh,
+        admin_email="admin@example.com",
+        gitea_user_email="stefan.koch@hslu.ch",
+        gitea_user_password="userpw",
+        repo_name="nexus-foo",
+        gitea_repo_owner="admin",
+        is_mirror_mode=False,
+        enabled_services=["jupyter", "marimo"],
+        ready_timeout_s=1.0,
+        db_sync_attempts=1,
+        db_sync_interval_s=0.01,
+    )
+
+    assert result.is_success is True
+    assert result.token == "tok123"
+    assert result.db_pw_synced is True
+    assert result.admin.status == "synced"
+    assert result.user is not None
+    assert result.user.status == "synced"
+    assert result.repo is not None
+    assert result.repo.status == "created"
+    assert result.collaborator_added is True
+    assert result.restart_services == ("jupyter", "marimo")
+
+
+@responses.activate
+def test_run_configure_gitea_admin_does_not_exist_creates() -> None:
+    """Empty admin list → CREATE branch."""
+    responses.add(responses.GET, f"{BASE_URL}/api/healthz", status=200)
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/users/admin/tokens",
+        status=201,
+        json={"sha1": "tok"},
+    )
+    responses.add(responses.POST, f"{BASE_URL}/api/v1/user/repos", status=201, json={"id": 1})
+
+    ssh = _make_ssh(
+        [
+            (0, "RESULT db_pw=synced\n"),
+            (0, "ID Username Email\n"),  # empty list
+            (0, "New user 'admin' has been created\n"),  # create_admin
+        ]
+    )
+
+    result = run_configure_gitea(
+        _make_config(),
+        base_url=BASE_URL,
+        ssh=ssh,
+        admin_email="admin@example.com",
+        gitea_user_email=None,
+        gitea_user_password=None,
+        repo_name="nexus-foo",
+        gitea_repo_owner="admin",
+        is_mirror_mode=False,
+        enabled_services=[],
+        ready_timeout_s=1.0,
+        db_sync_attempts=1,
+        db_sync_interval_s=0.01,
+    )
+
+    assert result.admin.status == "created"
+    assert result.user is None  # GITEA_USER_EMAIL was None
+    assert result.token == "tok"
+
+
+@responses.activate
+def test_round_2_legacy_email_collision_triggers_patch() -> None:
+    """Admin row's email == GITEA_USER_EMAIL → PATCH fires before sync."""
+    responses.add(responses.GET, f"{BASE_URL}/api/healthz", status=200)
+    # The PATCH call we want to verify
+    responses.add(
+        responses.PATCH,
+        f"{BASE_URL}/api/v1/admin/users/admin",
+        status=200,
+    )
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/users/admin/tokens",
+        status=201,
+        json={"sha1": "tok"},
+    )
+    responses.add(responses.POST, f"{BASE_URL}/api/v1/user/repos", status=201, json={"id": 1})
+    responses.add(
+        responses.PUT,
+        f"{BASE_URL}/api/v1/repos/admin/nexus-foo/collaborators/stefan.koch",
+        status=204,
+    )
+
+    # admin's email column == GITEA_USER_EMAIL == "stefan.koch@hslu.ch"
+    legacy_admin_list = "ID Username Email FullName\n1 admin stefan.koch@hslu.ch Admin\n"
+    ssh = _make_ssh(
+        [
+            (0, ""),  # DB pw sync (not interesting here)
+            (0, legacy_admin_list),  # admin list — collision
+            (0, ""),  # admin sync_password
+            (0, "ID Username Email\n"),  # user list — empty
+            (0, "New user 'stefan.koch' has been created\n"),  # create_user
+        ]
+    )
+
+    result = run_configure_gitea(
+        _make_config(),
+        base_url=BASE_URL,
+        ssh=ssh,
+        admin_email="admin@new-domain.com",
+        gitea_user_email="stefan.koch@hslu.ch",
+        gitea_user_password="userpw",
+        repo_name="nexus-foo",
+        gitea_repo_owner="admin",
+        is_mirror_mode=False,
+        enabled_services=["jupyter"],
+        ready_timeout_s=1.0,
+        db_sync_attempts=1,
+        db_sync_interval_s=0.01,
+    )
+
+    assert result.is_success is True
+    # Verify a PATCH was made with the new admin email
+    patch_calls = [c for c in responses.calls if c.request.method == "PATCH"]
+    assert len(patch_calls) == 1
+    body = json.loads(patch_calls[0].request.body)  # type: ignore[arg-type]
+    assert body["email"] == "admin@new-domain.com"
+
+
+@responses.activate
+def test_round_6_repo_already_exists_falls_back_to_patch_private() -> None:
+    """409 on POST → PATCH /repos/<o>/<n> with private=True."""
+    responses.add(responses.GET, f"{BASE_URL}/api/healthz", status=200)
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/users/admin/tokens",
+        status=201,
+        json={"sha1": "tok"},
+    )
+    # Repo create returns 409
+    responses.add(responses.POST, f"{BASE_URL}/api/v1/user/repos", status=409)
+    # PATCH private fallback
+    responses.add(
+        responses.PATCH,
+        f"{BASE_URL}/api/v1/repos/admin/nexus-foo",
+        status=200,
+    )
+
+    ssh = _make_ssh(
+        [
+            (0, "RESULT db_pw=synced\n"),
+            (0, _ADMIN_LIST_FIXTURE),
+            (0, ""),
+        ]
+    )
+
+    result = run_configure_gitea(
+        _make_config(),
+        base_url=BASE_URL,
+        ssh=ssh,
+        admin_email="a@b.c",
+        gitea_user_email=None,
+        gitea_user_password=None,
+        repo_name="nexus-foo",
+        gitea_repo_owner="admin",
+        is_mirror_mode=False,
+        enabled_services=[],
+        ready_timeout_s=1.0,
+        db_sync_attempts=1,
+        db_sync_interval_s=0.01,
+    )
+
+    assert result.repo is not None
+    assert result.repo.status == "already_exists"
+    # Verify PATCH was issued to set private=true
+    patch_calls = [c for c in responses.calls if c.request.method == "PATCH"]
+    assert len(patch_calls) == 1
+    body = json.loads(patch_calls[0].request.body)  # type: ignore[arg-type]
+    assert body["private"] is True
+
+
+@responses.activate
+def test_run_configure_gitea_mirror_mode_skips_repo_and_collaborator() -> None:
+    responses.add(responses.GET, f"{BASE_URL}/api/healthz", status=200)
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/users/admin/tokens",
+        status=201,
+        json={"sha1": "tok"},
+    )
+
+    ssh = _make_ssh(
+        [
+            (0, ""),
+            (0, _ADMIN_LIST_FIXTURE),
+            (0, ""),
+        ]
+    )
+
+    result = run_configure_gitea(
+        _make_config(),
+        base_url=BASE_URL,
+        ssh=ssh,
+        admin_email="a@b.c",
+        gitea_user_email=None,
+        gitea_user_password=None,
+        repo_name="nexus-foo",
+        gitea_repo_owner="admin",
+        is_mirror_mode=True,  # ← mirror mode
+        enabled_services=[],
+        ready_timeout_s=1.0,
+        db_sync_attempts=1,
+        db_sync_interval_s=0.01,
+    )
+
+    assert result.repo is None
+    assert result.collaborator_added is False
+    # No POST to /api/v1/user/repos was made
+    repo_calls = [c for c in responses.calls if "/user/repos" in (c.request.url or "")]
+    assert len(repo_calls) == 0
+
+
+@responses.activate
+def test_run_configure_gitea_not_ready_returns_failed_admin() -> None:
+    """Health endpoint never 200 → admin.status=='failed', no token."""
+    responses.add(responses.GET, f"{BASE_URL}/api/healthz", status=503)
+
+    ssh = _make_ssh([(0, "RESULT db_pw=synced\n")])
+
+    result = run_configure_gitea(
+        _make_config(),
+        base_url=BASE_URL,
+        ssh=ssh,
+        admin_email="a@b.c",
+        gitea_user_email=None,
+        gitea_user_password=None,
+        repo_name="nexus-foo",
+        gitea_repo_owner="admin",
+        is_mirror_mode=False,
+        enabled_services=["jupyter"],
+        ready_timeout_s=0.2,
+        db_sync_attempts=1,
+        db_sync_interval_s=0.01,
+    )
+
+    assert result.is_success is False
+    assert result.admin.status == "failed"
+    assert result.token is None
+    assert result.restart_services == ("jupyter",)
+
+
+@responses.activate
+def test_run_configure_gitea_token_mint_failure_returns_failure() -> None:
+    """Token can't be minted (5xx on both attempts) → token=None, is_success=False."""
+    responses.add(responses.GET, f"{BASE_URL}/api/healthz", status=200)
+    responses.add(responses.POST, f"{BASE_URL}/api/v1/users/admin/tokens", status=500)
+
+    ssh = _make_ssh(
+        [
+            (0, "RESULT db_pw=synced\n"),
+            (0, _ADMIN_LIST_FIXTURE),
+            (0, ""),
+        ]
+    )
+
+    result = run_configure_gitea(
+        _make_config(),
+        base_url=BASE_URL,
+        ssh=ssh,
+        admin_email="a@b.c",
+        gitea_user_email=None,
+        gitea_user_password=None,
+        repo_name="nexus-foo",
+        gitea_repo_owner="admin",
+        is_mirror_mode=False,
+        enabled_services=[],
+        ready_timeout_s=1.0,
+        db_sync_attempts=1,
+        db_sync_interval_s=0.01,
+    )
+    assert result.token is None
+    assert result.is_success is False
+
+
+# ---------------------------------------------------------------------------
+# is_success on GiteaResult
+# ---------------------------------------------------------------------------
+
+
+def test_is_success_true_on_clean_path() -> None:
+    r = GiteaResult(
+        db_pw_synced=True,
+        admin=CreateUserResult(name="admin", status="synced"),
+        user=CreateUserResult(name="stefan", status="created"),
+        token="t",
+        repo=CreateRepoResult(name="nexus-foo", status="created"),
+        collaborator_added=True,
+        restart_services=("jupyter",),
+    )
+    assert r.is_success is True
+
+
+def test_is_success_false_when_admin_failed() -> None:
+    r = GiteaResult(
+        db_pw_synced=True,
+        admin=CreateUserResult(name="admin", status="failed"),
+        user=None,
+        token="t",
+        repo=None,
+        collaborator_added=False,
+        restart_services=(),
+    )
+    assert r.is_success is False
+
+
+def test_is_success_false_when_token_missing() -> None:
+    r = GiteaResult(
+        db_pw_synced=True,
+        admin=CreateUserResult(name="admin", status="synced"),
+        user=None,
+        token=None,
+        repo=None,
+        collaborator_added=False,
+        restart_services=(),
+    )
+    assert r.is_success is False
+
+
+def test_is_success_false_when_user_failed() -> None:
+    r = GiteaResult(
+        db_pw_synced=True,
+        admin=CreateUserResult(name="admin", status="synced"),
+        user=CreateUserResult(name="stefan", status="failed"),
+        token="t",
+        repo=None,
+        collaborator_added=False,
+        restart_services=(),
+    )
+    assert r.is_success is False
+
+
+def test_is_success_false_when_repo_failed() -> None:
+    r = GiteaResult(
+        db_pw_synced=True,
+        admin=CreateUserResult(name="admin", status="synced"),
+        user=None,
+        token="t",
+        repo=CreateRepoResult(name="nexus-foo", status="failed"),
+        collaborator_added=False,
+        restart_services=(),
+    )
+    assert r.is_success is False
+
+
+# ---------------------------------------------------------------------------
+# R8 — CLI stdout emits eval-able GITEA_TOKEN= AND RESTART_SERVICES=
+# ---------------------------------------------------------------------------
+
+
+def test_round_8_cli_emits_eval_able_stdout(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Happy-path stdout must contain BOTH eval-able lines and use shlex.quote."""
+    fake_result = GiteaResult(
+        db_pw_synced=True,
+        admin=CreateUserResult(name="admin", status="synced"),
+        user=CreateUserResult(name="stefan", status="created"),
+        token="abc123def-token",
+        repo=CreateRepoResult(name="nexus-foo", status="created"),
+        collaborator_added=True,
+        restart_services=("jupyter", "marimo"),
+    )
+
+    def fake_run(*_args: Any, **_kwargs: Any) -> GiteaResult:
+        return fake_result
+
+    monkeypatch.setattr("nexus_deploy.__main__.run_configure_gitea", fake_run)
+    monkeypatch.setattr(
+        "sys.stdin.read",
+        lambda: json.dumps(
+            {
+                "admin_username": "admin",
+                "gitea_admin_password": "x",
+            }
+        ),
+    )
+    monkeypatch.setenv("ADMIN_EMAIL", "a@b.c")
+    monkeypatch.setenv("REPO_NAME", "nexus-foo")
+    monkeypatch.setenv("GITEA_REPO_OWNER", "admin")
+    monkeypatch.setenv("ENABLED_SERVICES", "jupyter,marimo")
+
+    # Mock the SSH context-manager + port_forward so we don't actually ssh
+    fake_ssh = MagicMock()
+    fake_ssh.__enter__ = MagicMock(return_value=fake_ssh)
+    fake_ssh.__exit__ = MagicMock(return_value=None)
+    fake_pf_cm = MagicMock()
+    fake_pf_cm.__enter__ = MagicMock(return_value=12345)
+    fake_pf_cm.__exit__ = MagicMock(return_value=None)
+    fake_ssh.port_forward = MagicMock(return_value=fake_pf_cm)
+    monkeypatch.setattr("nexus_deploy.__main__.SSHClient", lambda host: fake_ssh)
+
+    from nexus_deploy.__main__ import _gitea_configure
+
+    rc = _gitea_configure([])
+    assert rc == 0
+
+    captured = capsys.readouterr()
+    out = captured.out
+    # Both eval-able lines present
+    assert re.search(r"^GITEA_TOKEN=.*abc123def-token", out, re.M)
+    assert re.search(r"^RESTART_SERVICES=", out, re.M)
+    # Token-line uses shlex-quoted form
+    token_line = next(line for line in out.splitlines() if line.startswith("GITEA_TOKEN="))
+    # Must be safely eval-able by bash; for a 40-hex-like value, no quotes
+    # is acceptable; we only require the token substring is present.
+    assert "abc123def-token" in token_line
+    # Verify RESTART_SERVICES= encodes the comma-list
+    rs_line = next(line for line in out.splitlines() if line.startswith("RESTART_SERVICES="))
+    assert "jupyter,marimo" in rs_line
+
+
+def test_round_8_cli_omits_token_line_when_token_none(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Token=None → only RESTART_SERVICES= on stdout, NO GITEA_TOKEN= line.
+
+    deploy.sh must not see a stale token from a previous deploy
+    leaking via empty-string assignment.
+    """
+    fake_result = GiteaResult(
+        db_pw_synced=True,
+        admin=CreateUserResult(name="admin", status="synced"),
+        user=None,
+        token=None,
+        repo=None,
+        collaborator_added=False,
+        restart_services=("jupyter",),
+    )
+
+    monkeypatch.setattr("nexus_deploy.__main__.run_configure_gitea", lambda *a, **k: fake_result)
+    monkeypatch.setattr("sys.stdin.read", lambda: '{"gitea_admin_password": "x"}')
+    monkeypatch.setenv("ADMIN_EMAIL", "a@b.c")
+    monkeypatch.setenv("REPO_NAME", "nexus-foo")
+    monkeypatch.setenv("GITEA_REPO_OWNER", "admin")
+    monkeypatch.setenv("ENABLED_SERVICES", "jupyter")
+
+    fake_ssh = MagicMock()
+    fake_ssh.__enter__ = MagicMock(return_value=fake_ssh)
+    fake_ssh.__exit__ = MagicMock(return_value=None)
+    fake_pf = MagicMock()
+    fake_pf.__enter__ = MagicMock(return_value=12345)
+    fake_pf.__exit__ = MagicMock(return_value=None)
+    fake_ssh.port_forward = MagicMock(return_value=fake_pf)
+    monkeypatch.setattr("nexus_deploy.__main__.SSHClient", lambda host: fake_ssh)
+
+    from nexus_deploy.__main__ import _gitea_configure
+
+    rc = _gitea_configure([])
+    assert rc == 1  # is_success=False (token is None)
+
+    out = capsys.readouterr().out
+    assert "GITEA_TOKEN=" not in out
+    assert re.search(r"^RESTART_SERVICES=", out, re.M)
+
+
+# ---------------------------------------------------------------------------
+# CLI argument validation — rc=2 on bad inputs
+# ---------------------------------------------------------------------------
+
+
+def test_cli_unknown_args_returns_rc_2(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from nexus_deploy.__main__ import _gitea_configure
+
+    rc = _gitea_configure(["--bogus"])
+    assert rc == 2
+    assert "unknown args" in capsys.readouterr().err
+
+
+def test_cli_missing_required_env_returns_rc_2(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.delenv("ADMIN_EMAIL", raising=False)
+    monkeypatch.delenv("REPO_NAME", raising=False)
+    monkeypatch.delenv("GITEA_REPO_OWNER", raising=False)
+
+    from nexus_deploy.__main__ import _gitea_configure
+
+    rc = _gitea_configure([])
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "ADMIN_EMAIL" in err
+    assert "REPO_NAME" in err
+    assert "GITEA_REPO_OWNER" in err
+
+
+def test_cli_missing_admin_pass_returns_rc_1_with_empty_restart(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """No gitea_admin_password → rc=1 (yellow), still emits empty RESTART_SERVICES."""
+    monkeypatch.setenv("ADMIN_EMAIL", "a@b.c")
+    monkeypatch.setenv("REPO_NAME", "nexus-foo")
+    monkeypatch.setenv("GITEA_REPO_OWNER", "admin")
+    monkeypatch.setattr("sys.stdin.read", lambda: "{}")
+
+    from nexus_deploy.__main__ import _gitea_configure
+
+    rc = _gitea_configure([])
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert "RESTART_SERVICES=" in out
+    assert "GITEA_TOKEN=" not in out
+
+
+def test_cli_bad_secrets_json_returns_rc_2(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setenv("ADMIN_EMAIL", "a@b.c")
+    monkeypatch.setenv("REPO_NAME", "nexus-foo")
+    monkeypatch.setenv("GITEA_REPO_OWNER", "admin")
+    monkeypatch.setattr("sys.stdin.read", lambda: "not-json")
+
+    from nexus_deploy.__main__ import _gitea_configure
+
+    rc = _gitea_configure([])
+    assert rc == 2
+
+
+def test_cli_ssh_tunnel_failure_returns_rc_2(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """SSHError during port_forward → rc=2, NO token in stdout."""
+    monkeypatch.setenv("ADMIN_EMAIL", "a@b.c")
+    monkeypatch.setenv("REPO_NAME", "nexus-foo")
+    monkeypatch.setenv("GITEA_REPO_OWNER", "admin")
+    monkeypatch.setattr("sys.stdin.read", lambda: '{"gitea_admin_password": "x"}')
+
+    from nexus_deploy.ssh import SSHError
+
+    class _BoomSSH:
+        def __init__(self, _host: str) -> None: ...
+        def __enter__(self) -> _BoomSSH:
+            return self
+
+        def __exit__(self, *_: Any) -> None: ...
+        def port_forward(self, *_a: Any, **_k: Any) -> Any:
+            raise SSHError("ssh tunnel boom")
+
+    monkeypatch.setattr("nexus_deploy.__main__.SSHClient", _BoomSSH)
+
+    from nexus_deploy.__main__ import _gitea_configure
+
+    rc = _gitea_configure([])
+    assert rc == 2
+    captured = capsys.readouterr()
+    assert "ssh tunnel" in captured.err
+    assert "GITEA_TOKEN=" not in captured.out
+
+
+def test_cli_unexpected_exception_returns_rc_2(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Generic exception caught and reroutes Python's default rc=1 to rc=2."""
+    monkeypatch.setenv("ADMIN_EMAIL", "a@b.c")
+    monkeypatch.setenv("REPO_NAME", "nexus-foo")
+    monkeypatch.setenv("GITEA_REPO_OWNER", "admin")
+    monkeypatch.setattr("sys.stdin.read", lambda: '{"gitea_admin_password": "x"}')
+
+    fake_ssh = MagicMock()
+    fake_ssh.__enter__ = MagicMock(return_value=fake_ssh)
+    fake_ssh.__exit__ = MagicMock(return_value=None)
+    fake_pf = MagicMock()
+    fake_pf.__enter__ = MagicMock(return_value=12345)
+    fake_pf.__exit__ = MagicMock(return_value=None)
+    fake_ssh.port_forward = MagicMock(return_value=fake_pf)
+    monkeypatch.setattr("nexus_deploy.__main__.SSHClient", lambda host: fake_ssh)
+
+    secret_in_message = "do-not-leak-secret-XYZZY"
+
+    def boom(*_a: Any, **_k: Any) -> Any:
+        raise RuntimeError(secret_in_message)
+
+    monkeypatch.setattr("nexus_deploy.__main__.run_configure_gitea", boom)
+
+    from nexus_deploy.__main__ import _gitea_configure
+
+    rc = _gitea_configure([])
+    assert rc == 2
+    err = capsys.readouterr().err
+    # Type name only, never str(exc) — the exception's message MUST NOT leak
+    assert "RuntimeError" in err
+    assert secret_in_message not in err
+
+
+def test_cli_transport_failure_returns_rc_2(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """CalledProcessError from ssh/rsync → rc=2."""
+    monkeypatch.setenv("ADMIN_EMAIL", "a@b.c")
+    monkeypatch.setenv("REPO_NAME", "nexus-foo")
+    monkeypatch.setenv("GITEA_REPO_OWNER", "admin")
+    monkeypatch.setattr("sys.stdin.read", lambda: '{"gitea_admin_password": "x"}')
+
+    fake_ssh = MagicMock()
+    fake_ssh.__enter__ = MagicMock(return_value=fake_ssh)
+    fake_ssh.__exit__ = MagicMock(return_value=None)
+    fake_pf = MagicMock()
+    fake_pf.__enter__ = MagicMock(return_value=12345)
+    fake_pf.__exit__ = MagicMock(return_value=None)
+    fake_ssh.port_forward = MagicMock(return_value=fake_pf)
+    monkeypatch.setattr("nexus_deploy.__main__.SSHClient", lambda host: fake_ssh)
+
+    def boom(*_a: Any, **_k: Any) -> Any:
+        raise subprocess.CalledProcessError(255, ["ssh", "secret-arg"])
+
+    monkeypatch.setattr("nexus_deploy.__main__.run_configure_gitea", boom)
+
+    from nexus_deploy.__main__ import _gitea_configure
+
+    rc = _gitea_configure([])
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "transport failure" in err
+    assert "secret-arg" not in err  # exc.cmd MUST NOT leak
+
+
+def test_cli_dispatcher_routes_gitea_configure(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """`python -m nexus_deploy gitea configure` reaches the handler."""
+    monkeypatch.setattr(sys, "argv", ["nexus_deploy", "gitea", "configure", "--bogus"])
+
+    from nexus_deploy.__main__ import main
+
+    rc = main()
+    assert rc == 2  # --bogus rejected
+    assert "gitea configure" in capsys.readouterr().err

--- a/tests/unit/test_gitea.py
+++ b/tests/unit/test_gitea.py
@@ -850,6 +850,100 @@ def test_run_configure_gitea_admin_does_not_exist_creates() -> None:
 
 
 @responses.activate
+def test_create_admin_already_exists_falls_back_to_sync_password() -> None:
+    """Defence in depth: if list_admin_users returns empty (false negative —
+    e.g. transient ssh+docker exec failure), CREATE runs and may report
+    "already exists" from Gitea. Without a follow-up sync, the admin
+    password drift stays and the subsequent REST token mint 401s.
+    The orchestrator now falls back to sync_password automatically.
+
+    Regression test for Copilot round 1.
+    """
+    responses.add(responses.GET, f"{BASE_URL}/api/healthz", status=200)
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/users/admin/tokens",
+        status=201,
+        json={"sha1": "tok"},
+    )
+
+    ssh = _make_ssh(
+        [
+            (0, "RESULT db_pw=synced\n"),
+            (0, ""),  # admin list — empty (false negative)
+            (0, "user already exists\n"),  # create_admin → already_exists
+            (0, ""),  # FALLBACK: sync_password runs and succeeds
+        ]
+    )
+
+    result = run_configure_gitea(
+        _make_config(),
+        base_url=BASE_URL,
+        ssh=ssh,
+        admin_email="a@b.c",
+        gitea_user_email=None,
+        gitea_user_password=None,
+        repo_name="nexus-foo",
+        gitea_repo_owner="admin",
+        is_mirror_mode=True,  # skip repo to keep test focused
+        enabled_services=[],
+        ready_timeout_s=1.0,
+        db_sync_attempts=1,
+        db_sync_interval_s=0.01,
+    )
+
+    # Final admin status must be "synced" (not "already_exists") —
+    # the fallback ran and the result was overwritten.
+    assert result.admin.status == "synced"
+    # 4 ssh.run_script calls: db_sync, list, create, sync_password
+    assert ssh.run_script.call_count == 4
+
+
+@responses.activate
+def test_create_user_already_exists_falls_back_to_sync_password() -> None:
+    """Same fallback as admin — protects against the false-negative
+    list path for the regular user (Copilot round 1).
+    """
+    responses.add(responses.GET, f"{BASE_URL}/api/healthz", status=200)
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/users/admin/tokens",
+        status=201,
+        json={"sha1": "tok"},
+    )
+
+    ssh = _make_ssh(
+        [
+            (0, "RESULT db_pw=synced\n"),
+            (0, _ADMIN_LIST_FIXTURE),  # admin exists
+            (0, ""),  # admin sync_password
+            (0, ""),  # user list — empty (false negative)
+            (0, "user already exists\n"),  # create_user → already_exists
+            (0, ""),  # FALLBACK: sync_password
+        ]
+    )
+
+    result = run_configure_gitea(
+        _make_config(),
+        base_url=BASE_URL,
+        ssh=ssh,
+        admin_email="a@b.c",
+        gitea_user_email="stefan.koch@hslu.ch",
+        gitea_user_password="userpw",
+        repo_name="nexus-foo",
+        gitea_repo_owner="admin",
+        is_mirror_mode=True,
+        enabled_services=[],
+        ready_timeout_s=1.0,
+        db_sync_attempts=1,
+        db_sync_interval_s=0.01,
+    )
+
+    assert result.user is not None
+    assert result.user.status == "synced"
+
+
+@responses.activate
 def test_round_2_legacy_email_collision_triggers_patch() -> None:
     """Admin row's email == GITEA_USER_EMAIL → PATCH fires before sync."""
     responses.add(responses.GET, f"{BASE_URL}/api/healthz", status=200)


### PR DESCRIPTION
## Summary

Phase 2 Modul 2.2e (#505) — migrates deploy.sh L2465-2810 (synchronous Gitea-configure block) to `nexus_deploy.gitea`.

- DB password sync (peer-auth psql ALTER USER inside gitea-db, retry-bounded)
- Admin/user lifecycle: create OR sync via docker-exec CLI; idempotent
- Legacy email-collision PATCH (Stage 3 v0.51.9 fix preserved)
- API token mint with retry-via-delete on 409 conflict
- Workspace repo create with private-PATCH fallback on already-exists
- Collaborator add (idempotent: 204 + 422 → success)

Two transports by design — mirrors deploy.sh's split:
- `ssh.run_script` for admin/user CRUD (peer auth bypasses the chicken-egg of "need to sync password before basic-auth works")
- `port-forward + requests` for token, email PATCH, repo CRUD, collaborator (basic-auth works post-sync)

Token handoff via stdout `GITEA_TOKEN=<sha1>` + `RESTART_SERVICES=<csv>` (eval-able by deploy.sh; tempfile mode 600 + `rm -f` every exit path). Same pattern as `config dump-shell` (#508).

**Out of scope** (deferred to Modul 2.2f): mirror mode (`GH_MIRROR_REPOS` block) and Woodpecker OAuth registration. Both still in deploy.sh, both still gated by the `$GITEA_TOKEN` that this PR's CLI now mints.

**deploy.sh delta:** -246 lines (5539 → 3628 — ~35% migrated cumulative).

## Files

- `src/nexus_deploy/gitea.py` — NEW (~720 LoC): `GiteaCli` (SSH-driven), `GiteaClient` (REST), `run_configure_gitea` orchestrator, `CreateUserResult` / `CreateRepoResult` / `GiteaResult` dataclasses, `TokenExistsError` / `GiteaError` exceptions, pure-logic helpers (`_parse_admin_list_for_user`, `_escape_sql_string_literal`, `_render_db_pw_sync_script`, `_compute_restart_services`, `_validate_path_segment`)
- `tests/unit/test_gitea.py` — NEW (~1374 LoC, 101 tests): 8 named regression rounds (R1-R8) + orthogonal + CLI integration
- `src/nexus_deploy/__main__.py` — `gitea configure` subcommand wired (~170 new lines)
- `scripts/deploy.sh` — synchronous core replaced with ~70-line CLI wrapper; old DB-sync, admin/user CRUD, token mint, workspace-repo creation, restart-services loop all migrated to Python

## 8 named regression rounds

| # | Round | Test |
|---|---|---|
| R1 | Column-exact awk on user existence (PR #464 substring-grep bug class — `koch` MUST NOT match `stefan.koch@hslu.ch`) | `test_round_1_column_exact_*` (3 cases) |
| R2 | Legacy email-collision PATCH with full body `{email, source_id: 0, login_name}` (Gitea schema rejects partial bodies) | `test_round_2_*` (3 cases) |
| R3 | DB password retry loop (15×2s default) | `test_round_3_db_sync_*` (2 cases) |
| R4 | Token create + retry-via-delete on 409 / 422-with-already-exists | `test_round_4_create_token_with_retry_409_then_delete_then_201` |
| R5 | Path safety regex `^[a-zA-Z0-9._-]+$` rejects shell-meta + `..`/`.` traversal | `test_round_5_path_safety_*` (16 parametrized cases) |
| R6 | Repo-create 409 → patch_repo_private fallback; 422 with "already exists" body also → already_exists | `test_round_6_*` (3 cases) |
| R7 | Token NEVER in argv or URL — only `Authorization: token <sha>` header | `test_round_7_token_in_authorization_header_not_argv_or_url` (scans request body + URL for token substring) |
| R8 | CLI stdout emits eval-able `GITEA_TOKEN=` + `RESTART_SERVICES=` (shlex-quoted); omits token line when None to avoid stale-eval | `test_round_8_*` (2 cases) |

## Quality gate

- `uv run ruff format --check`: 29 files clean
- `uv run ruff check`: 0 errors
- `uv run mypy --strict`: 0 errors (29 source files)
- `uv run pytest --cov=src/nexus_deploy --cov-fail-under=80`: **575 passed**
- Coverage: `gitea.py` 93%, total 97.66% (uncovered lines = transport-error exception paths in REST methods, all defensive)
- `bash -n scripts/deploy.sh`: clean

## Test plan

- [ ] `gh workflow run initial-setup.yaml --ref feat/python-migration-phase-2-2e-gitea`
- [ ] First-run on fresh VM: admin created, user created, token minted, workspace repo `nexus-<slug>-gitea` created (private), collaborator added, jupyter/marimo/code-server restarted, Kestra system-flows registered using the new token
- [ ] Re-run (no code change): admin exists → SYNC password (idempotent), user exists → SYNC, token "already exists" → DELETE + retry, repo "already exists" → PATCH private — all green
- [ ] Verify Kestra Git sync onboarding still completes (downstream gate that the token actually works)
- [ ] Mirror mode (`GH_MIRROR_REPOS` set) — verify the new CLI skips repo+collab; mirror block in deploy.sh still wires forks (Modul 2.2f scope)

Closes part of #505.
