### PR TITLE
feat(nexus_deploy): Migrate Gitea mirror-mode loop (Modul 2.2f part 2)

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -3238,178 +3238,54 @@ if echo "$ENABLED_SERVICES" | grep -qw "gitea" \
     echo "  Setting up GitHub Mirrors"
     echo "=========================================="
 
-    # Get admin user ID (required by Gitea migration API)
-    GITEA_ADMIN_UID=$(ssh nexus "curl -s \
-        'http://localhost:3200/api/v1/users/$ADMIN_USERNAME' \
-        -H 'Authorization: token $GITEA_TOKEN'" 2>/dev/null \
-        | jq -r '.id // empty')
-
-    if [ -z "$GITEA_ADMIN_UID" ]; then
-        echo -e "${YELLOW}  ⚠ Could not get Gitea admin UID - skipping mirrors${NC}"
-    else
-        IFS=',' read -ra MIRROR_REPOS <<< "$GH_MIRROR_REPOS"
-        for REPO_URL in "${MIRROR_REPOS[@]}"; do
-            REPO_URL=$(echo "$REPO_URL" | tr -d ' ')
-            [ -z "$REPO_URL" ] && continue
-            REPO_NAME="mirror-readonly-$(basename "$REPO_URL" .git)"
-
-            echo "  Mirroring: $REPO_NAME..."
-
-            # Check if mirror already exists (idempotent re-deploy)
-            HTTP_CODE=$(ssh nexus "curl -s -o /dev/null -w '%{http_code}' \
-                'http://localhost:3200/api/v1/repos/$ADMIN_USERNAME/$REPO_NAME' \
-                -H 'Authorization: token $GITEA_TOKEN'")
-
-            MIRROR_OK=0
-            if [ "$HTTP_CODE" = "200" ]; then
-                echo -e "${YELLOW}  ⚠ Mirror '$REPO_NAME' already exists, skipping creation${NC}"
-                MIRROR_OK=1
-            else
-                MIGRATE_PAYLOAD=$(jq -n \
-                    --arg clone_addr "$REPO_URL" \
-                    --arg repo_name "$REPO_NAME" \
-                    --arg auth_token "$GH_MIRROR_TOKEN" \
-                    --argjson uid "$GITEA_ADMIN_UID" \
-                    '{
-                        clone_addr: $clone_addr,
-                        repo_name: $repo_name,
-                        private: true,
-                        mirror: true,
-                        mirror_interval: "10m0s",
-                        auth_token: $auth_token,
-                        uid: $uid
-                    }')
-
-                MIRROR_RESULT=$(printf '%s' "$MIGRATE_PAYLOAD" | ssh nexus "curl -s -X POST \
-                    'http://localhost:3200/api/v1/repos/migrate' \
-                    -H 'Authorization: token $GITEA_TOKEN' \
-                    -H 'Content-Type: application/json' \
-                    -d @-" 2>/dev/null || echo "")
-
-                if echo "$MIRROR_RESULT" | jq -e '.id' >/dev/null 2>&1; then
-                    echo -e "${GREEN}  ✓ Mirror '$REPO_NAME' created (syncs every 10 min)${NC}"
-                    MIRROR_OK=1
-                else
-                    echo -e "${YELLOW}  ⚠ Mirror '$REPO_NAME' setup failed${NC}"
-                    echo -e "${YELLOW}    Verify GH_MIRROR_TOKEN has Contents:read permission${NC}"
-                    echo -e "${YELLOW}    and GH_MIRROR_REPOS contains valid GitHub HTTPS URLs${NC}"
-                fi
+    # Phase 2 Modul 2.2f part 2 (#505): the mirror loop (admin-UID
+    # lookup + per-repo migrate + per-user fork via temp-token +
+    # collab + mirror-sync + merge-upstream) is now in
+    # nexus_deploy.gitea.run_mirror_setup. Same idempotent semantics
+    # as before; CLI emits FORK_NAME=<name> + GITEA_REPO_OWNER=<user>
+    # on stdout (eval-able) iff a fork was provisioned, so the
+    # downstream seed_workspace_files (still in deploy.sh) hits the
+    # user's fork rather than the per-iteration mirror name.
+    #
+    # Clear any stale eval values from prior iterations so an rc=1
+    # (CLI failed pre-fork) doesn't leak old values into the seed
+    # call below.
+    unset FORK_NAME
+    MIRROR_OUT=$(mktemp)
+    chmod 600 "$MIRROR_OUT"
+    echo "$MIRROR_OUT" >> "$RUNNER_CLEANUP_PATHS"
+    MIRROR_RC=0
+    ADMIN_USERNAME="$ADMIN_USERNAME" \
+        GITEA_ADMIN_PASS="$GITEA_ADMIN_PASS" \
+        GITEA_TOKEN="$GITEA_TOKEN" \
+        GITEA_USER_USERNAME="${GITEA_USER_USERNAME:-}" \
+        GH_MIRROR_REPOS="$GH_MIRROR_REPOS" \
+        GH_MIRROR_TOKEN="$GH_MIRROR_TOKEN" \
+        WORKSPACE_BRANCH="${WORKSPACE_BRANCH:-main}" \
+        uv run --quiet --project "$PROJECT_ROOT" \
+        python -m nexus_deploy gitea mirror-setup > "$MIRROR_OUT" \
+        || MIRROR_RC=$?
+    case "$MIRROR_RC" in
+        0)
+            if [ -s "$MIRROR_OUT" ]; then
+                eval "$(cat "$MIRROR_OUT")"
             fi
-
-            if [ "$MIRROR_OK" = "1" ]; then
-                # Fork the first mirror as the user's workspace repo (idempotent)
-                # FORKED_WORKSPACE flag ensures we only fork once (the first mirror)
-                if [ "${FORKED_WORKSPACE:-}" != "1" ] && [ -n "${GITEA_USER_USERNAME:-}" ]; then
-                    ORIG_NAME=$(basename "$REPO_URL" .git)
-                    GITEA_USER_SANITIZED="${GITEA_USER_USERNAME//[^a-zA-Z0-9]/_}"
-                    FORK_NAME="${ORIG_NAME}_${GITEA_USER_SANITIZED}"
-                    echo "  Forking ${ADMIN_USERNAME}/${REPO_NAME} into ${GITEA_USER_USERNAME}/${FORK_NAME}..."
-
-                    # Create a user token so the fork lands in the user's namespace (not admin's)
-                    USER_TOKEN=$(ssh nexus "curl -s -X POST 'http://localhost:3200/api/v1/users/$GITEA_USER_USERNAME/tokens' \
-                        -u '$ADMIN_USERNAME:$GITEA_ADMIN_PASS' \
-                        -H 'Content-Type: application/json' \
-                        -d '{\"name\":\"nexus-workspace-fork\",\"scopes\":[\"all\"]}'" 2>/dev/null | jq -r '.sha1 // empty')
-                    if [ -z "$USER_TOKEN" ]; then
-                        ssh nexus "curl -s -X DELETE 'http://localhost:3200/api/v1/users/$GITEA_USER_USERNAME/tokens/nexus-workspace-fork' \
-                            -u '$ADMIN_USERNAME:$GITEA_ADMIN_PASS'" >/dev/null 2>&1 || true
-                        USER_TOKEN=$(ssh nexus "curl -s -X POST 'http://localhost:3200/api/v1/users/$GITEA_USER_USERNAME/tokens' \
-                            -u '$ADMIN_USERNAME:$GITEA_ADMIN_PASS' \
-                            -H 'Content-Type: application/json' \
-                            -d '{\"name\":\"nexus-workspace-fork\",\"scopes\":[\"all\"]}'" 2>/dev/null | jq -r '.sha1 // empty')
-                    fi
-                    if [ -n "$USER_TOKEN" ]; then
-                        FORK_RESULT=$(ssh nexus "curl -s -o /dev/null -w '%{http_code}' \
-                            -X POST 'http://localhost:3200/api/v1/repos/${ADMIN_USERNAME}/${REPO_NAME}/forks' \
-                            -H 'Authorization: token $USER_TOKEN' \
-                            -H 'Content-Type: application/json' \
-                            -d '{\"name\":\"$FORK_NAME\"}'")
-                        if [ "$FORK_RESULT" = "202" ]; then
-                            echo -e "${GREEN}  ✓ Forked into ${GITEA_USER_USERNAME}/${FORK_NAME}${NC}"
-                            FORKED_WORKSPACE=1
-                        elif [ "$FORK_RESULT" = "409" ]; then
-                            echo -e "${YELLOW}  ⚠ Fork ${GITEA_USER_USERNAME}/${FORK_NAME} already exists${NC}"
-                            FORKED_WORKSPACE=1
-                        else
-                            echo -e "${YELLOW}  ⚠ Fork returned HTTP $FORK_RESULT${NC}"
-                        fi
-                        ssh nexus "curl -s -X DELETE 'http://localhost:3200/api/v1/users/$GITEA_USER_USERNAME/tokens/nexus-workspace-fork' \
-                            -u '$ADMIN_USERNAME:$GITEA_ADMIN_PASS'" >/dev/null 2>&1 || true
-                    else
-                        echo -e "${YELLOW}  ⚠ Could not create user token for fork${NC}"
-                    fi
-                fi
-
-                # Grant student user (gitea_user) read-only access to the mirror
-                if [ -n "$GITEA_USER_USERNAME" ]; then
-                    COLLAB_PAYLOAD=$(jq -n '{permission: "read"}')
-                    printf '%s' "$COLLAB_PAYLOAD" | ssh nexus "curl -s -X PUT \
-                        'http://localhost:3200/api/v1/repos/$ADMIN_USERNAME/$REPO_NAME/collaborators/$GITEA_USER_USERNAME' \
-                        -H 'Authorization: token $GITEA_TOKEN' \
-                        -H 'Content-Type: application/json' \
-                        -d @-" >/dev/null 2>&1 || true
-                    echo -e "${GREEN}  ✓ Read access granted to '$GITEA_USER_USERNAME'${NC}"
-                fi
-
-                # Sync fork from upstream mirror (ensures fork has latest code on every Spin Up)
-                # Uses Gitea's merge-upstream API to fast-forward the fork from the mirror.
-                if [ "${FORKED_WORKSPACE:-}" = "1" ] && [ "${SYNCED_FORK:-}" != "1" ]; then
-                    SYNCED_FORK=1
-                    ORIG_NAME=$(basename "$REPO_URL" .git)
-                    GITEA_USER_SANITIZED="${GITEA_USER_USERNAME//[^a-zA-Z0-9]/_}"
-                    SYNC_FORK_NAME="${ORIG_NAME}_${GITEA_USER_SANITIZED}"
-                    echo "  Syncing fork ${GITEA_USER_USERNAME}/${SYNC_FORK_NAME} from upstream..."
-
-                    # First trigger mirror sync to pull latest from GitHub
-                    ssh nexus "curl -s -X POST \
-                        'http://localhost:3200/api/v1/repos/$ADMIN_USERNAME/$REPO_NAME/mirror-sync' \
-                        -H 'Authorization: token $GITEA_TOKEN'" >/dev/null 2>&1 || true
-                    # Wait briefly for mirror sync to complete
-                    sleep 3
-
-                    # Merge upstream into fork (fast-forward) on the
-                    # branch detected at script-start time (resolved into
-                    # $WORKSPACE_BRANCH from the GitHub API for the first
-                    # mirror URL — defaults to `main` if detection failed
-                    # or no token was supplied). Hardcoding `main` here
-                    # broke `master`-default upstreams: merge-upstream
-                    # 404s and the fork drifts.
-                    #
-                    # Auth header + branch body go through a remote
-                    # `curl --config` file (mode 0600, removed via local
-                    # trap) so $GITEA_TOKEN never appears in argv on the
-                    # server (would otherwise be visible in `ps` while
-                    # curl runs). Same argv-safe pattern as the other
-                    # token-bearing calls in this script.
-                    MERGE_TOKEN_B64=$(printf '%s' "$GITEA_TOKEN" | base64 | tr -d '\n')
-                    MERGE_BRANCH_B64=$(printf '%s' "$WORKSPACE_BRANCH" | base64 | tr -d '\n')
-                    MERGE_RESULT=$(ssh nexus "bash -s" <<REMOTE_MERGE_EOF 2>/dev/null
-TOK=\$(printf '%s' '$MERGE_TOKEN_B64' | base64 -d)
-BR=\$(printf '%s' '$MERGE_BRANCH_B64' | base64 -d)
-CFG=\$(mktemp)
-chmod 600 "\$CFG"
-trap 'rm -f "\$CFG"' EXIT
-{
-    printf 'header = "Authorization: token %s"\n' "\$TOK"
-    printf 'header = "Content-Type: application/json"\n'
-} > "\$CFG"
-printf '{"branch":"%s"}' "\$BR" | curl -s -o /dev/null -w '%{http_code}' \\
-    -X POST 'http://localhost:3200/api/v1/repos/$GITEA_USER_USERNAME/$SYNC_FORK_NAME/merge-upstream' \\
-    --config "\$CFG" \\
-    --data-binary @-
-REMOTE_MERGE_EOF
-)
-
-                    if [ "$MERGE_RESULT" = "200" ]; then
-                        echo -e "${GREEN}  ✓ Fork synced from upstream (new commits merged)${NC}"
-                    elif [ "$MERGE_RESULT" = "409" ]; then
-                        echo "  ✓ Fork already up to date"
-                    else
-                        echo -e "${YELLOW}  ⚠ Fork sync returned HTTP $MERGE_RESULT (may need manual sync)${NC}"
-                    fi
-                fi
+            ;;
+        1)
+            if [ -s "$MIRROR_OUT" ]; then
+                eval "$(cat "$MIRROR_OUT")"
             fi
-        done
+            echo -e "${YELLOW}  ⚠ Mirror setup had partial failures (continuing)${NC}"
+            ;;
+        *)
+            rm -f "$MIRROR_OUT"
+            echo -e "${RED}  ✗ Mirror setup hard failure (rc=$MIRROR_RC); aborting${NC}"
+            exit "$MIRROR_RC"
+            ;;
+    esac
+    rm -f "$MIRROR_OUT"
+
+    if [ "$MIRROR_RC" -le 1 ]; then
 
         # Seed Nexus-Stack example workspace files into the now-existing
         # fork. The mirror loop above OVERWRITES `$REPO_NAME` per

--- a/src/nexus_deploy/__main__.py
+++ b/src/nexus_deploy/__main__.py
@@ -1262,7 +1262,16 @@ def _gitea_mirror_setup(args: list[str]) -> int:
 
     # Per-step status lines on stderr.
     if result.admin_uid is None:
-        sys.stderr.write("  • admin UID not found — skipping all mirrors\n")
+        # Distinguish "admin user genuinely doesn't exist (404)" from
+        # auth/transport/5xx failures via admin_uid_error. Without
+        # this, the message was misleadingly the same for all paths.
+        # (Copilot R4)
+        if result.admin_uid_error:
+            sys.stderr.write(
+                f"  • admin UID lookup failed ({result.admin_uid_error}) — skipping all mirrors\n"
+            )
+        else:
+            sys.stderr.write("  • admin user not found in Gitea — skipping all mirrors\n")
         return 1
     sys.stderr.write(f"  • admin UID: {result.admin_uid}\n")
     for m in result.mirrors:

--- a/src/nexus_deploy/__main__.py
+++ b/src/nexus_deploy/__main__.py
@@ -1145,7 +1145,6 @@ def _gitea_mirror_setup(args: list[str]) -> int:
 
     Required env:
 
-    - ``ADMIN_USERNAME`` — admin user (path-validated)
     - ``GITEA_ADMIN_PASS`` — admin password (basic-auth for the
       temp user-token mint inside the fork flow)
     - ``GITEA_TOKEN`` — admin's bearer token for migrate / collab /
@@ -1156,6 +1155,11 @@ def _gitea_mirror_setup(args: list[str]) -> int:
 
     Optional env:
 
+    - ``ADMIN_USERNAME`` — admin username, path-validated (default
+      ``admin``). Mirrors :class:`NexusConfig`'s ``admin_username``
+      default so the CLI works without the deploy.sh env-passing
+      layer when invoked manually. (Same default as
+      ``gitea woodpecker-oauth`` — Copilot R1 consistency fix.)
     - ``GITEA_USER_USERNAME`` — Gitea username for the per-user fork.
       If unset, the fork step is skipped (mirrors-only mode).
     - ``WORKSPACE_BRANCH`` — branch for the merge-upstream step

--- a/src/nexus_deploy/__main__.py
+++ b/src/nexus_deploy/__main__.py
@@ -12,6 +12,7 @@ Currently:
 - ``kestra register-system-flows`` (#505 Modul 2.3)
 - ``gitea configure`` (#505 Modul 2.2e)
 - ``gitea woodpecker-oauth`` (#505 Modul 2.2f)
+- ``gitea mirror-setup`` (#505 Modul 2.2f part 2)
 """
 
 from __future__ import annotations
@@ -24,7 +25,12 @@ from pathlib import Path
 from nexus_deploy import __version__, hello
 from nexus_deploy.compose_runner import run_compose_up
 from nexus_deploy.config import ConfigError, NexusConfig
-from nexus_deploy.gitea import GiteaError, run_configure_gitea, run_woodpecker_oauth_setup
+from nexus_deploy.gitea import (
+    GiteaError,
+    run_configure_gitea,
+    run_mirror_setup,
+    run_woodpecker_oauth_setup,
+)
 from nexus_deploy.infisical import (
     BootstrapEnv,
     InfisicalClient,
@@ -1120,6 +1126,169 @@ def _gitea_woodpecker_oauth(args: list[str]) -> int:
     return 0
 
 
+def _gitea_mirror_setup(args: list[str]) -> int:
+    """`nexus-deploy gitea mirror-setup`.
+
+    Provisions GH_MIRROR_REPOS as Gitea pull-mirrors plus per-user
+    forks (Modul 2.2f part 2). Mirrors deploy.sh's mirror-loop block
+    (L3224-3412 pre-migration); per-mirror operations:
+
+    1. Migrate (clone-mirror via Gitea's /api/v1/repos/migrate +
+       GitHub PAT) — idempotent: already_exists is soft-success
+    2. On the FIRST mirror with a configured user: fork into the
+       user's namespace via temp user-token (created+deleted
+       around the fork POST)
+    3. Add the user as read-collaborator on every mirror
+    4. On the first iteration where a fork was created/exists:
+       trigger mirror-sync + merge-upstream so the fork is
+       fast-forwarded from upstream
+
+    Required env:
+
+    - ``ADMIN_USERNAME`` — admin user (path-validated)
+    - ``GITEA_ADMIN_PASS`` — admin password (basic-auth for the
+      temp user-token mint inside the fork flow)
+    - ``GITEA_TOKEN`` — admin's bearer token for migrate / collab /
+      mirror-sync (from earlier ``gitea configure`` invocation)
+    - ``GH_MIRROR_REPOS`` — comma-separated GitHub repo URLs
+    - ``GH_MIRROR_TOKEN`` — GitHub PAT (Contents:read for private
+      sources)
+
+    Optional env:
+
+    - ``GITEA_USER_USERNAME`` — Gitea username for the per-user fork.
+      If unset, the fork step is skipped (mirrors-only mode).
+    - ``WORKSPACE_BRANCH`` — branch for the merge-upstream step
+      (default ``main``). deploy.sh resolves this from the GitHub
+      API ahead of time and exports it.
+    - ``GITEA_HOST`` — SSH host alias (default ``nexus``)
+
+    **stdout** (eval-able, only when fork was created/exists):
+
+    - ``FORK_NAME=<name>``
+    - ``GITEA_REPO_OWNER=<user>``
+
+    These two are consumed by deploy.sh's existing
+    ``seed_workspace_files`` wrapper (already migrated, #512) so the
+    seed POST hits the user's fork rather than the per-iteration
+    mirror name. When no fork was created/exists, no stdout output
+    is emitted.
+
+    Exit codes:
+
+    - 0: every mirror succeeded (created or already_exists), fork
+      (if attempted) succeeded too
+    - 1: at least one mirror failed OR fork failed. Deploy.sh keeps
+      going (next spin-up retries; mirrors are idempotent).
+    - 2: bad args / missing required env / SSH tunnel / unexpected
+      exception. Abort.
+    """
+    if args:
+        print(f"gitea mirror-setup: unknown args {args!r}", file=sys.stderr)
+        return 2
+
+    admin_username = os.environ.get("ADMIN_USERNAME") or "admin"
+    admin_password = os.environ.get("GITEA_ADMIN_PASS") or ""
+    gitea_token = os.environ.get("GITEA_TOKEN") or ""
+    gh_mirror_repos_csv = os.environ.get("GH_MIRROR_REPOS") or ""
+    gh_mirror_token = os.environ.get("GH_MIRROR_TOKEN") or ""
+    gitea_user_username = os.environ.get("GITEA_USER_USERNAME") or None
+    workspace_branch = os.environ.get("WORKSPACE_BRANCH") or "main"
+    ssh_host = os.environ.get("GITEA_HOST") or "nexus"
+
+    missing: list[str] = []
+    if not admin_password:
+        missing.append("GITEA_ADMIN_PASS")
+    if not gitea_token:
+        missing.append("GITEA_TOKEN")
+    if not gh_mirror_repos_csv:
+        missing.append("GH_MIRROR_REPOS")
+    if not gh_mirror_token:
+        missing.append("GH_MIRROR_TOKEN")
+    if missing:
+        print(
+            f"gitea mirror-setup: missing required env: {', '.join(missing)}",
+            file=sys.stderr,
+        )
+        return 2
+
+    repos = [s.strip() for s in gh_mirror_repos_csv.split(",") if s.strip()]
+    if not repos:
+        print("gitea mirror-setup: GH_MIRROR_REPOS contained no repo URLs", file=sys.stderr)
+        return 2
+
+    try:
+        local_port = _allocate_free_port()
+        with (
+            SSHClient(ssh_host) as ssh,
+            ssh.port_forward(local_port, "localhost", 3200) as port,
+        ):
+            _ = ssh
+            result = run_mirror_setup(
+                base_url=f"http://localhost:{port}",
+                admin_username=admin_username,
+                admin_password=admin_password,
+                gitea_token=gitea_token,
+                gitea_user_username=gitea_user_username,
+                gh_mirror_repos=repos,
+                gh_mirror_token=gh_mirror_token,
+                workspace_branch=workspace_branch,
+            )
+    except SSHError as exc:
+        print(f"gitea mirror-setup: ssh tunnel failed: {exc}", file=sys.stderr)
+        return 2
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError) as exc:
+        print(
+            f"gitea mirror-setup: transport failure ({type(exc).__name__})",
+            file=sys.stderr,
+        )
+        return 2
+    except GiteaError as exc:
+        # Path-safety violations + REST-layer errors not caught by
+        # the orchestrator's per-call try/except. Surface verbatim
+        # (messages are constructed from format strings only).
+        print(f"gitea mirror-setup: {exc}", file=sys.stderr)
+        return 2
+    except Exception as exc:
+        print(
+            f"gitea mirror-setup: unexpected error ({type(exc).__name__})",
+            file=sys.stderr,
+        )
+        return 2
+
+    # Per-step status lines on stderr.
+    if result.admin_uid is None:
+        sys.stderr.write("  • admin UID not found — skipping all mirrors\n")
+        return 1
+    sys.stderr.write(f"  • admin UID: {result.admin_uid}\n")
+    for m in result.mirrors:
+        sys.stderr.write(
+            f"  • mirror: {m.name} → {m.status}{(' — ' + m.detail) if m.detail else ''}\n"
+        )
+    if result.fork is not None:
+        sys.stderr.write(
+            f"  • fork: {result.fork.owner}/{result.fork.name} → {result.fork.status}"
+            f"{(' — ' + result.fork.detail) if result.fork.detail else ''}\n"
+        )
+    if result.collaborator_added_count > 0:
+        sys.stderr.write(f"  • collaborator added on {result.collaborator_added_count} mirror(s)\n")
+    if result.fork_synced:
+        sys.stderr.write("  • fork merge-upstream attempted\n")
+
+    # Eval-able stdout: emit FORK_NAME + GITEA_REPO_OWNER iff the
+    # fork is in a usable state. seed_workspace_files (deploy.sh side)
+    # uses these to point its seed POST at the user's fork rather
+    # than the most recently-mutated $REPO_NAME from the legacy
+    # mirror loop.
+    import shlex as _shlex
+
+    if result.fork is not None and result.fork.status in ("created", "already_exists"):
+        sys.stdout.write(f"FORK_NAME={_shlex.quote(result.fork.name)}\n")
+        sys.stdout.write(f"GITEA_REPO_OWNER={_shlex.quote(result.fork.owner)}\n")
+
+    return 0 if result.is_success else 1
+
+
 def _allocate_free_port() -> int:
     """Ask the kernel for a free IPv4 ephemeral port on the loopback.
 
@@ -1206,6 +1375,8 @@ def main() -> int:
         return _gitea_configure(args[2:])
     if args[:2] == ["gitea", "woodpecker-oauth"]:
         return _gitea_woodpecker_oauth(args[2:])
+    if args[:2] == ["gitea", "mirror-setup"]:
+        return _gitea_mirror_setup(args[2:])
     print(
         f"nexus_deploy {__version__}: unknown command {' '.join(args)!r}",
         file=sys.stderr,
@@ -1220,7 +1391,8 @@ def main() -> int:
         "services configure --enabled <comma-list> (reads SECRETS_JSON from stdin), "
         "kestra register-system-flows (reads SECRETS_JSON from stdin + env vars), "
         "gitea configure (reads SECRETS_JSON from stdin + env vars; emits eval-able stdout), "
-        "gitea woodpecker-oauth (env-only; emits WOODPECKER_GITEA_CLIENT + WOODPECKER_GITEA_SECRET)",
+        "gitea woodpecker-oauth (env-only; emits WOODPECKER_GITEA_CLIENT + WOODPECKER_GITEA_SECRET), "
+        "gitea mirror-setup (env-only; emits FORK_NAME + GITEA_REPO_OWNER iff a fork was provisioned)",
         file=sys.stderr,
     )
     return 2

--- a/src/nexus_deploy/__main__.py
+++ b/src/nexus_deploy/__main__.py
@@ -1145,13 +1145,18 @@ def _gitea_mirror_setup(args: list[str]) -> int:
 
     Required env:
 
-    - ``GITEA_ADMIN_PASS`` — admin password (basic-auth for the
-      temp user-token mint inside the fork flow)
     - ``GITEA_TOKEN`` — admin's bearer token for migrate / collab /
       mirror-sync (from earlier ``gitea configure`` invocation)
     - ``GH_MIRROR_REPOS`` — comma-separated GitHub repo URLs
     - ``GH_MIRROR_TOKEN`` — GitHub PAT (Contents:read for private
       sources)
+
+    Conditionally required env:
+
+    - ``GITEA_ADMIN_PASS`` — admin password (basic-auth for the
+      temp user-token mint inside the fork flow). Required ONLY
+      when ``GITEA_USER_USERNAME`` is set; mirrors-only mode
+      (no user, no fork) doesn't need it. (Copilot R6)
 
     Optional env:
 
@@ -1161,7 +1166,8 @@ def _gitea_mirror_setup(args: list[str]) -> int:
       layer when invoked manually. (Same default as
       ``gitea woodpecker-oauth`` — Copilot R1 consistency fix.)
     - ``GITEA_USER_USERNAME`` — Gitea username for the per-user fork.
-      If unset, the fork step is skipped (mirrors-only mode).
+      If unset, the fork step is skipped (mirrors-only mode);
+      ``GITEA_ADMIN_PASS`` becomes optional in this case.
     - ``WORKSPACE_BRANCH`` — branch for the merge-upstream step
       (default ``main``). deploy.sh resolves this from the GitHub
       API ahead of time and exports it.
@@ -1201,14 +1207,18 @@ def _gitea_mirror_setup(args: list[str]) -> int:
     ssh_host = os.environ.get("GITEA_HOST") or "nexus"
 
     missing: list[str] = []
-    if not admin_password:
-        missing.append("GITEA_ADMIN_PASS")
     if not gitea_token:
         missing.append("GITEA_TOKEN")
     if not gh_mirror_repos_csv:
         missing.append("GH_MIRROR_REPOS")
     if not gh_mirror_token:
         missing.append("GH_MIRROR_TOKEN")
+    # GITEA_ADMIN_PASS is only consumed by the fork flow's temp
+    # user-token mint (basic-auth: admin acts on behalf of user).
+    # Mirrors-only mode (no GITEA_USER_USERNAME) doesn't need it.
+    # (Copilot R6)
+    if gitea_user_username and not admin_password:
+        missing.append("GITEA_ADMIN_PASS (required when GITEA_USER_USERNAME is set)")
     if missing:
         print(
             f"gitea mirror-setup: missing required env: {', '.join(missing)}",

--- a/src/nexus_deploy/gitea.py
+++ b/src/nexus_deploy/gitea.py
@@ -1019,12 +1019,15 @@ class GiteaClient:
         belongs to the target user (else the fork lands in admin's
         namespace, not the user's). Admin can create tokens on behalf
         of other users via basic-auth (NOT token-auth — token bearer
-        only acts on its own user). Idempotent: on first 201-failure
-        it deletes the token by name and retries.
+        only acts on its own user). Idempotent: on any first-attempt
+        failure (non-200/201, transport, JSON parse, missing sha1)
+        it deletes the token by name and retries once. (Copilot R6 —
+        the previous "201-failure" wording was confusing because 201
+        is the success code; the retry trigger is anything-not-success.)
 
-        Returns the sha1 string on success, None on permanent
-        failure. None routes to a yellow warning + skip-fork at the
-        orchestrator level.
+        Returns the sha1 string on success, None on persistent failure
+        (both attempts return non-success). None routes to a yellow
+        warning + skip-fork at the orchestrator level.
         """
         _validate_path_segment(username, kind="username")
         _validate_path_segment(token_name, kind="token_name")

--- a/src/nexus_deploy/gitea.py
+++ b/src/nexus_deploy/gitea.py
@@ -1697,6 +1697,7 @@ def run_mirror_setup(
 
     mirrors: list[MirrorResult] = []
     fork: ForkResult | None = None
+    last_fork_failure: ForkResult | None = None
     fork_synced = False
     collaborator_added_count = 0
 
@@ -1751,6 +1752,12 @@ def run_mirror_setup(
 
         # Fork the FIRST successful mirror into the user's namespace
         # (idempotent across spin-ups via the existing-fork 409 branch).
+        # On transient failure (token mint glitch, fork POST 5xx),
+        # retry on the next mirror iteration — matches the legacy
+        # deploy.sh's ``FORKED_WORKSPACE`` flag which only got set
+        # to 1 on HTTP 202/409 success. Without retry, a single
+        # bad first mirror would prevent the fork on every later
+        # mirror in the same loop too. (Copilot R3)
         if fork is None and gitea_user_username:
             sanitized = _sanitize_user_for_fork_name(gitea_user_username)
             fork_name = f"{orig_name}_{sanitized}"
@@ -1763,7 +1770,7 @@ def run_mirror_setup(
                 admin_password=admin_password,
             )
             if user_token is None:
-                fork = ForkResult(
+                attempt: ForkResult = ForkResult(
                     name=fork_name,
                     owner=gitea_user_username,
                     status="failed",
@@ -1788,26 +1795,36 @@ def run_mirror_setup(
                     )
 
                 if fork_status == "202":
-                    fork = ForkResult(
+                    attempt = ForkResult(
                         name=fork_name,
                         owner=gitea_user_username,
                         status="created",
                         detail="POST 202",
                     )
                 elif fork_status == "409":
-                    fork = ForkResult(
+                    attempt = ForkResult(
                         name=fork_name,
                         owner=gitea_user_username,
                         status="already_exists",
                         detail="POST 409",
                     )
                 else:
-                    fork = ForkResult(
+                    attempt = ForkResult(
                         name=fork_name,
                         owner=gitea_user_username,
                         status="failed",
                         detail=f"POST {fork_status}",
                     )
+
+            if attempt.status in ("created", "already_exists"):
+                # Finalize — no more fork attempts on later iterations.
+                fork = attempt
+            else:
+                # Transient failure: keep ``fork=None`` so the next
+                # iteration retries. Save the most recent attempt's
+                # diagnostic so the FINAL result still surfaces the
+                # last failure if every iteration fails.
+                last_fork_failure = attempt
 
         # Grant the user read-only access to the mirror (separate from
         # the fork above — every mirror gets the user as collaborator,
@@ -1827,6 +1844,14 @@ def run_mirror_setup(
             # fast-forward attempt. legacy bash sleeps the same.
             time.sleep(mirror_sync_settle_seconds)
             client.merge_upstream(fork.owner, fork.name, workspace_branch)
+
+    # If every fork attempt across the loop failed, surface the last
+    # one's diagnostic in the final result so the operator can see WHY
+    # the fork never succeeded. (Copilot R3 — without this, a multi-
+    # mirror loop where every fork POST fails would return fork=None
+    # which is indistinguishable from the no-user-configured branch.)
+    if fork is None and last_fork_failure is not None:
+        fork = last_fork_failure
 
     return MirrorSetupResult(
         admin_uid=admin_uid,

--- a/src/nexus_deploy/gitea.py
+++ b/src/nexus_deploy/gitea.py
@@ -879,13 +879,13 @@ class GiteaClient:
         the request body as ``auth_token`` and is never logged
         locally or rendered into argv.
 
-        Returns:
-        - ``CreateRepoResult(status="created")`` on 201 + parseable id.
-        - ``CreateRepoResult(status="already_exists")`` on 409 OR 422
-          where the message contains "already exists".
-        - ``CreateRepoResult(status="failed")`` for other non-201 /
-          missing id paths. Caller routes to a yellow warning per
-          mirror so a single bad URL doesn't abort the whole loop.
+        Returns :class:`MirrorResult`:
+        - ``status="created"`` on 201 + parseable id.
+        - ``status="already_exists"`` on 409 OR 422 where the
+          message contains "already exists".
+        - ``status="failed"`` for other non-201 / missing id paths.
+          Caller routes to a yellow warning per mirror so a single
+          bad URL doesn't abort the whole loop.
         """
         _validate_path_segment(repo_name, kind="repo_name")
         body = {
@@ -1701,6 +1701,27 @@ def run_mirror_setup(
             continue
         orig_name = _basename_no_git(repo_url)
         mirror_name = f"mirror-readonly-{orig_name}"
+
+        # Validate the derived mirror_name BEFORE calling repo_exists
+        # / migrate_mirror — both internally invoke
+        # ``_validate_path_segment`` which raises GiteaError on
+        # unsafe values. Without this guard, one bad URL with
+        # shell-meta chars in the basename (e.g.
+        # ``.../repo?evil`` or ``.../repo;sh``) would propagate the
+        # GiteaError out of the loop and turn into rc=2 (hard
+        # abort), defeating the per-mirror-failed-result intent.
+        # (Copilot R1)
+        try:
+            _validate_path_segment(mirror_name, kind="mirror_name")
+        except GiteaError as exc:
+            mirrors.append(
+                MirrorResult(
+                    name=mirror_name,
+                    status="failed",
+                    detail=f"path validation: {exc}",
+                )
+            )
+            continue
 
         # Idempotent re-deploy: skip migration if mirror already exists.
         try:

--- a/src/nexus_deploy/gitea.py
+++ b/src/nexus_deploy/gitea.py
@@ -885,10 +885,13 @@ class GiteaClient:
         locally or rendered into argv.
 
         Returns :class:`MirrorResult`:
-        - ``status="created"`` on 201 + parseable id.
+        - ``status="created"`` on 200 OR 201 with a parseable
+          integer ``id`` in the body. Gitea v1.20+ documents 201
+          for /repos/migrate, but we accept 200 too for forward-
+          compat with older / forked Gitea variants.
         - ``status="already_exists"`` on 409 OR 422 where the
           message contains "already exists".
-        - ``status="failed"`` for other non-201 / missing id paths.
+        - ``status="failed"`` for other non-2xx / missing id paths.
           Caller routes to a yellow warning per mirror so a single
           bad URL doesn't abort the whole loop.
         """
@@ -1613,6 +1616,12 @@ class MirrorSetupResult:
     """
 
     admin_uid: int | None
+    # Diagnostic when admin_uid is None — distinguishes "user
+    # genuinely doesn't exist (404)" from auth/5xx/transport
+    # failures so the CLI can print the real cause instead of
+    # the misleading "admin UID not found". Empty string when
+    # admin_uid was successfully resolved. (Copilot R4)
+    admin_uid_error: str
     mirrors: tuple[MirrorResult, ...]
     fork: ForkResult | None
     collaborator_added_count: int
@@ -1679,16 +1688,27 @@ def run_mirror_setup(
         admin_password=admin_password,
     ).with_token(gitea_token)
 
-    # 1. Admin UID lookup. Failure → no migrate possible (admin
-    # doesn't exist yet, or transport issue). Return early with
-    # admin_uid=None so the CLI can route to a yellow warning.
+    # 1. Admin UID lookup. Failure → no migrate possible. Distinguish
+    # three failure modes so the CLI can surface the real cause
+    # instead of the misleading "admin UID not found" for every path
+    # (Copilot R4):
+    #   - get_user_id raises GiteaError: auth/transport/5xx —
+    #     stash exc message in admin_uid_error
+    #   - get_user_id returns None: 404 (user genuinely doesn't
+    #     exist) — admin_uid_error stays "" but admin_uid is None
+    admin_uid: int | None = None
+    admin_uid_error = ""
     try:
         admin_uid = client.get_user_id(admin_username)
-    except GiteaError:
-        admin_uid = None
+    except GiteaError as exc:
+        # GiteaError messages here are constructed from format
+        # strings only (HTTP status / type names), no secrets —
+        # safe to surface verbatim.
+        admin_uid_error = str(exc)
     if admin_uid is None:
         return MirrorSetupResult(
             admin_uid=None,
+            admin_uid_error=admin_uid_error,
             mirrors=(),
             fork=None,
             collaborator_added_count=0,
@@ -1855,6 +1875,7 @@ def run_mirror_setup(
 
     return MirrorSetupResult(
         admin_uid=admin_uid,
+        admin_uid_error="",  # admin_uid resolved successfully
         mirrors=tuple(mirrors),
         fork=fork,
         collaborator_added_count=collaborator_added_count,

--- a/src/nexus_deploy/gitea.py
+++ b/src/nexus_deploy/gitea.py
@@ -109,6 +109,35 @@ def _validate_path_segment(value: str, *, kind: str) -> None:
         raise GiteaError(f"unsafe {kind}: {value!r}")
 
 
+_USER_FORK_SANITIZE_RE: re.Pattern[str] = re.compile(r"[^a-zA-Z0-9]")
+
+
+def _sanitize_user_for_fork_name(username: str) -> str:
+    """Mirror deploy.sh's ``${GITEA_USER_USERNAME//[^a-zA-Z0-9]/_}``.
+
+    Used to derive a fork repo name like ``<orig>_<sanitized_user>``
+    where the user's username may contain dots or hyphens that
+    Gitea allows in usernames but operators want flattened in repo
+    names. Keeps the legacy naming scheme byte-identical so existing
+    forks across re-deploys keep matching.
+    """
+    return _USER_FORK_SANITIZE_RE.sub("_", username)
+
+
+def _basename_no_git(repo_url: str) -> str:
+    """``basename "$REPO_URL" .git`` — the last path segment with a
+    trailing ``.git`` stripped if present.
+
+    Mirrors deploy.sh's clone-mirror name derivation. Handles both
+    ``https://github.com/owner/repo.git`` and ``https://.../repo``
+    (no .git suffix); both yield ``repo``.
+    """
+    last = repo_url.rstrip("/").rsplit("/", 1)[-1]
+    if last.endswith(".git"):
+        return last[: -len(".git")]
+    return last
+
+
 def _escape_sql_string_literal(value: str) -> str:
     """Escape a value for safe inclusion in a single-quoted SQL string.
 
@@ -219,6 +248,44 @@ class CreateUserResult:
 class CreateRepoResult:
     name: str
     status: CreateRepoStatus
+    detail: str = ""
+
+
+MirrorStatus = Literal["created", "already_exists", "failed"]
+ForkStatus = Literal["created", "already_exists", "skipped", "failed"]
+
+
+@dataclass(frozen=True)
+class MirrorResult:
+    """One pull-mirror entry from the GH_MIRROR_REPOS loop.
+
+    ``name`` is the Gitea-side repo name (``mirror-readonly-<basename>``),
+    NOT the upstream GitHub URL. ``status`` distinguishes the
+    idempotent re-deploy paths: ``already_exists`` is a soft-success
+    (the mirror was created on a previous spin-up), ``created`` means
+    Gitea ran the migration this call, ``failed`` means the migrate
+    POST didn't return a usable id (caller routes to a yellow warning).
+    """
+
+    name: str
+    status: MirrorStatus
+    detail: str = ""
+
+
+@dataclass(frozen=True)
+class ForkResult:
+    """The user-fork carved off the FIRST mirror in the loop.
+
+    Only the first iteration's fork is created (matching the legacy
+    bash's ``FORKED_WORKSPACE`` flag) — there's exactly one workspace
+    repo per stack. ``skipped`` is the no-user-configured branch
+    (``GITEA_USER_USERNAME`` empty); ``failed`` covers fork-creation
+    HTTP failures.
+    """
+
+    name: str
+    owner: str
+    status: ForkStatus
     detail: str = ""
 
 
@@ -764,6 +831,279 @@ class GiteaClient:
         return resp.status_code in (204, 422)
 
     # -------------------------------------------------------------------
+    # Mirror-mode operations (Modul 2.2f part 2)
+    # -------------------------------------------------------------------
+
+    def get_user_id(self, username: str) -> int | None:
+        """``GET /api/v1/users/<u>`` — returns user's numeric id, or None.
+
+        Used by the mirror-migrate flow: Gitea's ``/api/v1/repos/migrate``
+        requires the target owner's UID (not username) in the
+        ``uid`` field. We can't substitute the admin's username
+        directly. None on 404 (user doesn't exist).
+        """
+        _validate_path_segment(username, kind="username")
+        try:
+            resp = requests.get(
+                f"{self.base_url}/api/v1/users/{username}",
+                timeout=_HTTP_TIMEOUT,
+                **self._request_kwargs(),  # type: ignore[arg-type]
+            )
+        except (requests.ConnectionError, requests.Timeout) as exc:
+            raise GiteaError(f"get_user_id transport ({type(exc).__name__})") from exc
+        if resp.status_code == 404:
+            return None
+        if resp.status_code != 200:
+            raise GiteaError(f"get_user_id HTTP {resp.status_code}")
+        try:
+            payload = resp.json()
+        except ValueError as exc:
+            raise GiteaError("get_user_id response was not JSON") from exc
+        uid = payload.get("id") if isinstance(payload, dict) else None
+        return uid if isinstance(uid, int) else None
+
+    def migrate_mirror(
+        self,
+        repo_name: str,
+        clone_url: str,
+        owner_uid: int,
+        github_pat: str,
+        *,
+        mirror_interval: str = "10m0s",
+    ) -> MirrorResult:
+        """``POST /api/v1/repos/migrate`` — clone-mirror a remote repo.
+
+        Mirrors deploy.sh's ``GH_MIRROR_REPOS`` migration call.
+        ``github_pat`` is the GitHub personal access token used by
+        Gitea to clone the (private) source repo; it travels in
+        the request body as ``auth_token`` and is never logged
+        locally or rendered into argv.
+
+        Returns:
+        - ``CreateRepoResult(status="created")`` on 201 + parseable id.
+        - ``CreateRepoResult(status="already_exists")`` on 409 OR 422
+          where the message contains "already exists".
+        - ``CreateRepoResult(status="failed")`` for other non-201 /
+          missing id paths. Caller routes to a yellow warning per
+          mirror so a single bad URL doesn't abort the whole loop.
+        """
+        _validate_path_segment(repo_name, kind="repo_name")
+        body = {
+            "clone_addr": clone_url,
+            "repo_name": repo_name,
+            "private": True,
+            "mirror": True,
+            "mirror_interval": mirror_interval,
+            "auth_token": github_pat,
+            "uid": owner_uid,
+        }
+        try:
+            resp = requests.post(
+                f"{self.base_url}/api/v1/repos/migrate",
+                json=body,
+                timeout=_HTTP_TIMEOUT,
+                **self._request_kwargs(),  # type: ignore[arg-type]
+            )
+        except (requests.ConnectionError, requests.Timeout) as exc:
+            return MirrorResult(
+                name=repo_name,
+                status="failed",
+                detail=f"transport ({type(exc).__name__})",
+            )
+        if resp.status_code in (200, 201):
+            try:
+                payload = resp.json()
+            except ValueError:
+                return MirrorResult(name=repo_name, status="failed", detail="response not JSON")
+            if isinstance(payload, dict) and isinstance(payload.get("id"), int):
+                return MirrorResult(
+                    name=repo_name, status="created", detail=f"POST {resp.status_code}"
+                )
+            return MirrorResult(name=repo_name, status="failed", detail="response missing id")
+        if resp.status_code == 409:
+            return MirrorResult(name=repo_name, status="already_exists", detail="POST 409")
+        if resp.status_code == 422:
+            try:
+                msg = resp.json().get("message", "") if resp.content else ""
+            except ValueError:
+                msg = ""
+            if isinstance(msg, str) and "already exists" in msg.lower():
+                return MirrorResult(
+                    name=repo_name,
+                    status="already_exists",
+                    detail="POST 422 already exists",
+                )
+        return MirrorResult(name=repo_name, status="failed", detail=f"POST {resp.status_code}")
+
+    def trigger_mirror_sync(self, owner: str, name: str) -> bool:
+        """``POST /api/v1/repos/<o>/<n>/mirror-sync`` — pull fresh from upstream.
+
+        Returns True on 200 (Gitea queued the sync), False otherwise.
+        Best-effort: caller doesn't abort on False — the next 10-min
+        cron tick of the mirror schedule will re-sync.
+        """
+        _validate_path_segment(owner, kind="owner")
+        _validate_path_segment(name, kind="repo_name")
+        try:
+            resp = requests.post(
+                f"{self.base_url}/api/v1/repos/{owner}/{name}/mirror-sync",
+                timeout=_HTTP_TIMEOUT,
+                **self._request_kwargs(),  # type: ignore[arg-type]
+            )
+        except (requests.ConnectionError, requests.Timeout):
+            return False
+        return resp.status_code == 200
+
+    def merge_upstream(self, owner: str, name: str, branch: str) -> str:
+        """``POST /api/v1/repos/<o>/<n>/merge-upstream`` — fast-forward fork
+        from its parent's branch. Returns HTTP status code as a string
+        for the caller's dispatch.
+
+        Gitea's responses:
+        - 200: merged (fork advanced)
+        - 409: already up to date
+        - 404: fork doesn't have a parent / branch missing on upstream
+        - 5xx: server-side error
+
+        Returns ``"200"`` / ``"409"`` / etc. or ``"transport"`` on
+        connection failure — caller pattern-matches like the legacy
+        bash's HTTP-code dispatch.
+        """
+        _validate_path_segment(owner, kind="owner")
+        _validate_path_segment(name, kind="repo_name")
+        # Branch may contain a slash (e.g. ``feat/branch``), so it's
+        # passed in the body, not as a URL segment — no path-validation
+        # needed for branch.
+        try:
+            resp = requests.post(
+                f"{self.base_url}/api/v1/repos/{owner}/{name}/merge-upstream",
+                json={"branch": branch},
+                timeout=_HTTP_TIMEOUT,
+                **self._request_kwargs(),  # type: ignore[arg-type]
+            )
+        except (requests.ConnectionError, requests.Timeout):
+            return "transport"
+        return str(resp.status_code)
+
+    def create_user_token(
+        self,
+        username: str,
+        token_name: str,
+        scopes: list[str],
+        *,
+        admin_username: str,
+        admin_password: str,
+    ) -> str | None:
+        """Mint a token for ``username`` using admin's basic-auth.
+
+        Used by the fork flow: forking a mirror needs a token that
+        belongs to the target user (else the fork lands in admin's
+        namespace, not the user's). Admin can create tokens on behalf
+        of other users via basic-auth (NOT token-auth — token bearer
+        only acts on its own user). Idempotent: on first 201-failure
+        it deletes the token by name and retries.
+
+        Returns the sha1 string on success, None on permanent
+        failure. None routes to a yellow warning + skip-fork at the
+        orchestrator level.
+        """
+        _validate_path_segment(username, kind="username")
+        _validate_path_segment(token_name, kind="token_name")
+        body = {"name": token_name, "scopes": scopes}
+        auth = (admin_username, admin_password)
+
+        def _attempt() -> str | None:
+            try:
+                resp = requests.post(
+                    f"{self.base_url}/api/v1/users/{username}/tokens",
+                    json=body,
+                    auth=auth,
+                    timeout=_HTTP_TIMEOUT,
+                )
+            except (requests.ConnectionError, requests.Timeout):
+                return None
+            if resp.status_code not in (200, 201):
+                return None
+            try:
+                payload = resp.json()
+            except ValueError:
+                return None
+            sha1 = payload.get("sha1") if isinstance(payload, dict) else None
+            return sha1 if isinstance(sha1, str) and sha1 else None
+
+        sha1 = _attempt()
+        if sha1:
+            return sha1
+        # First attempt failed — token name may already exist.
+        # Delete and retry once. Errors here are silenced; the next
+        # _attempt() will surface any persistent failure as None.
+        self.delete_user_token(
+            username,
+            token_name,
+            admin_username=admin_username,
+            admin_password=admin_password,
+        )
+        return _attempt()
+
+    def delete_user_token(
+        self,
+        username: str,
+        token_name: str,
+        *,
+        admin_username: str,
+        admin_password: str,
+    ) -> bool:
+        """``DELETE /api/v1/users/<u>/tokens/<n>`` with admin basic-auth.
+
+        Idempotent: 204 + 404 → True. Used by the fork flow to clean
+        up a temp user-token after the fork POST settles, AND to
+        clear a stale token before retrying create_user_token.
+        """
+        _validate_path_segment(username, kind="username")
+        _validate_path_segment(token_name, kind="token_name")
+        try:
+            resp = requests.delete(
+                f"{self.base_url}/api/v1/users/{username}/tokens/{token_name}",
+                auth=(admin_username, admin_password),
+                timeout=_HTTP_TIMEOUT,
+            )
+        except (requests.ConnectionError, requests.Timeout):
+            return False
+        return resp.status_code in (204, 404)
+
+    def fork_repo_as_user(
+        self,
+        source_owner: str,
+        source_name: str,
+        fork_name: str,
+        *,
+        user_token: str,
+    ) -> str:
+        """``POST /api/v1/repos/<o>/<n>/forks`` with the USER's bearer token.
+
+        Returns HTTP status code as a string — caller dispatches:
+        - ``"202"``: Gitea accepted the fork (queued)
+        - ``"409"``: fork already exists in user's namespace
+        - other: failure
+
+        Uses the user's token (not admin's) so the fork lands in the
+        user's namespace. Mirrors deploy.sh's per-user fork pattern.
+        """
+        _validate_path_segment(source_owner, kind="owner")
+        _validate_path_segment(source_name, kind="repo_name")
+        _validate_path_segment(fork_name, kind="fork_name")
+        try:
+            resp = requests.post(
+                f"{self.base_url}/api/v1/repos/{source_owner}/{source_name}/forks",
+                json={"name": fork_name},
+                headers={"Authorization": f"token {user_token}"},
+                timeout=_HTTP_TIMEOUT,
+            )
+        except (requests.ConnectionError, requests.Timeout):
+            return "transport"
+        return str(resp.status_code)
+
+    # -------------------------------------------------------------------
     # OAuth2 application management (Woodpecker CI integration, Modul 2.2f)
     # -------------------------------------------------------------------
 
@@ -1246,3 +1586,226 @@ def run_woodpecker_oauth_setup(
         )
     except GiteaError as exc:
         return None, f"create_oauth_app: {exc}", rotation_started
+
+
+# ---------------------------------------------------------------------------
+# Mirror-mode orchestrator (Modul 2.2f part 2)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class MirrorSetupResult:
+    """Aggregate result of a GH_MIRROR_REPOS spin-up.
+
+    The CLI handler emits ``FORK_NAME=<name>`` + ``GITEA_REPO_OWNER=<owner>``
+    on stdout when ``fork`` reached ``created`` or ``already_exists``,
+    so deploy.sh can call the existing seed-into-fork wrapper post-eval.
+
+    ``is_success`` is True iff every mirror reached ``created`` or
+    ``already_exists`` AND (if a fork was attempted) the fork did
+    too. The CLI maps False → rc=1 (yellow warn, deploy continues —
+    next spin-up retries).
+    """
+
+    admin_uid: int | None
+    mirrors: tuple[MirrorResult, ...]
+    fork: ForkResult | None
+    collaborator_added_count: int
+    fork_synced: bool
+
+    @property
+    def is_success(self) -> bool:
+        if self.admin_uid is None:
+            return False
+        if any(m.status == "failed" for m in self.mirrors):
+            return False
+        return not (self.fork is not None and self.fork.status == "failed")
+
+
+def run_mirror_setup(
+    *,
+    base_url: str,
+    admin_username: str,
+    admin_password: str,
+    gitea_token: str,
+    gitea_user_username: str | None,
+    gh_mirror_repos: list[str],
+    gh_mirror_token: str,
+    workspace_branch: str,
+    fork_token_name: str = "nexus-workspace-fork",  # noqa: S107
+    mirror_sync_settle_seconds: float = 3.0,
+) -> MirrorSetupResult:
+    """End-to-end GH_MIRROR_REPOS provisioning (Modul 2.2f part 2).
+
+    Mirrors deploy.sh's mirror loop (L3224-3412 pre-migration):
+
+    1. GET admin's UID (required by Gitea's migrate API).
+    2. For each repo URL in ``gh_mirror_repos``:
+       a. Compute mirror name ``mirror-readonly-<basename>``.
+       b. POST /repos/migrate (or skip if 409/already_exists).
+       c. On the FIRST mirror with a configured user, fork it
+          into the user's namespace via a temp user-token
+          (created + deleted on this call).
+       d. Add the user as a read-collaborator on the mirror.
+       e. If the fork was created on this iteration: trigger
+          ``mirror-sync`` on the mirror, sleep
+          ``mirror_sync_settle_seconds``, then ``merge-upstream``
+          on the fork at ``workspace_branch``.
+
+    The fork creation (step c) and fork-sync (step e) happen ONLY
+    on the first iteration that has both a successful migrate AND a
+    configured user — same single-fork-per-stack semantics as
+    deploy.sh's ``FORKED_WORKSPACE`` / ``SYNCED_FORK`` flags. Later
+    iterations still do mirror+collab.
+
+    All admin actions use ``gitea_token`` (token-bearer). The fork
+    creation step uses a temporary token minted on behalf of
+    ``gitea_user_username`` via admin basic-auth, then deleted right
+    after — mirrors the legacy bash pattern. Both ``gitea_token`` and
+    ``admin_password`` reach REST as request-auth only, never argv.
+    """
+    # Path safety on admin_username — used in URL interpolation
+    # immediately below.
+    _validate_path_segment(admin_username, kind="admin_username")
+
+    client = GiteaClient(
+        base_url=base_url,
+        admin_username=admin_username,
+        admin_password=admin_password,
+    ).with_token(gitea_token)
+
+    # 1. Admin UID lookup. Failure → no migrate possible (admin
+    # doesn't exist yet, or transport issue). Return early with
+    # admin_uid=None so the CLI can route to a yellow warning.
+    try:
+        admin_uid = client.get_user_id(admin_username)
+    except GiteaError:
+        admin_uid = None
+    if admin_uid is None:
+        return MirrorSetupResult(
+            admin_uid=None,
+            mirrors=(),
+            fork=None,
+            collaborator_added_count=0,
+            fork_synced=False,
+        )
+
+    mirrors: list[MirrorResult] = []
+    fork: ForkResult | None = None
+    fork_synced = False
+    collaborator_added_count = 0
+
+    for repo_url in gh_mirror_repos:
+        repo_url = repo_url.strip()
+        if not repo_url:
+            continue
+        orig_name = _basename_no_git(repo_url)
+        mirror_name = f"mirror-readonly-{orig_name}"
+
+        # Idempotent re-deploy: skip migration if mirror already exists.
+        try:
+            already_present = client.repo_exists(admin_username, mirror_name)
+        except GiteaError:
+            already_present = False
+
+        if already_present:
+            mirror_result = MirrorResult(
+                name=mirror_name,
+                status="already_exists",
+                detail="GET /repos returned 200",
+            )
+        else:
+            mirror_result = client.migrate_mirror(mirror_name, repo_url, admin_uid, gh_mirror_token)
+        mirrors.append(mirror_result)
+
+        if mirror_result.status == "failed":
+            # Don't try to fork off a failed mirror; continue to next
+            # iteration so a single bad URL doesn't abort the loop.
+            continue
+
+        # Fork the FIRST successful mirror into the user's namespace
+        # (idempotent across spin-ups via the existing-fork 409 branch).
+        if fork is None and gitea_user_username:
+            sanitized = _sanitize_user_for_fork_name(gitea_user_username)
+            fork_name = f"{orig_name}_{sanitized}"
+
+            user_token = client.create_user_token(
+                gitea_user_username,
+                fork_token_name,
+                ["all"],
+                admin_username=admin_username,
+                admin_password=admin_password,
+            )
+            if user_token is None:
+                fork = ForkResult(
+                    name=fork_name,
+                    owner=gitea_user_username,
+                    status="failed",
+                    detail="could not create user token for fork",
+                )
+            else:
+                try:
+                    fork_status = client.fork_repo_as_user(
+                        admin_username,
+                        mirror_name,
+                        fork_name,
+                        user_token=user_token,
+                    )
+                finally:
+                    # Always cleanup the temp user-token regardless
+                    # of fork outcome.
+                    client.delete_user_token(
+                        gitea_user_username,
+                        fork_token_name,
+                        admin_username=admin_username,
+                        admin_password=admin_password,
+                    )
+
+                if fork_status == "202":
+                    fork = ForkResult(
+                        name=fork_name,
+                        owner=gitea_user_username,
+                        status="created",
+                        detail="POST 202",
+                    )
+                elif fork_status == "409":
+                    fork = ForkResult(
+                        name=fork_name,
+                        owner=gitea_user_username,
+                        status="already_exists",
+                        detail="POST 409",
+                    )
+                else:
+                    fork = ForkResult(
+                        name=fork_name,
+                        owner=gitea_user_username,
+                        status="failed",
+                        detail=f"POST {fork_status}",
+                    )
+
+        # Grant the user read-only access to the mirror (separate from
+        # the fork above — every mirror gets the user as collaborator,
+        # not just the first).
+        if gitea_user_username and client.add_collaborator(
+            admin_username, mirror_name, gitea_user_username, permission="read"
+        ):
+            collaborator_added_count += 1
+
+        # Sync the fork from upstream — only on the first iteration
+        # where the fork was actually created/already-existed (matches
+        # deploy.sh's SYNCED_FORK flag scoped to the first iteration).
+        if fork is not None and fork.status in ("created", "already_exists") and not fork_synced:
+            fork_synced = True  # set even if the merge below soft-fails
+            client.trigger_mirror_sync(admin_username, mirror_name)
+            # Brief settle for Gitea's async mirror clone before the
+            # fast-forward attempt. legacy bash sleeps the same.
+            time.sleep(mirror_sync_settle_seconds)
+            client.merge_upstream(fork.owner, fork.name, workspace_branch)
+
+    return MirrorSetupResult(
+        admin_uid=admin_uid,
+        mirrors=tuple(mirrors),
+        fork=fork,
+        collaborator_added_count=collaborator_added_count,
+        fork_synced=fork_synced,
+    )

--- a/src/nexus_deploy/gitea.py
+++ b/src/nexus_deploy/gitea.py
@@ -857,6 +857,10 @@ class GiteaClient:
         except (requests.ConnectionError, requests.Timeout) as exc:
             raise GiteaError(f"get_user_id transport ({type(exc).__name__})") from exc
         if resp.status_code == 404:
+            # Genuine "user doesn't exist" — this is the only path
+            # that returns None. Distinct from malformed-response
+            # handling below which raises so the caller can surface
+            # the diagnostic via admin_uid_error.
             return None
         if resp.status_code != 200:
             raise GiteaError(f"get_user_id HTTP {resp.status_code}")
@@ -865,7 +869,14 @@ class GiteaClient:
         except ValueError as exc:
             raise GiteaError("get_user_id response was not JSON") from exc
         uid = payload.get("id") if isinstance(payload, dict) else None
-        return uid if isinstance(uid, int) else None
+        if not isinstance(uid, int):
+            # 200 but the response shape is wrong (proxy mangling,
+            # Gitea schema drift). Raise so admin_uid_error surfaces
+            # the diagnostic — without this, run_mirror_setup would
+            # treat it as a genuine 404 and the CLI would print the
+            # misleading "admin user not found in Gitea". (Copilot R5)
+            raise GiteaError("get_user_id response missing integer 'id'")
+        return uid
 
     def migrate_mirror(
         self,

--- a/src/nexus_deploy/gitea.py
+++ b/src/nexus_deploy/gitea.py
@@ -252,7 +252,7 @@ class CreateRepoResult:
 
 
 MirrorStatus = Literal["created", "already_exists", "failed"]
-ForkStatus = Literal["created", "already_exists", "skipped", "failed"]
+ForkStatus = Literal["created", "already_exists", "failed"]
 
 
 @dataclass(frozen=True)
@@ -278,9 +278,14 @@ class ForkResult:
 
     Only the first iteration's fork is created (matching the legacy
     bash's ``FORKED_WORKSPACE`` flag) — there's exactly one workspace
-    repo per stack. ``skipped`` is the no-user-configured branch
-    (``GITEA_USER_USERNAME`` empty); ``failed`` covers fork-creation
-    HTTP failures.
+    repo per stack. ``status`` is one of ``created`` (POST 202),
+    ``already_exists`` (POST 409 — fork survived a prior deploy),
+    or ``failed`` (HTTP non-2xx-non-409, transport, or temp-token
+    mint failed before the fork POST could run).
+
+    The no-user-configured branch (``GITEA_USER_USERNAME`` empty)
+    leaves :class:`MirrorSetupResult.fork` as ``None`` — no
+    ``ForkResult`` is constructed at all on that path.
     """
 
     name: str

--- a/tests/unit/test_gitea.py
+++ b/tests/unit/test_gitea.py
@@ -2413,6 +2413,35 @@ def test_get_user_id_raises_on_5xx() -> None:
 
 
 @responses.activate
+def test_get_user_id_raises_on_200_with_missing_id() -> None:
+    """200 + payload without integer 'id' (proxy mangling, schema
+    drift) must raise — NOT silently return None. Without this, the
+    caller would treat it as a genuine 404 and the CLI would print
+    the misleading 'admin user not found in Gitea'. (Copilot R5)
+    """
+    responses.add(
+        responses.GET,
+        f"{BASE_URL}/api/v1/users/admin",
+        status=200,
+        json={"login": "admin"},  # id missing
+    )
+    with pytest.raises(GiteaError, match="missing integer 'id'"):
+        _client(token="t").get_user_id("admin")
+
+
+@responses.activate
+def test_get_user_id_raises_on_200_with_non_int_id() -> None:
+    responses.add(
+        responses.GET,
+        f"{BASE_URL}/api/v1/users/admin",
+        status=200,
+        json={"id": "not-an-int", "login": "admin"},
+    )
+    with pytest.raises(GiteaError, match="missing integer 'id'"):
+        _client(token="t").get_user_id("admin")
+
+
+@responses.activate
 def test_migrate_mirror_returns_created_on_201() -> None:
     responses.add(
         responses.POST,

--- a/tests/unit/test_gitea.py
+++ b/tests/unit/test_gitea.py
@@ -2937,6 +2937,51 @@ def test_run_mirror_setup_fork_only_first_iteration() -> None:
 
 
 @responses.activate
+def test_run_mirror_setup_unsafe_basename_marks_failed_and_continues() -> None:
+    """A repo URL whose basename contains shell-meta chars (e.g.
+    ``?`` or ``;``) derives an unsafe ``mirror_name``. Without the
+    pre-validation guard, ``_validate_path_segment`` inside
+    ``repo_exists`` / ``migrate_mirror`` would raise GiteaError out
+    of the loop → CLI rc=2 (hard abort) — defeating the per-mirror
+    failed-result intent. (Copilot R1)
+
+    Now: bad mirror_name → MirrorResult(failed) + continue, the
+    second mirror still gets processed.
+    """
+    responses.add(
+        responses.GET,
+        f"{BASE_URL}/api/v1/users/admin",
+        status=200,
+        json={"id": 1},
+    )
+    # Second mirror succeeds normally.
+    responses.add(responses.GET, f"{BASE_URL}/api/v1/repos/admin/mirror-readonly-good", status=404)
+    responses.add(responses.POST, f"{BASE_URL}/api/v1/repos/migrate", status=201, json={"id": 10})
+
+    result = run_mirror_setup(
+        base_url=BASE_URL,
+        admin_username="admin",
+        admin_password="admin-pw",
+        gitea_token="admin-tok",
+        gitea_user_username=None,
+        gh_mirror_repos=[
+            # Basename "repo?evil" contains '?' — unsafe in path
+            # segment, must NOT propagate as a raised exception.
+            "https://github.com/o/repo?evil.git",
+            "https://github.com/o/good.git",
+        ],
+        gh_mirror_token="ghp",
+        workspace_branch="main",
+        mirror_sync_settle_seconds=0.0,
+    )
+    # Loop did NOT abort — both URLs got processed.
+    assert len(result.mirrors) == 2
+    assert result.mirrors[0].status == "failed"
+    assert "path validation" in result.mirrors[0].detail
+    assert result.mirrors[1].status == "created"
+
+
+@responses.activate
 def test_run_mirror_setup_partial_failure_continues_loop() -> None:
     """One failed mirror in a multi-mirror loop doesn't abort —
     is_success becomes False but other mirrors still get processed.

--- a/tests/unit/test_gitea.py
+++ b/tests/unit/test_gitea.py
@@ -3276,11 +3276,16 @@ def test_cli_mirror_setup_unknown_args_returns_rc_2(
 def test_cli_mirror_setup_missing_env_returns_rc_2(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
+    """Mirrors-only mode (no GITEA_USER_USERNAME) → GITEA_ADMIN_PASS
+    is NOT in the required list (Copilot R6). Only the unconditional
+    three are required.
+    """
     for var in (
         "GITEA_ADMIN_PASS",
         "GITEA_TOKEN",
         "GH_MIRROR_REPOS",
         "GH_MIRROR_TOKEN",
+        "GITEA_USER_USERNAME",
     ):
         monkeypatch.delenv(var, raising=False)
 
@@ -3289,10 +3294,34 @@ def test_cli_mirror_setup_missing_env_returns_rc_2(
     rc = _gitea_mirror_setup([])
     assert rc == 2
     err = capsys.readouterr().err
-    assert "GITEA_ADMIN_PASS" in err
     assert "GITEA_TOKEN" in err
     assert "GH_MIRROR_REPOS" in err
     assert "GH_MIRROR_TOKEN" in err
+    # Mirrors-only mode: GITEA_ADMIN_PASS is conditional, NOT in
+    # the missing list when GITEA_USER_USERNAME is unset.
+    assert "GITEA_ADMIN_PASS" not in err
+
+
+def test_cli_mirror_setup_admin_pass_required_when_user_set(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Fork mode (GITEA_USER_USERNAME set) → GITEA_ADMIN_PASS
+    becomes required because the temp user-token mint inside the
+    fork flow uses admin basic-auth. (Copilot R6)
+    """
+    monkeypatch.setenv("GITEA_USER_USERNAME", "stefan")
+    monkeypatch.setenv("GITEA_TOKEN", "x")
+    monkeypatch.setenv("GH_MIRROR_REPOS", "https://x.git")
+    monkeypatch.setenv("GH_MIRROR_TOKEN", "x")
+    monkeypatch.delenv("GITEA_ADMIN_PASS", raising=False)
+
+    from nexus_deploy.__main__ import _gitea_mirror_setup
+
+    rc = _gitea_mirror_setup([])
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "GITEA_ADMIN_PASS" in err
+    assert "when GITEA_USER_USERNAME is set" in err
 
 
 def test_cli_mirror_setup_empty_repos_csv_returns_rc_2(

--- a/tests/unit/test_gitea.py
+++ b/tests/unit/test_gitea.py
@@ -2937,6 +2937,153 @@ def test_run_mirror_setup_fork_only_first_iteration() -> None:
 
 
 @responses.activate
+def test_run_mirror_setup_fork_retries_on_next_iteration_after_transient_failure() -> None:
+    """Multi-mirror loop: first fork attempt fails (transient
+    user-token mint glitch), second iteration retries the fork
+    against the next mirror and succeeds. Final result shows the
+    successful fork — not the earlier transient failure.
+
+    Mirrors the legacy bash's FORKED_WORKSPACE flag semantics:
+    only set on HTTP 202/409 success, so failure leaves the flag
+    unset and later iterations get another attempt. (Copilot R3)
+    """
+    responses.add(responses.GET, f"{BASE_URL}/api/v1/users/admin", status=200, json={"id": 1})
+    # First mirror: created OK
+    responses.add(responses.GET, f"{BASE_URL}/api/v1/repos/admin/mirror-readonly-r1", status=404)
+    responses.add(responses.POST, f"{BASE_URL}/api/v1/repos/migrate", status=201, json={"id": 10})
+    # First user-token mint: persistent failure (initial + delete + retry)
+    responses.add(responses.POST, f"{BASE_URL}/api/v1/users/stefan/tokens", status=500)
+    responses.add(
+        responses.DELETE,
+        f"{BASE_URL}/api/v1/users/stefan/tokens/nexus-workspace-fork",
+        status=204,
+    )
+    responses.add(responses.POST, f"{BASE_URL}/api/v1/users/stefan/tokens", status=500)
+    # First-iteration collab still happens
+    responses.add(
+        responses.PUT,
+        f"{BASE_URL}/api/v1/repos/admin/mirror-readonly-r1/collaborators/stefan",
+        status=204,
+    )
+    # Second mirror: created OK
+    responses.add(responses.GET, f"{BASE_URL}/api/v1/repos/admin/mirror-readonly-r2", status=404)
+    responses.add(responses.POST, f"{BASE_URL}/api/v1/repos/migrate", status=201, json={"id": 11})
+    # Second iteration: user-token mint succeeds this time
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/users/stefan/tokens",
+        status=201,
+        json={"sha1": "user-tok"},
+    )
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/repos/admin/mirror-readonly-r2/forks",
+        status=202,
+    )
+    responses.add(
+        responses.DELETE,
+        f"{BASE_URL}/api/v1/users/stefan/tokens/nexus-workspace-fork",
+        status=204,
+    )
+    responses.add(
+        responses.PUT,
+        f"{BASE_URL}/api/v1/repos/admin/mirror-readonly-r2/collaborators/stefan",
+        status=204,
+    )
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/repos/admin/mirror-readonly-r2/mirror-sync",
+        status=200,
+    )
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/repos/stefan/r2_stefan/merge-upstream",
+        status=200,
+    )
+
+    result = run_mirror_setup(
+        base_url=BASE_URL,
+        admin_username="admin",
+        admin_password="admin-pw",
+        gitea_token="admin-tok",
+        gitea_user_username="stefan",
+        gh_mirror_repos=[
+            "https://github.com/o/r1.git",
+            "https://github.com/o/r2.git",
+        ],
+        gh_mirror_token="ghp",
+        workspace_branch="main",
+        mirror_sync_settle_seconds=0.0,
+    )
+    # Final fork is the SECOND mirror's successful fork, NOT the
+    # first iteration's transient failure.
+    assert result.fork is not None
+    assert result.fork.status == "created"
+    assert result.fork.name == "r2_stefan"
+    assert result.is_success is True
+    assert result.collaborator_added_count == 2
+
+
+@responses.activate
+def test_run_mirror_setup_surfaces_last_fork_failure_when_every_attempt_fails() -> None:
+    """Multi-mirror loop where every fork attempt fails — final
+    result surfaces the LAST attempt's diagnostic in
+    ``fork.status="failed"`` so the operator can debug. Without
+    this, fork=None would be ambiguous with the no-user-configured
+    branch. (Copilot R3)
+    """
+    responses.add(responses.GET, f"{BASE_URL}/api/v1/users/admin", status=200, json={"id": 1})
+    # Both mirrors create OK; both fork attempts fail (user-token
+    # mint persistent fail).
+    for repo in ("r1", "r2"):
+        responses.add(
+            responses.GET,
+            f"{BASE_URL}/api/v1/repos/admin/mirror-readonly-{repo}",
+            status=404,
+        )
+        responses.add(
+            responses.POST,
+            f"{BASE_URL}/api/v1/repos/migrate",
+            status=201,
+            json={"id": 10},
+        )
+        responses.add(responses.POST, f"{BASE_URL}/api/v1/users/stefan/tokens", status=500)
+        responses.add(
+            responses.DELETE,
+            f"{BASE_URL}/api/v1/users/stefan/tokens/nexus-workspace-fork",
+            status=204,
+        )
+        responses.add(responses.POST, f"{BASE_URL}/api/v1/users/stefan/tokens", status=500)
+        responses.add(
+            responses.PUT,
+            f"{BASE_URL}/api/v1/repos/admin/mirror-readonly-{repo}/collaborators/stefan",
+            status=204,
+        )
+
+    result = run_mirror_setup(
+        base_url=BASE_URL,
+        admin_username="admin",
+        admin_password="admin-pw",
+        gitea_token="admin-tok",
+        gitea_user_username="stefan",
+        gh_mirror_repos=[
+            "https://github.com/o/r1.git",
+            "https://github.com/o/r2.git",
+        ],
+        gh_mirror_token="ghp",
+        workspace_branch="main",
+        mirror_sync_settle_seconds=0.0,
+    )
+    # fork=last_fork_failure (the second iteration's attempt) so the
+    # operator sees a diagnostic — not None.
+    assert result.fork is not None
+    assert result.fork.status == "failed"
+    assert result.fork.name == "r2_stefan"
+    assert "user token" in result.fork.detail
+    assert result.is_success is False
+
+
+@responses.activate
 def test_run_mirror_setup_unsafe_basename_marks_failed_and_continues() -> None:
     """A repo URL whose basename contains shell-meta chars (e.g.
     ``?`` or ``;``) derives an unsafe ``mirror_name``. Without the

--- a/tests/unit/test_gitea.py
+++ b/tests/unit/test_gitea.py
@@ -36,13 +36,17 @@ from nexus_deploy.gitea import (
     GiteaClient,
     GiteaError,
     GiteaResult,
+    MirrorResult,
     OAuthAppResult,
+    _basename_no_git,
     _compute_restart_services,
     _escape_sql_string_literal,
     _parse_admin_list_for_user,
     _render_db_pw_sync_script,
+    _sanitize_user_for_fork_name,
     _validate_path_segment,
     run_configure_gitea,
+    run_mirror_setup,
     run_woodpecker_oauth_setup,
 )
 
@@ -2345,6 +2349,877 @@ def test_cli_woodpecker_oauth_unexpected_exception_returns_rc_2(
     # Type name only — message body MUST NOT leak.
     assert "RuntimeError" in err
     assert secret_in_msg not in err
+
+
+# ---------------------------------------------------------------------------
+# Mirror-mode helpers (Modul 2.2f part 2)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    [
+        ("https://github.com/owner/repo.git", "repo"),
+        ("https://github.com/owner/repo", "repo"),
+        ("https://github.com/owner/Bsc_EDS_GIS_FS2026.git", "Bsc_EDS_GIS_FS2026"),
+        ("https://gitea.foo.com/o/r.git/", "r"),  # trailing slash stripped
+    ],
+)
+def test_basename_no_git(url: str, expected: str) -> None:
+    assert _basename_no_git(url) == expected
+
+
+@pytest.mark.parametrize(
+    ("user", "expected"),
+    [
+        ("admin", "admin"),
+        ("stefan.koch", "stefan_koch"),
+        ("user-with-dash", "user_with_dash"),
+        ("user.with.dots-and-dashes", "user_with_dots_and_dashes"),
+        ("UPPER_lower", "UPPER_lower"),  # underscore is alphanumeric-safe-ish in regex
+    ],
+)
+def test_sanitize_user_for_fork_name(user: str, expected: str) -> None:
+    assert _sanitize_user_for_fork_name(user) == expected
+
+
+# ---------------------------------------------------------------------------
+# GiteaClient mirror REST methods
+# ---------------------------------------------------------------------------
+
+
+@responses.activate
+def test_get_user_id_returns_int_on_200() -> None:
+    responses.add(
+        responses.GET,
+        f"{BASE_URL}/api/v1/users/admin",
+        status=200,
+        json={"id": 42, "login": "admin"},
+    )
+    assert _client(token="t").get_user_id("admin") == 42
+
+
+@responses.activate
+def test_get_user_id_returns_none_on_404() -> None:
+    responses.add(responses.GET, f"{BASE_URL}/api/v1/users/admin", status=404)
+    assert _client(token="t").get_user_id("admin") is None
+
+
+@responses.activate
+def test_get_user_id_raises_on_5xx() -> None:
+    responses.add(responses.GET, f"{BASE_URL}/api/v1/users/admin", status=500)
+    with pytest.raises(GiteaError, match="HTTP 500"):
+        _client(token="t").get_user_id("admin")
+
+
+@responses.activate
+def test_migrate_mirror_returns_created_on_201() -> None:
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/repos/migrate",
+        status=201,
+        json={"id": 10, "name": "mirror-readonly-x"},
+    )
+    result = _client(token="t").migrate_mirror(
+        "mirror-readonly-x", "https://github.com/o/x.git", 1, "ghp_xxx"
+    )
+    assert result.status == "created"
+    body = json.loads(responses.calls[0].request.body)  # type: ignore[arg-type]
+    assert body["clone_addr"] == "https://github.com/o/x.git"
+    assert body["repo_name"] == "mirror-readonly-x"
+    assert body["mirror"] is True
+    assert body["mirror_interval"] == "10m0s"
+    assert body["uid"] == 1
+    # GitHub PAT travels in body, never in URL/headers
+    assert body["auth_token"] == "ghp_xxx"
+    assert "ghp_xxx" not in (responses.calls[0].request.url or "")
+
+
+@responses.activate
+def test_migrate_mirror_409_returns_already_exists() -> None:
+    responses.add(responses.POST, f"{BASE_URL}/api/v1/repos/migrate", status=409)
+    result = _client(token="t").migrate_mirror("mirror-readonly-x", "https://x.git", 1, "ghp")
+    assert result.status == "already_exists"
+
+
+@responses.activate
+def test_migrate_mirror_422_already_exists_returns_already_exists() -> None:
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/repos/migrate",
+        status=422,
+        json={"message": "repository already exists"},
+    )
+    result = _client(token="t").migrate_mirror("mirror-readonly-x", "https://x.git", 1, "ghp")
+    assert result.status == "already_exists"
+
+
+@responses.activate
+def test_migrate_mirror_5xx_returns_failed() -> None:
+    responses.add(responses.POST, f"{BASE_URL}/api/v1/repos/migrate", status=503)
+    result = _client(token="t").migrate_mirror("mirror-readonly-x", "https://x.git", 1, "ghp")
+    assert result.status == "failed"
+    assert "503" in result.detail
+
+
+@responses.activate
+def test_trigger_mirror_sync_200_returns_true() -> None:
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/repos/admin/mirror-readonly-x/mirror-sync",
+        status=200,
+    )
+    assert _client(token="t").trigger_mirror_sync("admin", "mirror-readonly-x")
+
+
+@responses.activate
+def test_trigger_mirror_sync_returns_false_on_non_200() -> None:
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/repos/admin/mirror-readonly-x/mirror-sync",
+        status=403,
+    )
+    assert not _client(token="t").trigger_mirror_sync("admin", "mirror-readonly-x")
+
+
+@responses.activate
+def test_merge_upstream_returns_status_string() -> None:
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/repos/user/fork/merge-upstream",
+        status=200,
+    )
+    rc = _client(token="t").merge_upstream("user", "fork", "main")
+    assert rc == "200"
+    body = json.loads(responses.calls[0].request.body)  # type: ignore[arg-type]
+    assert body == {"branch": "main"}
+
+
+@responses.activate
+def test_merge_upstream_409_already_up_to_date() -> None:
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/repos/user/fork/merge-upstream",
+        status=409,
+    )
+    assert _client(token="t").merge_upstream("user", "fork", "main") == "409"
+
+
+@responses.activate
+def test_merge_upstream_handles_non_main_branch() -> None:
+    """merge-upstream supports any branch — `master`-default upstreams
+    were broken when deploy.sh hardcoded `main`. Verify the body
+    branch is whatever caller passes.
+    """
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/repos/user/fork/merge-upstream",
+        status=200,
+    )
+    _client(token="t").merge_upstream("user", "fork", "master")
+    body = json.loads(responses.calls[0].request.body)  # type: ignore[arg-type]
+    assert body["branch"] == "master"
+
+
+@responses.activate
+def test_create_user_token_uses_basic_auth_not_bearer() -> None:
+    """Admin creating a token on behalf of a user MUST use basic-auth.
+
+    Token-bearer auth would only let admin act on its own user
+    (Gitea constraint). Regression test pins this contract: the
+    request must carry an Authorization: Basic ... header, not
+    a token header.
+    """
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/users/stefan/tokens",
+        status=201,
+        json={"sha1": "abc-user-token"},
+    )
+    sha1 = _client().create_user_token(
+        "stefan",
+        "nexus-workspace-fork",
+        ["all"],
+        admin_username="admin",
+        admin_password="admin-pw",
+    )
+    assert sha1 == "abc-user-token"
+    auth_header = responses.calls[0].request.headers.get("Authorization", "")
+    assert auth_header.startswith("Basic ")
+    # NOT a token-bearer
+    assert not auth_header.startswith("token ")
+
+
+@responses.activate
+def test_create_user_token_retries_via_delete_on_first_failure() -> None:
+    """On first 4xx (token name conflict), delete + retry once."""
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/users/stefan/tokens",
+        status=409,
+    )
+    responses.add(
+        responses.DELETE,
+        f"{BASE_URL}/api/v1/users/stefan/tokens/nexus-workspace-fork",
+        status=204,
+    )
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/users/stefan/tokens",
+        status=201,
+        json={"sha1": "fresh-token"},
+    )
+    sha1 = _client().create_user_token(
+        "stefan",
+        "nexus-workspace-fork",
+        ["all"],
+        admin_username="admin",
+        admin_password="admin-pw",
+    )
+    assert sha1 == "fresh-token"
+    assert [c.request.method for c in responses.calls] == ["POST", "DELETE", "POST"]
+
+
+@responses.activate
+def test_create_user_token_returns_none_on_persistent_failure() -> None:
+    responses.add(responses.POST, f"{BASE_URL}/api/v1/users/stefan/tokens", status=500)
+    responses.add(
+        responses.DELETE,
+        f"{BASE_URL}/api/v1/users/stefan/tokens/nexus-workspace-fork",
+        status=204,
+    )
+    responses.add(responses.POST, f"{BASE_URL}/api/v1/users/stefan/tokens", status=500)
+    sha1 = _client().create_user_token(
+        "stefan",
+        "nexus-workspace-fork",
+        ["all"],
+        admin_username="admin",
+        admin_password="admin-pw",
+    )
+    assert sha1 is None
+
+
+@responses.activate
+def test_fork_repo_as_user_uses_user_token_not_admin_token() -> None:
+    """Fork POST must use the USER's bearer token so the fork lands in
+    the user's namespace, not admin's. Regression test pins the auth.
+    """
+    user_token = "user-bearer-do-not-leak"
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/repos/admin/mirror-readonly-x/forks",
+        status=202,
+    )
+    rc = _client(token="ADMIN-TOKEN-WRONG").fork_repo_as_user(
+        "admin", "mirror-readonly-x", "x_stefan", user_token=user_token
+    )
+    assert rc == "202"
+    auth = responses.calls[0].request.headers.get("Authorization", "")
+    # User token in header, NOT admin token
+    assert auth == f"token {user_token}"
+    assert "ADMIN-TOKEN-WRONG" not in auth
+
+
+# ---------------------------------------------------------------------------
+# run_mirror_setup orchestrator
+# ---------------------------------------------------------------------------
+
+
+@responses.activate
+def test_run_mirror_setup_happy_path_with_user() -> None:
+    """One mirror, one user → mirror created, fork created, collab added,
+    fork synced via mirror-sync + merge-upstream.
+    """
+    # admin UID lookup
+    responses.add(
+        responses.GET,
+        f"{BASE_URL}/api/v1/users/admin",
+        status=200,
+        json={"id": 1},
+    )
+    # Idempotent existence check (mirror does not exist yet)
+    responses.add(
+        responses.GET,
+        f"{BASE_URL}/api/v1/repos/admin/mirror-readonly-myrepo",
+        status=404,
+    )
+    # migrate POST
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/repos/migrate",
+        status=201,
+        json={"id": 10},
+    )
+    # user-token mint (basic-auth)
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/users/stefan/tokens",
+        status=201,
+        json={"sha1": "user-tok"},
+    )
+    # fork POST (user's bearer)
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/repos/admin/mirror-readonly-myrepo/forks",
+        status=202,
+    )
+    # cleanup user-token
+    responses.add(
+        responses.DELETE,
+        f"{BASE_URL}/api/v1/users/stefan/tokens/nexus-workspace-fork",
+        status=204,
+    )
+    # collaborator add
+    responses.add(
+        responses.PUT,
+        f"{BASE_URL}/api/v1/repos/admin/mirror-readonly-myrepo/collaborators/stefan",
+        status=204,
+    )
+    # mirror-sync
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/repos/admin/mirror-readonly-myrepo/mirror-sync",
+        status=200,
+    )
+    # merge-upstream (fork)
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/repos/stefan/myrepo_stefan/merge-upstream",
+        status=200,
+    )
+
+    result = run_mirror_setup(
+        base_url=BASE_URL,
+        admin_username="admin",
+        admin_password="admin-pw",
+        gitea_token="admin-tok",
+        gitea_user_username="stefan",
+        gh_mirror_repos=["https://github.com/o/myrepo.git"],
+        gh_mirror_token="ghp_xxx",
+        workspace_branch="main",
+        mirror_sync_settle_seconds=0.0,  # don't sleep in tests
+    )
+    assert result.is_success is True
+    assert result.admin_uid == 1
+    assert len(result.mirrors) == 1
+    assert result.mirrors[0].status == "created"
+    assert result.fork is not None
+    assert result.fork.owner == "stefan"
+    assert result.fork.name == "myrepo_stefan"
+    assert result.fork.status == "created"
+    assert result.collaborator_added_count == 1
+    assert result.fork_synced is True
+
+
+@responses.activate
+def test_run_mirror_setup_idempotent_skips_existing_mirror() -> None:
+    """Mirror already exists → skip migrate, still do fork+collab+sync."""
+    responses.add(
+        responses.GET,
+        f"{BASE_URL}/api/v1/users/admin",
+        status=200,
+        json={"id": 1},
+    )
+    # existence check returns 200 — skip migrate
+    responses.add(
+        responses.GET,
+        f"{BASE_URL}/api/v1/repos/admin/mirror-readonly-myrepo",
+        status=200,
+    )
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/users/stefan/tokens",
+        status=201,
+        json={"sha1": "tok"},
+    )
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/repos/admin/mirror-readonly-myrepo/forks",
+        status=409,  # fork already exists too
+    )
+    responses.add(
+        responses.DELETE,
+        f"{BASE_URL}/api/v1/users/stefan/tokens/nexus-workspace-fork",
+        status=204,
+    )
+    responses.add(
+        responses.PUT,
+        f"{BASE_URL}/api/v1/repos/admin/mirror-readonly-myrepo/collaborators/stefan",
+        status=204,
+    )
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/repos/admin/mirror-readonly-myrepo/mirror-sync",
+        status=200,
+    )
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/repos/stefan/myrepo_stefan/merge-upstream",
+        status=409,
+    )
+
+    result = run_mirror_setup(
+        base_url=BASE_URL,
+        admin_username="admin",
+        admin_password="admin-pw",
+        gitea_token="admin-tok",
+        gitea_user_username="stefan",
+        gh_mirror_repos=["https://github.com/o/myrepo.git"],
+        gh_mirror_token="ghp",
+        workspace_branch="main",
+        mirror_sync_settle_seconds=0.0,
+    )
+    assert result.is_success is True
+    assert result.mirrors[0].status == "already_exists"
+    assert result.fork is not None
+    assert result.fork.status == "already_exists"
+    # POST migrate must NOT have been issued (idempotent skip).
+    assert all(c.request.url != f"{BASE_URL}/api/v1/repos/migrate" for c in responses.calls)
+
+
+@responses.activate
+def test_run_mirror_setup_no_user_skips_fork() -> None:
+    """gitea_user_username=None → mirror+collab branches skipped where
+    user-dependent. fork=None.
+    """
+    responses.add(
+        responses.GET,
+        f"{BASE_URL}/api/v1/users/admin",
+        status=200,
+        json={"id": 1},
+    )
+    responses.add(
+        responses.GET,
+        f"{BASE_URL}/api/v1/repos/admin/mirror-readonly-x",
+        status=404,
+    )
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/repos/migrate",
+        status=201,
+        json={"id": 10},
+    )
+    # No fork mocks, no collab mock — should not be called.
+
+    result = run_mirror_setup(
+        base_url=BASE_URL,
+        admin_username="admin",
+        admin_password="admin-pw",
+        gitea_token="admin-tok",
+        gitea_user_username=None,
+        gh_mirror_repos=["https://github.com/o/x.git"],
+        gh_mirror_token="ghp",
+        workspace_branch="main",
+        mirror_sync_settle_seconds=0.0,
+    )
+    assert result.is_success is True
+    assert result.fork is None
+    assert result.collaborator_added_count == 0
+    assert result.fork_synced is False
+
+
+@responses.activate
+def test_run_mirror_setup_returns_no_admin_uid_early() -> None:
+    """Admin UID lookup 404 → return early with admin_uid=None and
+    is_success=False (CLI rc=1).
+    """
+    responses.add(responses.GET, f"{BASE_URL}/api/v1/users/admin", status=404)
+    result = run_mirror_setup(
+        base_url=BASE_URL,
+        admin_username="admin",
+        admin_password="admin-pw",
+        gitea_token="admin-tok",
+        gitea_user_username="stefan",
+        gh_mirror_repos=["https://github.com/o/x.git"],
+        gh_mirror_token="ghp",
+        workspace_branch="main",
+        mirror_sync_settle_seconds=0.0,
+    )
+    assert result.admin_uid is None
+    assert result.mirrors == ()
+    assert result.fork is None
+    assert result.is_success is False
+
+
+@responses.activate
+def test_run_mirror_setup_fork_only_first_iteration() -> None:
+    """Multi-mirror: fork only happens on the first successful mirror
+    even when later iterations also succeed (matches the legacy
+    FORKED_WORKSPACE flag scoped to first iteration).
+    """
+    responses.add(
+        responses.GET,
+        f"{BASE_URL}/api/v1/users/admin",
+        status=200,
+        json={"id": 1},
+    )
+    # Two mirrors, both new
+    responses.add(responses.GET, f"{BASE_URL}/api/v1/repos/admin/mirror-readonly-r1", status=404)
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/repos/migrate",
+        status=201,
+        json={"id": 10},
+    )
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/users/stefan/tokens",
+        status=201,
+        json={"sha1": "tok"},
+    )
+    # Fork the FIRST one
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/repos/admin/mirror-readonly-r1/forks",
+        status=202,
+    )
+    responses.add(
+        responses.DELETE,
+        f"{BASE_URL}/api/v1/users/stefan/tokens/nexus-workspace-fork",
+        status=204,
+    )
+    # First-iteration collab + sync
+    responses.add(
+        responses.PUT,
+        f"{BASE_URL}/api/v1/repos/admin/mirror-readonly-r1/collaborators/stefan",
+        status=204,
+    )
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/repos/admin/mirror-readonly-r1/mirror-sync",
+        status=200,
+    )
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/repos/stefan/r1_stefan/merge-upstream",
+        status=200,
+    )
+    # Second iteration: mirror still gets created + collab, but no fork
+    responses.add(responses.GET, f"{BASE_URL}/api/v1/repos/admin/mirror-readonly-r2", status=404)
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/repos/migrate",
+        status=201,
+        json={"id": 11},
+    )
+    responses.add(
+        responses.PUT,
+        f"{BASE_URL}/api/v1/repos/admin/mirror-readonly-r2/collaborators/stefan",
+        status=204,
+    )
+
+    result = run_mirror_setup(
+        base_url=BASE_URL,
+        admin_username="admin",
+        admin_password="admin-pw",
+        gitea_token="admin-tok",
+        gitea_user_username="stefan",
+        gh_mirror_repos=[
+            "https://github.com/o/r1.git",
+            "https://github.com/o/r2.git",
+        ],
+        gh_mirror_token="ghp",
+        workspace_branch="main",
+        mirror_sync_settle_seconds=0.0,
+    )
+    assert result.is_success is True
+    assert len(result.mirrors) == 2
+    assert all(m.status == "created" for m in result.mirrors)
+    # Only ONE fork (from the first mirror)
+    assert result.fork is not None
+    assert result.fork.name == "r1_stefan"
+    # Both mirrors got the collaborator
+    assert result.collaborator_added_count == 2
+    # No fork POST against r2
+    fork_calls = [c for c in responses.calls if "/forks" in (c.request.url or "")]
+    assert len(fork_calls) == 1
+    assert "mirror-readonly-r1" in (fork_calls[0].request.url or "")
+
+
+@responses.activate
+def test_run_mirror_setup_partial_failure_continues_loop() -> None:
+    """One failed mirror in a multi-mirror loop doesn't abort —
+    is_success becomes False but other mirrors still get processed.
+    """
+    responses.add(
+        responses.GET,
+        f"{BASE_URL}/api/v1/users/admin",
+        status=200,
+        json={"id": 1},
+    )
+    # First mirror fails
+    responses.add(responses.GET, f"{BASE_URL}/api/v1/repos/admin/mirror-readonly-bad", status=404)
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/repos/migrate",
+        status=503,
+    )
+    # Second mirror succeeds
+    responses.add(responses.GET, f"{BASE_URL}/api/v1/repos/admin/mirror-readonly-good", status=404)
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/repos/migrate",
+        status=201,
+        json={"id": 10},
+    )
+
+    result = run_mirror_setup(
+        base_url=BASE_URL,
+        admin_username="admin",
+        admin_password="admin-pw",
+        gitea_token="admin-tok",
+        gitea_user_username=None,  # no fork to keep test focused
+        gh_mirror_repos=[
+            "https://github.com/o/bad.git",
+            "https://github.com/o/good.git",
+        ],
+        gh_mirror_token="ghp",
+        workspace_branch="main",
+        mirror_sync_settle_seconds=0.0,
+    )
+    assert len(result.mirrors) == 2
+    assert result.mirrors[0].status == "failed"
+    assert result.mirrors[1].status == "created"
+    assert result.is_success is False  # because one mirror failed
+
+
+@responses.activate
+def test_run_mirror_setup_user_token_failure_marks_fork_failed() -> None:
+    """user-token mint persistently fails → fork status='failed', no
+    fork POST attempted.
+    """
+    responses.add(
+        responses.GET,
+        f"{BASE_URL}/api/v1/users/admin",
+        status=200,
+        json={"id": 1},
+    )
+    responses.add(responses.GET, f"{BASE_URL}/api/v1/repos/admin/mirror-readonly-r", status=404)
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/repos/migrate",
+        status=201,
+        json={"id": 10},
+    )
+    # Both user-token POST attempts fail (initial + post-delete retry)
+    responses.add(responses.POST, f"{BASE_URL}/api/v1/users/stefan/tokens", status=500)
+    responses.add(
+        responses.DELETE,
+        f"{BASE_URL}/api/v1/users/stefan/tokens/nexus-workspace-fork",
+        status=204,
+    )
+    responses.add(responses.POST, f"{BASE_URL}/api/v1/users/stefan/tokens", status=500)
+    responses.add(
+        responses.PUT,
+        f"{BASE_URL}/api/v1/repos/admin/mirror-readonly-r/collaborators/stefan",
+        status=204,
+    )
+
+    result = run_mirror_setup(
+        base_url=BASE_URL,
+        admin_username="admin",
+        admin_password="admin-pw",
+        gitea_token="admin-tok",
+        gitea_user_username="stefan",
+        gh_mirror_repos=["https://github.com/o/r.git"],
+        gh_mirror_token="ghp",
+        workspace_branch="main",
+        mirror_sync_settle_seconds=0.0,
+    )
+    assert result.fork is not None
+    assert result.fork.status == "failed"
+    assert "user token" in result.fork.detail
+    assert result.is_success is False
+    # Collab still attempted
+    assert result.collaborator_added_count == 1
+    # No fork POST issued
+    fork_calls = [c for c in responses.calls if "/forks" in (c.request.url or "")]
+    assert len(fork_calls) == 0
+
+
+# ---------------------------------------------------------------------------
+# CLI handler for `gitea mirror-setup`
+# ---------------------------------------------------------------------------
+
+
+def test_cli_mirror_setup_unknown_args_returns_rc_2(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from nexus_deploy.__main__ import _gitea_mirror_setup
+
+    rc = _gitea_mirror_setup(["--bogus"])
+    assert rc == 2
+    assert "unknown args" in capsys.readouterr().err
+
+
+def test_cli_mirror_setup_missing_env_returns_rc_2(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    for var in (
+        "GITEA_ADMIN_PASS",
+        "GITEA_TOKEN",
+        "GH_MIRROR_REPOS",
+        "GH_MIRROR_TOKEN",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+    from nexus_deploy.__main__ import _gitea_mirror_setup
+
+    rc = _gitea_mirror_setup([])
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "GITEA_ADMIN_PASS" in err
+    assert "GITEA_TOKEN" in err
+    assert "GH_MIRROR_REPOS" in err
+    assert "GH_MIRROR_TOKEN" in err
+
+
+def test_cli_mirror_setup_empty_repos_csv_returns_rc_2(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setenv("GITEA_ADMIN_PASS", "x")
+    monkeypatch.setenv("GITEA_TOKEN", "x")
+    monkeypatch.setenv("GH_MIRROR_REPOS", " , ,")  # only whitespace + commas
+    monkeypatch.setenv("GH_MIRROR_TOKEN", "x")
+
+    from nexus_deploy.__main__ import _gitea_mirror_setup
+
+    rc = _gitea_mirror_setup([])
+    assert rc == 2
+    assert "no repo URLs" in capsys.readouterr().err
+
+
+def test_cli_mirror_setup_emits_fork_name_and_owner_on_success(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Happy path stdout: FORK_NAME=<name> + GITEA_REPO_OWNER=<user>
+    eval-able. Required by deploy.sh's seed_workspace_files post-eval.
+    """
+    from nexus_deploy.gitea import ForkResult, MirrorSetupResult
+
+    monkeypatch.setenv("GITEA_ADMIN_PASS", "x")
+    monkeypatch.setenv("GITEA_TOKEN", "x")
+    monkeypatch.setenv("GH_MIRROR_REPOS", "https://x.git")
+    monkeypatch.setenv("GH_MIRROR_TOKEN", "x")
+    monkeypatch.setenv("GITEA_USER_USERNAME", "stefan")
+    _setup_fake_ssh(monkeypatch)
+
+    fake_result = MirrorSetupResult(
+        admin_uid=42,
+        mirrors=(MirrorResult(name="m", status="created"),),
+        fork=ForkResult(name="myrepo_stefan", owner="stefan", status="created"),
+        collaborator_added_count=1,
+        fork_synced=True,
+    )
+    monkeypatch.setattr("nexus_deploy.__main__.run_mirror_setup", lambda **kwargs: fake_result)
+
+    from nexus_deploy.__main__ import _gitea_mirror_setup
+
+    rc = _gitea_mirror_setup([])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "FORK_NAME='myrepo_stefan'" in out or "FORK_NAME=myrepo_stefan" in out
+    assert "GITEA_REPO_OWNER='stefan'" in out or "GITEA_REPO_OWNER=stefan" in out
+
+
+def test_cli_mirror_setup_omits_stdout_when_no_fork(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """No fork (no user, or fork failed) → empty stdout. deploy.sh's
+    seed wrapper falls back to its existing $REPO_NAME / $GITEA_REPO_OWNER.
+    """
+    from nexus_deploy.gitea import MirrorSetupResult
+
+    monkeypatch.setenv("GITEA_ADMIN_PASS", "x")
+    monkeypatch.setenv("GITEA_TOKEN", "x")
+    monkeypatch.setenv("GH_MIRROR_REPOS", "https://x.git")
+    monkeypatch.setenv("GH_MIRROR_TOKEN", "x")
+    monkeypatch.delenv("GITEA_USER_USERNAME", raising=False)
+    _setup_fake_ssh(monkeypatch)
+
+    fake_result = MirrorSetupResult(
+        admin_uid=42,
+        mirrors=(MirrorResult(name="m", status="created"),),
+        fork=None,
+        collaborator_added_count=0,
+        fork_synced=False,
+    )
+    monkeypatch.setattr("nexus_deploy.__main__.run_mirror_setup", lambda **kwargs: fake_result)
+
+    from nexus_deploy.__main__ import _gitea_mirror_setup
+
+    rc = _gitea_mirror_setup([])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "FORK_NAME" not in out
+    assert "GITEA_REPO_OWNER" not in out
+
+
+def test_cli_mirror_setup_admin_uid_none_returns_rc_1(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from nexus_deploy.gitea import MirrorSetupResult
+
+    monkeypatch.setenv("GITEA_ADMIN_PASS", "x")
+    monkeypatch.setenv("GITEA_TOKEN", "x")
+    monkeypatch.setenv("GH_MIRROR_REPOS", "https://x.git")
+    monkeypatch.setenv("GH_MIRROR_TOKEN", "x")
+    _setup_fake_ssh(monkeypatch)
+
+    fake_result = MirrorSetupResult(
+        admin_uid=None,
+        mirrors=(),
+        fork=None,
+        collaborator_added_count=0,
+        fork_synced=False,
+    )
+    monkeypatch.setattr("nexus_deploy.__main__.run_mirror_setup", lambda **kwargs: fake_result)
+
+    from nexus_deploy.__main__ import _gitea_mirror_setup
+
+    rc = _gitea_mirror_setup([])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "admin UID not found" in err
+
+
+def test_cli_mirror_setup_ssh_tunnel_failure_returns_rc_2(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setenv("GITEA_ADMIN_PASS", "x")
+    monkeypatch.setenv("GITEA_TOKEN", "x")
+    monkeypatch.setenv("GH_MIRROR_REPOS", "https://x.git")
+    monkeypatch.setenv("GH_MIRROR_TOKEN", "x")
+
+    from nexus_deploy.ssh import SSHError
+
+    class _BoomSSH:
+        def __init__(self, _host: str) -> None: ...
+        def __enter__(self) -> _BoomSSH:
+            return self
+
+        def __exit__(self, *_: Any) -> None: ...
+        def port_forward(self, *_a: Any, **_k: Any) -> Any:
+            raise SSHError("ssh tunnel boom")
+
+    monkeypatch.setattr("nexus_deploy.__main__.SSHClient", _BoomSSH)
+
+    from nexus_deploy.__main__ import _gitea_mirror_setup
+
+    rc = _gitea_mirror_setup([])
+    assert rc == 2
+    assert "ssh tunnel" in capsys.readouterr().err
+
+
+def test_cli_dispatcher_routes_mirror_setup(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(sys, "argv", ["nexus_deploy", "gitea", "mirror-setup", "--bogus"])
+    from nexus_deploy.__main__ import main
+
+    rc = main()
+    assert rc == 2
+    assert "mirror-setup" in capsys.readouterr().err
 
 
 def test_cli_dispatcher_routes_woodpecker_oauth(

--- a/tests/unit/test_gitea.py
+++ b/tests/unit/test_gitea.py
@@ -3298,6 +3298,7 @@ def test_cli_mirror_setup_emits_fork_name_and_owner_on_success(
 
     fake_result = MirrorSetupResult(
         admin_uid=42,
+        admin_uid_error="",
         mirrors=(MirrorResult(name="m", status="created"),),
         fork=ForkResult(name="myrepo_stefan", owner="stefan", status="created"),
         collaborator_added_count=1,
@@ -3331,6 +3332,7 @@ def test_cli_mirror_setup_omits_stdout_when_no_fork(
 
     fake_result = MirrorSetupResult(
         admin_uid=42,
+        admin_uid_error="",
         mirrors=(MirrorResult(name="m", status="created"),),
         fork=None,
         collaborator_added_count=0,
@@ -3347,9 +3349,12 @@ def test_cli_mirror_setup_omits_stdout_when_no_fork(
     assert "GITEA_REPO_OWNER" not in out
 
 
-def test_cli_mirror_setup_admin_uid_none_returns_rc_1(
+def test_cli_mirror_setup_admin_uid_none_404_returns_rc_1(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
+    """admin user genuinely doesn't exist (404 → admin_uid=None,
+    admin_uid_error="" empty) → rc=1 with "admin user not found".
+    """
     from nexus_deploy.gitea import MirrorSetupResult
 
     monkeypatch.setenv("GITEA_ADMIN_PASS", "x")
@@ -3360,6 +3365,7 @@ def test_cli_mirror_setup_admin_uid_none_returns_rc_1(
 
     fake_result = MirrorSetupResult(
         admin_uid=None,
+        admin_uid_error="",  # genuine 404
         mirrors=(),
         fork=None,
         collaborator_added_count=0,
@@ -3372,7 +3378,47 @@ def test_cli_mirror_setup_admin_uid_none_returns_rc_1(
     rc = _gitea_mirror_setup([])
     assert rc == 1
     err = capsys.readouterr().err
-    assert "admin UID not found" in err
+    assert "admin user not found in Gitea" in err
+    # Must NOT use the misleading "lookup failed" wording reserved
+    # for the auth/transport/5xx branch.
+    assert "lookup failed" not in err
+
+
+def test_cli_mirror_setup_admin_uid_lookup_failure_surfaces_diagnostic(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Auth/transport/5xx during get_user_id → admin_uid_error
+    populated → CLI surfaces the real cause (e.g. "HTTP 503")
+    instead of the misleading "user not found". (Copilot R4)
+    """
+    from nexus_deploy.gitea import MirrorSetupResult
+
+    monkeypatch.setenv("GITEA_ADMIN_PASS", "x")
+    monkeypatch.setenv("GITEA_TOKEN", "x")
+    monkeypatch.setenv("GH_MIRROR_REPOS", "https://x.git")
+    monkeypatch.setenv("GH_MIRROR_TOKEN", "x")
+    _setup_fake_ssh(monkeypatch)
+
+    fake_result = MirrorSetupResult(
+        admin_uid=None,
+        admin_uid_error="get_user_id HTTP 503",
+        mirrors=(),
+        fork=None,
+        collaborator_added_count=0,
+        fork_synced=False,
+    )
+    monkeypatch.setattr("nexus_deploy.__main__.run_mirror_setup", lambda **kwargs: fake_result)
+
+    from nexus_deploy.__main__ import _gitea_mirror_setup
+
+    rc = _gitea_mirror_setup([])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "admin UID lookup failed" in err
+    assert "HTTP 503" in err
+    # Must NOT use the "user not found" wording reserved for the
+    # genuine 404 branch.
+    assert "not found in Gitea" not in err
 
 
 def test_cli_mirror_setup_ssh_tunnel_failure_returns_rc_2(


### PR DESCRIPTION
## Summary

Second half of Modul 2.2f (#505) — migrates deploy.sh's `GH_MIRROR_REPOS` block (L3224-3412 pre-migration) to `nexus_deploy.gitea`. Closes the Gitea-mirroring chapter of the migration. The post-loop seed_workspace_files wrapper + Kestra system.flow-sync re-trigger + git-integrated service restart loop stay in deploy.sh as orchestration glue around already-migrated CLIs.

**What it does (idempotent over re-deploys):**
- Look up admin UID (required by Gitea's migrate API)
- For each repo in `$GH_MIRROR_REPOS`:
  - Skip migrate if mirror already exists
  - POST `/repos/migrate` with GitHub PAT (in JSON body, never argv)
  - First successful mirror with a configured user → fork into user's namespace via temp user-token (created+deleted around the fork POST)
  - Add user as read-collab on every mirror
  - First iteration where fork exists → trigger mirror-sync + merge-upstream so fork is fast-forwarded from upstream
- Emit `FORK_NAME=<name>` + `GITEA_REPO_OWNER=<user>` on stdout iff fork was provisioned

## Files

- `src/nexus_deploy/gitea.py`: +~470 LoC — 7 REST methods (`get_user_id`, `migrate_mirror`, `trigger_mirror_sync`, `merge_upstream`, `create_user_token`, `delete_user_token`, `fork_repo_as_user`), 3 dataclasses (`MirrorResult`, `ForkResult`, `MirrorSetupResult`), 2 helpers (`_basename_no_git`, `_sanitize_user_for_fork_name`), `run_mirror_setup` orchestrator
- `src/nexus_deploy/__main__.py`: +~150 LoC — `_gitea_mirror_setup` CLI handler wired into dispatcher
- `tests/unit/test_gitea.py`: +~600 LoC — 40 new tests
- `scripts/deploy.sh`: -124 lines (3662 → 3538). Replaced ~190 lines of bash + REST-via-curl-via-ssh with the CLI wrapper using the same tempfile + eval pattern as `gitea configure` (#519) and `gitea woodpecker-oauth` (#521)

**Cumulative deploy.sh delta:** 5539 → 3538 (~36% migrated to Python).

## Auth boundary

Two transports as established across the migration:
- **token-bearer** (admin's `GITEA_TOKEN`): migrate / existence check / mirror-sync / merge-upstream / collab add. All token in `Authorization: token <sha>` header — never argv, never URL.
- **basic-auth** (admin username + password): temp user-token mint inside the fork flow. Token-bearer auth would only let admin act on its own user (Gitea constraint); minting on behalf of another user requires basic-auth. Pinned by `test_create_user_token_uses_basic_auth_not_bearer`.

GitHub PAT (`GH_MIRROR_TOKEN`) travels in the migrate POST's JSON body — never URL/argv. Pinned by `test_migrate_mirror_returns_created_on_201`.

User's bearer token (for fork POST) lands the fork in user's namespace, not admin's. Pinned by `test_fork_repo_as_user_uses_user_token_not_admin_token`.

## Idempotency

| Re-deploy step | Idempotent because |
|---|---|
| Mirror migrate | GET existence check skips POST when 200; otherwise 409 / 422-with-already-exists → `already_exists` |
| User-token mint | First-attempt failure → DELETE the named token → retry once |
| Fork creation | 409 → `already_exists` |
| Collab add | 422 (already a collaborator) → success |
| Mirror-sync + merge-upstream | best-effort, 409 (already up to date) → success |

## Quality gate

- `uv run ruff format --check`: clean
- `uv run ruff check`: 0 errors
- `uv run mypy --strict`: 0 errors
- `uv run pytest --cov=src/nexus_deploy --cov-fail-under=80`: **657 passed** (40 new)
- Coverage: `gitea.py` **91%**, total **96.37%**
- `bash -n scripts/deploy.sh`: clean

## Test plan

- [ ] `gh workflow run initial-setup.yaml --ref feat/python-migration-phase-2-2f-mirror -f enabled_services=gitea,kestra,jupyter,marimo` with `GH_MIRROR_TOKEN` + `GH_MIRROR_REPOS` set in repo secrets
- [ ] First-run: each mirror in CSV gets created (`mirror-readonly-<basename>`), first one's fork lands in user's namespace, every mirror gets user as read-collab, fork is fast-forwarded from upstream, `seed_workspace_files` post-eval picks up the FORK_NAME from CLI's stdout, Kestra `system.flow-sync` re-trigger fires
- [ ] Re-run: mirror existence-check skips migrate, fork 409 → already_exists, merge-upstream 409 → already up to date — all green
- [ ] Validate Modul 2.2f-1 + 2.2f-2 + 2.2e together on real Gitea (testing #521 + this PR in one shot once both are merged)

Closes part of #505 (Modul 2.2f, half 2 of 2).
