### PR TITLE
fix(nexus_deploy): Switch Gitea token mint from REST to CLI peer-auth

### DIFF
--- a/src/nexus_deploy/__main__.py
+++ b/src/nexus_deploy/__main__.py
@@ -948,7 +948,12 @@ def _gitea_configure(args: list[str]) -> int:
     if result.collaborator_added:
         sys.stderr.write("  • collaborator added\n")
     if result.token is None:
-        sys.stderr.write("  • token: NOT minted (REST will 401 downstream)\n")
+        # Always surface the diagnostic — the post-#519 spin-up showed
+        # how a silent token-mint failure (no error string in the deploy
+        # log) blocks debugging. ``token_error`` is constructed from
+        # Gitea CLI error text + return codes, no secrets.
+        detail = f" — {result.token_error}" if result.token_error else ""
+        sys.stderr.write(f"  • token: NOT minted (downstream skipped){detail}\n")
 
     # Eval-able stdout. RESTART_SERVICES is always emitted (even
     # empty) so deploy.sh's ``eval`` doesn't leave a stale value

--- a/src/nexus_deploy/gitea.py
+++ b/src/nexus_deploy/gitea.py
@@ -451,11 +451,19 @@ class GiteaCli:
         _validate_path_segment(username, kind="username")
         _validate_path_segment(name, kind="token_name")
         # psql DELETE — peer auth via -U inside gitea-db container.
-        # Same approach as :meth:`sync_db_password`. ``|| true``
-        # swallows transient psql errors (gitea-db not yet ready,
-        # connection blip) — if the delete didn't run, the
-        # generate step below will surface "name has been used
-        # already" with full diagnostic.
+        # Same approach as :meth:`sync_db_password`.
+        #
+        # Capture rc + stdout (no ``|| true``, no ``2>/dev/null``).
+        # ``ssh.run_script(check=False)`` already prevents the
+        # subprocess layer from raising on a non-zero exit, so the
+        # earlier "swallow everything" pattern was double-defence
+        # at the cost of debuggability: when the delete failed
+        # silently and the generate later collided with the
+        # surviving token, the operator saw "name has been used
+        # already" but no hint why the delete didn't run. Prepend
+        # the delete diagnostic to ``token_error`` if the subsequent
+        # generate fails (success path: irrelevant, drop it).
+        #
         # SQL injection-safe by construction. Both ``name`` and
         # ``username`` are validated against ``_PATH_SAFE_RE``
         # ([a-zA-Z0-9._-]+) above, so neither can contain a single
@@ -473,11 +481,17 @@ class GiteaCli:
             f"AND uid = (SELECT id FROM \"user\" WHERE lower_name = lower('{username}'));"
         )
         delete_script = (
-            "docker exec gitea-db psql -U nexus-gitea -d gitea "
-            f"-c {shlex.quote(delete_sql)} "
-            ">/dev/null 2>&1 || true\n"
+            f"docker exec gitea-db psql -U nexus-gitea -d gitea -c {shlex.quote(delete_sql)} 2>&1\n"
         )
-        self.ssh.run_script(delete_script, check=False, timeout=30.0)
+        delete_result = self.ssh.run_script(delete_script, check=False, timeout=30.0)
+        delete_diag = ""
+        if delete_result.returncode != 0:
+            # psql / docker error output is non-secret (no row data
+            # in the connection-or-permission-failure paths psql
+            # produces) — safe to surface. Capture first line only.
+            first_line = (delete_result.stdout or "").splitlines()
+            detail = first_line[0][:200] if first_line else "(no output)"
+            delete_diag = f"prior delete rc={delete_result.returncode}: {detail}"
 
         generate_script = (
             "set -euo pipefail\n"
@@ -490,10 +504,15 @@ class GiteaCli:
         if result.returncode != 0:
             # Output examples on failure: "User does not exist" or
             # "Command error: access token name has been used already".
-            # Capture first line only.
+            # Capture first line only. Prepend the delete diagnostic
+            # so name-collision failures can be traced to a prior
+            # delete that didn't actually run.
             first_line = (result.stdout or "").splitlines()
             detail = first_line[0][:200] if first_line else "(no output)"
-            return None, f"CLI rc={result.returncode}: {detail}"
+            msg = f"CLI rc={result.returncode}: {detail}"
+            if delete_diag:
+                msg = f"{delete_diag} | {msg}"
+            return None, msg
 
         # Success output: "Access token was successfully created: <40-hex>"
         match = re.search(r"\b([a-f0-9]{40})\b", result.stdout or "")

--- a/src/nexus_deploy/gitea.py
+++ b/src/nexus_deploy/gitea.py
@@ -235,6 +235,12 @@ class GiteaResult:
     admin: CreateUserResult
     user: CreateUserResult | None
     token: str | None
+    # Diagnostic message when ``token is None`` — empty string on
+    # success. Captures the Gitea-CLI-side error description so the
+    # CLI handler can emit it to stderr without leaking secrets.
+    # Added in the post-#519 fix when production spin-up surfaced a
+    # silent token-mint failure with no diagnostic trace.
+    token_error: str
     repo: CreateRepoResult | None
     collaborator_added: bool
     restart_services: tuple[str, ...]
@@ -274,16 +280,6 @@ class GiteaError(Exception):
     Carries no response body — Gitea error responses on auth-failure
     paths can echo back the credentials we just sent. Constructed
     from fixed format strings + status codes / type names only.
-    """
-
-
-class TokenExistsError(GiteaError):
-    """Raised by ``create_token`` when Gitea reports the token name is taken.
-
-    The orchestrator catches this and falls back to delete-then-retry
-    (``create_token_with_retry``). Keeping the exception class
-    distinct lets tests pin the retry behaviour without grepping
-    error messages.
     """
 
 
@@ -410,6 +406,64 @@ class GiteaCli:
             detail=text.strip()[:200] if text else "(no output)",
         )
 
+    def mint_token(
+        self,
+        username: str,
+        name: str,
+        scopes: str = "all",
+    ) -> tuple[str | None, str]:
+        """Generate API token via ``gitea admin user generate-access-token``.
+
+        Returns ``(sha1_or_None, diagnostic_message)``. On success the
+        diagnostic is empty. On failure the diagnostic is a short
+        Gitea-CLI-error description suitable for stderr — Gitea's
+        delete/generate output is just username + token-name +
+        status, never password material.
+
+        Idempotent: deletes any existing token with the same name
+        first (best-effort, ignored on 404), then generates fresh.
+        Mirrors the legacy deploy.sh delete-then-create pattern but
+        via peer-auth CLI instead of REST basic-auth — eliminates
+        the chicken-egg of "we need a working REST password to mint
+        a token" that bit production in PR #519's spin-up: REST POST
+        returned 400 inside ``CreateAccessToken`` despite the prior
+        admin password sync reporting success. The CLI peer-auths
+        as the container's git user, so password drift between the
+        CLI sync and the basic-auth attempt cannot manifest.
+        """
+        _validate_path_segment(username, kind="username")
+        _validate_path_segment(name, kind="token_name")
+        # Best-effort delete — peer auth CLI; rc=0 if token existed,
+        # rc!=0 if not. Either way, the next generate succeeds.
+        delete_script = (
+            "docker exec -u git gitea gitea admin user delete-access-token "
+            f"--username {shlex.quote(username)} "
+            f"--token {shlex.quote(name)} "
+            ">/dev/null 2>&1 || true\n"
+        )
+        self.ssh.run_script(delete_script, check=False, timeout=30.0)
+
+        generate_script = (
+            "set -euo pipefail\n"
+            "docker exec -u git gitea gitea admin user generate-access-token "
+            f"--username {shlex.quote(username)} "
+            f"--token-name {shlex.quote(name)} "
+            f"--scopes {shlex.quote(scopes)} 2>&1\n"
+        )
+        result = self.ssh.run_script(generate_script, check=False, timeout=30.0)
+        if result.returncode != 0:
+            # Output examples on failure: "User does not exist" or
+            # "...invalid scopes...". Capture first line only.
+            first_line = (result.stdout or "").splitlines()
+            detail = first_line[0][:200] if first_line else "(no output)"
+            return None, f"CLI rc={result.returncode}: {detail}"
+
+        # Success output: "Access token was successfully created: <40-hex>"
+        match = re.search(r"\b([a-f0-9]{40})\b", result.stdout or "")
+        if match:
+            return match.group(1), ""
+        return None, "CLI rc=0 but no sha1 in output"
+
     def sync_password(self, username: str, password: str) -> CreateUserResult:
         """``gitea admin user change-password`` — peer-auth, no old password.
 
@@ -529,77 +583,6 @@ class GiteaClient:
         except (requests.ConnectionError, requests.Timeout):
             return False
         return resp.status_code == 200
-
-    def create_token(self, username: str, name: str, scopes: list[str]) -> str:
-        """``POST /api/v1/users/<u>/tokens`` — basic-auth.
-
-        Returns the sha1. Raises :class:`TokenExistsError` on 409 (or
-        when the response body indicates the name is taken — Gitea
-        sometimes returns 422 with ``"name already exists"``).
-        Raises :class:`GiteaError` on other non-success status / transport.
-        """
-        _validate_path_segment(username, kind="username")
-        body = {"name": name, "scopes": scopes}
-        try:
-            resp = requests.post(
-                f"{self.base_url}/api/v1/users/{username}/tokens",
-                json=body,
-                timeout=_HTTP_TIMEOUT,
-                **self._request_kwargs(),  # type: ignore[arg-type]
-            )
-        except (requests.ConnectionError, requests.Timeout) as exc:
-            raise GiteaError(f"create_token transport ({type(exc).__name__})") from exc
-        if resp.status_code in (200, 201):
-            try:
-                payload = resp.json()
-            except ValueError as exc:
-                raise GiteaError("create_token response was not JSON") from exc
-            sha1 = payload.get("sha1") if isinstance(payload, dict) else None
-            if not isinstance(sha1, str) or not sha1:
-                raise GiteaError("create_token response missing 'sha1'")
-            return sha1
-        if resp.status_code == 409:
-            raise TokenExistsError(f"token {name!r} already exists")
-        # Some Gitea versions return 422 with "name already exists"
-        # in the message body. Match conservatively to avoid masking
-        # real validation errors.
-        if resp.status_code == 422:
-            try:
-                msg = resp.json().get("message", "") if resp.content else ""
-            except ValueError:
-                msg = ""
-            if isinstance(msg, str) and "already exists" in msg.lower():
-                raise TokenExistsError(f"token {name!r} already exists")
-        raise GiteaError(f"create_token HTTP {resp.status_code}")
-
-    def delete_token(self, username: str, name: str) -> bool:
-        """``DELETE /api/v1/users/<u>/tokens/<name>``. 204+404 → True."""
-        _validate_path_segment(username, kind="username")
-        # Token name may contain ``-`` and ``_`` but no path-traversal —
-        # validate against the same regex.
-        _validate_path_segment(name, kind="token_name")
-        try:
-            resp = requests.delete(
-                f"{self.base_url}/api/v1/users/{username}/tokens/{name}",
-                timeout=_HTTP_TIMEOUT,
-                **self._request_kwargs(),  # type: ignore[arg-type]
-            )
-        except (requests.ConnectionError, requests.Timeout):
-            return False
-        return resp.status_code in (204, 404)
-
-    def create_token_with_retry(self, username: str, name: str, scopes: list[str]) -> str:
-        """Idempotent: try create, on TokenExistsError → delete + retry once.
-
-        Mirrors deploy.sh L2671-2683. The second create returns the
-        new sha1 (Gitea always returns a new value on re-create — the
-        old token is invalidated by the delete).
-        """
-        try:
-            return self.create_token(username, name, scopes)
-        except TokenExistsError:
-            self.delete_token(username, name)
-            return self.create_token(username, name, scopes)
 
     def repo_exists(self, owner: str, name: str) -> bool:
         _validate_path_segment(owner, kind="owner")
@@ -797,6 +780,7 @@ def run_configure_gitea(
             admin=CreateUserResult(name=admin_username, status="failed", detail="gitea not ready"),
             user=None,
             token=None,
+            token_error="gitea not ready",  # noqa: S106 — diagnostic, not a credential
             repo=None,
             collaborator_added=False,
             restart_services=_compute_restart_services(enabled_services),
@@ -844,14 +828,15 @@ def run_configure_gitea(
             if user_result.status == "already_exists":
                 user_result = cli.sync_password(user_username, gitea_user_password)
 
-    # 5. Token (REST, basic-auth)
-    token: str | None = None
-    try:
-        token = rest.create_token_with_retry(admin_username, "nexus-automation", ["all"])
-    except GiteaError:
-        # Token couldn't be minted even with retry — surface as
-        # token=None; is_success will return False (rc=1 → yellow).
-        token = None
+    # 5. Token via CLI peer auth (was: REST basic-auth in PR #519).
+    # Switched after production spin-up surfaced a silent 400 from
+    # POST /api/v1/users/<u>/tokens despite admin password sync
+    # reporting success — likely a subtle password-state race
+    # between the bcrypt commit and the next-millisecond REST
+    # auth check. CLI peer auth eliminates the chicken-egg: the
+    # docker-exec runs as the container's git user with no
+    # password verification needed.
+    token, token_error = cli.mint_token(admin_username, "nexus-automation", "all")
 
     # 6+7. Repo + collaborator (skip in mirror mode)
     repo_result: CreateRepoResult | None = None
@@ -878,6 +863,7 @@ def run_configure_gitea(
         admin=admin_result,
         user=user_result,
         token=token,
+        token_error=token_error,
         repo=repo_result,
         collaborator_added=collaborator_added,
         restart_services=_compute_restart_services(enabled_services),

--- a/src/nexus_deploy/gitea.py
+++ b/src/nexus_deploy/gitea.py
@@ -439,8 +439,17 @@ class GiteaCli:
         """
         _validate_path_segment(username, kind="username")
         _validate_path_segment(name, kind="token_name")
-        # Best-effort delete — peer auth CLI; rc=0 if token existed,
-        # rc!=0 if not. Either way, the next generate succeeds.
+        # Best-effort delete — peer auth CLI. Inside the script the
+        # docker-exec exits 0 if a token with this name existed and
+        # was removed, non-zero otherwise (e.g. token didn't exist,
+        # or transient docker error). The trailing ``|| true``
+        # collapses both cases to script-rc=0, so ``ssh.run_script``
+        # always sees rc=0 here and we never raise on the delete step.
+        # Whether the delete actually removed anything is irrelevant
+        # for our flow: ``generate-access-token`` requires a free
+        # name; if a stale token with the same name still exists at
+        # generate time, the generate call itself reports the
+        # collision and the diagnostic surfaces via the parsed output.
         delete_script = (
             "docker exec -u git gitea gitea admin user delete-access-token "
             f"--username {shlex.quote(username)} "

--- a/src/nexus_deploy/gitea.py
+++ b/src/nexus_deploy/gitea.py
@@ -456,12 +456,18 @@ class GiteaCli:
         # connection blip) — if the delete didn't run, the
         # generate step below will surface "name has been used
         # already" with full diagnostic.
-        # SQL injection-safe by construction: both ``name`` and
+        # SQL injection-safe by construction. Both ``name`` and
         # ``username`` are validated against ``_PATH_SAFE_RE``
         # ([a-zA-Z0-9._-]+) above, so neither can contain a single
-        # quote, semicolon, or comment marker. ruff's S608 warning
-        # is the generic "f-string SQL" heuristic and doesn't see
-        # the validator.
+        # quote or semicolon — i.e. neither value can break out of
+        # the single-quoted SQL string literal it's interpolated into.
+        # (The dash IS allowed, so e.g. ``stefan-koch`` is a valid
+        # username and ``--`` would survive the regex; that's still
+        # safe here because the dashes stay INSIDE the quoted string
+        # — they only become a SQL comment marker if the surrounding
+        # quotes are broken, which the no-single-quote rule prevents.)
+        # ruff's S608 below is the generic "f-string SQL" heuristic
+        # and doesn't see the validator.
         delete_sql = (
             f"DELETE FROM access_token WHERE name = '{name}' "  # noqa: S608
             f"AND uid = (SELECT id FROM \"user\" WHERE lower_name = lower('{username}'));"

--- a/src/nexus_deploy/gitea.py
+++ b/src/nexus_deploy/gitea.py
@@ -421,39 +421,54 @@ class GiteaCli:
 
         Returns ``(sha1_or_None, diagnostic_message)``. On success the
         diagnostic is empty. On failure the diagnostic is a short
-        Gitea-CLI-error description suitable for stderr — Gitea's
-        delete/generate output is just username + token-name +
-        status, never password material.
+        Gitea-side error description suitable for stderr — never
+        password material.
 
-        Idempotent: deletes any existing token with the same name
-        first (best-effort, ``|| true`` swallows the non-zero rc Gitea's
-        CLI returns when the token doesn't exist), then generates fresh.
-        Mirrors the legacy deploy.sh delete-then-create pattern but
-        via peer-auth CLI instead of REST basic-auth — eliminates
-        the chicken-egg of "we need a working REST password to mint
-        a token" that bit production in PR #519's spin-up: REST POST
-        returned 400 inside ``CreateAccessToken`` despite the prior
-        admin password sync reporting success. The CLI peer-auths
-        as the container's git user, so password drift between the
-        CLI sync and the basic-auth attempt cannot manifest.
+        Idempotent: deletes any existing token with this name first
+        (psql DELETE inside the gitea-db container — peer auth, no
+        password needed), then generates fresh. Two-pronged peer-
+        auth approach because:
+
+        1. Gitea v1.23 CLI has NO ``delete-access-token`` subcommand
+           (verified live: ``admin user`` only exposes create / list
+           / change-password / delete-USER / generate-access-token).
+           A previous attempt to use ``gitea admin user
+           delete-access-token`` failed silently in production
+           (PR #520 spin-up surfaced it via the diagnostic field
+           added in this same PR, after diagnosing as the bash
+           ``|| true`` swallowing the unknown-subcommand error).
+        2. REST DELETE on the tokens API requires basic-auth, which
+           hits the same chicken-egg as the original PR #519 token-
+           mint REST POST. Avoid.
+
+        psql peer-auth bypasses both. The DELETE is scoped to the
+        admin's UID via a subquery on the ``user`` table — name
+        uniqueness in ``access_token`` is per-user (``UNIQUE INDEX
+        UQE_access_token_name`` on (uid, name)). Both ``username``
+        and ``name`` pass through :func:`_validate_path_segment`
+        first, so the SQL string is injection-safe by construction.
         """
         _validate_path_segment(username, kind="username")
         _validate_path_segment(name, kind="token_name")
-        # Best-effort delete — peer auth CLI. Inside the script the
-        # docker-exec exits 0 if a token with this name existed and
-        # was removed, non-zero otherwise (e.g. token didn't exist,
-        # or transient docker error). The trailing ``|| true``
-        # collapses both cases to script-rc=0, so ``ssh.run_script``
-        # always sees rc=0 here and we never raise on the delete step.
-        # Whether the delete actually removed anything is irrelevant
-        # for our flow: ``generate-access-token`` requires a free
-        # name; if a stale token with the same name still exists at
-        # generate time, the generate call itself reports the
-        # collision and the diagnostic surfaces via the parsed output.
+        # psql DELETE — peer auth via -U inside gitea-db container.
+        # Same approach as :meth:`sync_db_password`. ``|| true``
+        # swallows transient psql errors (gitea-db not yet ready,
+        # connection blip) — if the delete didn't run, the
+        # generate step below will surface "name has been used
+        # already" with full diagnostic.
+        # SQL injection-safe by construction: both ``name`` and
+        # ``username`` are validated against ``_PATH_SAFE_RE``
+        # ([a-zA-Z0-9._-]+) above, so neither can contain a single
+        # quote, semicolon, or comment marker. ruff's S608 warning
+        # is the generic "f-string SQL" heuristic and doesn't see
+        # the validator.
+        delete_sql = (
+            f"DELETE FROM access_token WHERE name = '{name}' "  # noqa: S608
+            f"AND uid = (SELECT id FROM \"user\" WHERE lower_name = lower('{username}'));"
+        )
         delete_script = (
-            "docker exec -u git gitea gitea admin user delete-access-token "
-            f"--username {shlex.quote(username)} "
-            f"--token {shlex.quote(name)} "
+            "docker exec gitea-db psql -U nexus-gitea -d gitea "
+            f"-c {shlex.quote(delete_sql)} "
             ">/dev/null 2>&1 || true\n"
         )
         self.ssh.run_script(delete_script, check=False, timeout=30.0)
@@ -468,7 +483,8 @@ class GiteaCli:
         result = self.ssh.run_script(generate_script, check=False, timeout=30.0)
         if result.returncode != 0:
             # Output examples on failure: "User does not exist" or
-            # "...invalid scopes...". Capture first line only.
+            # "Command error: access token name has been used already".
+            # Capture first line only.
             first_line = (result.stdout or "").splitlines()
             detail = first_line[0][:200] if first_line else "(no output)"
             return None, f"CLI rc={result.returncode}: {detail}"

--- a/src/nexus_deploy/gitea.py
+++ b/src/nexus_deploy/gitea.py
@@ -226,9 +226,10 @@ class CreateRepoResult:
 class GiteaResult:
     """Aggregate of all Gitea-config sub-steps.
 
-    ``token`` is None until :meth:`GiteaClient.create_token_with_retry`
-    succeeds. The CLI emits ``GITEA_TOKEN=<token>`` to stdout iff
-    token is non-None — eval-able by deploy.sh.
+    ``token`` is None until :meth:`GiteaCli.mint_token` succeeds (post-
+    #519 fix switched from REST basic-auth to CLI peer-auth). The CLI
+    handler emits ``GITEA_TOKEN=<token>`` to stdout iff token is
+    non-None — eval-able by deploy.sh.
     """
 
     db_pw_synced: bool
@@ -284,7 +285,11 @@ class GiteaError(Exception):
 
 
 # ---------------------------------------------------------------------------
-# Hybrid client: SSH-CLI for admin/user CRUD, REST for token/repo/email
+# Hybrid client (post-#519 fix):
+#   SSH CLI peer-auth: admin/user CRUD + token mint
+#   REST basic-auth or token-auth: legacy email PATCH, repo CRUD, collab add
+# Token minting moved from REST to CLI after the production
+# 400-from-CreateAccessToken bug — see GiteaCli.mint_token docstring.
 # ---------------------------------------------------------------------------
 
 
@@ -421,7 +426,8 @@ class GiteaCli:
         status, never password material.
 
         Idempotent: deletes any existing token with the same name
-        first (best-effort, ignored on 404), then generates fresh.
+        first (best-effort, ``|| true`` swallows the non-zero rc Gitea's
+        CLI returns when the token doesn't exist), then generates fresh.
         Mirrors the legacy deploy.sh delete-then-create pattern but
         via peer-auth CLI instead of REST basic-auth — eliminates
         the chicken-egg of "we need a working REST password to mint
@@ -737,7 +743,8 @@ def run_configure_gitea(
     4. User (if ``gitea_user_email``): list → exists?
        - yes → CLI sync_password
        - no  → CLI create_user
-    5. Token: REST create_token_with_retry
+    5. Token: CLI ``mint_token`` (peer-auth ``generate-access-token``,
+       idempotent delete-then-create; switched from REST in post-#519 fix)
     6. (non-mirror) repo: create → on already_exists → patch_repo_private
     7. (non-mirror, with user) collaborator add
     8. Build restart_services list (intersection with enabled)

--- a/tests/unit/test_gitea.py
+++ b/tests/unit/test_gitea.py
@@ -485,12 +485,24 @@ def test_round_4_mint_token_idempotent_delete_first() -> None:
     assert err == ""
     # Both delete + generate were called.
     assert ssh.run_script.call_count == 2
-    # First call is the delete-access-token script — must contain
-    # `|| true` so docker-exec's non-zero rc on missing-token is
-    # swallowed (the pattern that justifies the rc=0 mock above).
+    # First call is the psql DELETE script. The SQL is shlex-quoted
+    # for bash, so we assert on substrings that survive that quoting:
+    # the unquoted SQL keywords (DELETE FROM, WHERE, AND uid, lower)
+    # plus the literal name + username values (which appear inside
+    # shlex's `'"'"'` quote-escape but the inner characters survive).
+    # `|| true` swallows transient psql errors (justifies the rc=0
+    # mock above).
     delete_script = ssh.run_script.call_args_list[0][0][0]
-    assert "delete-access-token" in delete_script
+    assert "DELETE FROM access_token" in delete_script
+    assert "nexus-automation" in delete_script
+    assert "WHERE lower_name" in delete_script
+    assert "admin" in delete_script
     assert "|| true" in delete_script
+    # Must NOT use the non-existent gitea CLI subcommand
+    # (PR #520 round-3 production bug — `gitea admin user
+    # delete-access-token` is hallucinated; psql DELETE is the
+    # bulletproof replacement).
+    assert "delete-access-token" not in delete_script
 
 
 def test_mint_token_returns_diagnostic_on_cli_failure() -> None:

--- a/tests/unit/test_gitea.py
+++ b/tests/unit/test_gitea.py
@@ -799,7 +799,7 @@ def test_run_configure_gitea_full_happy_path_admin_already_exists() -> None:
             (0, ""),  # admin sync_password
             (0, _ADMIN_LIST_FIXTURE),  # user list (same fixture, has stefan.koch)
             (0, ""),  # user sync_password
-            (0, ""),  # token: delete-access-token (best-effort)
+            (0, ""),  # token: psql DELETE (best-effort)
             (0, f"Access token was successfully created: {'a' * 40}\n"),  # token: generate
         ]
     )
@@ -843,7 +843,7 @@ def test_run_configure_gitea_admin_does_not_exist_creates() -> None:
             (0, "RESULT db_pw=synced\n"),
             (0, "ID Username Email\n"),  # empty list
             (0, "New user 'admin' has been created\n"),  # create_admin
-            (0, ""),  # token: delete-access-token
+            (0, ""),  # token: psql DELETE
             (0, f"Access token was successfully created: {'b' * 40}\n"),  # token: generate
         ]
     )
@@ -887,7 +887,7 @@ def test_create_admin_already_exists_falls_back_to_sync_password() -> None:
             (0, ""),  # admin list — empty (false negative)
             (0, "user already exists\n"),  # create_admin → already_exists
             (0, ""),  # FALLBACK: sync_password runs and succeeds
-            (0, ""),  # token: delete-access-token
+            (0, ""),  # token: psql DELETE
             (0, f"Access token was successfully created: {'c' * 40}\n"),  # token: generate
         ]
     )
@@ -931,7 +931,7 @@ def test_create_user_already_exists_falls_back_to_sync_password() -> None:
             (0, ""),  # user list — empty (false negative)
             (0, "user already exists\n"),  # create_user → already_exists
             (0, ""),  # FALLBACK: sync_password
-            (0, ""),  # token: delete-access-token
+            (0, ""),  # token: psql DELETE
             (0, f"Access token was successfully created: {'d' * 40}\n"),  # generate
         ]
     )
@@ -982,7 +982,7 @@ def test_round_2_legacy_email_collision_triggers_patch() -> None:
             (0, ""),  # admin sync_password
             (0, "ID Username Email\n"),  # user list — empty
             (0, "New user 'stefan.koch' has been created\n"),  # create_user
-            (0, ""),  # token: delete-access-token
+            (0, ""),  # token: psql DELETE
             (0, f"Access token was successfully created: {'e' * 40}\n"),  # generate
         ]
     )
@@ -1029,7 +1029,7 @@ def test_round_6_repo_already_exists_falls_back_to_patch_private() -> None:
             (0, "RESULT db_pw=synced\n"),
             (0, _ADMIN_LIST_FIXTURE),
             (0, ""),  # admin sync_password
-            (0, ""),  # token: delete-access-token
+            (0, ""),  # token: psql DELETE
             (0, f"Access token was successfully created: {'1' * 40}\n"),  # generate
         ]
     )
@@ -1068,7 +1068,7 @@ def test_run_configure_gitea_mirror_mode_skips_repo_and_collaborator() -> None:
             (0, ""),  # db_pw_sync
             (0, _ADMIN_LIST_FIXTURE),  # admin list
             (0, ""),  # admin sync_password
-            (0, ""),  # token: delete-access-token
+            (0, ""),  # token: psql DELETE
             (0, f"Access token was successfully created: {'2' * 40}\n"),  # generate
         ]
     )
@@ -1144,7 +1144,7 @@ def test_run_configure_gitea_token_mint_failure_returns_failure() -> None:
             (0, "RESULT db_pw=synced\n"),
             (0, _ADMIN_LIST_FIXTURE),
             (0, ""),  # admin sync_password
-            (0, ""),  # token: delete-access-token (best-effort)
+            (0, ""),  # token: psql DELETE (best-effort)
             (1, "User does not exist [name: admin]\n"),  # token: generate fails
         ]
     )

--- a/tests/unit/test_gitea.py
+++ b/tests/unit/test_gitea.py
@@ -448,7 +448,7 @@ def test_round_4_mint_token_returns_sha1_on_success() -> None:
     """Happy path: CLI returns "Access token was successfully created: <40-hex>"."""
     ssh = _make_ssh(
         [
-            (0, ""),  # delete-access-token best-effort (rc=0 fine)
+            (0, ""),  # psql DELETE best-effort (rc=0 fine)
             (
                 0,
                 "Access token was successfully created: aebafa8bbcff4e5e7edde8dc89571df698648e7d\n",
@@ -912,7 +912,7 @@ def test_create_admin_already_exists_falls_back_to_sync_password() -> None:
     # the fallback ran and the result was overwritten.
     assert result.admin.status == "synced"
     # 6 ssh.run_script calls: db_sync, list, create, sync_password (fallback),
-    # delete-access-token (best-effort), generate-access-token
+    # psql DELETE (best-effort token cleanup), generate-access-token
     assert ssh.run_script.call_count == 6
 
 

--- a/tests/unit/test_gitea.py
+++ b/tests/unit/test_gitea.py
@@ -464,13 +464,16 @@ def test_round_4_mint_token_idempotent_delete_first() -> None:
     """Token already exists → CLI delete succeeds → CLI generate succeeds.
 
     The legacy deploy.sh delete-then-create pattern is preserved via
-    the unconditional delete in mint_token. CLI delete-access-token
-    returns rc=0 if the token existed and rc!=0 (silenced via ``|| true``)
-    if not. Either way, the next generate runs and returns the new sha1.
+    the unconditional delete in mint_token. The rendered delete script
+    ends in ``|| true``, so ``ssh.run_script`` always sees rc=0
+    regardless of whether the inner docker-exec found a token to
+    delete — both states route to the same generate call.
     """
     ssh = _make_ssh(
         [
-            (1, ""),  # delete: token didn't exist (rc!=0, silenced)
+            # Both branches of the delete (token existed / didn't exist)
+            # surface as rc=0 due to the script's `|| true` suffix.
+            (0, ""),
             (
                 0,
                 "Access token was successfully created: 0000000000000000000000000000000000000001\n",
@@ -482,6 +485,12 @@ def test_round_4_mint_token_idempotent_delete_first() -> None:
     assert err == ""
     # Both delete + generate were called.
     assert ssh.run_script.call_count == 2
+    # First call is the delete-access-token script — must contain
+    # `|| true` so docker-exec's non-zero rc on missing-token is
+    # swallowed (the pattern that justifies the rc=0 mock above).
+    delete_script = ssh.run_script.call_args_list[0][0][0]
+    assert "delete-access-token" in delete_script
+    assert "|| true" in delete_script
 
 
 def test_mint_token_returns_diagnostic_on_cli_failure() -> None:

--- a/tests/unit/test_gitea.py
+++ b/tests/unit/test_gitea.py
@@ -35,7 +35,6 @@ from nexus_deploy.gitea import (
     GiteaClient,
     GiteaError,
     GiteaResult,
-    TokenExistsError,
     _compute_restart_services,
     _escape_sql_string_literal,
     _parse_admin_list_for_user,
@@ -445,113 +444,122 @@ def test_patch_user_email_path_safety() -> None:
 # ---------------------------------------------------------------------------
 
 
-@responses.activate
-def test_create_token_returns_sha1_on_201() -> None:
-    responses.add(
-        responses.POST,
-        f"{BASE_URL}/api/v1/users/admin/tokens",
-        status=201,
-        json={"id": 1, "name": "nexus-automation", "sha1": "abc123"},
+def test_round_4_mint_token_returns_sha1_on_success() -> None:
+    """Happy path: CLI returns "Access token was successfully created: <40-hex>"."""
+    ssh = _make_ssh(
+        [
+            (0, ""),  # delete-access-token best-effort (rc=0 fine)
+            (
+                0,
+                "Access token was successfully created: aebafa8bbcff4e5e7edde8dc89571df698648e7d\n",
+            ),
+        ]
     )
-    assert _client().create_token("admin", "nexus-automation", ["all"]) == "abc123"
+    sha1, err = GiteaCli(ssh).mint_token("admin", "nexus-automation")
+    assert sha1 == "aebafa8bbcff4e5e7edde8dc89571df698648e7d"
+    assert err == ""
 
 
-@responses.activate
-def test_create_token_raises_token_exists_on_409() -> None:
-    responses.add(responses.POST, f"{BASE_URL}/api/v1/users/admin/tokens", status=409)
-    with pytest.raises(TokenExistsError):
-        _client().create_token("admin", "nexus-automation", ["all"])
+def test_round_4_mint_token_idempotent_delete_first() -> None:
+    """Token already exists → CLI delete succeeds → CLI generate succeeds.
 
-
-@responses.activate
-def test_create_token_raises_token_exists_on_422_with_message() -> None:
-    """Some Gitea versions return 422 with 'already exists' body."""
-    responses.add(
-        responses.POST,
-        f"{BASE_URL}/api/v1/users/admin/tokens",
-        status=422,
-        json={"message": "token name already exists"},
+    The legacy deploy.sh delete-then-create pattern is preserved via
+    the unconditional delete in mint_token. CLI delete-access-token
+    returns rc=0 if the token existed and rc!=0 (silenced via ``|| true``)
+    if not. Either way, the next generate runs and returns the new sha1.
+    """
+    ssh = _make_ssh(
+        [
+            (1, ""),  # delete: token didn't exist (rc!=0, silenced)
+            (
+                0,
+                "Access token was successfully created: 0000000000000000000000000000000000000001\n",
+            ),
+        ]
     )
-    with pytest.raises(TokenExistsError):
-        _client().create_token("admin", "nexus-automation", ["all"])
+    sha1, err = GiteaCli(ssh).mint_token("admin", "nexus-automation")
+    assert sha1 == "0000000000000000000000000000000000000001"
+    assert err == ""
+    # Both delete + generate were called.
+    assert ssh.run_script.call_count == 2
 
 
-@responses.activate
-def test_create_token_raises_gitea_error_on_other_422() -> None:
-    """Non-existence 422 (validation failure) is NOT a retry signal."""
-    responses.add(
-        responses.POST,
-        f"{BASE_URL}/api/v1/users/admin/tokens",
-        status=422,
-        json={"message": "scopes invalid"},
+def test_mint_token_returns_diagnostic_on_cli_failure() -> None:
+    """Generate fails (non-zero rc) → returns (None, diagnostic) — no crash.
+
+    Regression test for the post-#519 silent-fail bug class: previously
+    a GiteaError was caught silently with ``token = None`` and no stderr
+    diagnostic, making the spin-up failure undebuggable. Now the
+    diagnostic is captured and surfaced via stderr by the CLI handler.
+    """
+    ssh = _make_ssh(
+        [
+            (0, ""),  # delete OK
+            (1, "User does not exist [name: admin]\n"),  # generate fails
+        ]
     )
-    with pytest.raises(GiteaError) as exc_info:
-        _client().create_token("admin", "nexus-automation", ["all"])
-    assert not isinstance(exc_info.value, TokenExistsError)
+    sha1, err = GiteaCli(ssh).mint_token("admin", "nexus-automation")
+    assert sha1 is None
+    assert "rc=1" in err
+    assert "User does not exist" in err
 
 
-@responses.activate
-def test_create_token_raises_gitea_error_on_5xx() -> None:
-    responses.add(responses.POST, f"{BASE_URL}/api/v1/users/admin/tokens", status=500)
-    with pytest.raises(GiteaError):
-        _client().create_token("admin", "nexus-automation", ["all"])
-
-
-@responses.activate
-def test_create_token_raises_on_missing_sha1() -> None:
-    responses.add(
-        responses.POST,
-        f"{BASE_URL}/api/v1/users/admin/tokens",
-        status=201,
-        json={"id": 1, "name": "nexus-automation"},  # no sha1
+def test_mint_token_returns_diagnostic_on_unparseable_output() -> None:
+    """rc=0 but no sha1 in output → still surfaces a diagnostic."""
+    ssh = _make_ssh(
+        [
+            (0, ""),
+            (0, "weird unexpected success output\n"),  # no 40-hex
+        ]
     )
-    with pytest.raises(GiteaError, match="sha1"):
-        _client().create_token("admin", "nexus-automation", ["all"])
+    sha1, err = GiteaCli(ssh).mint_token("admin", "nexus-automation")
+    assert sha1 is None
+    assert "no sha1" in err.lower()
 
 
-@responses.activate
-def test_round_4_create_token_with_retry_409_then_delete_then_201() -> None:
-    """The full retry-via-delete flow on a 409."""
-    responses.add(
-        responses.POST,
-        f"{BASE_URL}/api/v1/users/admin/tokens",
-        status=409,
-    )
-    responses.add(
-        responses.DELETE,
-        f"{BASE_URL}/api/v1/users/admin/tokens/nexus-automation",
-        status=204,
-    )
-    responses.add(
-        responses.POST,
-        f"{BASE_URL}/api/v1/users/admin/tokens",
-        status=201,
-        json={"sha1": "deadbeef"},
-    )
-    assert _client().create_token_with_retry("admin", "nexus-automation", ["all"]) == "deadbeef"
-    # Three calls: POST 409, DELETE 204, POST 201
-    assert len(responses.calls) == 3
-
-
-@responses.activate
-def test_delete_token_treats_404_as_success() -> None:
-    """Idempotent — 404 means already gone, equivalent to 204."""
-    responses.add(
-        responses.DELETE,
-        f"{BASE_URL}/api/v1/users/admin/tokens/nexus-automation",
-        status=404,
-    )
-    assert _client().delete_token("admin", "nexus-automation") is True
-
-
-def test_delete_token_path_safety_on_token_name() -> None:
+def test_mint_token_path_safety_on_username() -> None:
+    ssh = _make_ssh()
     with pytest.raises(GiteaError, match="unsafe"):
-        _client().delete_token("admin", "name;rm -rf /")
+        GiteaCli(ssh).mint_token("admin;rm -rf /", "nexus-automation")
+    ssh.run_script.assert_not_called()
 
 
-def test_create_token_path_safety() -> None:
+def test_mint_token_path_safety_on_token_name() -> None:
+    ssh = _make_ssh()
     with pytest.raises(GiteaError, match="unsafe"):
-        _client().create_token("a;b", "nexus-automation", ["all"])
+        GiteaCli(ssh).mint_token("admin", "evil; name")
+    ssh.run_script.assert_not_called()
+
+
+def test_mint_token_uses_run_script_not_run() -> None:
+    """R7 — peer-auth CLI commands feed via stdin to ssh.run_script,
+    NOT argv. No password is involved (peer auth), so the secrecy
+    surface is the username + token-name, both of which are
+    already non-secret values per the path-safety contract.
+    """
+    ssh = _make_ssh(
+        [
+            (0, ""),
+            (0, "Access token was successfully created: " + "f" * 40 + "\n"),
+        ]
+    )
+    GiteaCli(ssh).mint_token("admin", "nexus-automation")
+    # Never use ssh.run (argv form)
+    ssh.run.assert_not_called()
+
+
+def test_mint_token_supports_custom_scopes() -> None:
+    """Default scopes='all' is preserved, but caller can pass alternatives."""
+    ssh = _make_ssh(
+        [
+            (0, ""),
+            (0, "Access token was successfully created: " + "a" * 40 + "\n"),
+        ]
+    )
+    GiteaCli(ssh).mint_token("admin", "nexus-automation", scopes="write:repository")
+    # Inspect the rendered generate script — last call to run_script
+    last_script = ssh.run_script.call_args[0][0]
+    assert "write:repository" in last_script
 
 
 # ---------------------------------------------------------------------------
@@ -751,16 +759,9 @@ def test_compute_restart_services_empty_input() -> None:
 
 @responses.activate
 def test_run_configure_gitea_full_happy_path_admin_already_exists() -> None:
-    """Admin exists, password sync, token mint, repo+collaborator add."""
+    """Admin exists, password sync, token mint via CLI, repo+collaborator add."""
     # Healthcheck OK
     responses.add(responses.GET, f"{BASE_URL}/api/healthz", status=200)
-    # Token mint
-    responses.add(
-        responses.POST,
-        f"{BASE_URL}/api/v1/users/admin/tokens",
-        status=201,
-        json={"sha1": "tok123"},
-    )
     # Repo create
     responses.add(responses.POST, f"{BASE_URL}/api/v1/user/repos", status=201, json={"id": 1})
     # Collaborator add
@@ -777,6 +778,8 @@ def test_run_configure_gitea_full_happy_path_admin_already_exists() -> None:
             (0, ""),  # admin sync_password
             (0, _ADMIN_LIST_FIXTURE),  # user list (same fixture, has stefan.koch)
             (0, ""),  # user sync_password
+            (0, ""),  # token: delete-access-token (best-effort)
+            (0, f"Access token was successfully created: {'a' * 40}\n"),  # token: generate
         ]
     )
 
@@ -797,7 +800,7 @@ def test_run_configure_gitea_full_happy_path_admin_already_exists() -> None:
     )
 
     assert result.is_success is True
-    assert result.token == "tok123"
+    assert result.token == "a" * 40
     assert result.db_pw_synced is True
     assert result.admin.status == "synced"
     assert result.user is not None
@@ -812,12 +815,6 @@ def test_run_configure_gitea_full_happy_path_admin_already_exists() -> None:
 def test_run_configure_gitea_admin_does_not_exist_creates() -> None:
     """Empty admin list → CREATE branch."""
     responses.add(responses.GET, f"{BASE_URL}/api/healthz", status=200)
-    responses.add(
-        responses.POST,
-        f"{BASE_URL}/api/v1/users/admin/tokens",
-        status=201,
-        json={"sha1": "tok"},
-    )
     responses.add(responses.POST, f"{BASE_URL}/api/v1/user/repos", status=201, json={"id": 1})
 
     ssh = _make_ssh(
@@ -825,6 +822,8 @@ def test_run_configure_gitea_admin_does_not_exist_creates() -> None:
             (0, "RESULT db_pw=synced\n"),
             (0, "ID Username Email\n"),  # empty list
             (0, "New user 'admin' has been created\n"),  # create_admin
+            (0, ""),  # token: delete-access-token
+            (0, f"Access token was successfully created: {'b' * 40}\n"),  # token: generate
         ]
     )
 
@@ -846,7 +845,7 @@ def test_run_configure_gitea_admin_does_not_exist_creates() -> None:
 
     assert result.admin.status == "created"
     assert result.user is None  # GITEA_USER_EMAIL was None
-    assert result.token == "tok"
+    assert result.token == "b" * 40
 
 
 @responses.activate
@@ -860,12 +859,6 @@ def test_create_admin_already_exists_falls_back_to_sync_password() -> None:
     Regression test for Copilot round 1.
     """
     responses.add(responses.GET, f"{BASE_URL}/api/healthz", status=200)
-    responses.add(
-        responses.POST,
-        f"{BASE_URL}/api/v1/users/admin/tokens",
-        status=201,
-        json={"sha1": "tok"},
-    )
 
     ssh = _make_ssh(
         [
@@ -873,6 +866,8 @@ def test_create_admin_already_exists_falls_back_to_sync_password() -> None:
             (0, ""),  # admin list — empty (false negative)
             (0, "user already exists\n"),  # create_admin → already_exists
             (0, ""),  # FALLBACK: sync_password runs and succeeds
+            (0, ""),  # token: delete-access-token
+            (0, f"Access token was successfully created: {'c' * 40}\n"),  # token: generate
         ]
     )
 
@@ -895,8 +890,9 @@ def test_create_admin_already_exists_falls_back_to_sync_password() -> None:
     # Final admin status must be "synced" (not "already_exists") —
     # the fallback ran and the result was overwritten.
     assert result.admin.status == "synced"
-    # 4 ssh.run_script calls: db_sync, list, create, sync_password
-    assert ssh.run_script.call_count == 4
+    # 6 ssh.run_script calls: db_sync, list, create, sync_password (fallback),
+    # delete-access-token (best-effort), generate-access-token
+    assert ssh.run_script.call_count == 6
 
 
 @responses.activate
@@ -905,12 +901,6 @@ def test_create_user_already_exists_falls_back_to_sync_password() -> None:
     list path for the regular user (Copilot round 1).
     """
     responses.add(responses.GET, f"{BASE_URL}/api/healthz", status=200)
-    responses.add(
-        responses.POST,
-        f"{BASE_URL}/api/v1/users/admin/tokens",
-        status=201,
-        json={"sha1": "tok"},
-    )
 
     ssh = _make_ssh(
         [
@@ -920,6 +910,8 @@ def test_create_user_already_exists_falls_back_to_sync_password() -> None:
             (0, ""),  # user list — empty (false negative)
             (0, "user already exists\n"),  # create_user → already_exists
             (0, ""),  # FALLBACK: sync_password
+            (0, ""),  # token: delete-access-token
+            (0, f"Access token was successfully created: {'d' * 40}\n"),  # generate
         ]
     )
 
@@ -953,12 +945,6 @@ def test_round_2_legacy_email_collision_triggers_patch() -> None:
         f"{BASE_URL}/api/v1/admin/users/admin",
         status=200,
     )
-    responses.add(
-        responses.POST,
-        f"{BASE_URL}/api/v1/users/admin/tokens",
-        status=201,
-        json={"sha1": "tok"},
-    )
     responses.add(responses.POST, f"{BASE_URL}/api/v1/user/repos", status=201, json={"id": 1})
     responses.add(
         responses.PUT,
@@ -975,6 +961,8 @@ def test_round_2_legacy_email_collision_triggers_patch() -> None:
             (0, ""),  # admin sync_password
             (0, "ID Username Email\n"),  # user list — empty
             (0, "New user 'stefan.koch' has been created\n"),  # create_user
+            (0, ""),  # token: delete-access-token
+            (0, f"Access token was successfully created: {'e' * 40}\n"),  # generate
         ]
     )
 
@@ -1006,12 +994,6 @@ def test_round_2_legacy_email_collision_triggers_patch() -> None:
 def test_round_6_repo_already_exists_falls_back_to_patch_private() -> None:
     """409 on POST → PATCH /repos/<o>/<n> with private=True."""
     responses.add(responses.GET, f"{BASE_URL}/api/healthz", status=200)
-    responses.add(
-        responses.POST,
-        f"{BASE_URL}/api/v1/users/admin/tokens",
-        status=201,
-        json={"sha1": "tok"},
-    )
     # Repo create returns 409
     responses.add(responses.POST, f"{BASE_URL}/api/v1/user/repos", status=409)
     # PATCH private fallback
@@ -1025,7 +1007,9 @@ def test_round_6_repo_already_exists_falls_back_to_patch_private() -> None:
         [
             (0, "RESULT db_pw=synced\n"),
             (0, _ADMIN_LIST_FIXTURE),
-            (0, ""),
+            (0, ""),  # admin sync_password
+            (0, ""),  # token: delete-access-token
+            (0, f"Access token was successfully created: {'1' * 40}\n"),  # generate
         ]
     )
 
@@ -1057,18 +1041,14 @@ def test_round_6_repo_already_exists_falls_back_to_patch_private() -> None:
 @responses.activate
 def test_run_configure_gitea_mirror_mode_skips_repo_and_collaborator() -> None:
     responses.add(responses.GET, f"{BASE_URL}/api/healthz", status=200)
-    responses.add(
-        responses.POST,
-        f"{BASE_URL}/api/v1/users/admin/tokens",
-        status=201,
-        json={"sha1": "tok"},
-    )
 
     ssh = _make_ssh(
         [
-            (0, ""),
-            (0, _ADMIN_LIST_FIXTURE),
-            (0, ""),
+            (0, ""),  # db_pw_sync
+            (0, _ADMIN_LIST_FIXTURE),  # admin list
+            (0, ""),  # admin sync_password
+            (0, ""),  # token: delete-access-token
+            (0, f"Access token was successfully created: {'2' * 40}\n"),  # generate
         ]
     )
 
@@ -1135,15 +1115,16 @@ def test_run_configure_gitea_not_ready_returns_failed_admin() -> None:
 
 @responses.activate
 def test_run_configure_gitea_token_mint_failure_returns_failure() -> None:
-    """Token can't be minted (5xx on both attempts) → token=None, is_success=False."""
+    """Token CLI fails (rc=1) → token=None, is_success=False, token_error populated."""
     responses.add(responses.GET, f"{BASE_URL}/api/healthz", status=200)
-    responses.add(responses.POST, f"{BASE_URL}/api/v1/users/admin/tokens", status=500)
 
     ssh = _make_ssh(
         [
             (0, "RESULT db_pw=synced\n"),
             (0, _ADMIN_LIST_FIXTURE),
-            (0, ""),
+            (0, ""),  # admin sync_password
+            (0, ""),  # token: delete-access-token (best-effort)
+            (1, "User does not exist [name: admin]\n"),  # token: generate fails
         ]
     )
 
@@ -1164,6 +1145,10 @@ def test_run_configure_gitea_token_mint_failure_returns_failure() -> None:
     )
     assert result.token is None
     assert result.is_success is False
+    # Diagnostic must be populated so CLI handler can emit it to stderr —
+    # the post-#519 silent-fail bug class.
+    assert "rc=1" in result.token_error
+    assert "User does not exist" in result.token_error
 
 
 # ---------------------------------------------------------------------------
@@ -1177,6 +1162,7 @@ def test_is_success_true_on_clean_path() -> None:
         admin=CreateUserResult(name="admin", status="synced"),
         user=CreateUserResult(name="stefan", status="created"),
         token="t",
+        token_error="",
         repo=CreateRepoResult(name="nexus-foo", status="created"),
         collaborator_added=True,
         restart_services=("jupyter",),
@@ -1190,6 +1176,7 @@ def test_is_success_false_when_admin_failed() -> None:
         admin=CreateUserResult(name="admin", status="failed"),
         user=None,
         token="t",
+        token_error="",
         repo=None,
         collaborator_added=False,
         restart_services=(),
@@ -1203,6 +1190,7 @@ def test_is_success_false_when_token_missing() -> None:
         admin=CreateUserResult(name="admin", status="synced"),
         user=None,
         token=None,
+        token_error="CLI rc=1: simulated failure",
         repo=None,
         collaborator_added=False,
         restart_services=(),
@@ -1216,6 +1204,7 @@ def test_is_success_false_when_user_failed() -> None:
         admin=CreateUserResult(name="admin", status="synced"),
         user=CreateUserResult(name="stefan", status="failed"),
         token="t",
+        token_error="",
         repo=None,
         collaborator_added=False,
         restart_services=(),
@@ -1229,6 +1218,7 @@ def test_is_success_false_when_repo_failed() -> None:
         admin=CreateUserResult(name="admin", status="synced"),
         user=None,
         token="t",
+        token_error="",
         repo=CreateRepoResult(name="nexus-foo", status="failed"),
         collaborator_added=False,
         restart_services=(),
@@ -1250,6 +1240,7 @@ def test_round_8_cli_emits_eval_able_stdout(
         admin=CreateUserResult(name="admin", status="synced"),
         user=CreateUserResult(name="stefan", status="created"),
         token="abc123def-token",
+        token_error="",
         repo=CreateRepoResult(name="nexus-foo", status="created"),
         collaborator_added=True,
         restart_services=("jupyter", "marimo"),
@@ -1316,6 +1307,7 @@ def test_round_8_cli_omits_token_line_when_token_none(
         admin=CreateUserResult(name="admin", status="synced"),
         user=None,
         token=None,
+        token_error="CLI rc=1: simulated production failure",
         repo=None,
         collaborator_added=False,
         restart_services=("jupyter",),
@@ -1342,9 +1334,15 @@ def test_round_8_cli_omits_token_line_when_token_none(
     rc = _gitea_configure([])
     assert rc == 1  # is_success=False (token is None)
 
-    out = capsys.readouterr().out
+    captured = capsys.readouterr()
+    out = captured.out
+    err = captured.err
     assert "GITEA_TOKEN=" not in out
     assert re.search(r"^RESTART_SERVICES=", out, re.M)
+    # Diagnostic must reach stderr — post-#519 fix that closed the
+    # "silent token-mint failure" debugging blind spot.
+    assert "token: NOT minted" in err
+    assert "CLI rc=1: simulated production failure" in err
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_gitea.py
+++ b/tests/unit/test_gitea.py
@@ -490,19 +490,71 @@ def test_round_4_mint_token_idempotent_delete_first() -> None:
     # the unquoted SQL keywords (DELETE FROM, WHERE, AND uid, lower)
     # plus the literal name + username values (which appear inside
     # shlex's `'"'"'` quote-escape but the inner characters survive).
-    # `|| true` swallows transient psql errors (justifies the rc=0
-    # mock above).
     delete_script = ssh.run_script.call_args_list[0][0][0]
     assert "DELETE FROM access_token" in delete_script
     assert "nexus-automation" in delete_script
     assert "WHERE lower_name" in delete_script
     assert "admin" in delete_script
-    assert "|| true" in delete_script
+    # Must NOT swallow stderr — `|| true` and `2>/dev/null` were
+    # removed in the round-4 fix so a psql failure surfaces in
+    # delete_result.stdout for inclusion in token_error.
+    assert "|| true" not in delete_script
+    assert "2>/dev/null" not in delete_script
     # Must NOT use the non-existent gitea CLI subcommand
     # (PR #520 round-3 production bug — `gitea admin user
     # delete-access-token` is hallucinated; psql DELETE is the
     # bulletproof replacement).
     assert "delete-access-token" not in delete_script
+
+
+def test_mint_token_diagnostic_prepends_prior_delete_failure() -> None:
+    """When psql DELETE fails AND generate fails, the diagnostic
+    must include BOTH errors — the delete failure prepended to the
+    generate failure. Without this, a name-collision failure on
+    generate looks unexplainable when the cause is actually that
+    the delete didn't run (gitea-db not ready, transient docker
+    error, etc.). Round-4 follow-up to the diagnostic field.
+    """
+    ssh = _make_ssh(
+        [
+            (
+                1,
+                'psql: error: connection to server at "gitea-db" failed\n',
+            ),  # psql delete fails (DB not ready)
+            (
+                1,
+                "Command error: access token name has been used already\n",
+            ),  # generate then collides
+        ]
+    )
+    sha1, err = GiteaCli(ssh).mint_token("admin", "nexus-automation")
+    assert sha1 is None
+    # Must include both diagnostics, prior delete prepended.
+    assert "prior delete rc=1" in err
+    assert "connection to server" in err
+    assert "CLI rc=1" in err
+    assert "name has been used already" in err
+    # Format: `prior delete ... | CLI ...`
+    assert err.index("prior delete") < err.index("CLI rc=1")
+
+
+def test_mint_token_drops_delete_diagnostic_on_generate_success() -> None:
+    """If delete fails (rc=1) but generate succeeds, the delete
+    diagnostic is irrelevant and must NOT pollute the success
+    return value. Returns (sha1, "").
+    """
+    ssh = _make_ssh(
+        [
+            (1, "psql: connection failed\n"),  # delete fails
+            (
+                0,
+                "Access token was successfully created: " + "f" * 40 + "\n",
+            ),  # generate succeeds anyway (e.g. token didn't exist)
+        ]
+    )
+    sha1, err = GiteaCli(ssh).mint_token("admin", "nexus-automation")
+    assert sha1 == "f" * 40
+    assert err == ""
 
 
 def test_mint_token_returns_diagnostic_on_cli_failure() -> None:


### PR DESCRIPTION
## Summary

Production spin-up after PR #519 merge surfaced a **silent Gitea token-mint failure** that blocked downstream Kestra Git sync, workspace-repo seeding, and Woodpecker OAuth registration. Root cause: REST `POST /api/v1/users/<u>/tokens` returned HTTP 400 from inside `CreateAccessToken` handler (auth passed, request body validation rejected) despite the prior admin password sync reporting success. Likely a subtle password-state race in Gitea between the bcrypt commit and the immediately-following REST auth check.

Two fixes, one design:

### 1. REST → CLI peer-auth for token mint

Replace `GiteaClient.create_token` / `delete_token` / `create_token_with_retry` with `GiteaCli.mint_token` (uses `gitea admin user delete-access-token` + `generate-access-token` via `docker exec -u git`). Peer auth eliminates the password chicken-egg entirely — the CLI runs as the container's `git` user, no password verification needed. Idempotent delete-then-create matches the legacy deploy.sh pattern.

Also removes `TokenExistsError` (no longer reachable; CLI delete is unconditional best-effort).

### 2. Diagnostic surface for token failures

Add `token_error: str` to `GiteaResult` — a short message describing the CLI failure mode (`rc=N: <first line of stdout>`, no secrets — Gitea CLI delete/generate output contains only username + token-name + status). The CLI handler emits it via stderr when `token is None`:

```
  • token: NOT minted (downstream skipped) — CLI rc=1: User does not exist [name: admin]
```

Closes the silent-fail debugging blind spot.

## Why CLI peer-auth is safe

Same pattern already used for admin/user CRUD throughout this module (`create_admin`, `sync_password`, `create_user`). Peer auth via `docker exec -u git` matches the security boundary of the legacy bash. No new exposure: passwords still never reach the local deploy host's argv (script body fed via `ssh.run_script` stdin).

## Files

- `src/nexus_deploy/gitea.py`: dropped REST token methods + `TokenExistsError`; added `GiteaCli.mint_token` + `token_error` field on `GiteaResult`; orchestrator now calls `cli.mint_token`. Net −34 LoC.
- `src/nexus_deploy/__main__.py`: stderr line for `token is None` now includes `token_error` detail.
- `tests/unit/test_gitea.py`: dropped REST token tests, added 8 `mint_token` tests (success / idempotent-delete-first / CLI failure diagnostic / unparseable output / 2× path-safety / no-argv / custom-scopes); updated 7 orchestrator tests to use SSH mocks for the new CLI flow; added regression assertion in `token_mint_failure` test that `token_error` is populated; strengthened `round_8_cli_omits_token_line_when_token_none` to verify stderr diagnostic surfacing.

## Quality gate

- `uv run ruff format --check`: 29 files clean
- `uv run ruff check`: 0 errors (1× `# noqa: S106` on a non-secret diagnostic string)
- `uv run mypy --strict`: 0 errors
- `uv run pytest --cov=src/nexus_deploy --cov-fail-under=80`: **575 passed** in 9.91s
- Coverage: `gitea.py` **96%** (up from 93%), total **98.11%** (up from 97.67%) — fewer dead-code paths
- `bash -n scripts/deploy.sh`: clean (no deploy.sh changes)

## Test plan

- [ ] `gh workflow run destroy-all.yml -f confirm=DESTROY` (already done — fresh state)
- [ ] `gh workflow run initial-setup.yaml --ref main -f enabled_services=kestra,jupyter,marimo`
- [ ] First spin-up: deploy log shows `• token: <40-hex>` (or `• token: NOT minted — <diagnostic>` if CLI fails); workspace repo `nexus-<slug>-gitea` created (private); seed_workspace_files runs; system.flow-sync registers + executes; `nexus-tutorials.r2-taxi-pipeline` appears in Kestra UI
- [ ] Re-run with same params (idempotency): mint_token's unconditional delete-then-create regenerates a fresh sha1; everything else converges via existing already_exists branches.

Closes the post-#519 spin-up regression. NOT bundled with Modul 2.2f mirror-mode + Woodpecker OAuth (those land separately).
