### PR TITLE
feat(nexus_deploy): Add stack_sync.py (Phase 3 Modul 3.3)

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -162,6 +162,26 @@ jobs:
           create-new-comment: false
           report-only-changed-files: false
 
+      - name: Upload coverage to Codecov
+        # External coverage trend graphs + auto-updating README badge.
+        # Public repos technically don't require a token, but Codecov has
+        # been progressively rolling out token-required uploads since
+        # 2023 to deal with token-free upload abuse — providing the
+        # CODECOV_TOKEN secret avoids the intermittent rate-limit /
+        # rejection. `fail_ci_if_error: false` makes the step
+        # non-blocking: if Codecov is down, the gate-relevant local
+        # `--cov-fail-under=80` step has already passed and CI stays
+        # green. The MishaKav comment step above is independent of
+        # Codecov (local-only PR comment); both run.
+        if: always()
+        uses: codecov/codecov-action@v4
+        with:
+          files: ./coverage.xml
+          flags: unittests
+          name: nexus_deploy
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
+
       - name: Upload coverage artifact
         if: always()
         uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 [![GitHub Issues](https://img.shields.io/github/issues/stefanko-ch/Nexus-Stack)](https://github.com/stefanko-ch/Nexus-Stack/issues)
 [![GitHub Pull Requests](https://img.shields.io/github/issues-pr/stefanko-ch/Nexus-Stack)](https://github.com/stefanko-ch/Nexus-Stack/pulls)
 [![GitHub Last Commit](https://img.shields.io/github/last-commit/stefanko-ch/Nexus-Stack)](https://github.com/stefanko-ch/Nexus-Stack/commits/main)
+[![Tests](https://github.com/stefanko-ch/Nexus-Stack/actions/workflows/python-tests.yml/badge.svg)](https://github.com/stefanko-ch/Nexus-Stack/actions/workflows/python-tests.yml)
+[![codecov](https://codecov.io/gh/stefanko-ch/Nexus-Stack/branch/main/graph/badge.svg)](https://codecov.io/gh/stefanko-ch/Nexus-Stack)
 
 [![OpenTofu](https://img.shields.io/badge/OpenTofu-FFDA18?logo=opentofu&logoColor=black)](https://opentofu.org/)
 [![Hetzner](https://img.shields.io/badge/Hetzner-D50C2D?logo=hetzner&logoColor=white)](https://www.hetzner.com/)

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1398,50 +1398,23 @@ EOF
     done
 fi
 
-# Sync only enabled stacks
-echo "{\"location\":\"deploy.sh:378\",\"message\":\"Starting stack sync\",\"data\":{\"enabled_services\":\"$ENABLED_SERVICES\"},\"timestamp\":$(date +%s)000,\"sessionId\":\"debug-session\",\"runId\":\"run1\"}" >> "$LOG_FILE" 2>/dev/null || true
-
-for service in $ENABLED_SERVICES; do
-    echo "{\"location\":\"deploy.sh:379\",\"message\":\"Processing service for sync\",\"data\":{\"service\":\"$service\",\"stack_dir_exists\":$([ -d "$STACKS_DIR/$service" ] && echo "true" || echo "false")},\"timestamp\":$(date +%s)000,\"sessionId\":\"debug-session\",\"runId\":\"run1\"}" >> "$LOG_FILE" 2>/dev/null || true
-    if [ -d "$STACKS_DIR/$service" ]; then
-        echo "  Syncing $service..."
-        rsync -av "$STACKS_DIR/$service/" "nexus:$REMOTE_STACKS_DIR/$service/"
-        echo "{\"location\":\"deploy.sh:382\",\"message\":\"Service synced\",\"data\":{\"service\":\"$service\",\"exit_code\":$?},\"timestamp\":$(date +%s)000,\"sessionId\":\"debug-session\",\"runId\":\"run1\"}" >> "$LOG_FILE" 2>/dev/null || true
-    else
-        echo -e "${YELLOW}  Warning: Stack folder 'stacks/$service' not found - skipping${NC}"
-        echo "{\"location\":\"deploy.sh:384\",\"message\":\"Stack folder not found\",\"data\":{\"service\":\"$service\"},\"timestamp\":$(date +%s)000,\"sessionId\":\"debug-session\",\"runId\":\"run1\"}" >> "$LOG_FILE" 2>/dev/null || true
-    fi
-done
-echo -e "${GREEN}  ✓ Stacks synced${NC}"
-
-# -----------------------------------------------------------------------------
-# Stop disabled services
-# -----------------------------------------------------------------------------
+# Phase 3 Modul 3.3 (#505) — was 44 lines: per-stack rsync loop +
+# disabled-stack cleanup ssh heredoc. Both replaced by one CLI call.
+# Same idempotent contract: rsync `stacks/<svc>/` → `:/opt/...stacks/<svc>/`,
+# then docker-compose-down + rm -rf any folder NOT in $ENABLED_SERVICES.
 echo ""
-echo -e "${YELLOW}[4/7] Cleaning up disabled services...${NC}"
-
-ENABLED_LIST=$(echo $ENABLED_SERVICES | tr '\n' ' ')
-
-ssh nexus "
-# Find all stack directories on server
-for stack_dir in $REMOTE_STACKS_DIR/*/; do
-    [ -d \"\$stack_dir\" ] || continue
-    stack_name=\$(basename \"\$stack_dir\")
-    
-    # Check if this stack is in the enabled list
-    if ! echo '$ENABLED_LIST' | grep -qw \"\$stack_name\"; then
-        # Stack is disabled - stop and remove
-        if [ -f \"\${stack_dir}docker-compose.yml\" ]; then
-            echo \"  Stopping \$stack_name (disabled)...\"
-            cd \"\$stack_dir\"
-            docker compose down 2>/dev/null || true
-        fi
-        echo \"  Removing \$stack_name stack folder...\"
-        rm -rf \"\$stack_dir\"
-    fi
-done
-echo '  ✓ Cleanup complete'
-"
+echo -e "${YELLOW}[3+4/7] Syncing stacks and cleaning up disabled ones...${NC}"
+SYNC_RC=0
+uv run --quiet --project "$PROJECT_ROOT" \
+    python -m nexus_deploy stack-sync \
+    --enabled "$(echo "$ENABLED_SERVICES" | tr '\n ' ',,')" \
+    --stacks-dir "$STACKS_DIR" \
+    || SYNC_RC=$?
+case "$SYNC_RC" in
+    0) echo -e "${GREEN}  ✓ Stacks synced and disabled stacks cleaned up${NC}" ;;
+    1) echo -e "${YELLOW}  ⚠ Stack sync had partial failures (continuing)${NC}" ;;
+    *) echo -e "${RED}  ✗ Stack sync hard failure (rc=$SYNC_RC); aborting${NC}"; exit "$SYNC_RC" ;;
+esac
 
 # -----------------------------------------------------------------------------
 # Docker Hub Login (optional - for increased pull rate limits)

--- a/src/nexus_deploy/__main__.py
+++ b/src/nexus_deploy/__main__.py
@@ -1402,7 +1402,13 @@ def _stack_sync(args: list[str]) -> int:
         return 2
 
     # Per-service rsync diagnostics on stderr — same pattern as the
-    # cleanup script (which streams its own diagnostics).
+    # cleanup script (which streams its own diagnostics). On rsync
+    # failure we ALSO surface the captured stderr excerpt as an
+    # indented block — Round-2 PR #523 finding: a bare "rc=23"
+    # gave operators no actionable signal, the underlying rsync
+    # error message ("Permission denied", "No space left on device",
+    # "ssh: connect to host nexus port 22: Connection refused", etc.)
+    # is what they need to see.
     for r in result.rsync:
         if r.status == "synced":
             sys.stderr.write(f"  ✓ {r.service} synced\n")
@@ -1411,6 +1417,9 @@ def _stack_sync(args: list[str]) -> int:
         else:
             detail = f" ({r.detail})" if r.detail else ""
             sys.stderr.write(f"  ✗ {r.service} rsync failed{detail}\n")
+            if r.stderr_excerpt:
+                for line in r.stderr_excerpt.splitlines():
+                    sys.stderr.write(f"      {line}\n")
 
     cleanup_summary = (
         f"stopped={result.cleanup.stopped} removed={result.cleanup.removed} "

--- a/src/nexus_deploy/__main__.py
+++ b/src/nexus_deploy/__main__.py
@@ -13,6 +13,7 @@ Currently:
 - ``gitea configure`` (#505 Modul 2.2e)
 - ``gitea woodpecker-oauth`` (#505 Modul 2.2f)
 - ``gitea mirror-setup`` (#505 Modul 2.2f part 2)
+- ``stack-sync --enabled <comma-list>`` (#505 Modul 3.3)
 """
 
 from __future__ import annotations
@@ -41,6 +42,7 @@ from nexus_deploy.secret_sync import StackTarget, run_sync_for_stack
 from nexus_deploy.seeder import _is_safe_repo_path, run_seed_for_repo
 from nexus_deploy.services import run_admin_setups
 from nexus_deploy.ssh import SSHClient, SSHError
+from nexus_deploy.stack_sync import run_stack_sync
 
 
 def _config_dump_shell(args: list[str]) -> int:
@@ -1312,6 +1314,128 @@ def _gitea_mirror_setup(args: list[str]) -> int:
     return 0 if result.is_success else 1
 
 
+def _stack_sync(args: list[str]) -> int:
+    """`nexus-deploy stack-sync --enabled <comma-list> [--stacks-dir PATH]`.
+
+    Replaces deploy.sh L1401-1444 (#505 Modul 3.3): per-stack rsync of
+    ``stacks/<svc>/`` → ``nexus:/opt/docker-server/stacks/<svc>/``,
+    plus disabled-stack cleanup (server-side ``docker compose down``
+    + ``rm -rf`` for any folder NOT in the enabled list).
+
+    The comma-list maps directly to deploy.sh's ``$ENABLED_SERVICES``
+    (``tr '\\n ' ',,'`` already happens on the bash side, same wire-
+    format as compose_runner).
+
+    Optional ``--stacks-dir`` defaults to ``stacks`` relative to the
+    repo root — exposed for tests. Production callers leave it off.
+
+    Exit codes:
+
+    - 0: every enabled service was either rsynced successfully or
+      reported missing-local (deploy.sh's pre-migration warning
+      branch, kept as soft-success); the cleanup script ran and
+      returned RESULT with failed=0.
+    - 1: at least one rsync failed OR the cleanup loop reported
+      ``failed > 0``, but at least one operation succeeded. deploy.sh:
+      yellow warning, continue.
+    - 2: bad args, transport (ssh/rsync) failure, no parseable RESULT
+      line, or unexpected exception. deploy.sh: red, abort.
+    """
+    enabled_str: str | None = None
+    stacks_dir_arg: str | None = None
+    i = 0
+    while i < len(args):
+        if args[i] == "--enabled":
+            if i + 1 >= len(args):
+                print("stack-sync: --enabled requires a value", file=sys.stderr)
+                return 2
+            enabled_str = args[i + 1]
+            i += 2
+        elif args[i] == "--stacks-dir":
+            if i + 1 >= len(args):
+                print("stack-sync: --stacks-dir requires a value", file=sys.stderr)
+                return 2
+            stacks_dir_arg = args[i + 1]
+            i += 2
+        else:
+            print(f"stack-sync: unknown arg {args[i]!r}", file=sys.stderr)
+            return 2
+
+    if enabled_str is None:
+        print(
+            "stack-sync: --enabled <comma-separated-services> is required",
+            file=sys.stderr,
+        )
+        return 2
+
+    enabled = [s.strip() for s in enabled_str.split(",") if s.strip()]
+    if not enabled:
+        # Empty list: nothing to rsync, but the cleanup loop still
+        # has work — every existing folder on the server is "not in
+        # the enabled list" and gets removed. That matches deploy.sh's
+        # behaviour: a deploy with zero enabled services would tear
+        # down every stack on the server.
+        pass
+
+    stacks_dir = Path(stacks_dir_arg) if stacks_dir_arg else Path("stacks")
+    if not stacks_dir.is_dir():
+        print(
+            f"stack-sync: stacks dir {stacks_dir!s} is not a directory",
+            file=sys.stderr,
+        )
+        return 2
+
+    try:
+        result = run_stack_sync(stacks_dir, enabled)
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError) as exc:
+        print(
+            f"stack-sync: transport failure ({type(exc).__name__})",
+            file=sys.stderr,
+        )
+        return 2
+    except Exception as exc:
+        # Force rc=2 (Python's default rc=1 collides with our
+        # partial-failure semantic). Class name only — no str/repr,
+        # which could embed secret-bearing values from a future
+        # config-aware helper.
+        print(f"stack-sync: unexpected error ({type(exc).__name__})", file=sys.stderr)
+        return 2
+
+    # Per-service rsync diagnostics on stderr — same pattern as the
+    # cleanup script (which streams its own diagnostics).
+    for r in result.rsync:
+        if r.status == "synced":
+            sys.stderr.write(f"  ✓ {r.service} synced\n")
+        elif r.status == "missing-local":
+            sys.stderr.write(f"  ⚠ {r.service}: local stack folder not found - skipping\n")
+        else:
+            detail = f" ({r.detail})" if r.detail else ""
+            sys.stderr.write(f"  ✗ {r.service} rsync failed{detail}\n")
+
+    cleanup_summary = (
+        f"stopped={result.cleanup.stopped} removed={result.cleanup.removed} "
+        f"failed={result.cleanup.failed}"
+        if result.cleanup is not None
+        else "stopped=? removed=? failed=? (cleanup did not return RESULT)"
+    )
+    print(
+        f"stack-sync: synced={result.synced} missing={result.missing} "
+        f"failed_rsync={result.failed_rsync} cleanup: {cleanup_summary}",
+    )
+
+    if result.cleanup is None:
+        # No parseable RESULT: hard failure (same defensive parse as
+        # compose_runner / seeder).
+        return 2
+    if result.is_success:
+        return 0
+    # Partial: at least one rsync OR cleanup failure. Distinguish
+    # "everything failed" (rc=2) from "some succeeded" (rc=1).
+    if result.synced == 0 and result.cleanup.stopped + result.cleanup.removed == 0:
+        return 2
+    return 1
+
+
 def _allocate_free_port() -> int:
     """Ask the kernel for a free IPv4 ephemeral port on the loopback.
 
@@ -1400,6 +1524,8 @@ def main() -> int:
         return _gitea_woodpecker_oauth(args[2:])
     if args[:2] == ["gitea", "mirror-setup"]:
         return _gitea_mirror_setup(args[2:])
+    if args[:1] == ["stack-sync"]:
+        return _stack_sync(args[1:])
     print(
         f"nexus_deploy {__version__}: unknown command {' '.join(args)!r}",
         file=sys.stderr,
@@ -1415,7 +1541,8 @@ def main() -> int:
         "kestra register-system-flows (reads SECRETS_JSON from stdin + env vars), "
         "gitea configure (reads SECRETS_JSON from stdin + env vars; emits eval-able stdout), "
         "gitea woodpecker-oauth (env-only; emits WOODPECKER_GITEA_CLIENT + WOODPECKER_GITEA_SECRET), "
-        "gitea mirror-setup (env-only; emits FORK_NAME + GITEA_REPO_OWNER iff a fork was provisioned)",
+        "gitea mirror-setup (env-only; emits FORK_NAME + GITEA_REPO_OWNER iff a fork was provisioned), "
+        "stack-sync --enabled <comma-list> [--stacks-dir PATH]",
         file=sys.stderr,
     )
     return 2

--- a/src/nexus_deploy/stack_sync.py
+++ b/src/nexus_deploy/stack_sync.py
@@ -105,10 +105,14 @@ class CleanupResult:
     successfully (their ``docker-compose.yml`` was present).
     ``removed`` counts service folders that ``rm -rf`` cleared. Both
     are strictly per-disabled-service — already-missing folders aren't
-    touched. ``failed`` is the count of disabled services where either
-    ``compose down`` OR ``rm -rf`` exited non-zero. A disabled service
-    with no compose.yml that ``rm -rf`` succeeds on increments
-    ``removed`` only.
+    touched. ``failed`` is incremented once per ``docker compose down``
+    failure AND once per ``rm -rf`` failure, so a single disabled
+    service whose compose-down crashes BUT whose folder is still
+    successfully removed contributes ``failed=1 removed=1`` (the
+    counts intentionally do not sum to "number of disabled services" —
+    they each count distinct sub-failures). A disabled service with
+    no compose.yml that ``rm -rf`` succeeds on increments ``removed``
+    only.
     """
 
     stopped: int
@@ -161,11 +165,19 @@ class StackSyncResult:
 
 
 def _is_safe_name(name: str) -> bool:
-    """True iff ``name`` matches the allow-list regex.
+    """True iff ``name`` matches the allow-list regex AND is not a
+    path-traversal segment.
 
-    Wraps the regex in a function so future tightening (e.g. minimum
-    length, deny-list of reserved bash keywords) lives in one place.
+    The regex ``[A-Za-z0-9._-]+`` permits ``.`` and ``..`` since both
+    are dots-only strings. We reject those explicitly: an enabled
+    service name of ``..`` would make ``local_stacks_dir / ".."``
+    escape the stacks directory on the local side and the rsync
+    target ``nexus:/opt/docker-server/stacks/../..`` escape the
+    remote stacks dir. ``.`` is similarly meaningless and the same
+    class of error. (Round-1 PR #523 finding.)
     """
+    if name in (".", ".."):
+        return False
     return bool(_SAFE_NAME.match(name))
 
 
@@ -211,13 +223,29 @@ for stack_dir in "$STACKS_DIR"/*/; do
     fi
     if [ -f "${{stack_dir}}docker-compose.yml" ]; then
         echo "  Stopping $name (disabled)..." >&2
-        if ( cd "$stack_dir" && docker compose down 2>/dev/null ); then
+        # Capture compose-down stderr to a tmpfile so a failed down
+        # surfaces the underlying error in the deploy log instead of
+        # the unhelpful bare-counter "failed=1" the legacy heredoc
+        # produced. (Round-1 PR #523 finding: 2>/dev/null + bare
+        # counter blocks operator diagnosis.) The tmpfile is read,
+        # re-prefixed, forwarded to stderr, and removed in the same
+        # block — no leftover state.
+        DOWN_STDERR=$(mktemp)
+        if ( cd "$stack_dir" && docker compose down 2>"$DOWN_STDERR" >/dev/null ); then
             STOPPED=$((STOPPED+1))
         else
             echo "  ⚠ docker compose down failed for $name" >&2
+            sed 's/^/      /' "$DOWN_STDERR" >&2
             FAILED=$((FAILED+1))
-            continue
+            # NOTE: we do NOT `continue` here. Legacy deploy.sh used
+            # `docker compose down 2>/dev/null || true` and ran
+            # `rm -rf` regardless — a stuck container shouldn't block
+            # folder removal (next deploy will re-rsync if the stack
+            # is re-enabled). We count the down-failure but still
+            # attempt the removal, matching legacy idempotency.
+            # (Round-1 PR #523 finding.)
         fi
+        rm -f "$DOWN_STDERR"
     fi
     echo "  Removing $name stack folder..." >&2
     if rm -rf "$stack_dir"; then

--- a/src/nexus_deploy/stack_sync.py
+++ b/src/nexus_deploy/stack_sync.py
@@ -1,0 +1,379 @@
+"""Per-stack rsync + disabled-stack cleanup (Phase 3 Modul 3.3, #505).
+
+Replaces ``scripts/deploy.sh`` lines 1401-1444 (~45 LoC bash):
+
+* Per-stack rsync loop — for every entry in ``$ENABLED_SERVICES``,
+  rsync ``stacks/<svc>/`` → ``nexus:/opt/docker-server/stacks/<svc>/``.
+  Missing local stack folders produce a yellow warning and are skipped
+  (deploy.sh ``[ -d "$STACKS_DIR/$service" ]`` check).
+* Disabled-stack cleanup — server-side bash loop that walks
+  ``/opt/docker-server/stacks/*/``, ``docker compose down`` + ``rm -rf``
+  any folder NOT in ``$ENABLED_SERVICES``. Idempotent on re-run.
+
+Two transports, mirroring the rest of the migration:
+
+1. **Local rsync** (one subprocess per service) via
+   :func:`_remote.rsync_to_remote`. Each service rsyncs independently
+   so a single failure doesn't abort the rest of the loop — matches
+   deploy.sh's serial loop semantics (a non-zero rsync exit on one
+   stack would have triggered ``set -e`` and aborted the whole script;
+   the migration is STRICTLY-MORE-FORGIVING here, partial-failure
+   continues with a per-service ``failed`` counter).
+2. **Server-side cleanup script** via :func:`_remote.ssh_run_script`
+   (stdin) — one ssh round-trip. The list of enabled service names
+   is interpolated as a single ``shlex.quote``'d bash string literal
+   and matched line-exactly with ``grep -qFx`` (defence in depth: a
+   hypothetical service name containing regex metachars couldn't
+   false-positive against a similar folder name on the server).
+
+Path safety (R5 from prior modules): every service name passes
+``^[A-Za-z0-9._-]+$`` before being interpolated into either the
+rsync remote target OR the server-side bash. A name that fails
+validation is recorded as ``RsyncResult(status='failed', detail='unsafe name')``
+and excluded from the cleanup script's enabled-set, so the cleanup
+loop will (correctly) treat it as disabled and remove any folder
+that happens to match — there is no "safe" interpretation of an
+unsafe name. Operators see the warning and can fix the upstream
+``$ENABLED_SERVICES`` list.
+
+Phase 3 Modul 3.4 (#505 orchestrator) calls into here once the
+rest of the deploy pipeline lives in Python. Until then, deploy.sh
+invokes ``python -m nexus_deploy stack-sync --enabled <csv>``.
+"""
+
+from __future__ import annotations
+
+import re
+import shlex
+import subprocess
+import sys
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+from nexus_deploy import _remote
+
+# Mirrors deploy.sh:20 ``REMOTE_STACKS_DIR`` — the canonical location
+# on the nexus server where every stack's ``docker-compose.yml``
+# lives. Adjacent stacks live as sibling folders under here.
+_REMOTE_STACKS_DIR = "/opt/docker-server/stacks"
+
+# Path-safety regex (R5 invariant): every service name must match
+# this before we interpolate it into a shell command, an rsync remote
+# spec, or a server-side bash loop. ``[A-Za-z0-9._-]`` is the same
+# allow-list seeder.py uses for repo-path segments and gitea.py uses
+# for URL segments — broad enough for every existing stack name in
+# the repo (jupyter, marimo, seaweedfs-filer, …) but tight enough
+# that no shell metachar, newline, or whitespace can sneak through.
+_SAFE_NAME = re.compile(r"^[A-Za-z0-9._-]+$")
+
+# RESULT-line shape from the cleanup script — same wire-format family
+# as compose_runner / seeder / secret_sync.
+_RESULT_PATTERN = re.compile(
+    r"^RESULT stopped=(?P<stopped>\d+) removed=(?P<removed>\d+) failed=(?P<failed>\d+)$",
+    re.MULTILINE,
+)
+
+
+@dataclass(frozen=True)
+class RsyncResult:
+    """Per-service rsync outcome.
+
+    ``status`` values:
+
+    * ``synced`` — rsync exited 0; the service's stacks/<svc>/ dir
+      now matches the server's copy.
+    * ``missing-local`` — local stacks/<svc>/ does NOT exist; deploy.sh
+      yellow-warned and continued. Mirrors the legacy ``[ -d ... ]``
+      branch.
+    * ``failed`` — rsync exited non-zero (transport problem, permission
+      issue, broken pipe), OR the service name failed path-safety.
+      ``detail`` carries the rc / reason for the operator log.
+    """
+
+    service: str
+    status: Literal["synced", "missing-local", "failed"]
+    detail: str = ""
+
+
+@dataclass(frozen=True)
+class CleanupResult:
+    """Counters from the server-side cleanup loop.
+
+    ``stopped`` counts services where ``docker compose down`` ran
+    successfully (their ``docker-compose.yml`` was present).
+    ``removed`` counts service folders that ``rm -rf`` cleared. Both
+    are strictly per-disabled-service — already-missing folders aren't
+    touched. ``failed`` is the count of disabled services where either
+    ``compose down`` OR ``rm -rf`` exited non-zero. A disabled service
+    with no compose.yml that ``rm -rf`` succeeds on increments
+    ``removed`` only.
+    """
+
+    stopped: int
+    removed: int
+    failed: int
+
+    @property
+    def is_success(self) -> bool:
+        """True iff zero failures."""
+        return self.failed == 0
+
+
+@dataclass(frozen=True)
+class StackSyncResult:
+    """Aggregate of the rsync loop + cleanup step.
+
+    ``cleanup`` is ``None`` when the cleanup step never ran (e.g.
+    transport failure raising before script execution) OR the script
+    ran but produced no parseable RESULT line — caller (CLI) maps
+    both to rc=2.
+    """
+
+    rsync: tuple[RsyncResult, ...]
+    cleanup: CleanupResult | None
+
+    @property
+    def synced(self) -> int:
+        return sum(1 for r in self.rsync if r.status == "synced")
+
+    @property
+    def missing(self) -> int:
+        return sum(1 for r in self.rsync if r.status == "missing-local")
+
+    @property
+    def failed_rsync(self) -> int:
+        return sum(1 for r in self.rsync if r.status == "failed")
+
+    @property
+    def is_success(self) -> bool:
+        if self.failed_rsync > 0:
+            return False
+        if self.cleanup is None:
+            return False
+        return self.cleanup.is_success
+
+
+# ---------------------------------------------------------------------------
+# Pure logic — name validation + cleanup-script rendering.
+# ---------------------------------------------------------------------------
+
+
+def _is_safe_name(name: str) -> bool:
+    """True iff ``name`` matches the allow-list regex.
+
+    Wraps the regex in a function so future tightening (e.g. minimum
+    length, deny-list of reserved bash keywords) lives in one place.
+    """
+    return bool(_SAFE_NAME.match(name))
+
+
+def render_cleanup_script(
+    enabled: list[str],
+    *,
+    stacks_dir: str = _REMOTE_STACKS_DIR,
+) -> str:
+    """Render the server-side bash that removes disabled stacks.
+
+    The enabled list is interpolated as a single ``shlex.quote``'d
+    multi-line string literal; ``grep -qFx`` matches the current
+    folder name against it line-exactly. ``-F`` treats the pattern
+    as a fixed string (regex metachars in a hypothetical future stack
+    name don't matter), ``-x`` requires the entire line to match (so
+    "jupyter" doesn't false-positive against "jupyter-old"), ``--``
+    terminates options so a name starting with ``-`` doesn't get
+    parsed as a flag.
+
+    Caller MUST pre-validate names with :func:`_is_safe_name` —
+    rendering does not re-check, and an unsafe name reaching this
+    function is a programming error. The CLI / orchestrator is the
+    last line of defence; this module's tests pin the name-validation
+    contract via :func:`run_stack_sync`.
+    """
+    stacks_q = shlex.quote(stacks_dir)
+    enabled_blob = shlex.quote("\n".join(enabled))
+
+    return f"""set -euo pipefail
+
+STACKS_DIR={stacks_q}
+ENABLED_LIST={enabled_blob}
+
+STOPPED=0
+REMOVED=0
+FAILED=0
+
+for stack_dir in "$STACKS_DIR"/*/; do
+    [ -d "$stack_dir" ] || continue
+    name=$(basename "$stack_dir")
+    if printf '%s\\n' "$ENABLED_LIST" | grep -qFx -- "$name"; then
+        continue
+    fi
+    if [ -f "${{stack_dir}}docker-compose.yml" ]; then
+        echo "  Stopping $name (disabled)..." >&2
+        if ( cd "$stack_dir" && docker compose down 2>/dev/null ); then
+            STOPPED=$((STOPPED+1))
+        else
+            echo "  ⚠ docker compose down failed for $name" >&2
+            FAILED=$((FAILED+1))
+            continue
+        fi
+    fi
+    echo "  Removing $name stack folder..." >&2
+    if rm -rf "$stack_dir"; then
+        REMOVED=$((REMOVED+1))
+    else
+        echo "  ⚠ rm -rf failed for $name" >&2
+        FAILED=$((FAILED+1))
+    fi
+done
+
+echo "RESULT stopped=$STOPPED removed=$REMOVED failed=$FAILED"
+"""
+
+
+def parse_cleanup_result(stdout: str) -> CleanupResult | None:
+    """Extract the ``RESULT`` line from the cleanup-script stdout.
+
+    Returns None if no parseable RESULT — caller treats that as a
+    hard transport failure (same defensive parse as compose_runner).
+    """
+    match = _RESULT_PATTERN.search(stdout)
+    if match is None:
+        return None
+    g = match.groupdict()
+    return CleanupResult(
+        stopped=int(g["stopped"]),
+        removed=int(g["removed"]),
+        failed=int(g["failed"]),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Side-effect functions — rsync loop + cleanup orchestration.
+# ---------------------------------------------------------------------------
+
+
+RsyncRunner = Callable[[Path, str], subprocess.CompletedProcess[str]]
+ScriptRunner = Callable[[str], subprocess.CompletedProcess[str]]
+
+
+def rsync_enabled_stacks(
+    local_stacks_dir: Path,
+    enabled: list[str],
+    *,
+    rsync_runner: RsyncRunner | None = None,
+    remote_stacks_dir: str = _REMOTE_STACKS_DIR,
+    host: str = "nexus",
+) -> tuple[RsyncResult, ...]:
+    """Rsync each enabled service's local stack folder to the server.
+
+    One rsync subprocess per service. A failed rsync produces a
+    ``failed`` RsyncResult with the rc in ``detail``; the loop
+    continues for the remaining services (STRICTLY-MORE-FORGIVING
+    than deploy.sh's ``set -e`` abort-on-first-error semantics).
+
+    ``rsync_runner`` is a dependency-injection seam for tests.
+    Production callers leave it None and get :func:`_remote.rsync_to_remote`,
+    which wraps ``rsync -aq`` with capture_output. ``-aq`` (instead
+    of deploy.sh's ``-av``) is a deliberate divergence: rsync's
+    per-file output for an entire stack tree (n8n's node_modules
+    alone is thousands of files) would dominate the deploy log;
+    capture_output gives us the diagnostic on failure without the
+    happy-path noise.
+    """
+    runner = rsync_runner or (lambda local, remote: _remote.rsync_to_remote(local, remote))
+    results: list[RsyncResult] = []
+    for svc in enabled:
+        if not _is_safe_name(svc):
+            results.append(
+                RsyncResult(
+                    service=svc,
+                    status="failed",
+                    detail="unsafe name (must match [A-Za-z0-9._-]+)",
+                ),
+            )
+            continue
+        local = local_stacks_dir / svc
+        if not local.is_dir():
+            results.append(RsyncResult(service=svc, status="missing-local"))
+            continue
+        try:
+            runner(local, f"{host}:{remote_stacks_dir}/{svc}/")
+        except subprocess.CalledProcessError as exc:
+            # rsync's stderr for a stack-dir push contains only file
+            # paths + permission errors — no secrets. Surfacing the
+            # rc gives operators something to grep for; the captured
+            # stderr is left in CalledProcessError but not echoed
+            # here (the module-level orchestrator forwards it).
+            results.append(
+                RsyncResult(service=svc, status="failed", detail=f"rsync rc={exc.returncode}"),
+            )
+            continue
+        results.append(RsyncResult(service=svc, status="synced"))
+    return tuple(results)
+
+
+def cleanup_disabled_stacks(
+    enabled: list[str],
+    *,
+    script_runner: ScriptRunner | None = None,
+    remote_stacks_dir: str = _REMOTE_STACKS_DIR,
+) -> CleanupResult | None:
+    """Render → exec → parse the server-side cleanup script.
+
+    Filters ``enabled`` through :func:`_is_safe_name` before rendering
+    — an unsafe name is silently dropped from the enabled set, which
+    means any folder matching that unsafe name on the server WILL be
+    removed (the safe-by-default behaviour: an unsafe name in the
+    enabled list is itself a configuration error, not a hint to
+    preserve folders that match it).
+
+    Returns None on transport failure or unparseable RESULT line.
+    """
+    safe_enabled = [s for s in enabled if _is_safe_name(s)]
+    script = render_cleanup_script(safe_enabled, stacks_dir=remote_stacks_dir)
+    runner = script_runner or (lambda s: _remote.ssh_run_script(s))
+    completed = runner(script)
+
+    # Forward per-stack diagnostics ("Stopping foo...", "Removing
+    # foo...") to local stderr — same Modul-1.2-Round-4 pattern that
+    # compose_runner/seeder use.
+    for line in completed.stdout.splitlines():
+        if not line.startswith("RESULT "):
+            sys.stderr.write(line + "\n")
+
+    return parse_cleanup_result(completed.stdout)
+
+
+def run_stack_sync(
+    local_stacks_dir: Path,
+    enabled: list[str],
+    *,
+    rsync_runner: RsyncRunner | None = None,
+    script_runner: ScriptRunner | None = None,
+    remote_stacks_dir: str = _REMOTE_STACKS_DIR,
+    host: str = "nexus",
+) -> StackSyncResult:
+    """End-to-end orchestrator: rsync each enabled stack, then cleanup
+    disabled ones.
+
+    Order matters: rsync runs FIRST so an enabled service that's
+    already-disabled-on-the-server gets its compose.yml back before
+    the cleanup loop has a chance to see it as "not in enabled" (it
+    IS in enabled). The cleanup loop's enabled-list and the rsync
+    loop's enabled-list are the same — there's no race window.
+    """
+    rsync_results = rsync_enabled_stacks(
+        local_stacks_dir,
+        enabled,
+        rsync_runner=rsync_runner,
+        remote_stacks_dir=remote_stacks_dir,
+        host=host,
+    )
+    cleanup = cleanup_disabled_stacks(
+        enabled,
+        script_runner=script_runner,
+        remote_stacks_dir=remote_stacks_dir,
+    )
+    return StackSyncResult(rsync=rsync_results, cleanup=cleanup)

--- a/src/nexus_deploy/stack_sync.py
+++ b/src/nexus_deploy/stack_sync.py
@@ -90,11 +90,20 @@ class RsyncResult:
     * ``failed`` — rsync exited non-zero (transport problem, permission
       issue, broken pipe), OR the service name failed path-safety.
       ``detail`` carries the rc / reason for the operator log.
+
+    ``stderr_excerpt`` carries the captured rsync stderr (truncated)
+    when status='failed' due to rsync rc≠0. Empty for the other two
+    statuses. The CLI surfaces it as an indented block after the
+    per-service ✗ line so operators see WHY the rsync failed (legacy
+    deploy.sh's ``rsync -av`` streamed its stderr directly to the
+    deploy log; ``_remote.rsync_to_remote`` uses ``capture_output=True``
+    so we have to forward it explicitly — Round-2 PR #523 finding).
     """
 
     service: str
     status: Literal["synced", "missing-local", "failed"]
     detail: str = ""
+    stderr_excerpt: str = ""
 
 
 @dataclass(frozen=True)
@@ -330,12 +339,28 @@ def rsync_enabled_stacks(
             runner(local, f"{host}:{remote_stacks_dir}/{svc}/")
         except subprocess.CalledProcessError as exc:
             # rsync's stderr for a stack-dir push contains only file
-            # paths + permission errors — no secrets. Surfacing the
-            # rc gives operators something to grep for; the captured
-            # stderr is left in CalledProcessError but not echoed
-            # here (the module-level orchestrator forwards it).
+            # paths + permission errors — no secrets. We surface it
+            # so operators can see WHY a sync failed instead of just
+            # the bare rc (Round-2 PR #523 finding: the previous
+            # version captured stderr via _remote.rsync_to_remote's
+            # capture_output=True but discarded it, leaving only
+            # `rsync rc=N` for diagnosis).
+            #
+            # Truncate at 2000 chars: enough for a screen of file-
+            # path errors but bounded so a pathological retry loop
+            # can't flood the deploy log. exc.stderr/stdout may be
+            # None if the runner was a test stub raising a bare
+            # CalledProcessError without those fields populated;
+            # default to empty string for both branches.
+            stderr = (exc.stderr or "") + (exc.stdout or "")
+            excerpt = stderr[-2000:] if len(stderr) > 2000 else stderr
             results.append(
-                RsyncResult(service=svc, status="failed", detail=f"rsync rc={exc.returncode}"),
+                RsyncResult(
+                    service=svc,
+                    status="failed",
+                    detail=f"rsync rc={exc.returncode}",
+                    stderr_excerpt=excerpt.rstrip(),
+                ),
             )
             continue
         results.append(RsyncResult(service=svc, status="synced"))

--- a/tests/unit/test_stack_sync.py
+++ b/tests/unit/test_stack_sync.py
@@ -1,0 +1,690 @@
+"""Tests for nexus_deploy.stack_sync — Phase 3 Modul 3.3 (#505).
+
+Round-tagged invariants on the rendered cleanup bash, exec'd-bash
+regression tests for the disabled-stack matching semantics, rsync
+dependency-injection tests covering all three RsyncResult statuses,
+end-to-end run_stack_sync, and CLI rc=0/1/2 contract.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from nexus_deploy.stack_sync import (
+    CleanupResult,
+    RsyncResult,
+    StackSyncResult,
+    _is_safe_name,
+    cleanup_disabled_stacks,
+    parse_cleanup_result,
+    render_cleanup_script,
+    rsync_enabled_stacks,
+    run_stack_sync,
+)
+
+# ---------------------------------------------------------------------------
+# _is_safe_name — path-safety regex (R5 invariant)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [
+        ("jupyter", True),
+        ("seaweedfs-filer", True),
+        ("foo.bar", True),
+        ("FOO_BAR", True),
+        ("v1.2.3", True),
+        ("", False),
+        ("foo bar", False),  # space
+        ("foo;bar", False),  # shell meta
+        ("foo$bar", False),  # variable expansion attempt
+        ("foo`bar`", False),  # command substitution attempt
+        ("foo'bar", False),  # quote
+        ("foo\nbar", False),  # newline
+        ("../bar", False),  # path traversal attempt
+        ("foo/bar", False),  # slash
+        ("-rf", True),  # leading dash IS allowed; the bash uses `-- "$name"` to terminate options
+    ],
+)
+def test_is_safe_name_regex(name: str, expected: bool) -> None:
+    """Path-safety regex covers shell meta, whitespace, quotes, newlines."""
+    assert _is_safe_name(name) is expected
+
+
+# ---------------------------------------------------------------------------
+# render_cleanup_script — locks invariants in the rendered bash
+# ---------------------------------------------------------------------------
+
+
+def test_render_starts_with_set_euo_pipefail() -> None:
+    """R1 — `set -euo pipefail` is the first executable line."""
+    script = render_cleanup_script(["jupyter"])
+    first_executable = next(
+        line for line in script.splitlines() if line.strip() and not line.startswith("#")
+    )
+    assert first_executable == "set -euo pipefail"
+
+
+def test_render_uses_grep_qfx_for_line_exact_fixed_string_match() -> None:
+    """`grep -qFx --` for line-exact + fixed-string + option-terminator.
+
+    -F prevents regex-meta false-positives, -x requires whole-line
+    match (so 'jupyter' doesn't match 'jupyter-old'), -- prevents
+    a name starting with '-' from being parsed as a flag.
+    """
+    script = render_cleanup_script(["jupyter"])
+    assert "grep -qFx --" in script
+
+
+def test_render_emits_result_line_format() -> None:
+    """RESULT wire-format must match what parse_cleanup_result expects."""
+    script = render_cleanup_script(["jupyter"])
+    assert 'echo "RESULT stopped=$STOPPED removed=$REMOVED failed=$FAILED"' in script
+
+
+def test_render_quotes_enabled_list_safely() -> None:
+    """Enabled names land inside a shlex.quote'd string literal — no
+    name (even if it had unsafe chars) can break out of the quote."""
+    script = render_cleanup_script(["jupyter", "marimo"])
+    # The list comes through as a single quoted argument, with names
+    # joined by literal newlines that printf '%s\n' re-emits one per
+    # line. This is the same shape every other rendered-bash module
+    # uses.
+    assert "ENABLED_LIST=" in script
+    # Both names appear somewhere in the script (the exact
+    # interpolation form is shlex's choice).
+    assert "jupyter" in script
+    assert "marimo" in script
+
+
+def test_render_uses_docker_compose_yml_check_before_compose_down() -> None:
+    """Compose-down only fires when docker-compose.yml is present —
+    matches deploy.sh's branch (we don't try to `compose down` a
+    folder that's just leftover assets)."""
+    script = render_cleanup_script([])
+    assert 'if [ -f "${stack_dir}docker-compose.yml" ]' in script
+    assert "docker compose down" in script
+
+
+def test_render_empty_enabled_removes_everything() -> None:
+    """Empty enabled = every folder on the server is "not in enabled"
+    = every folder gets removed. Pinned because the CLI explicitly
+    documents this contract (a deploy with zero enabled services
+    tears down every stack)."""
+    script = render_cleanup_script([])
+    # The rendered script still has the for loop; the ENABLED_LIST is empty.
+    # printf '%s\n' "" produces a single empty line, and grep -qFx -- "<name>"
+    # against just an empty line never matches a real name. Net: every
+    # folder falls into the disabled branch.
+    assert 'for stack_dir in "$STACKS_DIR"/*/' in script
+
+
+# ---------------------------------------------------------------------------
+# Exec'd-bash semantic tests — pin the actual matching/exit behaviour
+# Modul-2.0 lesson: static-text tests don't catch dispatch bugs.
+# ---------------------------------------------------------------------------
+
+
+def _bash_can_be_invoked() -> bool:
+    return shutil.which("bash") is not None
+
+
+@pytest.mark.skipif(not _bash_can_be_invoked(), reason="bash not on PATH")
+def test_exec_cleanup_skips_enabled_removes_disabled() -> None:
+    """End-to-end: build a synthetic stacks dir, render, exec, verify
+    the disabled folder is gone and the enabled one stays."""
+    with tempfile.TemporaryDirectory() as tmp:
+        stacks = Path(tmp)
+        (stacks / "jupyter").mkdir()
+        (stacks / "marimo").mkdir()
+        (stacks / "old-stack").mkdir()
+        # Don't drop docker-compose.yml so `compose down` doesn't
+        # actually try to run docker — we just want to test the
+        # rm -rf branch.
+
+        script = render_cleanup_script(["jupyter", "marimo"], stacks_dir=str(stacks))
+        proc = subprocess.run(
+            ["bash", "-c", script],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert proc.returncode == 0, proc.stderr
+        assert "RESULT stopped=0 removed=1 failed=0" in proc.stdout
+        assert (stacks / "jupyter").exists()
+        assert (stacks / "marimo").exists()
+        assert not (stacks / "old-stack").exists()
+
+
+@pytest.mark.skipif(not _bash_can_be_invoked(), reason="bash not on PATH")
+def test_exec_cleanup_line_exact_match_no_substring_collision() -> None:
+    """Pin -x: 'jupyter' enabled must NOT shield 'jupyter-old' folder.
+
+    grep without -x would match 'jupyter' as a substring of
+    'jupyter-old' and incorrectly preserve the folder. -x requires
+    whole-line equality, which is what we want.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        stacks = Path(tmp)
+        (stacks / "jupyter").mkdir()
+        (stacks / "jupyter-old").mkdir()
+
+        script = render_cleanup_script(["jupyter"], stacks_dir=str(stacks))
+        proc = subprocess.run(
+            ["bash", "-c", script],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert proc.returncode == 0
+        assert (stacks / "jupyter").exists()
+        # jupyter-old must be removed despite 'jupyter' being a substring
+        assert not (stacks / "jupyter-old").exists()
+
+
+@pytest.mark.skipif(not _bash_can_be_invoked(), reason="bash not on PATH")
+def test_exec_cleanup_empty_stacks_dir_emits_zero_counts() -> None:
+    """No folders → no actions, RESULT stopped=0 removed=0 failed=0."""
+    with tempfile.TemporaryDirectory() as tmp:
+        script = render_cleanup_script(["jupyter"], stacks_dir=tmp)
+        proc = subprocess.run(
+            ["bash", "-c", script],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert proc.returncode == 0
+        assert "RESULT stopped=0 removed=0 failed=0" in proc.stdout
+
+
+@pytest.mark.skipif(not _bash_can_be_invoked(), reason="bash not on PATH")
+def test_exec_cleanup_handles_dotted_and_dashed_names() -> None:
+    """Names with dots/dashes must round-trip through grep -F intact."""
+    with tempfile.TemporaryDirectory() as tmp:
+        stacks = Path(tmp)
+        (stacks / "seaweedfs-filer").mkdir()
+        (stacks / "v1.2").mkdir()
+        (stacks / "old.stack").mkdir()
+
+        script = render_cleanup_script(["seaweedfs-filer", "v1.2"], stacks_dir=str(stacks))
+        proc = subprocess.run(
+            ["bash", "-c", script],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert proc.returncode == 0
+        assert (stacks / "seaweedfs-filer").exists()
+        assert (stacks / "v1.2").exists()
+        assert not (stacks / "old.stack").exists()
+
+
+# ---------------------------------------------------------------------------
+# parse_cleanup_result
+# ---------------------------------------------------------------------------
+
+
+def test_parse_result_happy() -> None:
+    out = "  Removing foo...\nRESULT stopped=2 removed=3 failed=0\n"
+    parsed = parse_cleanup_result(out)
+    assert parsed == CleanupResult(stopped=2, removed=3, failed=0)
+
+
+def test_parse_result_missing_returns_none() -> None:
+    """No RESULT line → None (caller treats as transport failure)."""
+    assert parse_cleanup_result("garbage output, no RESULT here") is None
+
+
+def test_parse_result_picks_first_match_only() -> None:
+    """Multiple RESULT lines are unexpected; picking the first is fine."""
+    out = "RESULT stopped=1 removed=1 failed=0\nRESULT stopped=99 removed=99 failed=99"
+    parsed = parse_cleanup_result(out)
+    assert parsed is not None
+    assert parsed.stopped == 1
+
+
+def test_cleanup_result_is_success_property() -> None:
+    assert CleanupResult(stopped=1, removed=2, failed=0).is_success is True
+    assert CleanupResult(stopped=0, removed=0, failed=1).is_success is False
+
+
+# ---------------------------------------------------------------------------
+# rsync_enabled_stacks — DI-based unit tests
+# ---------------------------------------------------------------------------
+
+
+def _ok_rsync(_local: Path, _remote: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(args=["rsync"], returncode=0, stdout="", stderr="")
+
+
+def test_rsync_enabled_synced_status_for_existing_local_dirs(tmp_path: Path) -> None:
+    (tmp_path / "jupyter").mkdir()
+    (tmp_path / "marimo").mkdir()
+
+    results = rsync_enabled_stacks(
+        tmp_path,
+        ["jupyter", "marimo"],
+        rsync_runner=_ok_rsync,
+    )
+    assert all(r.status == "synced" for r in results)
+    assert [r.service for r in results] == ["jupyter", "marimo"]
+
+
+def test_rsync_enabled_missing_local_status(tmp_path: Path) -> None:
+    """Local dir doesn't exist → status='missing-local', NOT failed."""
+    results = rsync_enabled_stacks(
+        tmp_path,
+        ["nonexistent"],
+        rsync_runner=_ok_rsync,
+    )
+    assert results[0].status == "missing-local"
+
+
+def test_rsync_enabled_failed_status_on_rsync_rc_nonzero(tmp_path: Path) -> None:
+    """rsync exits non-zero → status='failed' with rc in detail."""
+    (tmp_path / "jupyter").mkdir()
+
+    def fail_rsync(_local: Path, _remote: str) -> subprocess.CompletedProcess[str]:
+        raise subprocess.CalledProcessError(23, ["rsync"])
+
+    results = rsync_enabled_stacks(
+        tmp_path,
+        ["jupyter"],
+        rsync_runner=fail_rsync,
+    )
+    assert results[0].status == "failed"
+    assert "rc=23" in results[0].detail
+
+
+def test_rsync_enabled_failed_on_unsafe_name(tmp_path: Path) -> None:
+    """Unsafe name → status='failed' BEFORE attempting rsync.
+
+    Path-safety is the first gate; rsync_runner must not be called.
+    """
+    called = {"count": 0}
+
+    def counting_rsync(local: Path, remote: str) -> subprocess.CompletedProcess[str]:
+        called["count"] += 1
+        return _ok_rsync(local, remote)
+
+    results = rsync_enabled_stacks(
+        tmp_path,
+        ["foo;rm -rf /"],
+        rsync_runner=counting_rsync,
+    )
+    assert results[0].status == "failed"
+    assert "unsafe name" in results[0].detail
+    assert called["count"] == 0
+
+
+def test_rsync_enabled_continues_after_per_service_failure(tmp_path: Path) -> None:
+    """One service's rsync failure does NOT abort the loop — strictly
+    more forgiving than deploy.sh's `set -e` semantics."""
+    (tmp_path / "a").mkdir()
+    (tmp_path / "b").mkdir()
+    (tmp_path / "c").mkdir()
+
+    call_log: list[str] = []
+
+    def runner(local: Path, _remote: str) -> subprocess.CompletedProcess[str]:
+        call_log.append(local.name)
+        if local.name == "b":
+            raise subprocess.CalledProcessError(1, ["rsync"])
+        return _ok_rsync(local, _remote)
+
+    results = rsync_enabled_stacks(tmp_path, ["a", "b", "c"], rsync_runner=runner)
+    assert call_log == ["a", "b", "c"]
+    assert [r.status for r in results] == ["synced", "failed", "synced"]
+
+
+def test_rsync_enabled_targets_correct_remote_path(tmp_path: Path) -> None:
+    """remote spec is `<host>:<stacks_dir>/<svc>/`."""
+    (tmp_path / "jupyter").mkdir()
+    captured: dict[str, str] = {}
+
+    def capture(local: Path, remote: str) -> subprocess.CompletedProcess[str]:
+        captured["remote"] = remote
+        captured["local"] = str(local)
+        return _ok_rsync(local, remote)
+
+    rsync_enabled_stacks(
+        tmp_path,
+        ["jupyter"],
+        rsync_runner=capture,
+        remote_stacks_dir="/opt/foo",
+        host="bar",
+    )
+    assert captured["remote"] == "bar:/opt/foo/jupyter/"
+    assert captured["local"].endswith("jupyter")
+
+
+# ---------------------------------------------------------------------------
+# cleanup_disabled_stacks — DI + unsafe-name filter contract
+# ---------------------------------------------------------------------------
+
+
+def test_cleanup_filters_unsafe_names_from_enabled_set() -> None:
+    """Unsafe names are dropped before rendering — they would NOT
+    have been rsynced to the server, so the cleanup loop correctly
+    treats their folder names as disabled."""
+    captured: dict[str, str] = {}
+
+    def runner(script: str) -> subprocess.CompletedProcess[str]:
+        captured["script"] = script
+        return subprocess.CompletedProcess(
+            args=["ssh"], returncode=0, stdout="RESULT stopped=0 removed=0 failed=0", stderr=""
+        )
+
+    cleanup_disabled_stacks(
+        ["jupyter", "evil; rm -rf /", "marimo"],
+        script_runner=runner,
+    )
+    assert "evil" not in captured["script"]
+    # safe names still made it
+    assert "jupyter" in captured["script"]
+    assert "marimo" in captured["script"]
+
+
+def test_cleanup_returns_none_on_unparseable_result() -> None:
+    """No RESULT in stdout → None (CLI maps to rc=2)."""
+
+    def runner(_script: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(args=["ssh"], returncode=0, stdout="garbage", stderr="")
+
+    assert cleanup_disabled_stacks(["jupyter"], script_runner=runner) is None
+
+
+def test_cleanup_forwards_diagnostics_to_local_stderr(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Per-stack ✓/✗/⚠ lines reach local stderr; RESULT does NOT."""
+
+    def runner(_script: str) -> subprocess.CompletedProcess[str]:
+        out = (
+            "  Stopping old-stack (disabled)...\n"
+            "  Removing old-stack stack folder...\n"
+            "RESULT stopped=1 removed=1 failed=0\n"
+        )
+        return subprocess.CompletedProcess(args=["ssh"], returncode=0, stdout=out, stderr="")
+
+    cleanup_disabled_stacks(["jupyter"], script_runner=runner)
+    captured = capsys.readouterr()
+    assert "old-stack" in captured.err
+    assert "RESULT stopped=" not in captured.err
+
+
+# ---------------------------------------------------------------------------
+# run_stack_sync — orchestration
+# ---------------------------------------------------------------------------
+
+
+def _ok_cleanup_runner(
+    stopped: int = 0, removed: int = 0, failed: int = 0
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(
+        args=["ssh"],
+        returncode=0,
+        stdout=f"RESULT stopped={stopped} removed={removed} failed={failed}",
+        stderr="",
+    )
+
+
+def test_run_stack_sync_happy_path(tmp_path: Path) -> None:
+    (tmp_path / "jupyter").mkdir()
+    (tmp_path / "marimo").mkdir()
+
+    result = run_stack_sync(
+        tmp_path,
+        ["jupyter", "marimo"],
+        rsync_runner=_ok_rsync,
+        script_runner=lambda _: _ok_cleanup_runner(removed=2),
+    )
+    assert isinstance(result, StackSyncResult)
+    assert result.synced == 2
+    assert result.missing == 0
+    assert result.failed_rsync == 0
+    assert result.cleanup is not None
+    assert result.cleanup.removed == 2
+    assert result.is_success
+
+
+def test_run_stack_sync_partial_failure(tmp_path: Path) -> None:
+    """One rsync fails, cleanup OK → not is_success, but synced > 0."""
+    (tmp_path / "a").mkdir()
+    (tmp_path / "b").mkdir()
+
+    def runner(local: Path, _remote: str) -> subprocess.CompletedProcess[str]:
+        if local.name == "b":
+            raise subprocess.CalledProcessError(1, ["rsync"])
+        return _ok_rsync(local, _remote)
+
+    result = run_stack_sync(
+        tmp_path,
+        ["a", "b"],
+        rsync_runner=runner,
+        script_runner=lambda _: _ok_cleanup_runner(),
+    )
+    assert result.synced == 1
+    assert result.failed_rsync == 1
+    assert result.is_success is False
+
+
+def test_run_stack_sync_cleanup_unparseable_means_not_success(tmp_path: Path) -> None:
+    (tmp_path / "jupyter").mkdir()
+
+    def bad_runner(_script: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(args=["ssh"], returncode=0, stdout="garbage", stderr="")
+
+    result = run_stack_sync(
+        tmp_path,
+        ["jupyter"],
+        rsync_runner=_ok_rsync,
+        script_runner=bad_runner,
+    )
+    assert result.cleanup is None
+    assert result.is_success is False
+
+
+# ---------------------------------------------------------------------------
+# CLI rc=0/1/2 mapping (direct _stack_sync call, no subprocess)
+# ---------------------------------------------------------------------------
+
+
+def test_cli_stack_sync_missing_enabled_returns_2(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from nexus_deploy.__main__ import _stack_sync
+
+    rc = _stack_sync([])
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "--enabled" in err
+
+
+def test_cli_stack_sync_unknown_arg_returns_2(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from nexus_deploy.__main__ import _stack_sync
+
+    rc = _stack_sync(["--enabled", "jupyter", "--bogus"])
+    assert rc == 2
+    assert "unknown arg" in capsys.readouterr().err
+
+
+def test_cli_stack_sync_bad_stacks_dir_returns_2(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from nexus_deploy.__main__ import _stack_sync
+
+    bogus = tmp_path / "does-not-exist"
+    rc = _stack_sync(["--enabled", "jupyter", "--stacks-dir", str(bogus)])
+    assert rc == 2
+    assert "not a directory" in capsys.readouterr().err
+
+
+def test_cli_stack_sync_happy_returns_0(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from nexus_deploy.__main__ import _stack_sync
+
+    (tmp_path / "jupyter").mkdir()
+
+    def fake_run(_local: Path, _enabled: list[str]) -> StackSyncResult:
+        return StackSyncResult(
+            rsync=(RsyncResult(service="jupyter", status="synced"),),
+            cleanup=CleanupResult(stopped=0, removed=0, failed=0),
+        )
+
+    monkeypatch.setattr("nexus_deploy.__main__.run_stack_sync", fake_run)
+    rc = _stack_sync(["--enabled", "jupyter", "--stacks-dir", str(tmp_path)])
+    assert rc == 0
+
+
+def test_cli_stack_sync_partial_returns_1(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from nexus_deploy.__main__ import _stack_sync
+
+    (tmp_path / "jupyter").mkdir()
+    (tmp_path / "marimo").mkdir()
+
+    def fake_run(_local: Path, _enabled: list[str]) -> StackSyncResult:
+        return StackSyncResult(
+            rsync=(
+                RsyncResult(service="jupyter", status="synced"),
+                RsyncResult(service="marimo", status="failed", detail="rsync rc=1"),
+            ),
+            cleanup=CleanupResult(stopped=0, removed=0, failed=0),
+        )
+
+    monkeypatch.setattr("nexus_deploy.__main__.run_stack_sync", fake_run)
+    rc = _stack_sync(["--enabled", "jupyter,marimo", "--stacks-dir", str(tmp_path)])
+    assert rc == 1
+
+
+def test_cli_stack_sync_all_failed_returns_2(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Zero rsync succeeded AND zero cleanup actions → rc=2."""
+    from nexus_deploy.__main__ import _stack_sync
+
+    (tmp_path / "jupyter").mkdir()
+
+    def fake_run(_local: Path, _enabled: list[str]) -> StackSyncResult:
+        return StackSyncResult(
+            rsync=(RsyncResult(service="jupyter", status="failed", detail="rsync rc=1"),),
+            cleanup=CleanupResult(stopped=0, removed=0, failed=0),
+        )
+
+    monkeypatch.setattr("nexus_deploy.__main__.run_stack_sync", fake_run)
+    rc = _stack_sync(["--enabled", "jupyter", "--stacks-dir", str(tmp_path)])
+    assert rc == 2
+
+
+def test_cli_stack_sync_unparseable_cleanup_returns_2(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """cleanup=None (no RESULT line) → rc=2 even if rsync succeeded."""
+    from nexus_deploy.__main__ import _stack_sync
+
+    (tmp_path / "jupyter").mkdir()
+
+    def fake_run(_local: Path, _enabled: list[str]) -> StackSyncResult:
+        return StackSyncResult(
+            rsync=(RsyncResult(service="jupyter", status="synced"),),
+            cleanup=None,
+        )
+
+    monkeypatch.setattr("nexus_deploy.__main__.run_stack_sync", fake_run)
+    rc = _stack_sync(["--enabled", "jupyter", "--stacks-dir", str(tmp_path)])
+    assert rc == 2
+
+
+def test_cli_stack_sync_rc2_on_transport_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """ssh/rsync failure → rc=2; exc.cmd never leaks to stderr/stdout."""
+    from nexus_deploy.__main__ import _stack_sync
+
+    (tmp_path / "jupyter").mkdir()
+
+    def boom(_local: Path, _enabled: list[str]) -> StackSyncResult:
+        raise subprocess.CalledProcessError(255, ["ssh", "secret-bearing-arg"])
+
+    monkeypatch.setattr("nexus_deploy.__main__.run_stack_sync", boom)
+    rc = _stack_sync(["--enabled", "jupyter", "--stacks-dir", str(tmp_path)])
+    assert rc == 2
+    captured = capsys.readouterr()
+    assert "transport failure" in captured.err
+    assert "secret-bearing-arg" not in captured.err
+    assert "secret-bearing-arg" not in captured.out
+
+
+def test_cli_stack_sync_rc2_on_unexpected_exception(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Programming errors → rc=2 (NOT Python's default rc=1).
+
+    Class name only in stderr; no str/repr that could leak attribute
+    values.
+    """
+    from nexus_deploy.__main__ import _stack_sync
+
+    (tmp_path / "jupyter").mkdir()
+
+    def boom(_local: Path, _enabled: list[str]) -> StackSyncResult:
+        raise RuntimeError("secret-bearing-message-NEVER-print")
+
+    monkeypatch.setattr("nexus_deploy.__main__.run_stack_sync", boom)
+    rc = _stack_sync(["--enabled", "jupyter", "--stacks-dir", str(tmp_path)])
+    assert rc == 2
+    captured = capsys.readouterr()
+    assert "RuntimeError" in captured.err
+    assert "secret-bearing-message-NEVER-print" not in captured.err
+    assert "secret-bearing-message-NEVER-print" not in captured.out
+
+
+def test_cli_stack_sync_filters_empty_csv_entries(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`,jupyter,,marimo,` → ['jupyter', 'marimo'] — no empty entries."""
+    from nexus_deploy.__main__ import _stack_sync
+
+    (tmp_path / "jupyter").mkdir()
+    (tmp_path / "marimo").mkdir()
+
+    captured: dict[str, list[str]] = {}
+
+    def fake_run(_local: Path, enabled: list[str]) -> StackSyncResult:
+        captured["enabled"] = enabled
+        return StackSyncResult(
+            rsync=tuple(RsyncResult(service=s, status="synced") for s in enabled),
+            cleanup=CleanupResult(stopped=0, removed=0, failed=0),
+        )
+
+    monkeypatch.setattr("nexus_deploy.__main__.run_stack_sync", fake_run)
+    rc = _stack_sync(["--enabled", ",jupyter,,marimo,", "--stacks-dir", str(tmp_path)])
+    assert rc == 0
+    assert captured["enabled"] == ["jupyter", "marimo"]
+
+
+# ---------------------------------------------------------------------------
+# Subprocess-level CLI smoke (one happy path through the real entry point)
+# ---------------------------------------------------------------------------
+
+
+def test_cli_subprocess_unknown_arg_returns_2() -> None:
+    """`python -m nexus_deploy stack-sync --bogus` exits 2."""
+    proc = subprocess.run(
+        [sys.executable, "-m", "nexus_deploy", "stack-sync", "--bogus"],
+        capture_output=True,
+        text=True,
+        env={**os.environ},
+    )
+    assert proc.returncode == 2
+    assert "unknown arg" in proc.stderr

--- a/tests/unit/test_stack_sync.py
+++ b/tests/unit/test_stack_sync.py
@@ -52,11 +52,30 @@ from nexus_deploy.stack_sync import (
         ("../bar", False),  # path traversal attempt
         ("foo/bar", False),  # slash
         ("-rf", True),  # leading dash IS allowed; the bash uses `-- "$name"` to terminate options
+        # Round-1 PR #523: bare "." and ".." pass the regex (dots are
+        # in the char class) but ARE path-traversal segments. Explicit
+        # rejection in _is_safe_name covers them.
+        (".", False),
+        ("..", False),
     ],
 )
 def test_is_safe_name_regex(name: str, expected: bool) -> None:
-    """Path-safety regex covers shell meta, whitespace, quotes, newlines."""
+    """Path-safety regex covers shell meta, whitespace, quotes, newlines.
+
+    Explicit ``.`` / ``..`` rejection is layered ON TOP of the regex —
+    the regex's char class includes ``.`` so ``.`` and ``..`` match
+    but are reserved path-traversal segments.
+    """
     assert _is_safe_name(name) is expected
+
+
+def test_is_safe_name_rejects_dot_and_dotdot_explicitly() -> None:
+    """Round-1 PR #523 — `_is_safe_name(".")` and `_is_safe_name("..")`
+    must return False even though the character-class regex matches
+    them. Pinned independently of the parameterized test so a future
+    refactor of the regex doesn't accidentally re-allow them."""
+    assert _is_safe_name(".") is False
+    assert _is_safe_name("..") is False
 
 
 # ---------------------------------------------------------------------------
@@ -188,6 +207,58 @@ def test_exec_cleanup_line_exact_match_no_substring_collision() -> None:
         assert (stacks / "jupyter").exists()
         # jupyter-old must be removed despite 'jupyter' being a substring
         assert not (stacks / "jupyter-old").exists()
+
+
+@pytest.mark.skipif(not _bash_can_be_invoked(), reason="bash not on PATH")
+def test_exec_cleanup_rm_runs_even_when_compose_down_fails() -> None:
+    """Round-1 PR #523: a stuck container shouldn't block folder removal.
+
+    Legacy deploy.sh used ``docker compose down 2>/dev/null || true``
+    and ran ``rm -rf`` regardless. A previous version of this module
+    inserted a ``continue`` after the down-failure branch which
+    diverged from that contract and left orphan folders behind. This
+    test pins the post-fix behaviour: when ``docker compose down``
+    fails, the folder is STILL removed and BOTH counters move
+    (failed=1 because the down failed, removed=1 because the rm
+    succeeded).
+    """
+    with tempfile.TemporaryDirectory() as tmp_root:
+        # fakebin must live OUTSIDE the stacks dir — otherwise the
+        # cleanup loop iterates fakebin/ as a "disabled stack" and
+        # rm -rf's it before reaching stuck-stack/, leaving the
+        # subsequent docker invocation to fall through to the real
+        # docker on PATH.
+        fake_bin = Path(tmp_root) / "fakebin"
+        fake_bin.mkdir()
+        fake_docker = fake_bin / "docker"
+        fake_docker.write_text(
+            '#!/bin/bash\necho "Error: stuck container" >&2\nexit 1\n',
+        )
+        fake_docker.chmod(0o755)
+
+        stacks = Path(tmp_root) / "stacks"
+        stacks.mkdir()
+        bad = stacks / "stuck-stack"
+        bad.mkdir()
+        (bad / "docker-compose.yml").write_text("services: {}\n")
+
+        script = render_cleanup_script([], stacks_dir=str(stacks))
+        proc = subprocess.run(
+            ["bash", "-c", script],
+            capture_output=True,
+            text=True,
+            check=False,
+            env={**os.environ, "PATH": f"{fake_bin}:{os.environ.get('PATH', '')}"},
+        )
+        assert proc.returncode == 0, proc.stderr
+        # Down failed (compose.yml present, fake docker exits 1) but
+        # rm -rf still succeeded → failed=1, removed=1.
+        assert "RESULT stopped=0 removed=1 failed=1" in proc.stdout
+        # Folder must be gone
+        assert not bad.exists()
+        # The captured stderr from the failed compose down must
+        # surface in the script's stderr (not be silently swallowed).
+        assert "Error: stuck container" in proc.stderr
 
 
 @pytest.mark.skipif(not _bash_can_be_invoked(), reason="bash not on PATH")

--- a/tests/unit/test_stack_sync.py
+++ b/tests/unit/test_stack_sync.py
@@ -375,6 +375,60 @@ def test_rsync_enabled_failed_status_on_rsync_rc_nonzero(tmp_path: Path) -> None
     assert "rc=23" in results[0].detail
 
 
+def test_rsync_failed_captures_stderr_excerpt(tmp_path: Path) -> None:
+    """Round-2 PR #523: the captured rsync stderr must reach the
+    RsyncResult so the CLI can surface it in the deploy log. Without
+    this, operators get bare `rc=23` with no actionable signal."""
+    (tmp_path / "jupyter").mkdir()
+
+    def fail_rsync(_local: Path, _remote: str) -> subprocess.CompletedProcess[str]:
+        exc = subprocess.CalledProcessError(23, ["rsync"])
+        exc.stderr = "rsync: connection unexpectedly closed\nrsync error: code 23\n"
+        exc.stdout = ""
+        raise exc
+
+    results = rsync_enabled_stacks(tmp_path, ["jupyter"], rsync_runner=fail_rsync)
+    assert results[0].status == "failed"
+    assert "connection unexpectedly closed" in results[0].stderr_excerpt
+    assert "rsync error: code 23" in results[0].stderr_excerpt
+
+
+def test_rsync_failed_truncates_pathological_stderr(tmp_path: Path) -> None:
+    """Bound stderr_excerpt to ≤2000 chars so a pathological repeat-
+    line situation can't flood the deploy log. The TAIL is kept (the
+    actually-relevant final error line, not the file-by-file noise)."""
+    (tmp_path / "jupyter").mkdir()
+    huge = "rsync: file: " + ("x" * 100) + "\n"
+    payload = huge * 100  # ~10KB
+    payload += "rsync: connection broken at end\n"  # tail signal
+
+    def fail_rsync(_local: Path, _remote: str) -> subprocess.CompletedProcess[str]:
+        exc = subprocess.CalledProcessError(12, ["rsync"])
+        exc.stderr = payload
+        exc.stdout = ""
+        raise exc
+
+    results = rsync_enabled_stacks(tmp_path, ["jupyter"], rsync_runner=fail_rsync)
+    assert len(results[0].stderr_excerpt) <= 2000
+    # The tail must be preserved — that's where the actionable line lives
+    assert "connection broken at end" in results[0].stderr_excerpt
+
+
+def test_rsync_failed_handles_none_stderr_stdout(tmp_path: Path) -> None:
+    """A test stub raising bare CalledProcessError leaves exc.stderr
+    and exc.stdout as None (the default). The fallback to empty
+    string keeps stderr_excerpt empty, no AttributeError."""
+    (tmp_path / "jupyter").mkdir()
+
+    def fail_rsync(_local: Path, _remote: str) -> subprocess.CompletedProcess[str]:
+        # Note: stderr/stdout left as None (default)
+        raise subprocess.CalledProcessError(1, ["rsync"])
+
+    results = rsync_enabled_stacks(tmp_path, ["jupyter"], rsync_runner=fail_rsync)
+    assert results[0].status == "failed"
+    assert results[0].stderr_excerpt == ""
+
+
 def test_rsync_enabled_failed_on_unsafe_name(tmp_path: Path) -> None:
     """Unsafe name → status='failed' BEFORE attempting rsync.
 
@@ -674,6 +728,41 @@ def test_cli_stack_sync_unparseable_cleanup_returns_2(
     monkeypatch.setattr("nexus_deploy.__main__.run_stack_sync", fake_run)
     rc = _stack_sync(["--enabled", "jupyter", "--stacks-dir", str(tmp_path)])
     assert rc == 2
+
+
+def test_cli_stack_sync_forwards_rsync_stderr_excerpt(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Round-2 PR #523: when an rsync failed, the CLI must print the
+    captured stderr_excerpt to stderr so operators see WHY (not just
+    `rc=23`). Each line indented under the per-service ✗ line."""
+    from nexus_deploy.__main__ import _stack_sync
+
+    (tmp_path / "jupyter").mkdir()
+
+    def fake_run(_local: Path, _enabled: list[str]) -> StackSyncResult:
+        return StackSyncResult(
+            rsync=(
+                RsyncResult(
+                    service="jupyter",
+                    status="failed",
+                    detail="rsync rc=23",
+                    stderr_excerpt="rsync: connection unexpectedly closed\nrsync error: code 23",
+                ),
+            ),
+            cleanup=CleanupResult(stopped=0, removed=0, failed=0),
+        )
+
+    monkeypatch.setattr("nexus_deploy.__main__.run_stack_sync", fake_run)
+    rc = _stack_sync(["--enabled", "jupyter", "--stacks-dir", str(tmp_path)])
+    assert rc == 2  # all-failed → rc=2
+    err = capsys.readouterr().err
+    # Per-service ✗ line
+    assert "✗ jupyter rsync failed" in err
+    assert "rsync rc=23" in err
+    # Indented stderr block — both lines surfaced, indented
+    assert "      rsync: connection unexpectedly closed" in err
+    assert "      rsync error: code 23" in err
 
 
 def test_cli_stack_sync_rc2_on_transport_failure(


### PR DESCRIPTION
## Summary

This PR bundles two independent CI/migration changes that landed on the same branch:

### 1. Modul 3.3 — `nexus_deploy/stack_sync.py`

Migrates `scripts/deploy.sh` lines 1401-1444 (per-stack rsync loop + disabled-stack cleanup, ~44 LoC bash) to `nexus_deploy/stack_sync.py`. Phase 3 of the Python migration tracked in #505.

- **Per-stack rsync** (one subprocess per service via `_remote.rsync_to_remote`): rsync `stacks/<svc>/` → `nexus:/opt/docker-server/stacks/<svc>/`. A failed rsync produces a `failed` RsyncResult with the rc + captured stderr; the loop continues for the remaining services (strictly more forgiving than deploy.sh's `set -e` abort-on-first semantics).
- **Disabled-stack cleanup** (one ssh roundtrip via `_remote.ssh_run_script` stdin-fed bash): server-side loop walks `/opt/docker-server/stacks/*/`, runs `docker compose down` + `rm -rf` for any folder NOT in `$ENABLED_SERVICES`. Idempotent on re-run.

deploy.sh: **3538 → 3511 lines** (−27 LoC). Cumulative migration **~37%**.

### 2. Codecov coverage reporting (CI)

Wires the existing pytest `coverage.xml` output into Codecov for an auto-updating README badge, per-PR coverage trend graphs, and a coverage-trend view on main over time. The existing `MishaKav/pytest-coverage-comment` step (local-only PR comment) stays — Codecov supplements rather than replaces it. Activates on the next push to main after merge; first run populates the codecov.io project, then the README badge resolves.

## Critical invariants (R-tagged tests)

| # | Invariant | Test |
|---|---|---|
| R1 | `set -euo pipefail` first executable line | `test_render_starts_with_set_euo_pipefail` |
| R3 | EXIT-clean: rendered bash uses `[ -d "$stack_dir" ] || continue` guard | `test_exec_cleanup_empty_stacks_dir_emits_zero_counts` |
| R4 | HTTP-code-style dispatch via exec'd bash (✓/✗ paths verified) | `test_exec_cleanup_skips_enabled_removes_disabled` (synthetic dirs, real bash) |
| R5 | Path safety: `^[A-Za-z0-9._-]+$` enforced before any interpolation, plus explicit reject of `.` and `..` | `test_is_safe_name_regex` (17 parameterized cases incl. `.`/`..`) + `test_is_safe_name_rejects_dot_and_dotdot_explicitly` + `test_rsync_enabled_failed_on_unsafe_name` (rsync_runner never called) + `test_cleanup_filters_unsafe_names_from_enabled_set` |
| R6 | `grep -qFx --` line-exact fixed-string match | `test_render_uses_grep_qfx_for_line_exact_fixed_string_match` + `test_exec_cleanup_line_exact_match_no_substring_collision` (real bash; `jupyter` enabled does NOT shield `jupyter-old` folder) |
| R7 | Deterministic per-service order (operators rely on it) | `test_rsync_enabled_continues_after_per_service_failure` (call_log == `['a','b','c']`) |
| R8 | RESULT wire-format: `RESULT stopped=N removed=N failed=N` | `test_render_emits_result_line_format` + `test_parse_result_happy` + `test_cleanup_returns_none_on_unparseable_result` |
| Diag | Per-stack stderr forwarding for compose-down failure (Round 1) AND rsync failure (Round 2) | `test_exec_cleanup_rm_runs_even_when_compose_down_fails` (PATH-injected fake docker), `test_rsync_failed_captures_stderr_excerpt`, `test_rsync_failed_truncates_pathological_stderr`, `test_cli_stack_sync_forwards_rsync_stderr_excerpt` |

Plus CLI rc=0/1/2 contract (8 tests), exec'd-bash semantic regression tests (5 tests), and `_is_safe_name` property-style coverage.

**60 tests in test_stack_sync.py, stack_sync.py at 100% coverage.** Full suite: **724 tests, 96.6% total** (gate: 80%).

## Deliberate divergences from legacy

1. **`rsync -aq` instead of `-av`** — deploy.sh's `-av` per-file output dominated the deploy log (n8n's `node_modules` alone = thousands of lines). `_remote.rsync_to_remote` uses `-aq` with `capture_output`; we get the diagnostic on failure (`stderr_excerpt` field) without happy-path noise.
2. **Strictly-more-forgiving rsync loop** — deploy.sh's `set -e` aborted on the first failed rsync. The Python loop continues with a per-service `failed` counter; the orchestrator emits rc=1 (yellow) iff at least one rsync succeeded, rc=2 only if zero rsyncs succeeded AND zero cleanup actions ran.
3. **Removed inline JSON debug-logging lines** — deploy.sh interleaved `{"location":...,"message":"..."}` writes to `$LOG_FILE` after every rsync iteration. The new module emits structured per-service status (`✓ <svc> synced` / `⚠ ... not found` / `✗ ... rsync failed`) to stderr; the deploy log already captures stderr.
4. **`grep -qFx --` instead of `grep -qw`** — legacy used word-boundary grep, which CAN match substrings (`jupyter` would match `jupyter-old`). Tightened to line-exact fixed-string. Defence-in-depth: also covers a hypothetical future stack name with regex metachars.

## Round 1 + 2 review fixes

- (R1) `_is_safe_name` accepted bare `.` and `..` (regex char class `[A-Za-z0-9._-]+` matches them). Path-traversal vector — `local_stacks_dir / ".."` escapes. Added explicit reject layered on top of the regex.
- (R1) Cleanup loop's `continue` after compose-down failure skipped `rm -rf`, diverging from deploy.sh's legacy `|| true` semantics + leaving orphan folders. Dropped the `continue`; counters now move independently.
- (R1) compose-down stderr was suppressed via `2>/dev/null`. Now captured to a tmpfile and forwarded indented to stderr only on failure.
- (R2) rsync stderr was captured by `_remote.rsync_to_remote` (via `capture_output=True`) but discarded. Operators saw bare `rc=23`. Added `stderr_excerpt` field to `RsyncResult`, populated from `exc.stderr + exc.stdout`, truncated to ≤2000 chars (tail-preserving). CLI surfaces it as an indented block under the per-service ✗ line.

## Test plan

- [x] `uv run ruff format --check .` passes
- [x] `uv run ruff check .` passes
- [x] `uv run mypy --strict src/nexus_deploy/stack_sync.py src/nexus_deploy/__main__.py` passes
- [x] `uv run pytest --cov=src/nexus_deploy --cov-fail-under=80` passes (96.60% total, stack_sync.py 100%)
- [x] `bash -n scripts/deploy.sh` parses
- [ ] Spin-up gate (blocked on Hetzner ARM capacity since 2026-04-28): clean `gh workflow run initial-setup.yaml` against this branch — verify (a) every enabled stack's `stacks/<svc>/` is rsynced, (b) re-deploying with one service removed cleanly stops + removes that folder, (c) re-running is no-op (synced=N, removed=0).
- [ ] Codecov first-upload (post-merge): first push to `main` after merge populates the codecov.io project; then the README badge resolves from "unknown" to the real coverage figure.

## Closes

Part of #505 (Modul 3.3).
