### PR TITLE
feat(nexus_deploy): Migrate 4 final bash blocks to Python (Modul 3.4f)

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -436,108 +436,22 @@ else
 fi
 
 # -----------------------------------------------------------------------------
-# Setup SSH-Agent for Wetty (if enabled)
+# Setup SSH-Agent for Wetty (if enabled) — Phase 3 Modul 3.4f (#505)
 # -----------------------------------------------------------------------------
+# Was a 100-line ssh heredoc; now a Python CLI that renders the same
+# idempotent bash + parses RESULT_WETTY back into a typed result.
 if echo "$ENABLED_SERVICES" | grep -qw "wetty"; then
     echo ""
     echo -e "${YELLOW}[5.5/7] Setting up SSH-Agent for Wetty...${NC}"
-    ssh nexus "
-        # Create SSH directory if it doesn't exist
-        mkdir -p /root/.ssh
-        chmod 700 /root/.ssh
-        
-        # Generate SSH key pair for Wetty if it doesn't exist
-        WETTY_KEY_PATH=\"/root/.ssh/id_ed25519_wetty\"
-        if [ ! -f \"\$WETTY_KEY_PATH\" ]; then
-            echo '  Generating SSH key pair for Wetty...'
-            ssh-keygen -t ed25519 -f \"\$WETTY_KEY_PATH\" -N '' -C 'wetty-auto-generated' >/dev/null 2>&1
-            chmod 600 \"\$WETTY_KEY_PATH\"
-            chmod 644 \"\$WETTY_KEY_PATH.pub\"
-            echo '  ✓ SSH key pair generated for Wetty'
-        else
-            echo '  ✓ SSH key pair already exists for Wetty'
-        fi
-        
-        # Add public key to authorized_keys if not already present
-        WETTY_PUBKEY=\$(cat \"\$WETTY_KEY_PATH.pub\")
-        if ! grep -q \"\$WETTY_PUBKEY\" /root/.ssh/authorized_keys 2>/dev/null; then
-            echo \"\$WETTY_PUBKEY\" >> /root/.ssh/authorized_keys
-            chmod 600 /root/.ssh/authorized_keys
-            echo '  ✓ Public key added to authorized_keys'
-        else
-            echo '  ✓ Public key already in authorized_keys'
-        fi
-        
-        # Create SSH-Agent socket directory if it doesn't exist
-        SSH_AGENT_DIR=\"/tmp/ssh-agent\"
-        mkdir -p \"\$SSH_AGENT_DIR\"
-        
-        # Helper function to check if SSH-Agent is responsive
-        check_ssh_agent() {
-            if ssh-add -l >/dev/null 2>&1; then
-                return 0
-            else
-                return 1
-            fi
-        }
-        
-        # Check if SSH-Agent is already running (check for existing socket)
-        SSH_AUTH_SOCK_FILE=\"\$SSH_AGENT_DIR/agent.sock\"
-        if [ -S \"\$SSH_AUTH_SOCK_FILE\" ]; then
-            export SSH_AUTH_SOCK=\"\$SSH_AUTH_SOCK_FILE\"
-            # Test if agent is still responsive
-            if check_ssh_agent; then
-                echo '  ✓ SSH-Agent already running'
-            else
-                # Socket exists but agent is dead, remove it
-                rm -f \"\$SSH_AUTH_SOCK_FILE\"
-                unset SSH_AUTH_SOCK
-            fi
-        fi
-        
-        # Start SSH-Agent if not running
-        if [ -z \"\${SSH_AUTH_SOCK:-}\" ] || [ ! -S \"\$SSH_AUTH_SOCK\" ]; then
-            # Start SSH-Agent with socket in known location
-            eval \$(ssh-agent -a \"\$SSH_AUTH_SOCK_FILE\" -s) >/dev/null 2>&1
-            export SSH_AUTH_SOCK=\"\$SSH_AUTH_SOCK_FILE\"
-            echo '  ✓ SSH-Agent started'
-        fi
-        
-        # Add SSH key to agent if not already added
-        if [ -f \"\$WETTY_KEY_PATH\" ]; then
-            # Get key fingerprint for comparison
-            KEY_FINGERPRINT=\$(ssh-keygen -lf \"\$WETTY_KEY_PATH\" 2>/dev/null | awk '{print \$2}' || echo \"\")
-            
-            # Check if key is already in agent by comparing fingerprints
-            KEY_IN_AGENT=false
-            if [ -n \"\$KEY_FINGERPRINT\" ] && check_ssh_agent && ssh-add -l 2>/dev/null | grep -q \"\$KEY_FINGERPRINT\"; then
-                KEY_IN_AGENT=true
-            fi
-            
-            if [ \"\$KEY_IN_AGENT\" = \"false\" ]; then
-                # Add key to agent
-                if ssh-add \"\$WETTY_KEY_PATH\" 2>&1; then
-                    echo '  ✓ SSH key added to agent'
-                else
-                    echo -e \"  ${YELLOW}⚠ Failed to add SSH key to agent${NC}\"
-                fi
-            else
-                echo '  ✓ SSH key already in agent'
-            fi
-        else
-            echo -e \"  ${YELLOW}⚠ SSH key not found at \$WETTY_KEY_PATH${NC}\"
-        fi
-        
-        # Export SSH_AUTH_SOCK path in wetty .env file for docker-compose
-        WETTY_ENV=\"/opt/docker-server/stacks/wetty/.env\"
-        if [ -f \"\$WETTY_ENV\" ]; then
-            # Remove existing SSH_AUTH_SOCK line if present
-            sed -i '/^SSH_AUTH_SOCK=/d' \"\$WETTY_ENV\"
-        fi
-        echo \"SSH_AUTH_SOCK=\$SSH_AUTH_SOCK\" >> \"\$WETTY_ENV\"
-        echo '  ✓ SSH_AUTH_SOCK exported to wetty .env'
-    "
-    echo -e "${GREEN}  ✓ SSH-Agent configured for Wetty${NC}"
+    WETTY_RC=0
+    uv run --quiet --project "$PROJECT_ROOT" \
+        python -m nexus_deploy setup wetty-ssh-agent \
+        || WETTY_RC=$?
+    case "$WETTY_RC" in
+        0) echo -e "${GREEN}  ✓ SSH-Agent configured for Wetty${NC}" ;;
+        1) echo -e "${YELLOW}  ⚠ Wetty SSH-Agent setup produced no parseable result (continuing — Wetty is non-critical)${NC}" ;;
+        *) echo -e "${RED}  ✗ Wetty SSH-Agent setup failed (rc=$WETTY_RC); aborting${NC}"; exit "$WETTY_RC" ;;
+    esac
 fi
 
 # -----------------------------------------------------------------------------
@@ -792,79 +706,28 @@ CONFIG_JOBS=()
 # Configure Infisical admin and push secrets (idempotent - runs on every spin-up)
 if echo "$ENABLED_SERVICES" | grep -qw "infisical"; then
     echo "  Configuring Infisical..."
-
-    # Wait for Infisical to be ready (optimized: check container status first)
-    echo "  Waiting for Infisical to be ready (may take up to 2min)..."
-    INFISICAL_READY=false
-    for i in $(seq 1 20); do
-        CONTAINER_STATUS=$(ssh nexus "docker inspect --format='{{.State.Status}}' infisical 2>/dev/null" || echo "")
-        if [ "$CONTAINER_STATUS" = "running" ]; then break; fi
-        sleep 2
-    done
-    for i in $(seq 1 40); do
-        if ssh nexus "curl -s --connect-timeout 3 'http://localhost:8070/api/v1/admin/config'" 2>/dev/null | grep -q 'initialized'; then
-            INFISICAL_READY=true
-            break
-        fi
-        sleep 3
-    done
-
-    if [ "$INFISICAL_READY" = "false" ]; then
-        echo -e "${YELLOW}  ⚠ Infisical not responding after 120s - skipping config${NC}"
-    else
-    INFISICAL_TOKEN=""
-    PROJECT_ID=""
-    INIT_CHECK=$(ssh nexus "curl -s 'http://localhost:8070/api/v1/admin/config'" 2>/dev/null || echo "")
-
-    if echo "$INIT_CHECK" | grep -q '"initialized":true'; then
-        # Existing instance - load saved credentials
-        echo "  Infisical already initialized - loading saved credentials..."
-        INFISICAL_TOKEN=$(ssh nexus "cat /opt/docker-server/.infisical-token 2>/dev/null" || echo "")
-        PROJECT_ID=$(ssh nexus "cat /opt/docker-server/.infisical-project-id 2>/dev/null" || echo "")
-        if [ -z "$INFISICAL_TOKEN" ] || [ -z "$PROJECT_ID" ]; then
-            echo -e "${YELLOW}  ⚠ No saved credentials - run destroy-all + initial-setup to re-bootstrap${NC}"
-        else
-            echo -e "${GREEN}  ✓ Loaded Infisical credentials${NC}"
-        fi
-    else
-        # New instance - bootstrap admin + create project
-        BOOTSTRAP_JSON=$(cat <<EOF
-{"email": "$ADMIN_EMAIL", "password": "$INFISICAL_PASS", "organization": "Nexus"}
-EOF
-)
-        BOOTSTRAP_RESULT=$(ssh nexus "curl -s -X POST 'http://localhost:8070/api/v1/admin/bootstrap' \
-            -H 'Content-Type: application/json' \
-            -d '$(echo "$BOOTSTRAP_JSON" | tr -d '\n')'" 2>&1 || echo "")
-
-        if echo "$BOOTSTRAP_RESULT" | grep -q '"user"'; then
-            echo -e "${GREEN}  ✓ Infisical admin created (user: $ADMIN_EMAIL)${NC}"
-            INFISICAL_TOKEN=$(echo "$BOOTSTRAP_RESULT" | jq -r '.identity.credentials.token // empty')
-            ORG_ID=$(echo "$BOOTSTRAP_RESULT" | jq -r '.organization.id // empty')
-
-            if [ -n "$INFISICAL_TOKEN" ] && [ -n "$ORG_ID" ]; then
-                echo "  Creating Nexus secrets project..."
-                PROJECT_RESULT=$(ssh nexus "curl -s -X POST 'http://localhost:8070/api/v2/workspace' \
-                    -H 'Authorization: Bearer $INFISICAL_TOKEN' \
-                    -H 'Content-Type: application/json' \
-                    -d '{\"projectName\": \"Nexus Stack\", \"organizationId\": \"$ORG_ID\"}'" 2>&1 || echo "")
-                PROJECT_ID=$(echo "$PROJECT_RESULT" | jq -r '.project.id // .workspace.id // empty')
-
-                if [ -n "$PROJECT_ID" ] && [ "$PROJECT_ID" != "null" ]; then
-                    echo -e "${GREEN}  ✓ Project 'Nexus Stack' created${NC}"
-                    # Save credentials for subsequent spin-ups
-                    echo "$INFISICAL_TOKEN" | ssh nexus "cat > /opt/docker-server/.infisical-token && chmod 600 /opt/docker-server/.infisical-token"
-                    echo "$PROJECT_ID" | ssh nexus "cat > /opt/docker-server/.infisical-project-id && chmod 600 /opt/docker-server/.infisical-project-id"
-                    echo -e "${GREEN}  ✓ Credentials saved for subsequent deployments${NC}"
-                else
-                    echo -e "${YELLOW}  ⚠ Failed to create project${NC}"
-                fi
-            fi
-        elif echo "$BOOTSTRAP_RESULT" | grep -q 'already'; then
-            echo -e "${YELLOW}  ⚠ Infisical already configured${NC}"
-        else
-            echo -e "${YELLOW}  ⚠ Infisical bootstrap failed${NC}"
-        fi
-    fi
+    # Provision admin + project — Phase 3 Modul 3.4f (#505).
+    # Was a 75-line bash block (readiness probe + admin-bootstrap +
+    # project-create + cred-persist); now a Python CLI that emits
+    # eval-able stdout: INFISICAL_TOKEN=...; PROJECT_ID=... (both
+    # always emitted, may be empty when not-ready / soft-fail).
+    INFISICAL_OUT=$(mktemp)
+    RUNNER_CLEANUP_PATHS+="$INFISICAL_OUT\n"
+    INFISICAL_PROVISION_RC=0
+    ADMIN_EMAIL="$ADMIN_EMAIL" INFISICAL_PASS="$INFISICAL_PASS" \
+        uv run --quiet --project "$PROJECT_ROOT" \
+        python -m nexus_deploy infisical provision-admin > "$INFISICAL_OUT" \
+        || INFISICAL_PROVISION_RC=$?
+    case "$INFISICAL_PROVISION_RC" in
+        0) eval "$(cat "$INFISICAL_OUT")"  # sets INFISICAL_TOKEN + PROJECT_ID
+           echo -e "${GREEN}  ✓ Infisical provisioned${NC}" ;;
+        1) eval "$(cat "$INFISICAL_OUT")"  # may set empty values; surface via shell vars
+           echo -e "${YELLOW}  ⚠ Infisical provision soft-fail (see Python stderr above) — continuing without secret push${NC}" ;;
+        *) echo -e "${RED}  ✗ Infisical provision hard failure (rc=$INFISICAL_PROVISION_RC); aborting${NC}"
+           rm -f "$INFISICAL_OUT"
+           exit "$INFISICAL_PROVISION_RC" ;;
+    esac
+    rm -f "$INFISICAL_OUT"
 
     # ==========================================================================
     # Push secrets to Infisical (#505 Modul 1.1: nexus_deploy.infisical)
@@ -876,7 +739,9 @@ EOF
     # rsyncs them, and runs the same server-side curl loop. The
     # remaining BootstrapEnv fields (DOMAIN, ADMIN_EMAIL, GITEA_*,
     # WOODPECKER_*, etc.) are passed as env vars to the Python side.
-    if [ -n "$INFISICAL_TOKEN" ] && [ -n "$PROJECT_ID" ]; then
+    # Skipped when provision-admin reported soft-fail (empty token /
+    # project_id) — operator must investigate the Python stderr above.
+    if [ -n "${INFISICAL_TOKEN:-}" ] && [ -n "${PROJECT_ID:-}" ]; then
         echo "  Pushing secrets to Infisical (via nexus_deploy)..."
         INFISICAL_ENV="${INFISICAL_ENV:-dev}"
         # SSH_KEY_BASE64 must match the legacy `build_folder "ssh"`
@@ -932,8 +797,9 @@ EOF
             1) echo -e "${YELLOW}  ⚠ Infisical bootstrap had partial push failures (see output above)${NC}" ;;
             *) echo -e "${RED}  ✗ Infisical bootstrap transport failure (rc=$INFISICAL_RC); aborting${NC}"; exit 1 ;;
         esac
+    else
+        echo -e "${YELLOW}  ⚠ INFISICAL_TOKEN / PROJECT_ID empty — skipping secret push${NC}"
     fi
-    fi  # End of INFISICAL_READY check
 fi
 
 # Configure all admin-setup hooks via the Python services-configure CLI.
@@ -959,37 +825,12 @@ case "$SERVICES_RC" in
     *) echo -e "${RED}  ✗ services configure hard failure (rc=$SERVICES_RC) — bad args, transport, or unexpected error; check Python stderr above. Aborting.${NC}"; exit "$SERVICES_RC" ;;
 esac
 
-# Re-apply pg_ducklake bootstrap SQL (handles credential rotation)
-# /docker-entrypoint-initdb.d/ scripts only run on empty data dir, so we
-# also exec the same SQL after every spin-up to ensure rotated credentials
-# take effect on existing volumes.
-if echo "$ENABLED_SERVICES" | grep -qw "pg-ducklake" && [ -n "$PG_DUCKLAKE_PASS" ]; then
-    (
-        echo "  Configuring pg_ducklake (re-applying bootstrap SQL)..."
-        # Wait for healthcheck to be ready (~30s timeout)
-        PG_DUCKLAKE_READY=false
-        for i in $(seq 1 15); do
-            if ssh nexus "docker exec pg-ducklake pg_isready -U nexus-pgducklake -d ducklake" >/dev/null 2>&1; then
-                PG_DUCKLAKE_READY=true
-                break
-            fi
-            sleep 2
-        done
-
-        if [ "$PG_DUCKLAKE_READY" = "false" ]; then
-            echo -e "${YELLOW}  ⚠ pg_ducklake not ready after 30s - skipping re-apply${NC}"
-            exit 0
-        fi
-
-        # Re-apply bootstrap SQL via docker exec (idempotent, handles credential rotation)
-        if ssh nexus "docker exec pg-ducklake psql -U nexus-pgducklake -d ducklake -f /docker-entrypoint-initdb.d/00-ducklake-bootstrap.sql" >/dev/null 2>&1; then
-            echo -e "${GREEN}  ✓ pg_ducklake bootstrap SQL re-applied${NC}"
-        else
-            echo -e "${YELLOW}  ⚠ pg_ducklake bootstrap re-apply failed (may already be applied)${NC}"
-        fi
-    ) &
-    CONFIG_JOBS+=($!)
-fi
+# pg-ducklake bootstrap SQL re-apply moved into the services-configure
+# hook registry (Modul 3.4f, #505). The hook runs as part of the
+# services configure CLI invocation ABOVE — `pg-ducklake` is now in
+# the same dispatch loop as the other 14 admin-setup hooks. Same
+# 30-second pg_isready probe + idempotent psql exec, just folded into
+# a typed Python rendering layer.
 
 
 # All 14 admin-setup bash blocks that used to live here (Filestash,
@@ -1219,331 +1060,31 @@ if echo "$ENABLED_SERVICES" | grep -qw "gitea" && [ -n "$GITEA_ADMIN_PASS" ]; th
                     # Worth it: this is the ONLY mechanism that actually
                     # makes `{{ secret('GITEA_TOKEN') }}` resolve in flows.
                     # ----------------------------------------------------------
-                    KESTRA_SECRETS_TMP=$(mktemp)
-                    # Register with the global RUNNER_CLEANUP_PATHS list
-                    # so the EXIT trap wipes it even when one of the
-                    # `exit 1` paths below fires (sed-cleanup failure,
-                    # Kestra restart timeout, etc.). Without this, a
-                    # mid-flight abort can leave plaintext base64-
-                    # encoded Infisical secrets on the runner FS.
-                    echo "$KESTRA_SECRETS_TMP" >> "$RUNNER_CLEANUP_PATHS"
-                    KSEC_PUSHED=0
-                    KSEC_SKIPPED=0
-                    KSEC_FETCH_FAILED=0
-                    KSEC_COLLISIONS=0
-                    # KSEC_SEEN is allocated only inside the Infisical-guard
-                    # below, so the runner doesn't leak a tmp file on stacks
-                    # where Infisical isn't reachable. The post-guard
-                    # GITEA_TOKEN-special-case at the bottom of this block
-                    # checks `[ -n "$KSEC_SEEN" ] && [ -f ... ]` before
-                    # running awk, so an unset/missing seen-file is safe.
-                    KSEC_SEEN=""
-                    if [ -n "$INFISICAL_TOKEN" ] && [ -n "$PROJECT_ID" ]; then
-                        echo "  Building Kestra secret env from Infisical..."
-                        INFISICAL_ENV_KESTRA="${INFISICAL_ENV:-dev}"
-                        # Two-column file: "<KEY>\t<source-folder>". Used
-                        # both to skip cross-folder duplicates (first-
-                        # folder-wins, deterministic across re-runs) AND
-                        # to surface a collision warning that names BOTH
-                        # source folders so the operator can tell where
-                        # the divergence is.
-                        KSEC_SEEN=$(mktemp)
-
-                        # All Infisical fetches happen on the server
-                        # (localhost:8070 only listens there) but we need
-                        # jq on the runner to parse the responses. So:
-                        #
-                        #   - The Infisical bearer token, project ID, and
-                        #     env slug are base64-encoded on the runner
-                        #     and substituted into a `bash -s` heredoc
-                        #     body. The remote shell decodes them via
-                        #     the `printf` builtin (no fork-exec, no
-                        #     argv) and writes a mode-600 curl
-                        #     `--config` file with the auth header.
-                        #     Same argv-safe pattern PR #486 established.
-                        #   - Folder name + secretPath transit through
-                        #     `curl --get --data-urlencode ...` so
-                        #     names with whitespace or reserved chars
-                        #     produce valid URLs.
-                        #   - Folder iteration uses `while read` over
-                        #     newline-delimited input — `for X in $LIST`
-                        #     would word-split on whitespace.
-                        INF_TOKEN_B64=$(printf '%s' "$INFISICAL_TOKEN" | base64 | tr -d '\n')
-                        INF_PID_B64=$(printf '%s' "$PROJECT_ID" | base64 | tr -d '\n')
-                        INF_ENV_B64=$(printf '%s' "$INFISICAL_ENV_KESTRA" | base64 | tr -d '\n')
-
-                        # Each Infisical fetch (folders + per-path
-                        # secrets) needs to surface the HTTP status. We
-                        # use `curl -w "\n%{http_code}"` so the LAST line
-                        # of stdout is the status code; everything before
-                        # it is the response body. Runner-side splits
-                        # status from body and warns on non-200 instead
-                        # of silently feeding a 401/403/error JSON to jq.
-
-                        # 1a. Discover folders. Tempfile around the
-                        #     heredoc to avoid the awkward bash quirk where
-                        #     `$(... <<EOF body EOF)` parses the closing
-                        #     `)` of `$()` BEFORE the heredoc body, mis-
-                        #     matching parens against the `\$(printf ...)`
-                        #     escapes inside the body.
-                        FOLDERS_RAW_FILE=$(mktemp)
-                        ssh nexus "bash -s" > "$FOLDERS_RAW_FILE" 2>/dev/null <<REMOTE_INF_FOLDERS_EOF || true
-ITOK=\$(printf '%s' '$INF_TOKEN_B64' | base64 -d)
-PID=\$(printf '%s' '$INF_PID_B64' | base64 -d)
-INF_ENV=\$(printf '%s' '$INF_ENV_B64' | base64 -d)
-CFG=\$(mktemp)
-chmod 600 "\$CFG"
-trap 'rm -f "\$CFG"' EXIT
-printf 'header = "Authorization: Bearer %s"\n' "\$ITOK" > "\$CFG"
-curl -s -w "\n%{http_code}" --config "\$CFG" --get \\
-    --data-urlencode "workspaceId=\$PID" \\
-    --data-urlencode "environment=\$INF_ENV" \\
-    --data-urlencode "path=/" \\
-    "http://localhost:8070/api/v1/folders"
-REMOTE_INF_FOLDERS_EOF
-                        FOLDERS_RAW=$(cat "$FOLDERS_RAW_FILE")
-                        rm -f "$FOLDERS_RAW_FILE"
-                        # Last line = HTTP status; everything before = body.
-                        FOLDERS_STATUS=$(printf '%s' "$FOLDERS_RAW" | tail -n1)
-                        FOLDERS_STATUS="${FOLDERS_STATUS:-000}"
-                        FOLDERS_BODY=$(mktemp)
-                        printf '%s' "$FOLDERS_RAW" | sed '$d' > "$FOLDERS_BODY"
-                        if [ "$FOLDERS_STATUS" = "200" ]; then
-                            # Sort the folder list alphabetically so the
-                            # first-folder-wins collision policy is
-                            # deterministic across re-runs even if
-                            # Infisical's API returns folders in a
-                            # different order between calls.
-                            FOLDER_LIST=$(jq -r '.folders[]?.name' "$FOLDERS_BODY" 2>/dev/null | LC_ALL=C sort || echo "")
-                        else
-                            echo -e "${YELLOW}    ⚠ Infisical folder discovery returned HTTP $FOLDERS_STATUS — Kestra secret env will only contain root-path secrets + GITEA_TOKEN${NC}"
-                            KSEC_FETCH_FAILED=$((KSEC_FETCH_FAILED+1))
-                            FOLDER_LIST=""
-                        fi
-                        rm -f "$FOLDERS_BODY"
-
-                        # 1b. For each discovered folder + the root path,
-                        #     fetch all (key, value) pairs. Newline-safe
-                        #     iteration via while-read; secretPath URL-
-                        #     encoded via curl --data-urlencode.
-                        # Use a literal "/" as the root-path sentinel
-                        # rather than a magic name like "__root__". Infisical
-                        # folder names cannot contain a slash (it's the path
-                        # separator, not a name character), so "/" is
-                        # guaranteed not to collide with any real folder
-                        # name an operator might create.
-                        while IFS= read -r FOLDER; do
-                            [ -z "$FOLDER" ] && continue
-                            if [ "$FOLDER" = "/" ]; then
-                                SECRET_PATH="/"
-                                FOLDER_LABEL="<root>"
-                            else
-                                SECRET_PATH="/$FOLDER"
-                                FOLDER_LABEL="$FOLDER"
-                            fi
-                            INF_PATH_B64=$(printf '%s' "$SECRET_PATH" | base64 | tr -d '\n')
-                            # Same tempfile-around-heredoc pattern as the
-                            # folder-discovery call above (avoids paren
-                            # mismatch in `$(... <<EOF \$(...) EOF)`).
-                            SECRETS_RAW_FILE=$(mktemp)
-                            # Plaintext Infisical secrets land in this
-                            # file on the runner; register it with the
-                            # global RUNNER_CLEANUP_PATHS list so an
-                            # interrupted run still wipes it. The
-                            # explicit `rm -f "$SECRETS_RAW_FILE"` below
-                            # remains the happy-path cleanup.
-                            echo "$SECRETS_RAW_FILE" >> "$RUNNER_CLEANUP_PATHS"
-                            ssh nexus "bash -s" > "$SECRETS_RAW_FILE" 2>/dev/null <<REMOTE_INF_SECRETS_EOF || true
-ITOK=\$(printf '%s' '$INF_TOKEN_B64' | base64 -d)
-PID=\$(printf '%s' '$INF_PID_B64' | base64 -d)
-INF_ENV=\$(printf '%s' '$INF_ENV_B64' | base64 -d)
-SPATH=\$(printf '%s' '$INF_PATH_B64' | base64 -d)
-CFG=\$(mktemp)
-chmod 600 "\$CFG"
-trap 'rm -f "\$CFG"' EXIT
-printf 'header = "Authorization: Bearer %s"\n' "\$ITOK" > "\$CFG"
-curl -s -w "\n%{http_code}" --config "\$CFG" --get \\
-    --data-urlencode "workspaceId=\$PID" \\
-    --data-urlencode "environment=\$INF_ENV" \\
-    --data-urlencode "secretPath=\$SPATH" \\
-    "http://localhost:8070/api/v3/secrets/raw"
-REMOTE_INF_SECRETS_EOF
-                            SECRETS_RAW=$(cat "$SECRETS_RAW_FILE")
-                            rm -f "$SECRETS_RAW_FILE"
-                            SECRETS_STATUS=$(printf '%s' "$SECRETS_RAW" | tail -n1)
-                            SECRETS_STATUS="${SECRETS_STATUS:-000}"
-                            SECRETS_BODY=$(mktemp)
-                            # Plaintext Infisical secret values (after we
-                            # split off the trailing HTTP status line)
-                            # land in this tmp on the runner; register it
-                            # with RUNNER_CLEANUP_PATHS so an interrupted
-                            # run still wipes it. Both happy-path
-                            # `rm -f "$SECRETS_BODY"` calls below remain
-                            # as immediate cleanup.
-                            echo "$SECRETS_BODY" >> "$RUNNER_CLEANUP_PATHS"
-                            printf '%s' "$SECRETS_RAW" | sed '$d' > "$SECRETS_BODY"
-                            if [ "$SECRETS_STATUS" != "200" ]; then
-                                echo -e "${YELLOW}    ⚠ Infisical fetch '$FOLDER_LABEL' (path=$SECRET_PATH) returned HTTP $SECRETS_STATUS — secrets from this folder will be missing in Kestra${NC}"
-                                KSEC_FETCH_FAILED=$((KSEC_FETCH_FAILED+1))
-                                rm -f "$SECRETS_BODY"
-                                continue
-                            fi
-
-                            # jq base64-encodes the secretValue so newlines
-                            # / tabs / binary content (multi-line PEMs)
-                            # survive the TSV transit. Validate the
-                            # response shape before parsing — Infisical
-                            # occasionally returns a non-JSON error body
-                            # with HTTP 200 (e.g. mid-restart) or a JSON
-                            # blob without a `.secrets` array, and a
-                            # silently-empty TSV would skip the whole
-                            # folder without bumping KSEC_FETCH_FAILED.
-                            JQ_TSV_TMP=$(mktemp)
-                            echo "$JQ_TSV_TMP" >> "$RUNNER_CLEANUP_PATHS"
-                            if ! jq -er '.secrets | type == "array"' "$SECRETS_BODY" >/dev/null 2>&1; then
-                                echo -e "${YELLOW}    ⚠ Infisical fetch '$FOLDER_LABEL' (path=$SECRET_PATH) returned HTTP 200 but the body has no \`.secrets\` array — secrets from this folder will be missing in Kestra${NC}"
-                                KSEC_FETCH_FAILED=$((KSEC_FETCH_FAILED+1))
-                                rm -f "$SECRETS_BODY" "$JQ_TSV_TMP"
-                                continue
-                            fi
-                            jq -r '.secrets[]? | [.secretKey, (.secretValue | @base64)] | @tsv' "$SECRETS_BODY" > "$JQ_TSV_TMP" 2>/dev/null || JQ_TSV_RC=$?
-                            if [ -n "${JQ_TSV_RC:-}" ]; then
-                                echo -e "${YELLOW}    ⚠ Infisical fetch '$FOLDER_LABEL' (path=$SECRET_PATH) parsed as JSON but jq tsv-extract failed (exit $JQ_TSV_RC) — secrets from this folder will be missing in Kestra${NC}"
-                                KSEC_FETCH_FAILED=$((KSEC_FETCH_FAILED+1))
-                                rm -f "$SECRETS_BODY" "$JQ_TSV_TMP"
-                                unset JQ_TSV_RC
-                                continue
-                            fi
-                            while IFS=$'\t' read -r KEY VALUE_B64; do
-                                [ -z "$KEY" ] && continue
-                                # Kestra naming rule: ^[A-Za-z][A-Za-z0-9_]*$
-                                # Anything else (slashes, dots, hyphens) won't
-                                # produce a valid `SECRET_<NAME>` env var name.
-                                if ! [[ "$KEY" =~ ^[A-Za-z][A-Za-z0-9_]*$ ]]; then
-                                    KSEC_SKIPPED=$((KSEC_SKIPPED+1))
-                                    continue
-                                fi
-                                # Cross-folder dedupe (first-folder-wins is
-                                # deterministic across repeat runs; last-
-                                # wins would flip env-var values based on
-                                # iteration order). On collision: log a
-                                # warning naming the kept folder and the
-                                # dropped folder so the operator can spot
-                                # divergent values across folders.
-                                EXISTING_FOLDER=$(awk -F'\t' -v k="$KEY" '$1 == k {print $2; exit}' "$KSEC_SEEN" 2>/dev/null)
-                                if [ -n "$EXISTING_FOLDER" ]; then
-                                    echo -e "${YELLOW}    ⚠ Key collision: '$KEY' in folder '$FOLDER_LABEL' shadowed by earlier value from folder '$EXISTING_FOLDER' (first-wins)${NC}"
-                                    KSEC_COLLISIONS=$((KSEC_COLLISIONS+1))
-                                    continue
-                                fi
-                                printf '%s\t%s\n' "$KEY" "$FOLDER_LABEL" >> "$KSEC_SEEN"
-                                echo "SECRET_${KEY}=${VALUE_B64}" >> "$KESTRA_SECRETS_TMP"
-                                KSEC_PUSHED=$((KSEC_PUSHED+1))
-                            done < "$JQ_TSV_TMP"
-                            rm -f "$SECRETS_BODY" "$JQ_TSV_TMP"
-                        done < <(printf '%s\n/\n' "$FOLDER_LIST")
+                    # Phase 3 Modul 3.4f (#505) — replaces the 325-LoC
+                    # build-SECRETS + dedup + chmod + force-recreate
+                    # heredoc with the Python secret-sync CLI's kestra
+                    # mode. The CLI does steps 1-4 (Infisical fetch +
+                    # SECRET_<KEY>=<base64> append + force-recreate);
+                    # the post-restart auth-aware wait below stays in
+                    # bash (it's the bridge between the secret-sync
+                    # restart and the flow-registration step).
+                    if [ -n "${INFISICAL_TOKEN:-}" ] && [ -n "${PROJECT_ID:-}" ]; then
+                        echo "  Syncing Infisical secrets into Kestra env..."
+                        KESTRA_SS_RC=0
+                        PROJECT_ID="$PROJECT_ID" INFISICAL_TOKEN="$INFISICAL_TOKEN" \
+                            INFISICAL_ENV="${INFISICAL_ENV:-dev}" \
+                            GITEA_TOKEN="${GITEA_TOKEN:-}" \
+                            uv run --quiet --project "$PROJECT_ROOT" \
+                            python -m nexus_deploy secret-sync --stack kestra \
+                            || KESTRA_SS_RC=$?
+                        case "$KESTRA_SS_RC" in
+                            0) ;;
+                            1) echo -e "${YELLOW}  ⚠ Kestra secret-sync had partial folder-fetch failures (continuing)${NC}" ;;
+                            *) echo -e "${RED}  ✗ Kestra secret-sync transport failure (rc=$KESTRA_SS_RC); aborting${NC}"; exit "$KESTRA_SS_RC" ;;
+                        esac
+                    else
+                        echo -e "${YELLOW}  ⚠ INFISICAL_TOKEN / PROJECT_ID empty — skipping Kestra secret-sync${NC}"
                     fi
-
-                    # 2. Special case: GITEA_TOKEN is generated by deploy.sh
-                    #    after Gitea boots (it's the on-the-fly admin token
-                    #    used to create the workspace repo). It is NOT in
-                    #    Infisical at the time of the `build_folder()`
-                    #    pushes earlier in this script, so we add it here
-                    #    so seeded flows can use `{{ secret('GITEA_TOKEN') }}`.
-                    # Write SECRET_GITEA_TOKEN unless it was already
-                    # pushed via Infisical (guard against duplicate). The
-                    # awk dedupe-check only runs when KSEC_SEEN was
-                    # actually populated by the Infisical loop above; on
-                    # stacks where Infisical isn't reachable, the file
-                    # doesn't exist and we just write the token directly.
-                    if [ -n "$GITEA_TOKEN" ]; then
-                        ALREADY_HAVE_GITEA_TOKEN=false
-                        if [ -n "$KSEC_SEEN" ] && [ -f "$KSEC_SEEN" ]; then
-                            if awk -F'\t' '$1 == "GITEA_TOKEN" {found=1; exit} END {exit !found}' "$KSEC_SEEN" 2>/dev/null; then
-                                ALREADY_HAVE_GITEA_TOKEN=true
-                            fi
-                        fi
-                        if [ "$ALREADY_HAVE_GITEA_TOKEN" = "false" ]; then
-                            # Encode in a separate var rather than inline `$(…)` —
-                            # nested double quotes inside `$()` are valid bash
-                            # (the inner context is independent), but Copilot
-                            # repeatedly flagged it as ambiguous; the two-line
-                            # form costs nothing and silences the false positive.
-                            GITEA_TOKEN_B64=$(printf '%s' "$GITEA_TOKEN" | base64 | tr -d '\n')
-                            printf 'SECRET_GITEA_TOKEN=%s\n' "$GITEA_TOKEN_B64" >> "$KESTRA_SECRETS_TMP"
-                            KSEC_PUSHED=$((KSEC_PUSHED+1))
-                        fi
-                    fi
-                    [ -n "$KSEC_SEEN" ] && rm -f "$KSEC_SEEN"
-
-                    # 3. Append (or replace) the delimited block in
-                    #    Kestra's .env on the server. Fail fast if either
-                    #    the .env file is missing or the sed-based block
-                    #    removal fails — silently continuing would let
-                    #    SECRET_* entries accumulate across re-runs (or
-                    #    write to a non-existent file), and the operator
-                    #    has no way to notice unless secrets eventually
-                    #    fail at flow execution time.
-                    if [ -s "$KESTRA_SECRETS_TMP" ]; then
-                        if ! ssh nexus "
-                            set -e
-                            ENV_FILE=/opt/docker-server/stacks/kestra/.env
-                            if [ ! -f \"\$ENV_FILE\" ]; then
-                                echo \"ERROR: Kestra .env not found at \$ENV_FILE\" >&2
-                                exit 1
-                            fi
-                            sed -i '/^# === BEGIN nexus-secret-sync/,/^# === END nexus-secret-sync/d' \"\$ENV_FILE\"
-                        "; then
-                            echo -e "${RED}Error: failed to clean previous nexus-secret-sync block from Kestra .env. Aborting deploy to avoid duplicating SECRET_* lines.${NC}"
-                            exit 1
-                        fi
-
-                        # Lock the .env to mode 0600 BEFORE appending the
-                        # SECRET_* block, then append. Doing chmod first
-                        # closes the race window where the file could be
-                        # world-readable (0644 from rsync-preserved modes
-                        # under default umask) WHILE the new secrets are
-                        # being written — a concurrent reader could grab
-                        # a partial copy of base64-encoded R2 keys / DB
-                        # passwords / GITEA_TOKEN. chmod 600 idempotent
-                        # at the start; the file definitely exists
-                        # because the preceding sed-removal step opened
-                        # and re-wrote it.
-                        if ! {
-                            echo "# === BEGIN nexus-secret-sync (re-generated each spin-up; do not edit by hand) ==="
-                            cat "$KESTRA_SECRETS_TMP"
-                            echo "# === END nexus-secret-sync ==="
-                        } | ssh nexus "
-                            set -e
-                            ENV_FILE=/opt/docker-server/stacks/kestra/.env
-                            chmod 600 \"\$ENV_FILE\"
-                            cat >> \"\$ENV_FILE\"
-                        "; then
-                            echo -e "${RED}Error: failed to chmod 0600 + append nexus-secret-sync block to Kestra .env.${NC}"
-                            exit 1
-                        fi
-
-                        if [ "$KSEC_FETCH_FAILED" -gt 0 ]; then
-                            echo -e "${YELLOW}  ⚠ Wrote $KSEC_PUSHED Kestra SECRET_* env-vars to .env (skipped=$KSEC_SKIPPED invalid keys, collisions=$KSEC_COLLISIONS, $KSEC_FETCH_FAILED Infisical fetches failed — secret set is incomplete)${NC}"
-                        elif [ "$KSEC_COLLISIONS" -gt 0 ]; then
-                            echo -e "${YELLOW}  ⚠ Wrote $KSEC_PUSHED Kestra SECRET_* env-vars to .env (skipped=$KSEC_SKIPPED invalid keys, $KSEC_COLLISIONS cross-folder collisions — see warnings above; first-folder-wins applied)${NC}"
-                        else
-                            echo -e "${GREEN}  ✓ Wrote $KSEC_PUSHED Kestra SECRET_* env-vars to .env (skipped=$KSEC_SKIPPED invalid keys)${NC}"
-                        fi
-
-                        # 4. Force-recreate Kestra so the env vars get
-                        #    loaded. `up -d --force-recreate <svc>` keeps
-                        #    other containers untouched. Fail-fast: if
-                        #    the restart fails, the new SECRET_* values
-                        #    are sitting in .env but the live container
-                        #    is still running with the old set — flow-
-                        #    sync registration would proceed against a
-                        #    Kestra that can't resolve `{{ secret('GITEA_TOKEN') }}`.
-                        echo "  Restarting Kestra to load secrets..."
-                        if ! ssh nexus "cd $REMOTE_STACKS_DIR/kestra && docker compose up -d --force-recreate kestra" >/dev/null 2>&1; then
-                            echo -e "${RED}Error: docker compose up -d --force-recreate kestra failed. Aborting deploy to avoid continuing with un-reloaded secrets.${NC}"
-                            exit 1
-                        fi
 
                         # 5. Re-wait for Kestra to come back up — and
                         #    actually authenticate. The previous version
@@ -1598,10 +1139,6 @@ REMOTE_KESTRA_PROBE_EOF
                         if [ "$KESTRA_READY" != "true" ]; then
                             echo -e "${YELLOW}  ⚠ Kestra did not come back up after restart — Git sync flow registration will be skipped${NC}"
                         fi
-                    else
-                        echo -e "${YELLOW}  ⚠ No Kestra SECRET_* lines built (Infisical empty or unreachable, GITEA_TOKEN missing) — flows that reference {{ secret('NAME') }} will fail${NC}"
-                    fi
-                    rm -f "$KESTRA_SECRETS_TMP"
                 fi  # close: KESTRA_READY initial check
 
                 # ----------------------------------------------------------

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -712,7 +712,7 @@ if echo "$ENABLED_SERVICES" | grep -qw "infisical"; then
     # eval-able stdout: INFISICAL_TOKEN=...; PROJECT_ID=... (both
     # always emitted, may be empty when not-ready / soft-fail).
     INFISICAL_OUT=$(mktemp)
-    RUNNER_CLEANUP_PATHS+="$INFISICAL_OUT\n"
+    echo "$INFISICAL_OUT" >> "$RUNNER_CLEANUP_PATHS"
     INFISICAL_PROVISION_RC=0
     ADMIN_EMAIL="$ADMIN_EMAIL" INFISICAL_PASS="$INFISICAL_PASS" \
         uv run --quiet --project "$PROJECT_ROOT" \

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -449,7 +449,7 @@ if echo "$ENABLED_SERVICES" | grep -qw "wetty"; then
         || WETTY_RC=$?
     case "$WETTY_RC" in
         0) echo -e "${GREEN}  ✓ SSH-Agent configured for Wetty${NC}" ;;
-        1) echo -e "${YELLOW}  ⚠ Wetty SSH-Agent setup produced no parseable result (continuing — Wetty is non-critical)${NC}" ;;
+        1) echo -e "${YELLOW}  ⚠ Wetty SSH-Agent setup soft-failed — see stderr above (continuing — Wetty is non-critical)${NC}" ;;
         *) echo -e "${RED}  ✗ Wetty SSH-Agent setup failed (rc=$WETTY_RC); aborting${NC}"; exit "$WETTY_RC" ;;
     esac
 fi

--- a/scripts/init-r2-state.sh
+++ b/scripts/init-r2-state.sh
@@ -213,6 +213,53 @@ extract_error() {
     echo "$1" | grep -o '"message":"[^"]*"' | head -1 | sed 's/"message":"//;s/"$//'
 }
 
+# Proactive cleanup: delete ANY existing token with our target name BEFORE
+# trying to create a new one. Mirrors the bug-fix described in #530:
+# the legacy "already exists" → delete-and-retry path was unpaginated
+# (?per_page= unset → Cloudflare default of 25), so once an account
+# carried >25 tokens the matching token might not appear in the response
+# and the script would bail. Worse, if the API returned non-canonical
+# error wording the delete-existing branch wouldn't trigger at all and
+# orphans would leak. Doing this BEFORE create is idempotent and handles
+# every edge case uniformly. Uses ?per_page=100 (Cloudflare's max) to
+# tolerate accounts up to the 50-token hard cap. Treats the listing
+# as best-effort: a transient list failure leaves the create call to
+# discover the conflict on its own, falling back to the legacy path.
+echo -e "  ${CYAN}→${NC} Pre-cleanup: looking for stale '${TOKEN_NAME}' tokens..."
+STALE_TOKEN_LIST=$(curl -s "https://api.cloudflare.com/client/v4/user/tokens?per_page=100" \
+    -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" 2>/dev/null || echo "")
+if echo "$STALE_TOKEN_LIST" | jq -e '.success == true and (.result | type == "array")' >/dev/null 2>&1; then
+    # ALL tokens whose .name == $TOKEN_NAME, NOT just the first one. If the
+    # account somehow ended up with multiple tokens sharing the name (e.g.
+    # from an earlier Cloudflare API behavior change or a race during a
+    # parallel re-setup), we want to remove all of them.
+    STALE_IDS=$(echo "$STALE_TOKEN_LIST" | jq -r --arg name "$TOKEN_NAME" \
+        '.result[] | select(.name == $name) | .id')
+    if [ -n "$STALE_IDS" ]; then
+        STALE_COUNT=$(printf '%s\n' "$STALE_IDS" | wc -l | tr -d ' ')
+        echo -e "  ${YELLOW}⚠${NC}  Found ${STALE_COUNT} stale token(s) with name '${TOKEN_NAME}' — deleting before re-create..."
+        while IFS= read -r STALE_ID; do
+            [ -z "$STALE_ID" ] && continue
+            STALE_DEL=$(curl -s -X DELETE \
+                "https://api.cloudflare.com/client/v4/user/tokens/${STALE_ID}" \
+                -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" 2>/dev/null || echo "")
+            if echo "$STALE_DEL" | grep -q '"success":true'; then
+                echo -e "  ${GREEN}✓${NC} Deleted stale token ${STALE_ID}"
+            else
+                STALE_ERR=$(extract_error "$STALE_DEL")
+                echo -e "  ${YELLOW}⚠${NC}  Could not delete stale token ${STALE_ID}: ${STALE_ERR:-no error message}"
+                # Non-fatal: the create call below will still try; if the
+                # token couldn't be deleted, the create will fail with
+                # "already exists" and the legacy path runs as a fallback.
+            fi
+        done <<< "$STALE_IDS"
+    else
+        echo -e "  ${GREEN}✓${NC} No stale tokens found"
+    fi
+else
+    echo -e "  ${YELLOW}⚠${NC}  Could not list tokens for pre-cleanup (non-fatal — create call will still attempt)"
+fi
+
 MAX_RETRIES=3
 RETRY=0
 TOKEN_RESPONSE=""
@@ -253,9 +300,14 @@ while [ $RETRY -lt $MAX_RETRIES ]; do
         RETRY=$((RETRY + 1))
         echo -e "  ${YELLOW}⚠${NC}  Token '${TOKEN_NAME}' already exists — deleting and recreating..."
 
-        # Find the existing token by name (using jq for reliable JSON parsing)
+        # Find the existing token by name (using jq for reliable JSON parsing).
+        # Use ?per_page=100 (Cloudflare's max) so the matching token appears
+        # in the response even when the account is near the 50-token cap.
+        # Without this, the default per_page=25 missed tokens on later pages,
+        # producing the "Token exists but could not find its ID" hard-fail
+        # path observed in production accounts (see #530).
         EXISTING_TOKEN_ID=$(curl -s \
-            "https://api.cloudflare.com/client/v4/user/tokens" \
+            "https://api.cloudflare.com/client/v4/user/tokens?per_page=100" \
             -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
             | jq -r --arg TOKEN_NAME "$TOKEN_NAME" \
                 '.result[] | select(.name == $TOKEN_NAME) | .id' | head -n 1)

--- a/src/nexus_deploy/__main__.py
+++ b/src/nexus_deploy/__main__.py
@@ -2514,7 +2514,9 @@ def main() -> int:
         "Available: --version, hello, "
         "config dump-shell [--tofu-dir PATH (default: tofu/stack) | --stdin], "
         "infisical bootstrap (reads SECRETS_JSON from stdin + env vars), "
-        "secret-sync --stack <jupyter|marimo>, "
+        "infisical provision-admin (env: ADMIN_EMAIL + INFISICAL_PASS; emits "
+        "INFISICAL_TOKEN + PROJECT_ID), "
+        "secret-sync --stack <jupyter|marimo|kestra>, "
         "seed --repo <owner>/<name> [--root PATH] [--prefix nexus_seeds/], "
         "compose up --enabled <comma-list>, "
         "services configure --enabled <comma-list> (reads SECRETS_JSON from stdin), "
@@ -2523,10 +2525,12 @@ def main() -> int:
         "gitea woodpecker-oauth (env-only; emits WOODPECKER_GITEA_CLIENT + WOODPECKER_GITEA_SECRET), "
         "gitea mirror-setup (env-only; emits FORK_NAME + GITEA_REPO_OWNER iff a fork was provisioned), "
         "stack-sync --enabled <comma-list> [--stacks-dir PATH], "
-        "setup ssh-config | wait-ssh | ensure-jq | mount-volume, "
+        "setup ssh-config | wait-ssh | ensure-jq | mount-volume | wetty-ssh-agent, "
         "service-env --enabled <comma-list> [--stacks-dir PATH] (reads SECRETS_JSON from stdin), "
         "run-all (reads SECRETS_JSON from stdin + env vars; emits eval-able stdout: "
-        "RESTART_SERVICES + WOODPECKER_GITEA_CLIENT + WOODPECKER_GITEA_SECRET)",
+        "RESTART_SERVICES + WOODPECKER_GITEA_CLIENT + WOODPECKER_GITEA_SECRET), "
+        "r2-tokens list [--prefix STR] | cleanup --name|--prefix VALUE [--apply] "
+        "(env: TF_VAR_cloudflare_api_token)",
         file=sys.stderr,
     )
     return 2

--- a/src/nexus_deploy/__main__.py
+++ b/src/nexus_deploy/__main__.py
@@ -27,6 +27,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import requests
+
 from nexus_deploy import __version__, hello
 from nexus_deploy.compose_runner import run_compose_up
 from nexus_deploy.config import ConfigError, NexusConfig
@@ -44,6 +46,11 @@ from nexus_deploy.infisical import (
 )
 from nexus_deploy.kestra import run_register_system_flows
 from nexus_deploy.orchestrator import Orchestrator
+from nexus_deploy.r2_tokens import (
+    DEFAULT_NEXUS_R2_PREFIX,
+    build_inventory,
+    cleanup_orphan_tokens,
+)
 from nexus_deploy.secret_sync import StackTarget, run_sync_for_stack
 from nexus_deploy.seeder import _is_safe_repo_path, run_seed_for_repo
 from nexus_deploy.service_env import (
@@ -2060,6 +2067,162 @@ def _service_env(args: list[str]) -> int:
     return 0
 
 
+def _r2_tokens(args: list[str]) -> int:
+    """`nexus-deploy r2-tokens <list|cleanup>`.
+
+    Audit + reconciliation utility for Cloudflare R2 user API tokens.
+    Surfaces the 50-token-per-account hard cap and lets operators
+    proactively delete orphan ``nexus-r2-*`` tokens left behind by
+    earlier destroy/setup cycles (see #530 for the bug history).
+
+    Subcommands:
+
+    - ``list``: dry-run inventory. Prints account-wide token total +
+      remaining slots + the matched ``nexus-r2-*`` subset. Always
+      exit 0; deploy.sh / cron can scrape the output.
+    - ``cleanup --name <name>``: delete every token whose name equals
+      <name>. Used by re-setup to ensure no orphan exists before
+      ``init-r2-state.sh`` mints a fresh token.
+    - ``cleanup --prefix <prefix>``: delete every token whose name
+      starts with <prefix>. Refuses unless prefix begins with
+      ``nexus-r2-`` (defence-in-depth: prevents wiping the
+      ``Nexus-Stack`` / ``Nexus2`` / build tokens documented as
+      protected in CLAUDE.md).
+
+    Required env: ``TF_VAR_cloudflare_api_token`` (or
+    ``CLOUDFLARE_API_TOKEN``).
+
+    Exit codes:
+    - 0: success (list / cleanup completed; per-token failures within
+         cleanup are reported but don't change the rc)
+    - 1: cleanup completed with at least one delete failure
+    - 2: bad args / missing env / network error / API listing failed
+    """
+    if not args:
+        print(
+            "r2-tokens: subcommand required (list | cleanup --name|--prefix VALUE [--apply])",
+            file=sys.stderr,
+        )
+        return 2
+
+    # Tofu convention is lowercase TF_VAR_*; the upper-case alias is
+    # the more common dotenv style. SIM112 wants UPPERCASE only — but
+    # the lowercase form is the one Tofu / our setup-control-plane
+    # workflow already exports. Honor both with a noqa so SIM112's
+    # blanket rule doesn't conflict with the established convention.
+    api_token = (
+        os.environ.get("TF_VAR_cloudflare_api_token")  # noqa: SIM112
+        or os.environ.get("CLOUDFLARE_API_TOKEN")
+        or ""
+    ).strip()
+    if not api_token:
+        print(
+            "r2-tokens: TF_VAR_cloudflare_api_token (or CLOUDFLARE_API_TOKEN) required",
+            file=sys.stderr,
+        )
+        return 2
+
+    sub = args[0]
+    rest = args[1:]
+
+    if sub == "list":
+        list_prefix = DEFAULT_NEXUS_R2_PREFIX
+        i = 0
+        while i < len(rest):
+            if rest[i] == "--prefix":
+                if i + 1 >= len(rest):
+                    print("r2-tokens list: --prefix requires a value", file=sys.stderr)
+                    return 2
+                list_prefix = rest[i + 1]
+                i += 2
+            else:
+                print(f"r2-tokens list: unknown arg {rest[i]!r}", file=sys.stderr)
+                return 2
+        try:
+            inventory = build_inventory(api_token=api_token, prefix=list_prefix)
+        except (RuntimeError, requests.RequestException) as exc:
+            print(f"r2-tokens list: {type(exc).__name__}: {exc}", file=sys.stderr)
+            return 2
+        print(
+            f"r2-tokens list: total={inventory.total} / 50  "
+            f"remaining={inventory.remaining_slots}  "
+            f"prefix={list_prefix!r}  matched={len(inventory.matched)}",
+        )
+        if inventory.near_cap:
+            sys.stderr.write(
+                f"  ⚠ Approaching the 50-token cap (remaining={inventory.remaining_slots})\n",
+            )
+        for token in inventory.matched:
+            issued = token.issued_on or "?"
+            print(f"  {token.id}  {issued}  {token.name}")
+        return 0
+
+    if sub == "cleanup":
+        name: str | None = None
+        prefix: str | None = None
+        apply_changes = False
+        i = 0
+        while i < len(rest):
+            if rest[i] == "--name":
+                if i + 1 >= len(rest):
+                    print("r2-tokens cleanup: --name requires a value", file=sys.stderr)
+                    return 2
+                name = rest[i + 1]
+                i += 2
+            elif rest[i] == "--prefix":
+                if i + 1 >= len(rest):
+                    print("r2-tokens cleanup: --prefix requires a value", file=sys.stderr)
+                    return 2
+                prefix = rest[i + 1]
+                i += 2
+            elif rest[i] == "--apply":
+                apply_changes = True
+                i += 1
+            else:
+                print(f"r2-tokens cleanup: unknown arg {rest[i]!r}", file=sys.stderr)
+                return 2
+        if (name is None) == (prefix is None):
+            print(
+                "r2-tokens cleanup: pass exactly one of --name VALUE or --prefix VALUE",
+                file=sys.stderr,
+            )
+            return 2
+        try:
+            result = cleanup_orphan_tokens(
+                api_token=api_token,
+                name=name,
+                prefix=prefix,
+                dry_run=not apply_changes,
+            )
+        except ValueError as exc:
+            # Validation error (e.g. prefix doesn't start with nexus-r2-).
+            print(f"r2-tokens cleanup: {exc}", file=sys.stderr)
+            return 2
+        except (RuntimeError, requests.RequestException) as exc:
+            print(f"r2-tokens cleanup: {type(exc).__name__}: {exc}", file=sys.stderr)
+            return 2
+        print(
+            f"r2-tokens cleanup: total_before={result.total_tokens_before}  "
+            f"matched={len(result.matched)}  "
+            f"deleted={result.deleted_count}  failed={result.failed_count}  "
+            f"dry_run={result.dry_run}",
+        )
+        for token in result.matched:
+            issued = token.issued_on or "?"
+            print(f"  matched: {token.id}  {issued}  {token.name}")
+        for d in result.deletions:
+            status = "OK" if d.deleted else f"FAILED ({d.error})"
+            print(f"  delete: {d.id}  {d.name}  {status}")
+        if not apply_changes:
+            sys.stderr.write(
+                "  (dry-run; pass --apply to actually delete)\n",
+            )
+        return 0 if result.is_success else 1
+
+    print(f"r2-tokens: unknown subcommand {sub!r}", file=sys.stderr)
+    return 2
+
+
 def _run_all(args: list[str]) -> int:
     """`nexus-deploy run-all`.
 
@@ -2308,6 +2471,8 @@ def main() -> int:
         return _service_env(args[1:])
     if args[:1] == ["run-all"]:
         return _run_all(args[1:])
+    if args[:1] == ["r2-tokens"]:
+        return _r2_tokens(args[1:])
     print(
         f"nexus_deploy {__version__}: unknown command {' '.join(args)!r}",
         file=sys.stderr,

--- a/src/nexus_deploy/__main__.py
+++ b/src/nexus_deploy/__main__.py
@@ -2120,10 +2120,16 @@ def _r2_tokens(args: list[str]) -> int:
     ``CLOUDFLARE_API_TOKEN``).
 
     Exit codes:
-    - 0: success (list / cleanup completed; per-token failures within
-         cleanup are reported but don't change the rc)
-    - 1: cleanup completed with at least one delete failure
+    - 0: ``list`` always returns 0; ``cleanup`` returns 0 only when
+         every matched token deleted successfully (or dry-run with no
+         per-token attempts). Backed by ``CleanupResult.is_success``.
+    - 1: ``cleanup`` completed but at least one per-token delete
+         failed (the loop continues — every attempt is reported in
+         stdout — but the rc reflects the partial-failure so callers
+         like deploy.sh / a follow-up cron run can re-attempt).
     - 2: bad args / missing env / network error / API listing failed
+         / safety guard hit (e.g. ``--prefix`` doesn't start with
+         ``nexus-r2-``).
     """
     if not args:
         print(

--- a/src/nexus_deploy/__main__.py
+++ b/src/nexus_deploy/__main__.py
@@ -307,7 +307,15 @@ def _infisical_provision_admin(args: list[str]) -> int:
     # readable outcome (the eval-able stdout is for shell consumption).
     sys.stderr.write(f"infisical provision-admin: status={result.status}\n")
 
-    if result.status in ("loaded-existing", "freshly-bootstrapped"):
+    # rc=0 ONLY when the provision actually produced usable credentials
+    # (token AND project_id both populated). A `loaded-existing` /
+    # `freshly-bootstrapped` status with a dropped token (e.g.
+    # malformed-base64 → parse_provision_result returned None for
+    # token) MUST be reported as soft-fail so deploy.sh doesn't print
+    # "✓ Infisical provisioned" while emitting empty
+    # INFISICAL_TOKEN= / PROJECT_ID= lines that downstream eval'd
+    # consumers would treat as legitimate. Caught in #530 R2.
+    if result.status in ("loaded-existing", "freshly-bootstrapped") and result.has_credentials:
         return 0
     return 1
 
@@ -1828,9 +1836,16 @@ def _setup_wetty_ssh_agent(args: list[str]) -> int:
 
     Exit codes:
     - 0: all 5 steps completed (whether they were no-ops or made changes)
-    - 1: soft failure — script ran but emitted no parseable RESULT
-         (the operator sees the forwarded stderr; deploy continues
-         since Wetty is non-critical)
+         AND the .env file was written (i.e. ``auth_sock_written=1``).
+         A no-op idempotent run is still rc=0 because the .env append
+         is unconditional on the happy path.
+    - 1: soft failure — either (a) the script ran but emitted no
+         parseable RESULT, or (b) ``auth_sock_written=0`` (the fail-fast
+         paths in render_wetty_agent_script emit a parseable
+         all-zero RESULT line, so the absence of the .env write is a
+         real failure even though the script returned 0). Deploy
+         continues since Wetty is non-critical, but the operator sees
+         the forwarded stderr.
     - 2: hard transport / unexpected error
     """
     if args:
@@ -1885,6 +1900,18 @@ def _setup_wetty_ssh_agent(args: list[str]) -> int:
         parts.append("env-written")
     summary = "+".join(parts) if parts else "all-noop"
     print(f"setup wetty-ssh-agent: {summary}")
+    # auth_sock_written=0 means render_wetty_agent_script's fail-fast
+    # paths fired (ssh-agent unresponsive OR sed/printf to .env failed).
+    # Surface as rc=1 so the workflow log shows the soft-fail signal —
+    # deploy.sh continues since Wetty is non-critical but the operator
+    # sees that the agent socket isn't actually plumbed through.
+    if not result.auth_sock_written:
+        print(
+            "setup wetty-ssh-agent: soft-fail — SSH_AUTH_SOCK not written "
+            "to wetty/.env (Wetty container won't see agent socket)",
+            file=sys.stderr,
+        )
+        return 1
     return 0
 
 

--- a/src/nexus_deploy/__main__.py
+++ b/src/nexus_deploy/__main__.py
@@ -40,6 +40,7 @@ from nexus_deploy.infisical import (
     BootstrapEnv,
     InfisicalClient,
     compute_folders,
+    provision_admin,
 )
 from nexus_deploy.kestra import run_register_system_flows
 from nexus_deploy.orchestrator import Orchestrator
@@ -58,6 +59,7 @@ from nexus_deploy.setup import (
     configure_ssh,
     ensure_jq,
     mount_persistent_volume,
+    setup_wetty_ssh_agent,
     wait_for_service_token,
     wait_for_ssh,
 )
@@ -222,7 +224,88 @@ def _infisical_bootstrap(args: list[str]) -> int:
     return 0 if result.failed == 0 else 1
 
 
-_VALID_STACKS = ("jupyter", "marimo")
+def _infisical_provision_admin(args: list[str]) -> int:
+    """`nexus-deploy infisical provision-admin`.
+
+    Replaces the bash readiness-probe + admin-bootstrap + project-create
+    + cred-persist block at deploy.sh:792-869. Renders + runs a server-
+    side bash script via SSH that:
+
+    1. Waits for Infisical to be ready (60s container + 120s HTTP).
+    2. Detects whether Infisical is already initialized.
+    3. If yes: loads saved (token, project_id) from
+       ``/opt/docker-server/.infisical-{token,project-id}``.
+    4. If no: POST ``/api/v1/admin/bootstrap`` (admin user + org) →
+       POST ``/api/v2/workspace`` (project) → save creds to disk.
+
+    Required env: ``ADMIN_EMAIL`` + ``INFISICAL_PASS``.
+
+    Stdout (eval-able by deploy.sh):
+    - ``INFISICAL_TOKEN=<token>``
+    - ``PROJECT_ID=<workspace-id>``
+
+    Both lines are always emitted (even on the not-ready / failure
+    paths, with empty values) so deploy.sh's eval doesn't leak stale
+    values from a previous run.
+
+    Exit codes:
+    - 0: ``loaded-existing`` or ``freshly-bootstrapped`` —
+      (token, project_id) populated, downstream push can proceed.
+    - 1: ``not-ready`` / ``loaded-existing-missing-creds`` /
+      ``already-bootstrapped-no-saved-creds`` /
+      ``bootstrap-failed`` / ``project-create-failed`` — soft fail,
+      deploy.sh warns and continues without pushing secrets.
+    - 2: bad args, transport, unexpected error — deploy.sh aborts.
+    """
+    if args:
+        print(f"infisical provision-admin: unexpected arg {args[0]!r}", file=sys.stderr)
+        return 2
+
+    admin_email = os.environ.get("ADMIN_EMAIL", "").strip()
+    admin_password = os.environ.get("INFISICAL_PASS", "").strip()
+    if not admin_email or not admin_password:
+        print(
+            "infisical provision-admin: ADMIN_EMAIL and INFISICAL_PASS env vars required",
+            file=sys.stderr,
+        )
+        return 2
+
+    try:
+        result = provision_admin(
+            admin_email=admin_email,
+            admin_password=admin_password,
+        )
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError) as exc:
+        print(
+            f"infisical provision-admin: transport failure ({type(exc).__name__})",
+            file=sys.stderr,
+        )
+        return 2
+    except Exception as exc:
+        print(
+            f"infisical provision-admin: unexpected error ({type(exc).__name__})",
+            file=sys.stderr,
+        )
+        return 2
+
+    # Always emit the two values (even empty) — deploy.sh's eval relies
+    # on the assignment to clear any stale value left over from prior
+    # runs. shlex.quote handles the empty-string + edge cases.
+    import shlex as _shlex
+
+    sys.stdout.write(f"INFISICAL_TOKEN={_shlex.quote(result.token or '')}\n")
+    sys.stdout.write(f"PROJECT_ID={_shlex.quote(result.project_id or '')}\n")
+
+    # Per-status stderr line so the workflow log carries the human-
+    # readable outcome (the eval-able stdout is for shell consumption).
+    sys.stderr.write(f"infisical provision-admin: status={result.status}\n")
+
+    if result.status in ("loaded-existing", "freshly-bootstrapped"):
+        return 0
+    return 1
+
+
+_VALID_STACKS = ("jupyter", "marimo", "kestra")
 
 
 def _secret_sync(args: list[str]) -> int:
@@ -289,7 +372,21 @@ def _secret_sync(args: list[str]) -> int:
     infisical_env = os.environ.get("INFISICAL_ENV") or "dev"
     gitea_token = os.environ.get("GITEA_TOKEN") or ""
 
-    target = StackTarget(name=stack)
+    # Kestra writes SECRET_<KEY>=<base64> to .env directly (no separate
+    # .infisical.env), and force-recreates so EnvVarSecretProvider
+    # loads the new values. Jupyter/Marimo use the original
+    # plaintext-to-.infisical.env shape with `up -d` (no force).
+    if stack == "kestra":
+        target = StackTarget(
+            name="kestra",
+            key_prefix="SECRET_",
+            use_base64_values=True,
+            env_file_basename=".env",
+            legacy_env_file_basename=None,
+            force_recreate=True,
+        )
+    else:
+        target = StackTarget(name=stack)
     try:
         result = run_sync_for_stack(
             target,
@@ -1707,11 +1804,89 @@ def _setup_mount_volume(args: list[str]) -> int:
     return 1
 
 
+def _setup_wetty_ssh_agent(args: list[str]) -> int:
+    """`nexus-deploy setup wetty-ssh-agent`.
+
+    Replaces deploy.sh:439-540 (the ``[5.5/7]`` block). Renders +
+    runs a server-side bash that:
+
+    1. ssh-keygen the wetty key pair (idempotent — only if absent).
+    2. Append the public key to ``authorized_keys`` (idempotent).
+    3. Start ``ssh-agent`` with a known socket path (handles
+       dead-socket cleanup if the agent crashed previously).
+    4. ssh-add the key to the agent (idempotent — fingerprint check).
+    5. Write ``SSH_AUTH_SOCK=`` to ``stacks/wetty/.env``.
+
+    Optional env: ``SSH_HOST_ALIAS`` (default ``nexus``).
+
+    Exit codes:
+    - 0: all 5 steps completed (whether they were no-ops or made changes)
+    - 1: soft failure — script ran but emitted no parseable RESULT
+         (the operator sees the forwarded stderr; deploy continues
+         since Wetty is non-critical)
+    - 2: hard transport / unexpected error
+    """
+    if args:
+        print(f"setup wetty-ssh-agent: unknown args {args!r}", file=sys.stderr)
+        return 2
+    host_alias = os.environ.get("SSH_HOST_ALIAS") or "nexus"
+    try:
+        with SSHClient(host_alias) as ssh:
+            result = setup_wetty_ssh_agent(ssh)
+    except subprocess.CalledProcessError as exc:
+        # Same defence-in-depth as setup ensure-jq: forward the
+        # captured tail to local stderr but DON'T print exc.cmd.
+        print(
+            f"setup wetty-ssh-agent: remote command failed (rc={exc.returncode})",
+            file=sys.stderr,
+        )
+        if exc.output:
+            excerpt = exc.output[-2000:].rstrip()
+            for line in excerpt.splitlines():
+                sys.stderr.write(f"      {line}\n")
+        return 2
+    except (subprocess.TimeoutExpired, OSError) as exc:
+        print(
+            f"setup wetty-ssh-agent: transport failure ({type(exc).__name__})",
+            file=sys.stderr,
+        )
+        return 2
+    except Exception as exc:
+        print(
+            f"setup wetty-ssh-agent: unexpected error ({type(exc).__name__})",
+            file=sys.stderr,
+        )
+        return 2
+    if result is None:
+        print(
+            "setup wetty-ssh-agent: script ran but produced no RESULT_WETTY line",
+            file=sys.stderr,
+        )
+        return 1
+    # Per-step summary on stdout (workflow log) — same one-line shape
+    # as the other setup CLIs.
+    parts = []
+    if result.keypair_generated:
+        parts.append("key-generated")
+    if result.pubkey_added:
+        parts.append("pubkey-added")
+    if result.agent_started:
+        parts.append("agent-started")
+    if result.key_added_to_agent:
+        parts.append("key-added")
+    if result.auth_sock_written:
+        parts.append("env-written")
+    summary = "+".join(parts) if parts else "all-noop"
+    print(f"setup wetty-ssh-agent: {summary}")
+    return 0
+
+
 def _setup(args: list[str]) -> int:
     """Dispatch ``nexus-deploy setup <subcommand>``."""
     if not args:
         print(
-            "setup: subcommand required (ssh-config | wait-ssh | ensure-jq | mount-volume)",
+            "setup: subcommand required (ssh-config | wait-ssh | ensure-jq "
+            "| mount-volume | wetty-ssh-agent)",
             file=sys.stderr,
         )
         return 2
@@ -1725,6 +1900,8 @@ def _setup(args: list[str]) -> int:
         return _setup_ensure_jq(rest)
     if sub == "mount-volume":
         return _setup_mount_volume(rest)
+    if sub == "wetty-ssh-agent":
+        return _setup_wetty_ssh_agent(rest)
     print(f"setup: unknown subcommand {sub!r}", file=sys.stderr)
     return 2
 
@@ -2105,6 +2282,8 @@ def main() -> int:
         return _config_dump_shell(args[2:])
     if args[:2] == ["infisical", "bootstrap"]:
         return _infisical_bootstrap(args[2:])
+    if args[:2] == ["infisical", "provision-admin"]:
+        return _infisical_provision_admin(args[2:])
     if args[:1] == ["secret-sync"]:
         return _secret_sync(args[1:])
     if args[:1] == ["seed"]:

--- a/src/nexus_deploy/infisical.py
+++ b/src/nexus_deploy/infisical.py
@@ -34,11 +34,13 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import shlex
 import subprocess
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Literal
 
 from nexus_deploy import _remote
 from nexus_deploy.config import NexusConfig
@@ -135,6 +137,279 @@ class BootstrapResult:
     folders_built: int
     pushed: int
     failed: int
+
+
+# ---------------------------------------------------------------------------
+# Provision-admin (Phase 3 Modul 3.4f, #505) — replaces the bash readiness-
+# probe + admin-bootstrap + project-create + cred-persist block at
+# deploy.sh:792-869. The push-secrets step (BootstrapResult above) is the
+# downstream step that consumes the (token, project_id) this returns.
+# ---------------------------------------------------------------------------
+
+
+# Server-side paths where the freshly-minted token + project_id are
+# persisted on first run, so subsequent spin-ups can load them without
+# re-bootstrapping. Mirrors deploy.sh:823-824 + 858-861.
+_REMOTE_TOKEN_PATH = "/opt/docker-server/.infisical-token"  # noqa: S105 — file path
+_REMOTE_PROJECT_ID_PATH = "/opt/docker-server/.infisical-project-id"
+
+
+ProvisionStatus = Literal[
+    "freshly-bootstrapped",  # /admin/bootstrap + /workspace + creds saved
+    "loaded-existing",  # already initialized + saved-cred files readable
+    "loaded-existing-missing-creds",  # initialized but cred files empty/missing — operator must destroy-all
+    "already-bootstrapped-no-saved-creds",  # API returned "already" but no saved file (state mismatch)
+    "bootstrap-failed",  # /admin/bootstrap returned an unparseable body
+    "project-create-failed",  # /workspace returned no project.id
+    "not-ready",  # readiness probe timed out
+]
+
+
+@dataclass(frozen=True)
+class ProvisionResult:
+    """Outcome of :func:`provision_admin`.
+
+    On the success paths (``freshly-bootstrapped`` / ``loaded-existing``)
+    ``token`` + ``project_id`` are populated and the caller can proceed
+    to push secrets via :class:`InfisicalClient`. On every other status
+    they are ``None`` and the caller should warn-and-skip the push step
+    (downstream stacks reading from Infisical will degrade gracefully —
+    same behavior as the legacy bash).
+    """
+
+    status: ProvisionStatus
+    token: str | None  # Bearer token for /api/v2/workspace + downstream pushes
+    project_id: str | None  # Workspace ("project") id for the secret push folders
+
+    @property
+    def has_credentials(self) -> bool:
+        """True iff this run produced a (token, project_id) usable for downstream pushes."""
+        return self.token is not None and self.project_id is not None
+
+
+# RESULT line emitted by the rendered bash script. token is base64-encoded
+# (matches the same argv-safe transport pattern infisical bootstrap +
+# secret_sync.py use); project_id is plain (uuid-shaped, never has shell-
+# special chars — but anchored alphanumeric + dash for defence in depth).
+_PROVISION_RESULT_RE = re.compile(
+    r"^RESULT status=(?P<status>[a-z-]+)"
+    r"(?: token=(?P<token>[A-Za-z0-9+/=]+))?"
+    r"(?: project_id=(?P<project_id>[A-Za-z0-9_-]+))?$",
+    re.MULTILINE,
+)
+
+
+def render_provision_admin_script(
+    *,
+    admin_email: str,
+    admin_password: str,
+    organization_name: str = "Nexus",
+    project_name: str = "Nexus Stack",
+    base_url: str = "http://localhost:8070",
+    saved_token_path: str = _REMOTE_TOKEN_PATH,
+    saved_project_path: str = _REMOTE_PROJECT_ID_PATH,
+    container_wait_seconds: int = 60,
+    http_wait_seconds: int = 120,
+) -> str:
+    """Render the server-side bash that probes readiness, decides
+    init-state, and either loads saved creds or bootstraps a new admin
+    + project. Mirrors deploy.sh:792-869.
+
+    Two-stage readiness: docker container Status == "running"
+    (``container_wait_seconds`` ceiling) AND HTTP body of
+    ``/api/v1/admin/config`` contains ``initialized``
+    (``http_wait_seconds`` ceiling). Without the second check, the
+    admin-bootstrap POST would race against Infisical's data-provider
+    init and 401.
+
+    Init-branch:
+    - ``"initialized":true`` body → load creds from
+      ``{saved_token_path}`` + ``{saved_project_path}`` (mode 600,
+      written on first run). Empty/missing files → ``loaded-existing-
+      missing-creds`` (operator must run destroy-all + re-init).
+    - else → POST ``/api/v1/admin/bootstrap`` with email + password +
+      organization_name → extract ``identity.credentials.token`` +
+      ``organization.id``. Then POST ``/api/v2/workspace`` with
+      project_name + organizationId → extract ``project.id`` (or
+      legacy ``workspace.id``). Save token + project_id to disk.
+
+    All API calls keep the freshly-minted token in env vars / mode-600
+    curl --config tmpfile, NEVER in argv. The token IS embedded in the
+    RESULT line (base64-encoded) so the runner can extract it; that's
+    the documented eval-handoff contract used by gitea-configure +
+    woodpecker-oauth.
+    """
+    email_q = shlex.quote(admin_email)
+    pw_q = shlex.quote(admin_password)
+    org_q = shlex.quote(organization_name)
+    project_q = shlex.quote(project_name)
+    url_q = shlex.quote(base_url)
+    tok_path_q = shlex.quote(saved_token_path)
+    proj_path_q = shlex.quote(saved_project_path)
+    return f"""set -euo pipefail
+ADMIN_EMAIL={email_q}
+ADMIN_PW={pw_q}
+ORG_NAME={org_q}
+PROJECT_NAME={project_q}
+BASE_URL={url_q}
+SAVED_TOKEN_PATH={tok_path_q}
+SAVED_PROJECT_PATH={proj_path_q}
+
+# Stage 1: wait for docker container to be running.
+SECONDS=0
+while [ "$SECONDS" -lt {container_wait_seconds} ]; do
+    STATUS=$(docker inspect --format='{{{{.State.Status}}}}' infisical 2>/dev/null || echo "")
+    [ "$STATUS" = "running" ] && break
+    sleep 2
+done
+
+# Stage 2: wait for /admin/config body to mention 'initialized'.
+READY=false
+SECONDS=0
+while [ "$SECONDS" -lt {http_wait_seconds} ]; do
+    BODY=$(curl -s --connect-timeout 3 --max-time 5 \\
+        "$BASE_URL/api/v1/admin/config" 2>/dev/null || echo "")
+    if echo "$BODY" | grep -q 'initialized'; then
+        READY=true
+        break
+    fi
+    sleep 3
+done
+if [ "$READY" != "true" ]; then
+    echo "RESULT status=not-ready"
+    exit 0
+fi
+
+# Stage 3: re-fetch /admin/config to determine init state.
+INIT_BODY=$(curl -s --max-time 10 "$BASE_URL/api/v1/admin/config" 2>/dev/null || echo "")
+if echo "$INIT_BODY" | grep -q '"initialized":true'; then
+    SAVED_TOKEN=$(cat "$SAVED_TOKEN_PATH" 2>/dev/null || echo "")
+    SAVED_PROJECT=$(cat "$SAVED_PROJECT_PATH" 2>/dev/null || echo "")
+    if [ -z "$SAVED_TOKEN" ] || [ -z "$SAVED_PROJECT" ]; then
+        echo "RESULT status=loaded-existing-missing-creds"
+        exit 0
+    fi
+    TOKEN_B64=$(printf '%s' "$SAVED_TOKEN" | base64 | tr -d '\\n')
+    echo "RESULT status=loaded-existing token=$TOKEN_B64 project_id=$SAVED_PROJECT"
+    exit 0
+fi
+
+# Stage 4: fresh bootstrap. POST /admin/bootstrap with email + password
+# + organization name. NEXUS_E / NEXUS_PW / NEXUS_ORG route the values
+# through env vars to jq — never `--arg`, which would land them in
+# jq's argv.
+BOOTSTRAP_BODY=$(NEXUS_E="$ADMIN_EMAIL" NEXUS_PW="$ADMIN_PW" NEXUS_ORG="$ORG_NAME" jq -n \\
+    '{{email: env.NEXUS_E, password: env.NEXUS_PW, organization: env.NEXUS_ORG}}')
+BOOTSTRAP_RESP=$(printf '%s' "$BOOTSTRAP_BODY" | curl -s -X POST \\
+    "$BASE_URL/api/v1/admin/bootstrap" \\
+    --max-time 30 \\
+    -H 'Content-Type: application/json' \\
+    --data-binary @- 2>/dev/null || echo "")
+
+if echo "$BOOTSTRAP_RESP" | grep -qi 'already'; then
+    echo "RESULT status=already-bootstrapped-no-saved-creds"
+    exit 0
+fi
+
+NEW_TOKEN=$(echo "$BOOTSTRAP_RESP" | jq -r '.identity.credentials.token // empty' 2>/dev/null)
+ORG_ID=$(echo "$BOOTSTRAP_RESP" | jq -r '.organization.id // empty' 2>/dev/null)
+if [ -z "$NEW_TOKEN" ] || [ -z "$ORG_ID" ]; then
+    echo "RESULT status=bootstrap-failed"
+    exit 0
+fi
+
+# Stage 5: create the workspace ("project" in v2 API). Bearer token via
+# mode-600 curl --config tmpfile, NOT -H argv.
+TOKEN_CFG=$(mktemp)
+chmod 600 "$TOKEN_CFG"
+trap 'rm -f "$TOKEN_CFG"' EXIT
+printf 'header = "Authorization: Bearer %s"\\n' "$NEW_TOKEN" > "$TOKEN_CFG"
+PROJECT_BODY=$(NEXUS_PN="$PROJECT_NAME" NEXUS_OID="$ORG_ID" jq -n \\
+    '{{projectName: env.NEXUS_PN, organizationId: env.NEXUS_OID}}')
+PROJECT_RESP=$(printf '%s' "$PROJECT_BODY" | curl -s --config "$TOKEN_CFG" \\
+    -X POST "$BASE_URL/api/v2/workspace" \\
+    --max-time 30 \\
+    -H 'Content-Type: application/json' \\
+    --data-binary @- 2>/dev/null || echo "")
+NEW_PROJECT=$(echo "$PROJECT_RESP" | jq -r '.project.id // .workspace.id // empty' 2>/dev/null)
+if [ -z "$NEW_PROJECT" ] || [ "$NEW_PROJECT" = "null" ]; then
+    echo "RESULT status=project-create-failed"
+    exit 0
+fi
+
+# Stage 6: persist for next spin-up. mode 600 — these files contain
+# the bearer token + workspace id. cat-then-chmod is the standard
+# pattern (the file is created by the redirect; chmod tightens it
+# before any further read).
+printf '%s' "$NEW_TOKEN" > "$SAVED_TOKEN_PATH"
+chmod 600 "$SAVED_TOKEN_PATH"
+printf '%s' "$NEW_PROJECT" > "$SAVED_PROJECT_PATH"
+chmod 600 "$SAVED_PROJECT_PATH"
+
+NEW_TOKEN_B64=$(printf '%s' "$NEW_TOKEN" | base64 | tr -d '\\n')
+echo "RESULT status=freshly-bootstrapped token=$NEW_TOKEN_B64 project_id=$NEW_PROJECT"
+"""
+
+
+def parse_provision_result(stdout: str) -> ProvisionResult | None:
+    """Extract the RESULT line from the rendered script's stdout. Returns
+    None if no parseable RESULT line exists (treated as
+    transport-failure by the CLI dispatcher)."""
+    import base64
+
+    match = _PROVISION_RESULT_RE.search(stdout)
+    if match is None:
+        return None
+    g = match.groupdict()
+    status: ProvisionStatus = g["status"]  # type: ignore[assignment]
+    token_b64 = g.get("token")
+    project_id = g.get("project_id")
+    token: str | None = None
+    if token_b64:
+        try:
+            token = base64.b64decode(token_b64).decode("utf-8")
+        except (ValueError, UnicodeDecodeError):
+            # Malformed base64 → drop to no-token path; the status line
+            # itself is still useful for the operator-facing log.
+            token = None
+    return ProvisionResult(
+        status=status,
+        token=token,
+        project_id=project_id,
+    )
+
+
+def provision_admin(
+    *,
+    admin_email: str,
+    admin_password: str,
+    organization_name: str = "Nexus",
+    project_name: str = "Nexus Stack",
+    script_runner: Callable[[str], subprocess.CompletedProcess[str]] | None = None,
+) -> ProvisionResult:
+    """Render + run the provision script via SSH, parse result.
+
+    ``script_runner`` is a DI seam for tests; production callers pass
+    None and get :func:`_remote.ssh_run_script` (script-via-stdin so
+    secrets never reach argv / ps).
+    """
+    if not admin_email or not admin_password:
+        return ProvisionResult(status="not-ready", token=None, project_id=None)
+    runner = script_runner or (lambda s: _remote.ssh_run_script(s))
+    script = render_provision_admin_script(
+        admin_email=admin_email,
+        admin_password=admin_password,
+        organization_name=organization_name,
+        project_name=project_name,
+    )
+    completed = runner(script)
+    parsed = parse_provision_result(completed.stdout)
+    if parsed is None:
+        # No RESULT line → treat as not-ready; CLI dispatcher maps to rc=1
+        # (warn-and-continue) so the deploy doesn't abort on a transient
+        # Infisical hiccup.
+        return ProvisionResult(status="not-ready", token=None, project_id=None)
+    return parsed
 
 
 def _filter_empty(items: Mapping[str, str | None]) -> dict[str, str]:

--- a/src/nexus_deploy/infisical.py
+++ b/src/nexus_deploy/infisical.py
@@ -353,8 +353,17 @@ echo "RESULT status=freshly-bootstrapped token=$NEW_TOKEN_B64 project_id=$NEW_PR
 
 def parse_provision_result(stdout: str) -> ProvisionResult | None:
     """Extract the RESULT line from the rendered script's stdout. Returns
-    None if no parseable RESULT line exists (treated as
-    transport-failure by the CLI dispatcher)."""
+    None if no parseable RESULT line exists.
+
+    The caller (``provision_admin``) substitutes a
+    ``ProvisionResult(status="not-ready", ...)`` for the None — and
+    the CLI dispatcher then maps that to **rc=1** (soft-fail, warn-
+    and-continue), NOT rc=2. Real transport failures (SSH connection
+    drops, timeouts) raise ``CalledProcessError`` / ``OSError`` from
+    the runner BEFORE we reach this parser, and those are what the
+    CLI's rc=2 branch catches. Without a RESULT line the script ran
+    end-to-end but didn't reach the success path — that's a soft
+    Infisical-bootstrap-not-ready signal, not a transport break."""
     import base64
 
     match = _PROVISION_RESULT_RE.search(stdout)

--- a/src/nexus_deploy/r2_tokens.py
+++ b/src/nexus_deploy/r2_tokens.py
@@ -133,11 +133,10 @@ class TokenInventory:
         return self.remaining_slots < 5
 
 
-# Sentinel type for the ``client_factory`` test seam. Callers in
-# production leave ``client_factory=None`` and get the standard
-# ``requests`` module; tests pass a ``MagicMock`` (or a custom stub)
-# that implements ``.get()`` / ``.delete()`` with the same shape as
-# requests' API.
+# Sentinel type for the ``client`` test seam. Callers in production
+# leave ``client=None`` and get the standard ``requests`` module;
+# tests pass a ``MagicMock`` (or a custom stub) that implements
+# ``.get()`` / ``.delete()`` with the same shape as requests' API.
 HttpClient = Any
 
 

--- a/src/nexus_deploy/r2_tokens.py
+++ b/src/nexus_deploy/r2_tokens.py
@@ -1,0 +1,350 @@
+"""Cloudflare R2 user-token inventory + cleanup (Phase 3 Modul 3.4f, #530).
+
+Replaces the legacy ad-hoc shell-out that listed and deleted Cloudflare
+user API tokens directly with a typed Python equivalent. Two reasons
+this lives here as a proper module instead of a one-off bash script:
+
+1. The existing R2-token bug (`init-r2-state.sh` losing tokens past
+   page 1 of the unpaginated `/user/tokens` listing) was caused by
+   silent edge-cases in shell + curl + jq. Surfacing the same logic
+   as a typed function with unit tests makes those edge-cases
+   testable and protected against future regressions.
+
+2. The migration's overall direction is bash → Python; introducing a
+   brand-new utility as bash would just create more legacy to migrate
+   later.
+
+The Cloudflare User-Token API is account-wide; the token used here is
+the same `TF_VAR_cloudflare_api_token` the Tofu/init-r2-state.sh
+flows use. Hard cap: 50 tokens per Cloudflare account, account-wide.
+
+Public surface:
+
+* :func:`list_user_tokens` — paginated retrieval of every user token,
+  with `?per_page=100` (Cloudflare's max).
+* :func:`find_tokens_by_name` / :func:`find_tokens_by_prefix` —
+  pure-python filtering against a token list.
+* :func:`delete_token` — single-id delete, returns
+  :class:`DeleteResult`.
+* :func:`cleanup_orphan_tokens` — list + filter + delete in one call,
+  returns a :class:`CleanupResult` aggregating per-token outcomes.
+
+The CLI surfaces these via ``nexus-deploy r2-tokens list`` and
+``nexus-deploy r2-tokens cleanup``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, cast
+
+import requests
+
+CLOUDFLARE_API_BASE = "https://api.cloudflare.com/client/v4"
+USER_TOKENS_PATH = "/user/tokens"
+ACCOUNT_TOKEN_HARD_CAP = 50  # Cloudflare account-wide limit
+DEFAULT_NEXUS_R2_PREFIX = "nexus-r2-"
+
+
+@dataclass(frozen=True)
+class TokenInfo:
+    """Subset of the Cloudflare token JSON we care about.
+
+    Cloudflare returns more fields (status, condition, last_used_on,
+    expires_on, policies …) — we keep the minimum needed for the
+    cleanup-by-name/prefix operations + the operator-facing inventory.
+    Skip-empty silently on missing fields so a future Cloudflare API
+    addition doesn't break parsing.
+    """
+
+    id: str
+    name: str
+    issued_on: str = ""  # ISO8601, may be missing on older tokens
+
+    @classmethod
+    def from_api(cls, raw: dict[str, Any]) -> TokenInfo:
+        return cls(
+            id=str(raw.get("id") or ""),
+            name=str(raw.get("name") or ""),
+            issued_on=str(raw.get("issued_on") or ""),
+        )
+
+
+@dataclass(frozen=True)
+class DeleteResult:
+    """Outcome of a single token-delete API call."""
+
+    id: str
+    name: str
+    deleted: bool
+    error: str = ""
+
+    @property
+    def is_success(self) -> bool:
+        return self.deleted
+
+
+@dataclass(frozen=True)
+class CleanupResult:
+    """Aggregate result from :func:`cleanup_orphan_tokens`."""
+
+    total_tokens_before: int
+    matched: tuple[TokenInfo, ...]
+    deletions: tuple[DeleteResult, ...]
+    dry_run: bool = False
+
+    @property
+    def deleted_count(self) -> int:
+        return sum(1 for d in self.deletions if d.deleted)
+
+    @property
+    def failed_count(self) -> int:
+        return sum(1 for d in self.deletions if not d.deleted)
+
+    @property
+    def is_success(self) -> bool:
+        return self.failed_count == 0
+
+
+@dataclass(frozen=True)
+class TokenInventory:
+    """Tokens snapshot + counters used by the audit ("list") path.
+
+    ``total`` is the total count account-wide (across all prefixes);
+    ``matched`` is the subset matching the inventory's filter prefix.
+    ``remaining_slots`` is the account-wide free slots before the
+    50-token hard cap kicks in — surface this in the operator log so
+    we notice approaching the cap before a re-setup fails.
+    """
+
+    total: int
+    matched: tuple[TokenInfo, ...]
+    prefix: str = ""
+
+    @property
+    def remaining_slots(self) -> int:
+        return max(0, ACCOUNT_TOKEN_HARD_CAP - self.total)
+
+    @property
+    def near_cap(self) -> bool:
+        """True when fewer than 5 slots remain (matches the 'Should'
+        criterion in the bug report — the cron worker should warn
+        before we hit the wall)."""
+        return self.remaining_slots < 5
+
+
+# Sentinel type for the ``client_factory`` test seam. Callers in
+# production leave ``client_factory=None`` and get the standard
+# ``requests`` module; tests pass a ``MagicMock`` (or a custom stub)
+# that implements ``.get()`` / ``.delete()`` with the same shape as
+# requests' API.
+HttpClient = Any
+
+
+def _default_client() -> HttpClient:
+    """Production HTTP client. Module-level ``requests`` reference;
+    the indirection exists so tests can swap in a mock without
+    monkey-patching the requests module globally."""
+    return requests
+
+
+def list_user_tokens(
+    *,
+    api_token: str,
+    base_url: str = CLOUDFLARE_API_BASE,
+    per_page: int = 100,
+    client: HttpClient | None = None,
+    timeout_s: float = 15.0,
+) -> list[TokenInfo]:
+    """Fetch every Cloudflare user API token, walking ``result_info.total_pages``.
+
+    The 50-token cap means a single ``per_page=100`` request always
+    returns the full list — but we still paginate defensively so the
+    function stays correct if Cloudflare ever raises the cap or if
+    a future caller bypasses it for a different account.
+
+    Raises ``requests.HTTPError`` on non-2xx responses (no-retry — this
+    is a one-shot inventory, not a retry surface). Per-token
+    parsing is lenient: unknown-shape entries silently skip.
+    """
+    http = client if client is not None else _default_client()
+    headers = {
+        "Authorization": f"Bearer {api_token}",
+        "Content-Type": "application/json",
+    }
+    tokens: list[TokenInfo] = []
+    page = 1
+    total_pages = 1
+    while page <= total_pages:
+        resp = http.get(
+            f"{base_url}{USER_TOKENS_PATH}",
+            params={"per_page": per_page, "page": page},
+            headers=headers,
+            timeout=timeout_s,
+        )
+        resp.raise_for_status()
+        body = resp.json()
+        if not body.get("success"):
+            errs = body.get("errors") or []
+            msg = errs[0].get("message") if errs else "unknown"
+            raise RuntimeError(f"Cloudflare /user/tokens failed: {msg}")
+        for raw in body.get("result") or []:
+            if isinstance(raw, dict):
+                tokens.append(TokenInfo.from_api(cast("dict[str, Any]", raw)))
+        info = body.get("result_info") or {}
+        total_pages = int(info.get("total_pages") or 1)
+        page += 1
+    return tokens
+
+
+def find_tokens_by_name(tokens: list[TokenInfo], name: str) -> list[TokenInfo]:
+    """ALL tokens with exact-name match. Returns multiple entries if
+    the account somehow ended up with duplicates — this is the case
+    we want to clean up after the bug report's orphan scenario."""
+    return [t for t in tokens if t.name == name]
+
+
+def find_tokens_by_prefix(tokens: list[TokenInfo], prefix: str) -> list[TokenInfo]:
+    """All tokens whose name starts with ``prefix``."""
+    return [t for t in tokens if t.name.startswith(prefix)]
+
+
+def delete_token(
+    token_id: str,
+    *,
+    api_token: str,
+    name: str = "",
+    base_url: str = CLOUDFLARE_API_BASE,
+    client: HttpClient | None = None,
+    timeout_s: float = 15.0,
+) -> DeleteResult:
+    """Delete a single token by id. ``name`` is purely cosmetic
+    (carried into the result for log lines); the API only needs the id.
+
+    Returns a :class:`DeleteResult` with ``deleted=True`` on
+    ``success: true`` from Cloudflare; otherwise extracts the first
+    error message and surfaces it via ``error``. Network errors
+    propagate as ``requests.RequestException`` (caller decides whether
+    to abort the whole cleanup or continue with the next id)."""
+    http = client if client is not None else _default_client()
+    headers = {
+        "Authorization": f"Bearer {api_token}",
+        "Content-Type": "application/json",
+    }
+    resp = http.delete(
+        f"{base_url}{USER_TOKENS_PATH}/{token_id}",
+        headers=headers,
+        timeout=timeout_s,
+    )
+    body: dict[str, Any]
+    try:
+        body = resp.json()
+    except ValueError:
+        body = {}
+    if body.get("success"):
+        return DeleteResult(id=token_id, name=name, deleted=True)
+    errs = body.get("errors") or []
+    msg = (errs[0] or {}).get("message") if errs else f"HTTP {resp.status_code}"
+    return DeleteResult(id=token_id, name=name, deleted=False, error=str(msg))
+
+
+def cleanup_orphan_tokens(
+    *,
+    api_token: str,
+    name: str | None = None,
+    prefix: str | None = None,
+    dry_run: bool = True,
+    base_url: str = CLOUDFLARE_API_BASE,
+    client: HttpClient | None = None,
+) -> CleanupResult:
+    """One-shot reconciliation: list + filter + delete.
+
+    Exactly one of ``name`` / ``prefix`` must be set. ``dry_run=True``
+    (the default) just lists; ``dry_run=False`` calls
+    :func:`delete_token` for each match. Per-id delete failures are
+    recorded in :class:`CleanupResult.deletions` but don't stop
+    the loop — the operator sees per-token outcomes in the audit log.
+
+    **Safety invariant**: ``prefix`` MUST start with ``nexus-r2-``.
+    Without this guard, an operator typo could wipe the protected
+    ``Nexus-Stack`` / ``Nexus2`` / ``Nexus-Stack Template`` /
+    ``nexus-stack-ch build token`` entries documented in CLAUDE.md.
+    The function raises ``ValueError`` on a non-conforming prefix
+    rather than silently broadening the scope.
+    """
+    if (name is None) == (prefix is None):
+        raise ValueError("cleanup_orphan_tokens: pass exactly one of name= / prefix=")
+    if prefix is not None and not prefix.startswith(DEFAULT_NEXUS_R2_PREFIX):
+        raise ValueError(
+            f"cleanup_orphan_tokens: prefix={prefix!r} must start with "
+            f"{DEFAULT_NEXUS_R2_PREFIX!r} — refusing to broaden scope to "
+            "tokens outside the nexus-r2-* family (protected per CLAUDE.md)",
+        )
+    tokens = list_user_tokens(api_token=api_token, base_url=base_url, client=client)
+    if name is not None:
+        matched = find_tokens_by_name(tokens, name)
+    else:
+        # `prefix` is guaranteed non-None here by the XOR check above; cast
+        # for mypy strictness (Optional[str] → str).
+        matched = find_tokens_by_prefix(tokens, cast("str", prefix))
+    if dry_run:
+        return CleanupResult(
+            total_tokens_before=len(tokens),
+            matched=tuple(matched),
+            deletions=(),
+            dry_run=True,
+        )
+    deletions: list[DeleteResult] = []
+    for t in matched:
+        deletions.append(
+            delete_token(
+                t.id,
+                api_token=api_token,
+                name=t.name,
+                base_url=base_url,
+                client=client,
+            ),
+        )
+    return CleanupResult(
+        total_tokens_before=len(tokens),
+        matched=tuple(matched),
+        deletions=tuple(deletions),
+        dry_run=False,
+    )
+
+
+def build_inventory(
+    *,
+    api_token: str,
+    prefix: str = DEFAULT_NEXUS_R2_PREFIX,
+    base_url: str = CLOUDFLARE_API_BASE,
+    client: HttpClient | None = None,
+) -> TokenInventory:
+    """Audit shape: full account count + filtered subset + remaining
+    slots. Backs the ``nexus-deploy r2-tokens list`` CLI and the
+    optional admin-status panel called out in the bug report."""
+    tokens = list_user_tokens(api_token=api_token, base_url=base_url, client=client)
+    matched = find_tokens_by_prefix(tokens, prefix)
+    return TokenInventory(total=len(tokens), matched=tuple(matched), prefix=prefix)
+
+
+__all__ = [
+    "ACCOUNT_TOKEN_HARD_CAP",
+    "CLOUDFLARE_API_BASE",
+    "DEFAULT_NEXUS_R2_PREFIX",
+    "CleanupResult",
+    "DeleteResult",
+    "TokenInfo",
+    "TokenInventory",
+    "build_inventory",
+    "cleanup_orphan_tokens",
+    "delete_token",
+    "find_tokens_by_name",
+    "find_tokens_by_prefix",
+    "list_user_tokens",
+]
+
+
+# Defensive: reference the unused-on-this-path field annotation so
+# mypy --strict doesn't flag the dataclass(field) helper as unused.
+_ = field

--- a/src/nexus_deploy/secret_sync.py
+++ b/src/nexus_deploy/secret_sync.py
@@ -75,25 +75,59 @@ _VALID_KEY_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 @dataclass(frozen=True)
 class StackTarget:
-    """Per-stack parameters that vary between Jupyter and Marimo.
+    """Per-stack parameters for the Infisical secret-sync.
 
-    The two stacks share the entire sync logic; only these fields differ.
-    Both heredocs in deploy.sh are byte-for-byte identical apart from
-    these substitutions.
+    Three stacks are supported:
+
+    - **jupyter**, **marimo**: write plaintext ``KEY=value`` lines to
+      ``.infisical.env`` (separate from ``.env``). Restart via
+      ``docker compose up -d <stack>`` on change. The original
+      legacy-bash family (#510).
+    - **kestra**: write ``SECRET_<KEY>=<base64-value>`` lines to ``.env``
+      directly (no separate ``.infisical.env``). Force-recreate the
+      container so Kestra's ``EnvVarSecretProvider`` re-reads the
+      SECRET_* env vars at process start. Migrated in this PR
+      (Modul 3.4f).
+
+    The render pipeline is shared; ``key_prefix``, ``use_base64_values``,
+    ``env_file_basename``, ``legacy_env_file_basename``, and
+    ``force_recreate`` parameterise the ~5 lines that differ between
+    the two output formats.
     """
 
-    name: str  # "jupyter" | "marimo" — used for paths + the friendly
-    # name in the BEGIN marker comment.
+    name: str  # "jupyter" | "marimo" | "kestra" — paths + marker label.
+
+    # Output-format parameters. Defaults match the original Jupyter/Marimo
+    # behavior so existing call sites stay unchanged.
+    key_prefix: str = ""  # "" for jupyter/marimo; "SECRET_" for kestra
+    use_base64_values: bool = False  # False=plain-escaped, True=raw base64
+    env_file_basename: str = ".infisical.env"  # ".env" for kestra
+    # legacy_env_file_basename: separate file the sync used to write to
+    # before #495 — stripped on each successful run so the new location
+    # is the single source of truth. Set to ``None`` for stacks that
+    # have no separate legacy file (kestra writes to ``.env`` directly,
+    # no migration step needed).
+    legacy_env_file_basename: str | None = ".env"
+    # Kestra's EnvVarSecretProvider only loads SECRET_* on container
+    # start — `compose up -d` alone won't pick them up if the .env hash
+    # didn't change in compose's view. --force-recreate guarantees
+    # the new env makes it into the JVM. Jupyter/Marimo use plain env
+    # injection that takes effect on `up -d` without --force-recreate.
+    force_recreate: bool = False
 
     @property
     def env_file(self) -> str:
         """Server-side path the sync writes to."""
-        return f"{_REMOTE_STACKS_DIR}/{self.name}/.infisical.env"
+        return f"{_REMOTE_STACKS_DIR}/{self.name}/{self.env_file_basename}"
 
     @property
-    def legacy_env_file(self) -> str:
-        """Pre-#495 location of the same block. Stripped after successful write."""
-        return f"{_REMOTE_STACKS_DIR}/{self.name}/.env"
+    def legacy_env_file(self) -> str | None:
+        """Pre-#495 location of the same block. Stripped after successful
+        write. ``None`` for stacks where no separate legacy location
+        ever existed (e.g. kestra)."""
+        if self.legacy_env_file_basename is None:
+            return None
+        return f"{_REMOTE_STACKS_DIR}/{self.name}/{self.legacy_env_file_basename}"
 
     @property
     def compose_dir(self) -> str:
@@ -105,9 +139,16 @@ class StackTarget:
         """Marker comment ABOVE the rendered block. Preserves the legacy wording.
 
         The legacy deploy.sh heredocs used `Infisical → Jupyter env` /
-        `Infisical → Marimo env` (capitalised stack name) — same here so
-        existing greps + the sed-based legacy-strip continue to match.
+        `Infisical → Marimo env` (capitalised stack name); the strip-
+        regex matches the leading `# === BEGIN nexus-secret-sync` only,
+        so the wording AFTER that prefix is just for human readers.
+        Kestra uses a shorter wording matching its legacy
+        deploy.sh:1513 marker.
         """
+        if self.name == "kestra":
+            return (
+                "# === BEGIN nexus-secret-sync (re-generated each spin-up; do not edit by hand) ==="
+            )
         friendly = self.name.capitalize()
         return (
             f"# === BEGIN nexus-secret-sync (Infisical → {friendly} env, "
@@ -209,11 +250,15 @@ def render_remote_script(
     env_q = shlex.quote(infisical_env)
     gtoken_q = shlex.quote(gitea_token)
     env_file_q = shlex.quote(target.env_file)
-    legacy_q = shlex.quote(target.legacy_env_file)
+    # Legacy env-file is optional: kestra-style targets write to .env
+    # directly with no separate legacy file. We render an empty string
+    # (NOT a dummy path) so the bash branch can guard with [ -n ... ].
+    legacy_q = shlex.quote(target.legacy_env_file or "")
     begin_marker_q = shlex.quote(target.begin_marker)
     end_marker_q = shlex.quote(_END_MARKER)
     folders_url_q = shlex.quote(f"{_INFISICAL_BASE_URL}/api/v1/folders")
     secrets_url_q = shlex.quote(f"{_INFISICAL_BASE_URL}/api/v3/secrets/raw")
+    key_prefix_q = shlex.quote(target.key_prefix)
 
     # The bash below is the legacy deploy.sh secret-sync heredoc lifted
     # near-verbatim (see git history pre-#510 for the original blocks).
@@ -242,6 +287,13 @@ BEGIN_MARKER={begin_marker_q}
 END_MARKER={end_marker_q}
 FOLDERS_URL={folders_url_q}
 SECRETS_URL={secrets_url_q}
+# Kestra format toggles: KEY_PREFIX prepends to every appended key
+# (empty for jupyter/marimo, "SECRET_" for kestra). USE_B64=1 writes
+# the raw base64 value (kestra's EnvVarSecretProvider decodes); =0
+# uses the plain-escaped form (jupyter/marimo expect plaintext at
+# runtime via process env).
+KEY_PREFIX={key_prefix_q}
+USE_B64={"1" if target.use_base64_values else "0"}
 
 CFG=$(mktemp)
 SEEN=$(mktemp)
@@ -324,16 +376,31 @@ while IFS= read -r FOLDER; do
             echo "  ⚠ Key collision: '$KEY' in folder '$FOLDER_LABEL' shadowed by earlier value from '$EXISTING' (first-wins)" >&2
             continue
         fi
-        ESCAPED_VALUE=$(printf '%s' "$VALUE" | sed -e 's/\\\\/\\\\\\\\/g' -e 's/"/\\\\"/g')
         printf '%s\\t%s\\n' "$KEY" "$FOLDER_LABEL" >> "$SEEN"
-        printf '%s="%s"\\n' "$KEY" "$ESCAPED_VALUE" >> "$APPEND"
+        if [ "$USE_B64" = "1" ]; then
+            # Kestra: SECRET_<KEY>=<base64-value>. EnvVarSecretProvider
+            # decodes server-side. Newlines / binary content survive
+            # the env var via base64.
+            printf '%s%s=%s\\n' "$KEY_PREFIX" "$KEY" "$VALUE_B64" >> "$APPEND"
+        else
+            # Jupyter/Marimo: <KEY>="<escaped-value>". Plain text at
+            # runtime via process env; double-backslash + double-quote
+            # escapes preserve dotenv-parser semantics.
+            ESCAPED_VALUE=$(printf '%s' "$VALUE" | sed -e 's/\\\\/\\\\\\\\/g' -e 's/"/\\\\"/g')
+            printf '%s%s="%s"\\n' "$KEY_PREFIX" "$KEY" "$ESCAPED_VALUE" >> "$APPEND"
+        fi
         PUSHED=$((PUSHED+1))
     done < "$TSV"
 done <<< "$FOLDERS"
 
-if [ -n "$GTOKEN" ] && ! grep -qE '^GITEA_TOKEN=' "$APPEND"; then
-    ESCAPED_GTOKEN=$(printf '%s' "$GTOKEN" | sed -e 's/\\\\/\\\\\\\\/g' -e 's/"/\\\\"/g')
-    printf 'GITEA_TOKEN="%s"\\n' "$ESCAPED_GTOKEN" >> "$APPEND"
+if [ -n "$GTOKEN" ] && ! grep -qE "^${{KEY_PREFIX}}GITEA_TOKEN=" "$APPEND"; then
+    if [ "$USE_B64" = "1" ]; then
+        GTOKEN_B64=$(printf '%s' "$GTOKEN" | base64 | tr -d '\\n')
+        printf '%sGITEA_TOKEN=%s\\n' "$KEY_PREFIX" "$GTOKEN_B64" >> "$APPEND"
+    else
+        ESCAPED_GTOKEN=$(printf '%s' "$GTOKEN" | sed -e 's/\\\\/\\\\\\\\/g' -e 's/"/\\\\"/g')
+        printf '%sGITEA_TOKEN="%s"\\n' "$KEY_PREFIX" "$ESCAPED_GTOKEN" >> "$APPEND"
+    fi
     PUSHED=$((PUSHED+1))
 fi
 
@@ -369,7 +436,10 @@ mv "$TMP_OUT" "$ENV_FILE"
 chmod 600 "$ENV_FILE"
 WROTE=1
 
-if [ -f "$LEGACY_ENV" ]; then
+# Legacy-strip step: only runs when the target declared a legacy
+# location (jupyter/marimo). Kestra targets (LEGACY_ENV=="") skip
+# this — they write directly to .env, no migration step needed.
+if [ -n "$LEGACY_ENV" ] && [ -f "$LEGACY_ENV" ]; then
     LEGACY_TMP=$(mktemp -p "$(dirname "$LEGACY_ENV")" .env.XXXXXX)
     chmod 600 "$LEGACY_TMP"
     sed '/^# === BEGIN nexus-secret-sync/,/^# === END nexus-secret-sync/d' "$LEGACY_ENV" > "$LEGACY_TMP"
@@ -478,12 +548,18 @@ def run_sync_for_stack(
 
     if result.wrote:
         # Restart on change. Mirrors the legacy deploy.sh restart step —
-        # `docker compose up -d <stack>` recomputes the resolved-config
-        # hash and recreates only when env_file content changed. No
-        # --force-recreate.
-        # Restart failure does NOT alter result.wrote; we just emit the
-        # error to stderr so the operator sees it.
-        restart_cmd = f"cd {shlex.quote(target.compose_dir)} && docker compose up -d {shlex.quote(target.name)}"
+        # ``docker compose up -d <stack>`` recomputes the resolved-config
+        # hash and recreates only when env_file content changed. Kestra
+        # additionally needs ``--force-recreate`` because its
+        # ``EnvVarSecretProvider`` only loads SECRET_* env vars at
+        # process start, and a config-hash unchanged from compose's
+        # view (e.g. when the SECRET_* values rotated but the file
+        # length is identical) wouldn't otherwise trigger a recreate.
+        force_flag = " --force-recreate" if target.force_recreate else ""
+        restart_cmd = (
+            f"cd {shlex.quote(target.compose_dir)} && "
+            f"docker compose up -d{force_flag} {shlex.quote(target.name)}"
+        )
         try:
             run_cmd(restart_cmd)
         except subprocess.CalledProcessError as exc:

--- a/src/nexus_deploy/secret_sync.py
+++ b/src/nexus_deploy/secret_sync.py
@@ -79,15 +79,20 @@ class StackTarget:
 
     Three stacks are supported:
 
-    - **jupyter**, **marimo**: write plaintext ``KEY=value`` lines to
-      ``.infisical.env`` (separate from ``.env``). Restart via
-      ``docker compose up -d <stack>`` on change. The original
-      legacy-bash family (#510).
+    - **jupyter**, **marimo**: write dotenv-style ``KEY="<escaped-value>"``
+      lines to ``.infisical.env`` (separate from ``.env``). The value
+      is sed-escaped (``\\\\``→``\\\\\\\\``, ``"``→``\\\\"``) and double-
+      quoted so dotenv parsers accept characters that would otherwise
+      break the line; multi-line values are skipped earlier (their
+      newlines couldn't survive a single-line shell-readable form).
+      Restart via ``docker compose up -d <stack>`` on change. The
+      original legacy-bash family (#510).
     - **kestra**: write ``SECRET_<KEY>=<base64-value>`` lines to ``.env``
-      directly (no separate ``.infisical.env``). Force-recreate the
-      container so Kestra's ``EnvVarSecretProvider`` re-reads the
-      SECRET_* env vars at process start. Migrated in this PR
-      (Modul 3.4f).
+      directly — no quoting (base64 output is already safe for a
+      single-line env-var) and no separate ``.infisical.env`` file.
+      Force-recreate the container so Kestra's ``EnvVarSecretProvider``
+      re-reads the SECRET_* env vars at process start. Migrated in
+      this PR (Modul 3.4f).
 
     The render pipeline is shared; ``key_prefix``, ``use_base64_values``,
     ``env_file_basename``, ``legacy_env_file_basename``, and

--- a/src/nexus_deploy/secret_sync.py
+++ b/src/nexus_deploy/secret_sync.py
@@ -356,20 +356,30 @@ while IFS= read -r FOLDER; do
             SKIPPED_NAME=$((SKIPPED_NAME+1)); continue
         fi
         VALUE=$(printf '%s' "$VALUE_B64" | base64 -d || true)
-        # Multi-line guard: bash glob match, NOT `grep -q $'\\n'`. The
-        # legacy deploy.sh form processed input line-by-line where the
-        # implicit line-terminator could match the pattern, so EVERY
-        # non-empty single-line value falsely triggered the skip
-        # (resulting in only GITEA_TOKEN ever landing in .infisical.env).
-        # bash's case glob compares the variable's bytes directly and
-        # only matches genuine embedded newlines.
-        case "$VALUE" in
-            *$'\\n'*)
-                SKIPPED_MULTI=$((SKIPPED_MULTI+1))
-                echo "  ⚠ Skipping multi-line secret '$KEY' (folder '$FOLDER_LABEL')" >&2
-                continue
-                ;;
-        esac
+        # Multi-line guard. Bash glob match (NOT `grep -q $'\\n'`):
+        # the legacy form processed input line-by-line where the
+        # implicit line-terminator could match the pattern, so
+        # every non-empty single-line value falsely triggered the
+        # skip (resulting in only GITEA_TOKEN ever landing in
+        # .infisical.env). bash's case glob compares the variable's
+        # bytes directly and only matches genuine embedded newlines.
+        #
+        # GATED on USE_B64=0 (Jupyter/Marimo plain-text mode):
+        # multi-line values can't survive a `KEY="value"` env-file
+        # line without escaping, so we skip + warn. In USE_B64=1
+        # mode (Kestra) the value transits as base64 and Kestra's
+        # EnvVarSecretProvider decodes it server-side — multi-line
+        # PEMs / certs / multi-line tokens flow through fine, which
+        # matches the legacy Kestra-secret-sync behavior.
+        if [ "$USE_B64" = "0" ]; then
+            case "$VALUE" in
+                *$'\\n'*)
+                    SKIPPED_MULTI=$((SKIPPED_MULTI+1))
+                    echo "  ⚠ Skipping multi-line secret '$KEY' (folder '$FOLDER_LABEL')" >&2
+                    continue
+                    ;;
+            esac
+        fi
         EXISTING=$(awk -F'\\t' -v k="$KEY" '$1 == k {{print $2; exit}}' "$SEEN")
         if [ -n "$EXISTING" ]; then
             COLLISIONS=$((COLLISIONS+1))

--- a/src/nexus_deploy/services.py
+++ b/src/nexus_deploy/services.py
@@ -1443,7 +1443,9 @@ def render_pg_ducklake_hook(config: NexusConfig, env: BootstrapEnv) -> str:
     never make it into the running Postgres without this re-apply.
 
     Two stages:
-    1. Wait for ``pg_isready`` (15 iterations of 2s = 30s ceiling).
+    1. Wait for ``pg_isready`` — 30s wall-clock bound (``$SECONDS``-gated
+       loop, ``sleep 2`` per iteration, so up to ~15 probes plus the
+       partial second the loop entered on).
     2. Exec ``psql -f /docker-entrypoint-initdb.d/00-ducklake-bootstrap.sql``
        inside the container. Idempotent — the SQL itself uses
        ``DO $$ ... drop_secret EXCEPTION WHEN OTHERS THEN NULL ... $$``

--- a/src/nexus_deploy/services.py
+++ b/src/nexus_deploy/services.py
@@ -1431,6 +1431,64 @@ sftpgo_hook
 """
 
 
+def render_pg_ducklake_hook(config: NexusConfig, env: BootstrapEnv) -> str:
+    """pg-ducklake: re-apply ``00-ducklake-bootstrap.sql`` on every
+    spin-up to handle credential rotation.
+
+    Mirrors deploy.sh:962-992. The bootstrap SQL is written to
+    ``stacks/pg-ducklake/init/`` by service-env (PR #527), and Postgres'
+    docker-entrypoint-initdb.d only executes scripts on an EMPTY data
+    dir — so on persistent-volume deploys (named volume preserved
+    across spin-ups), the freshly-rotated credentials in the SQL
+    never make it into the running Postgres without this re-apply.
+
+    Two stages:
+    1. Wait for ``pg_isready`` (15 iterations of 2s = 30s ceiling).
+    2. Exec ``psql -f /docker-entrypoint-initdb.d/00-ducklake-bootstrap.sql``
+       inside the container. Idempotent — the SQL itself uses
+       ``DO $$ ... drop_secret EXCEPTION WHEN OTHERS THEN NULL ... $$``
+       so re-runs against an already-bootstrapped DB are safe.
+
+    Idempotency contract:
+    - pg_isready times out → ``skipped-not-ready``
+    - psql exec succeeds → ``configured``
+    - psql exec fails → ``failed`` (legacy bash treated this as a
+      yellow warning ``may already be applied``; we surface as failed
+      so the operator can inspect, since a real psql failure means
+      either the SQL has a syntax error OR the credentials in the
+      SQL file don't match what Postgres expects)
+    """
+    del config, env
+    return """
+pg_ducklake_hook() {
+    READY=false
+    SECONDS=0
+    while [ "$SECONDS" -lt 30 ]; do
+        if docker exec pg-ducklake pg_isready -U nexus-pgducklake -d ducklake \\
+                >/dev/null 2>&1; then
+            READY=true
+            break
+        fi
+        sleep 2
+    done
+    if [ "$READY" != "true" ]; then
+        echo "  ⚠ pg_ducklake not ready after 30s — skipping bootstrap re-apply" >&2
+        echo "RESULT hook=pg-ducklake status=skipped-not-ready"
+        return 0
+    fi
+    if docker exec pg-ducklake psql -U nexus-pgducklake -d ducklake \\
+            -f /docker-entrypoint-initdb.d/00-ducklake-bootstrap.sql \\
+            >/dev/null 2>&1; then
+        echo "RESULT hook=pg-ducklake status=configured"
+    else
+        echo "  ⚠ pg_ducklake bootstrap SQL re-apply failed (check container logs)" >&2
+        echo "RESULT hook=pg-ducklake status=failed"
+    fi
+}
+pg_ducklake_hook
+"""
+
+
 # ---------------------------------------------------------------------------
 # Modul 2.2d — Filestash (Python-side file mutation).
 #
@@ -1865,6 +1923,10 @@ _HOOK_REGISTRY: dict[str, HookRenderer] = {
     "dify": render_dify_hook,
     "windmill": render_windmill_hook,
     "sftpgo": render_sftpgo_hook,
+    # Modul 3.4f — pg-ducklake bootstrap re-apply (handles cred rotation
+    # on persistent-volume deploys where the entrypoint-initdb scripts
+    # only ran on first init).
+    "pg-ducklake": render_pg_ducklake_hook,
 }
 
 

--- a/src/nexus_deploy/services.py
+++ b/src/nexus_deploy/services.py
@@ -1483,7 +1483,8 @@ pg_ducklake_hook() {
             >/dev/null 2>&1; then
         echo "RESULT hook=pg-ducklake status=configured"
     else
-        echo "  ⚠ pg_ducklake bootstrap SQL re-apply failed (check container logs)" >&2
+        echo "  ⚠ pg_ducklake bootstrap SQL re-apply failed — re-run manually to see the actual psql error:" >&2
+        echo "    ssh nexus 'docker exec pg-ducklake psql -U nexus-pgducklake -d ducklake -f /docker-entrypoint-initdb.d/00-ducklake-bootstrap.sql'" >&2
         echo "RESULT hook=pg-ducklake status=failed"
     fi
 }

--- a/src/nexus_deploy/setup.py
+++ b/src/nexus_deploy/setup.py
@@ -849,14 +849,24 @@ def setup_wetty_ssh_agent(
     """Render + run the wetty-agent setup script. Returns None on
     unparseable output (soft failure — operator sees the script's
     forwarded stderr; the deploy continues without aborting since
-    Wetty is a non-critical UI service)."""
+    Wetty is a non-critical UI service).
+
+    ``check=True``: the rendered script ALWAYS terminates with
+    ``exit 0`` (fail-fast paths emit a parseable all-zero RESULT line
+    + ``exit 0``), so a non-zero returncode here can only mean the
+    SSH transport itself broke (rc=255, connection drop, ...). Letting
+    ``CalledProcessError`` propagate so the CLI handler maps it to
+    rc=2 ("transport failure") instead of silently returning None and
+    falling through to the rc=1 "soft fail" branch — caught in
+    #530 R4.
+    """
     script = render_wetty_agent_script(
         key_path=key_path,
         key_comment=key_comment,
         agent_socket=agent_socket,
         wetty_env_file=wetty_env_file,
     )
-    completed = ssh.run_script(script, check=False)
+    completed = ssh.run_script(script, check=True)
     # Forward non-RESULT stderr lines (the script's own diagnostics)
     # to the local terminal so operators see e.g. ssh-keygen errors.
     for line in completed.stdout.splitlines():

--- a/src/nexus_deploy/setup.py
+++ b/src/nexus_deploy/setup.py
@@ -871,8 +871,13 @@ def setup_wetty_ssh_agent(
         wetty_env_file=wetty_env_file,
     )
     completed = ssh.run_script(script, check=True)
-    # Forward non-RESULT stderr lines (the script's own diagnostics)
-    # to the local terminal so operators see e.g. ssh-keygen errors.
+    # Forward non-RESULT diagnostic lines (the script's own ⚠ /
+    # ssh-keygen errors etc.) to the local terminal. SSHClient.run_script
+    # uses merge_stderr=True by default, so the script's stderr is
+    # already folded into completed.stdout — iterating stdout here
+    # captures both the rendered bash's `echo … >&2` warnings AND any
+    # plain stdout, while skipping the parseable RESULT_WETTY line
+    # itself (which the parser below consumes).
     for line in completed.stdout.splitlines():
         if not line.startswith("RESULT_WETTY"):
             sys.stderr.write(line + "\n")

--- a/src/nexus_deploy/setup.py
+++ b/src/nexus_deploy/setup.py
@@ -693,7 +693,19 @@ chmod 700 /root/.ssh
 # (cat $KEY_PATH.pub, ssh-keygen -lf for fingerprint) would silently
 # fail and we'd report a misleading keypair_generated=1 while Wetty
 # can't actually SSH.
-if [ ! -f "$KEY_PATH" ]; then
+# Regenerate if EITHER file is missing — not just $KEY_PATH. A stale
+# private key with a missing/corrupted .pub (manual cleanup, partial
+# write, fs corruption) would otherwise pass the keygen-skip check
+# but later `cat "$KEY_PATH.pub"` would yield empty PUBKEY → the
+# authorized_keys append silently no-ops (empty grep -F matches the
+# whole file → PUBKEY_ADD stays 0) and Wetty can't actually SSH.
+# Removing both files first lets ssh-keygen emit a fresh, consistent
+# pair (it would refuse to overwrite an existing $KEY_PATH).
+if [ ! -f "$KEY_PATH" ] || [ ! -f "$KEY_PATH.pub" ]; then
+    if [ -f "$KEY_PATH" ] || [ -f "$KEY_PATH.pub" ]; then
+        echo "  ⚠ Wetty keypair half-present (one of $KEY_PATH / .pub missing) — regenerating" >&2
+        rm -f "$KEY_PATH" "$KEY_PATH.pub"
+    fi
     if ! ssh-keygen -t ed25519 -f "$KEY_PATH" -N '' -C "$KEY_COMMENT" >/dev/null 2>&1; then
         echo "  ⚠ ssh-keygen failed — Wetty will not have a working SSH key" >&2
         echo "RESULT_WETTY keypair_generated=0 pubkey_added=0 agent_started=0 key_added_to_agent=0 auth_sock_written=0"

--- a/src/nexus_deploy/setup.py
+++ b/src/nexus_deploy/setup.py
@@ -682,7 +682,11 @@ AUTH_SOCK_WROTE=0
 mkdir -p /root/.ssh
 chmod 700 /root/.ssh
 
-# Step 1: ssh-keygen if absent. Fail-fast (echo RESULT_WETTY with
+# Inline-step numbering matches the docstring's "1. mkdir + chmod 700"
+# precondition above. The flags below correspond to docstring steps
+# 2-6 (steps that produce a 0/1 in RESULT_WETTY).
+#
+# Step 2: ssh-keygen if absent. Fail-fast (echo RESULT_WETTY with
 # keypair_generated=0 + bail) when ssh-keygen reports non-zero OR
 # either of the expected output files ($KEY_PATH / $KEY_PATH.pub)
 # isn't on disk afterwards. Without this check, downstream steps
@@ -705,7 +709,7 @@ if [ ! -f "$KEY_PATH" ]; then
     KEYPAIR_GEN=1
 fi
 
-# Step 2: append pubkey to authorized_keys (idempotent — full-line
+# Step 3: append pubkey to authorized_keys (idempotent — full-line
 # match so a partial duplicate doesn't false-positive).
 PUBKEY=$(cat "$KEY_PATH.pub")
 touch /root/.ssh/authorized_keys
@@ -715,9 +719,13 @@ if ! grep -qF "$PUBKEY" /root/.ssh/authorized_keys 2>/dev/null; then
     PUBKEY_ADD=1
 fi
 
-# Step 3: ssh-agent. Two probes: (a) socket file present, (b) agent
+# Step 4: ssh-agent. Two probes: (a) socket file present, (b) agent
 # responsive (`ssh-add -l` exit code). A dead-socket from a previous
-# crash needs cleaning up before we can start a fresh agent.
+# crash needs cleaning up before we can start a fresh agent. After
+# starting, validate the agent IS responsive — without the validation,
+# `ssh-agent` failing silently (`|| true` was needed for the eval +
+# subshell case) would still set AGENT_STARTED=1 and we'd report
+# success for a broken socket.
 mkdir -p "$(dirname "$SOCKET")"
 AGENT_OK=0
 if [ -S "$SOCKET" ]; then
@@ -728,12 +736,38 @@ if [ -S "$SOCKET" ]; then
     fi
 fi
 if [ "$AGENT_OK" = "0" ]; then
-    eval "$(ssh-agent -a "$SOCKET" -s)" >/dev/null 2>&1 || true
-    AGENT_STARTED=1
+    # `ssh-agent -a SOCKET -s` prints `SSH_AUTH_SOCK=...; SSH_AGENT_PID=...`
+    # to stdout for eval; on success the agent forks and listens on
+    # SOCKET. Capture the eval's exit AND validate the result.
+    if eval "$(ssh-agent -a "$SOCKET" -s)" >/dev/null 2>&1; then
+        # Validate: socket file must exist AND the agent must respond.
+        # ssh-add -l exit code: 0=keys loaded, 1=no keys but agent OK,
+        # 2=can't connect (the failure case we're guarding against).
+        if [ -S "$SOCKET" ] && SSH_AUTH_SOCK="$SOCKET" ssh-add -l >/dev/null 2>&1; then
+            AGENT_STARTED=1
+        else
+            ADD_RC=0
+            SSH_AUTH_SOCK="$SOCKET" ssh-add -l >/dev/null 2>&1 || ADD_RC=$?
+            # rc=1 (no keys) is OK; rc=2 (can't connect) is a real failure.
+            if [ "$ADD_RC" = "1" ]; then
+                AGENT_STARTED=1
+            else
+                echo "  ⚠ ssh-agent started but socket isn't responsive — Wetty SSH-Agent setup incomplete" >&2
+                echo "RESULT_WETTY keypair_generated=$KEYPAIR_GEN pubkey_added=$PUBKEY_ADD agent_started=0 key_added_to_agent=0 auth_sock_written=0"
+                exit 0
+            fi
+        fi
+    else
+        echo "  ⚠ ssh-agent failed to start — Wetty SSH-Agent setup incomplete" >&2
+        echo "RESULT_WETTY keypair_generated=$KEYPAIR_GEN pubkey_added=$PUBKEY_ADD agent_started=0 key_added_to_agent=0 auth_sock_written=0"
+        exit 0
+    fi
 fi
 export SSH_AUTH_SOCK="$SOCKET"
 
-# Step 4: ssh-add the key if its fingerprint isn't already loaded.
+# Step 5: ssh-add the key if its fingerprint isn't already loaded.
+# Set KEY_ADDED=1 only on a successful add (legacy form unconditionally
+# set it after `|| true`, which masked an actual ssh-add failure).
 KEY_FP=$(ssh-keygen -lf "$KEY_PATH" 2>/dev/null | awk '{{print $2}}' || echo "")
 KEY_LOADED=0
 if [ -n "$KEY_FP" ]; then
@@ -742,18 +776,35 @@ if [ -n "$KEY_FP" ]; then
     fi
 fi
 if [ "$KEY_LOADED" = "0" ]; then
-    ssh-add "$KEY_PATH" >/dev/null 2>&1 || true
-    KEY_ADDED=1
+    if ssh-add "$KEY_PATH" >/dev/null 2>&1; then
+        KEY_ADDED=1
+    else
+        echo "  ⚠ ssh-add failed — Wetty key not loaded into agent" >&2
+        # Don't fail-fast: ssh-add can fail for a non-existent key (we
+        # already gated above) or transient agent issue. Leave
+        # KEY_ADDED=0 so the operator sees the discrepancy in the
+        # RESULT_WETTY line; the key file + agent socket still exist
+        # so the operator can ssh-add manually if needed.
+        :
+    fi
 fi
 
-# Step 5: write SSH_AUTH_SOCK= to wetty's .env (idempotent — strip
-# any prior line first). Done unconditionally because the agent
-# socket path is part of the contract Wetty's compose reads from.
+# Step 6: write SSH_AUTH_SOCK= to wetty's .env (idempotent — strip
+# any prior line first). Set AUTH_SOCK_WROTE=1 only after the append
+# succeeds; an mkdir/permission failure shouldn't be reported as
+# "written".
 if [ -f "$ENV_FILE" ]; then
-    sed -i '/^SSH_AUTH_SOCK=/d' "$ENV_FILE"
+    if ! sed -i '/^SSH_AUTH_SOCK=/d' "$ENV_FILE" 2>/dev/null; then
+        echo "  ⚠ failed to strip existing SSH_AUTH_SOCK= line from $ENV_FILE — Wetty .env may have stale entries" >&2
+    fi
 fi
-printf 'SSH_AUTH_SOCK=%s\\n' "$SSH_AUTH_SOCK" >> "$ENV_FILE"
-AUTH_SOCK_WROTE=1
+if printf 'SSH_AUTH_SOCK=%s\\n' "$SSH_AUTH_SOCK" >> "$ENV_FILE" 2>/dev/null; then
+    AUTH_SOCK_WROTE=1
+else
+    echo "  ⚠ failed to append SSH_AUTH_SOCK= to $ENV_FILE — Wetty container won't see the agent socket" >&2
+    echo "RESULT_WETTY keypair_generated=$KEYPAIR_GEN pubkey_added=$PUBKEY_ADD agent_started=$AGENT_STARTED key_added_to_agent=$KEY_ADDED auth_sock_written=0"
+    exit 0
+fi
 
 echo "RESULT_WETTY keypair_generated=$KEYPAIR_GEN pubkey_added=$PUBKEY_ADD agent_started=$AGENT_STARTED key_added_to_agent=$KEY_ADDED auth_sock_written=$AUTH_SOCK_WROTE"
 """

--- a/src/nexus_deploy/setup.py
+++ b/src/nexus_deploy/setup.py
@@ -127,9 +127,9 @@ class SSHReadinessResult:
 
 @dataclass(frozen=True)
 class WettyAgentResult:
-    """Outcome of :func:`setup_wetty_ssh_agent`. All four steps are
-    idempotent — re-runs that find nothing to do still return
-    successfully with the relevant ``*_changed`` flag = False.
+    """Outcome of :func:`setup_wetty_ssh_agent`. Tracks 5 idempotent
+    steps — re-runs that find nothing to do still return
+    successfully with the corresponding flag set to ``False``.
 
     Only the rendered server-side script knows whether each step ran
     or was a no-op; the result line is parsed back into this
@@ -642,19 +642,27 @@ def render_wetty_agent_script(
     ed25519 key pair, ssh-agent socket, and SSH_AUTH_SOCK injection
     Wetty needs to log into the host. Mirrors deploy.sh:445-538.
 
-    Five idempotent steps, each emits a 0/1 flag in the final RESULT
-    line indicating whether the step actually changed remote state:
+    The script does six numbered steps; only five of them produce a
+    0/1 flag in the final RESULT line (step 1 is a precondition that
+    always runs and is not reflected in the result):
 
-    1. mkdir + chmod 700 ``~/.ssh`` (silent — never reflected in the
-       result; just a precondition for the rest).
-    2. ssh-keygen -t ed25519 the key pair if absent.
+    1. mkdir + chmod 700 ``~/.ssh`` (silent precondition — not in the
+       RESULT line).
+    2. ssh-keygen -t ed25519 the key pair if absent. Fail-fast on a
+       non-zero ssh-keygen exit OR missing output files (would
+       otherwise produce a misleading ``keypair_generated=1`` while
+       downstream steps fail silently). → ``keypair_generated``.
     3. Append the public key to ``authorized_keys`` if not already
-       present.
+       present. → ``pubkey_added``.
     4. Start ssh-agent if the socket isn't there or the agent is
        unresponsive (dead-socket detection — the legacy bash had this).
+       → ``agent_started``.
     5. ssh-add the key if its fingerprint isn't already loaded.
+       → ``key_added_to_agent``.
     6. Strip any prior ``SSH_AUTH_SOCK=`` line from
        ``stacks/wetty/.env`` and re-append the current socket path.
+       → ``auth_sock_written`` (always 1 on the success path; the
+       env-var line is unconditional).
     """
     key_q = shlex.quote(key_path)
     comment_q = shlex.quote(key_comment)
@@ -674,9 +682,24 @@ AUTH_SOCK_WROTE=0
 mkdir -p /root/.ssh
 chmod 700 /root/.ssh
 
-# Step 1: ssh-keygen if absent
+# Step 1: ssh-keygen if absent. Fail-fast (echo RESULT_WETTY with
+# keypair_generated=0 + bail) when ssh-keygen reports non-zero OR
+# either of the expected output files ($KEY_PATH / $KEY_PATH.pub)
+# isn't on disk afterwards. Without this check, downstream steps
+# (cat $KEY_PATH.pub, ssh-keygen -lf for fingerprint) would silently
+# fail and we'd report a misleading keypair_generated=1 while Wetty
+# can't actually SSH.
 if [ ! -f "$KEY_PATH" ]; then
-    ssh-keygen -t ed25519 -f "$KEY_PATH" -N '' -C "$KEY_COMMENT" >/dev/null 2>&1
+    if ! ssh-keygen -t ed25519 -f "$KEY_PATH" -N '' -C "$KEY_COMMENT" >/dev/null 2>&1; then
+        echo "  ⚠ ssh-keygen failed — Wetty will not have a working SSH key" >&2
+        echo "RESULT_WETTY keypair_generated=0 pubkey_added=0 agent_started=0 key_added_to_agent=0 auth_sock_written=0"
+        exit 0
+    fi
+    if [ ! -f "$KEY_PATH" ] || [ ! -f "$KEY_PATH.pub" ]; then
+        echo "  ⚠ ssh-keygen reported success but key files missing (filesystem issue?)" >&2
+        echo "RESULT_WETTY keypair_generated=0 pubkey_added=0 agent_started=0 key_added_to_agent=0 auth_sock_written=0"
+        exit 0
+    fi
     chmod 600 "$KEY_PATH"
     chmod 644 "$KEY_PATH.pub"
     KEYPAIR_GEN=1

--- a/src/nexus_deploy/setup.py
+++ b/src/nexus_deploy/setup.py
@@ -722,11 +722,15 @@ if [ ! -f "$KEY_PATH" ] || [ ! -f "$KEY_PATH.pub" ]; then
 fi
 
 # Step 3: append pubkey to authorized_keys (idempotent — full-line
-# match so a partial duplicate doesn't false-positive).
+# fixed-string match so neither a partial duplicate (existing line
+# contains $PUBKEY as substring) nor a substring of $PUBKEY (existing
+# line that happens to be a substring of the pubkey we're checking)
+# can false-positive. `-F` = fixed string (no regex), `-x` = whole-
+# line match (the actual invariant the comment claims).
 PUBKEY=$(cat "$KEY_PATH.pub")
 touch /root/.ssh/authorized_keys
 chmod 600 /root/.ssh/authorized_keys
-if ! grep -qF "$PUBKEY" /root/.ssh/authorized_keys 2>/dev/null; then
+if ! grep -qFx "$PUBKEY" /root/.ssh/authorized_keys 2>/dev/null; then
     printf '%s\\n' "$PUBKEY" >> /root/.ssh/authorized_keys
     PUBKEY_ADD=1
 fi

--- a/src/nexus_deploy/setup.py
+++ b/src/nexus_deploy/setup.py
@@ -126,6 +126,24 @@ class SSHReadinessResult:
 
 
 @dataclass(frozen=True)
+class WettyAgentResult:
+    """Outcome of :func:`setup_wetty_ssh_agent`. All four steps are
+    idempotent — re-runs that find nothing to do still return
+    successfully with the relevant ``*_changed`` flag = False.
+
+    Only the rendered server-side script knows whether each step ran
+    or was a no-op; the result line is parsed back into this
+    dataclass for the workflow log + tests.
+    """
+
+    keypair_generated: bool  # ssh-keygen ran (False = key already existed)
+    pubkey_added: bool  # appended to authorized_keys (False = already present)
+    agent_started: bool  # ssh-agent forked (False = socket present + responsive)
+    key_added_to_agent: bool  # ssh-add ran (False = key fingerprint already loaded)
+    auth_sock_written: bool  # SSH_AUTH_SOCK= written to wetty .env (always True on success)
+
+
+@dataclass(frozen=True)
 class VolumeMountResult:
     """Outcome of the persistent-volume mount step.
 
@@ -592,3 +610,170 @@ def mount_persistent_volume(
     mounted, fstab_added = parsed
     detail: Literal["mounted", "fallback-failed"] = "mounted" if mounted else "fallback-failed"
     return VolumeMountResult(mounted=mounted, fstab_added=fstab_added, detail=detail)
+
+
+# ---------------------------------------------------------------------------
+# Wetty SSH-Agent setup (Phase 3 Modul 3.4f, #505) — replaces
+# deploy.sh:439-540, the ``[5.5/7]`` block that bootstraps the SSH key
+# pair + agent socket Wetty needs to log into the host as the same
+# user that runs the docker daemon.
+# ---------------------------------------------------------------------------
+
+
+_WETTY_RESULT_RE = re.compile(
+    r"^RESULT_WETTY"
+    r" keypair_generated=(?P<keypair_generated>[01])"
+    r" pubkey_added=(?P<pubkey_added>[01])"
+    r" agent_started=(?P<agent_started>[01])"
+    r" key_added_to_agent=(?P<key_added_to_agent>[01])"
+    r" auth_sock_written=(?P<auth_sock_written>[01])$",
+    re.MULTILINE,
+)
+
+
+def render_wetty_agent_script(
+    *,
+    key_path: str = "/root/.ssh/id_ed25519_wetty",
+    key_comment: str = "wetty-auto-generated",
+    agent_socket: str = "/tmp/ssh-agent/agent.sock",  # noqa: S108 — server-side path
+    wetty_env_file: str = "/opt/docker-server/stacks/wetty/.env",
+) -> str:
+    """Render the server-side bash that idempotently bootstraps the
+    ed25519 key pair, ssh-agent socket, and SSH_AUTH_SOCK injection
+    Wetty needs to log into the host. Mirrors deploy.sh:445-538.
+
+    Five idempotent steps, each emits a 0/1 flag in the final RESULT
+    line indicating whether the step actually changed remote state:
+
+    1. mkdir + chmod 700 ``~/.ssh`` (silent — never reflected in the
+       result; just a precondition for the rest).
+    2. ssh-keygen -t ed25519 the key pair if absent.
+    3. Append the public key to ``authorized_keys`` if not already
+       present.
+    4. Start ssh-agent if the socket isn't there or the agent is
+       unresponsive (dead-socket detection — the legacy bash had this).
+    5. ssh-add the key if its fingerprint isn't already loaded.
+    6. Strip any prior ``SSH_AUTH_SOCK=`` line from
+       ``stacks/wetty/.env`` and re-append the current socket path.
+    """
+    key_q = shlex.quote(key_path)
+    comment_q = shlex.quote(key_comment)
+    sock_q = shlex.quote(agent_socket)
+    env_q = shlex.quote(wetty_env_file)
+    return f"""set -uo pipefail
+KEY_PATH={key_q}
+KEY_COMMENT={comment_q}
+SOCKET={sock_q}
+ENV_FILE={env_q}
+KEYPAIR_GEN=0
+PUBKEY_ADD=0
+AGENT_STARTED=0
+KEY_ADDED=0
+AUTH_SOCK_WROTE=0
+
+mkdir -p /root/.ssh
+chmod 700 /root/.ssh
+
+# Step 1: ssh-keygen if absent
+if [ ! -f "$KEY_PATH" ]; then
+    ssh-keygen -t ed25519 -f "$KEY_PATH" -N '' -C "$KEY_COMMENT" >/dev/null 2>&1
+    chmod 600 "$KEY_PATH"
+    chmod 644 "$KEY_PATH.pub"
+    KEYPAIR_GEN=1
+fi
+
+# Step 2: append pubkey to authorized_keys (idempotent — full-line
+# match so a partial duplicate doesn't false-positive).
+PUBKEY=$(cat "$KEY_PATH.pub")
+touch /root/.ssh/authorized_keys
+chmod 600 /root/.ssh/authorized_keys
+if ! grep -qF "$PUBKEY" /root/.ssh/authorized_keys 2>/dev/null; then
+    printf '%s\\n' "$PUBKEY" >> /root/.ssh/authorized_keys
+    PUBKEY_ADD=1
+fi
+
+# Step 3: ssh-agent. Two probes: (a) socket file present, (b) agent
+# responsive (`ssh-add -l` exit code). A dead-socket from a previous
+# crash needs cleaning up before we can start a fresh agent.
+mkdir -p "$(dirname "$SOCKET")"
+AGENT_OK=0
+if [ -S "$SOCKET" ]; then
+    SSH_AUTH_SOCK="$SOCKET" ssh-add -l >/dev/null 2>&1 && AGENT_OK=1
+    if [ "$AGENT_OK" = "0" ]; then
+        # Stale socket — clean up before forking a fresh agent.
+        rm -f "$SOCKET"
+    fi
+fi
+if [ "$AGENT_OK" = "0" ]; then
+    eval "$(ssh-agent -a "$SOCKET" -s)" >/dev/null 2>&1 || true
+    AGENT_STARTED=1
+fi
+export SSH_AUTH_SOCK="$SOCKET"
+
+# Step 4: ssh-add the key if its fingerprint isn't already loaded.
+KEY_FP=$(ssh-keygen -lf "$KEY_PATH" 2>/dev/null | awk '{{print $2}}' || echo "")
+KEY_LOADED=0
+if [ -n "$KEY_FP" ]; then
+    if ssh-add -l 2>/dev/null | grep -qF "$KEY_FP"; then
+        KEY_LOADED=1
+    fi
+fi
+if [ "$KEY_LOADED" = "0" ]; then
+    ssh-add "$KEY_PATH" >/dev/null 2>&1 || true
+    KEY_ADDED=1
+fi
+
+# Step 5: write SSH_AUTH_SOCK= to wetty's .env (idempotent — strip
+# any prior line first). Done unconditionally because the agent
+# socket path is part of the contract Wetty's compose reads from.
+if [ -f "$ENV_FILE" ]; then
+    sed -i '/^SSH_AUTH_SOCK=/d' "$ENV_FILE"
+fi
+printf 'SSH_AUTH_SOCK=%s\\n' "$SSH_AUTH_SOCK" >> "$ENV_FILE"
+AUTH_SOCK_WROTE=1
+
+echo "RESULT_WETTY keypair_generated=$KEYPAIR_GEN pubkey_added=$PUBKEY_ADD agent_started=$AGENT_STARTED key_added_to_agent=$KEY_ADDED auth_sock_written=$AUTH_SOCK_WROTE"
+"""
+
+
+def parse_wetty_agent_result(stdout: str) -> WettyAgentResult | None:
+    """Parse the RESULT_WETTY line from rendered-script stdout. Returns
+    None if no parseable line exists (caller treats as soft failure)."""
+    match = _WETTY_RESULT_RE.search(stdout)
+    if match is None:
+        return None
+    g = match.groupdict()
+    return WettyAgentResult(
+        keypair_generated=g["keypair_generated"] == "1",
+        pubkey_added=g["pubkey_added"] == "1",
+        agent_started=g["agent_started"] == "1",
+        key_added_to_agent=g["key_added_to_agent"] == "1",
+        auth_sock_written=g["auth_sock_written"] == "1",
+    )
+
+
+def setup_wetty_ssh_agent(
+    ssh: SSHClient,
+    *,
+    key_path: str = "/root/.ssh/id_ed25519_wetty",
+    key_comment: str = "wetty-auto-generated",
+    agent_socket: str = "/tmp/ssh-agent/agent.sock",  # noqa: S108
+    wetty_env_file: str = "/opt/docker-server/stacks/wetty/.env",
+) -> WettyAgentResult | None:
+    """Render + run the wetty-agent setup script. Returns None on
+    unparseable output (soft failure — operator sees the script's
+    forwarded stderr; the deploy continues without aborting since
+    Wetty is a non-critical UI service)."""
+    script = render_wetty_agent_script(
+        key_path=key_path,
+        key_comment=key_comment,
+        agent_socket=agent_socket,
+        wetty_env_file=wetty_env_file,
+    )
+    completed = ssh.run_script(script, check=False)
+    # Forward non-RESULT stderr lines (the script's own diagnostics)
+    # to the local terminal so operators see e.g. ssh-keygen errors.
+    for line in completed.stdout.splitlines():
+        if not line.startswith("RESULT_WETTY"):
+            sys.stderr.write(line + "\n")
+    return parse_wetty_agent_result(completed.stdout)

--- a/tests/unit/__snapshots__/test_secret_sync.ambr
+++ b/tests/unit/__snapshots__/test_secret_sync.ambr
@@ -82,20 +82,30 @@
               SKIPPED_NAME=$((SKIPPED_NAME+1)); continue
           fi
           VALUE=$(printf '%s' "$VALUE_B64" | base64 -d || true)
-          # Multi-line guard: bash glob match, NOT `grep -q $'\n'`. The
-          # legacy deploy.sh form processed input line-by-line where the
-          # implicit line-terminator could match the pattern, so EVERY
-          # non-empty single-line value falsely triggered the skip
-          # (resulting in only GITEA_TOKEN ever landing in .infisical.env).
-          # bash's case glob compares the variable's bytes directly and
-          # only matches genuine embedded newlines.
-          case "$VALUE" in
-              *$'\n'*)
-                  SKIPPED_MULTI=$((SKIPPED_MULTI+1))
-                  echo "  ⚠ Skipping multi-line secret '$KEY' (folder '$FOLDER_LABEL')" >&2
-                  continue
-                  ;;
-          esac
+          # Multi-line guard. Bash glob match (NOT `grep -q $'\n'`):
+          # the legacy form processed input line-by-line where the
+          # implicit line-terminator could match the pattern, so
+          # every non-empty single-line value falsely triggered the
+          # skip (resulting in only GITEA_TOKEN ever landing in
+          # .infisical.env). bash's case glob compares the variable's
+          # bytes directly and only matches genuine embedded newlines.
+          #
+          # GATED on USE_B64=0 (Jupyter/Marimo plain-text mode):
+          # multi-line values can't survive a `KEY="value"` env-file
+          # line without escaping, so we skip + warn. In USE_B64=1
+          # mode (Kestra) the value transits as base64 and Kestra's
+          # EnvVarSecretProvider decodes it server-side — multi-line
+          # PEMs / certs / multi-line tokens flow through fine, which
+          # matches the legacy Kestra-secret-sync behavior.
+          if [ "$USE_B64" = "0" ]; then
+              case "$VALUE" in
+                  *$'\n'*)
+                      SKIPPED_MULTI=$((SKIPPED_MULTI+1))
+                      echo "  ⚠ Skipping multi-line secret '$KEY' (folder '$FOLDER_LABEL')" >&2
+                      continue
+                      ;;
+              esac
+          fi
           EXISTING=$(awk -F'\t' -v k="$KEY" '$1 == k {print $2; exit}' "$SEEN")
           if [ -n "$EXISTING" ]; then
               COLLISIONS=$((COLLISIONS+1))
@@ -263,20 +273,30 @@
               SKIPPED_NAME=$((SKIPPED_NAME+1)); continue
           fi
           VALUE=$(printf '%s' "$VALUE_B64" | base64 -d || true)
-          # Multi-line guard: bash glob match, NOT `grep -q $'\n'`. The
-          # legacy deploy.sh form processed input line-by-line where the
-          # implicit line-terminator could match the pattern, so EVERY
-          # non-empty single-line value falsely triggered the skip
-          # (resulting in only GITEA_TOKEN ever landing in .infisical.env).
-          # bash's case glob compares the variable's bytes directly and
-          # only matches genuine embedded newlines.
-          case "$VALUE" in
-              *$'\n'*)
-                  SKIPPED_MULTI=$((SKIPPED_MULTI+1))
-                  echo "  ⚠ Skipping multi-line secret '$KEY' (folder '$FOLDER_LABEL')" >&2
-                  continue
-                  ;;
-          esac
+          # Multi-line guard. Bash glob match (NOT `grep -q $'\n'`):
+          # the legacy form processed input line-by-line where the
+          # implicit line-terminator could match the pattern, so
+          # every non-empty single-line value falsely triggered the
+          # skip (resulting in only GITEA_TOKEN ever landing in
+          # .infisical.env). bash's case glob compares the variable's
+          # bytes directly and only matches genuine embedded newlines.
+          #
+          # GATED on USE_B64=0 (Jupyter/Marimo plain-text mode):
+          # multi-line values can't survive a `KEY="value"` env-file
+          # line without escaping, so we skip + warn. In USE_B64=1
+          # mode (Kestra) the value transits as base64 and Kestra's
+          # EnvVarSecretProvider decodes it server-side — multi-line
+          # PEMs / certs / multi-line tokens flow through fine, which
+          # matches the legacy Kestra-secret-sync behavior.
+          if [ "$USE_B64" = "0" ]; then
+              case "$VALUE" in
+                  *$'\n'*)
+                      SKIPPED_MULTI=$((SKIPPED_MULTI+1))
+                      echo "  ⚠ Skipping multi-line secret '$KEY' (folder '$FOLDER_LABEL')" >&2
+                      continue
+                      ;;
+              esac
+          fi
           EXISTING=$(awk -F'\t' -v k="$KEY" '$1 == k {print $2; exit}' "$SEEN")
           if [ -n "$EXISTING" ]; then
               COLLISIONS=$((COLLISIONS+1))
@@ -444,20 +464,30 @@
               SKIPPED_NAME=$((SKIPPED_NAME+1)); continue
           fi
           VALUE=$(printf '%s' "$VALUE_B64" | base64 -d || true)
-          # Multi-line guard: bash glob match, NOT `grep -q $'\n'`. The
-          # legacy deploy.sh form processed input line-by-line where the
-          # implicit line-terminator could match the pattern, so EVERY
-          # non-empty single-line value falsely triggered the skip
-          # (resulting in only GITEA_TOKEN ever landing in .infisical.env).
-          # bash's case glob compares the variable's bytes directly and
-          # only matches genuine embedded newlines.
-          case "$VALUE" in
-              *$'\n'*)
-                  SKIPPED_MULTI=$((SKIPPED_MULTI+1))
-                  echo "  ⚠ Skipping multi-line secret '$KEY' (folder '$FOLDER_LABEL')" >&2
-                  continue
-                  ;;
-          esac
+          # Multi-line guard. Bash glob match (NOT `grep -q $'\n'`):
+          # the legacy form processed input line-by-line where the
+          # implicit line-terminator could match the pattern, so
+          # every non-empty single-line value falsely triggered the
+          # skip (resulting in only GITEA_TOKEN ever landing in
+          # .infisical.env). bash's case glob compares the variable's
+          # bytes directly and only matches genuine embedded newlines.
+          #
+          # GATED on USE_B64=0 (Jupyter/Marimo plain-text mode):
+          # multi-line values can't survive a `KEY="value"` env-file
+          # line without escaping, so we skip + warn. In USE_B64=1
+          # mode (Kestra) the value transits as base64 and Kestra's
+          # EnvVarSecretProvider decodes it server-side — multi-line
+          # PEMs / certs / multi-line tokens flow through fine, which
+          # matches the legacy Kestra-secret-sync behavior.
+          if [ "$USE_B64" = "0" ]; then
+              case "$VALUE" in
+                  *$'\n'*)
+                      SKIPPED_MULTI=$((SKIPPED_MULTI+1))
+                      echo "  ⚠ Skipping multi-line secret '$KEY' (folder '$FOLDER_LABEL')" >&2
+                      continue
+                      ;;
+              esac
+          fi
           EXISTING=$(awk -F'\t' -v k="$KEY" '$1 == k {print $2; exit}' "$SEEN")
           if [ -n "$EXISTING" ]; then
               COLLISIONS=$((COLLISIONS+1))

--- a/tests/unit/__snapshots__/test_secret_sync.ambr
+++ b/tests/unit/__snapshots__/test_secret_sync.ambr
@@ -13,6 +13,13 @@
   END_MARKER='# === END nexus-secret-sync ==='
   FOLDERS_URL=http://localhost:8070/api/v1/folders
   SECRETS_URL=http://localhost:8070/api/v3/secrets/raw
+  # Kestra format toggles: KEY_PREFIX prepends to every appended key
+  # (empty for jupyter/marimo, "SECRET_" for kestra). USE_B64=1 writes
+  # the raw base64 value (kestra's EnvVarSecretProvider decodes); =0
+  # uses the plain-escaped form (jupyter/marimo expect plaintext at
+  # runtime via process env).
+  KEY_PREFIX=''
+  USE_B64=0
   
   CFG=$(mktemp)
   SEEN=$(mktemp)
@@ -95,16 +102,31 @@
               echo "  ⚠ Key collision: '$KEY' in folder '$FOLDER_LABEL' shadowed by earlier value from '$EXISTING' (first-wins)" >&2
               continue
           fi
-          ESCAPED_VALUE=$(printf '%s' "$VALUE" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g')
           printf '%s\t%s\n' "$KEY" "$FOLDER_LABEL" >> "$SEEN"
-          printf '%s="%s"\n' "$KEY" "$ESCAPED_VALUE" >> "$APPEND"
+          if [ "$USE_B64" = "1" ]; then
+              # Kestra: SECRET_<KEY>=<base64-value>. EnvVarSecretProvider
+              # decodes server-side. Newlines / binary content survive
+              # the env var via base64.
+              printf '%s%s=%s\n' "$KEY_PREFIX" "$KEY" "$VALUE_B64" >> "$APPEND"
+          else
+              # Jupyter/Marimo: <KEY>="<escaped-value>". Plain text at
+              # runtime via process env; double-backslash + double-quote
+              # escapes preserve dotenv-parser semantics.
+              ESCAPED_VALUE=$(printf '%s' "$VALUE" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g')
+              printf '%s%s="%s"\n' "$KEY_PREFIX" "$KEY" "$ESCAPED_VALUE" >> "$APPEND"
+          fi
           PUSHED=$((PUSHED+1))
       done < "$TSV"
   done <<< "$FOLDERS"
   
-  if [ -n "$GTOKEN" ] && ! grep -qE '^GITEA_TOKEN=' "$APPEND"; then
-      ESCAPED_GTOKEN=$(printf '%s' "$GTOKEN" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g')
-      printf 'GITEA_TOKEN="%s"\n' "$ESCAPED_GTOKEN" >> "$APPEND"
+  if [ -n "$GTOKEN" ] && ! grep -qE "^${KEY_PREFIX}GITEA_TOKEN=" "$APPEND"; then
+      if [ "$USE_B64" = "1" ]; then
+          GTOKEN_B64=$(printf '%s' "$GTOKEN" | base64 | tr -d '\n')
+          printf '%sGITEA_TOKEN=%s\n' "$KEY_PREFIX" "$GTOKEN_B64" >> "$APPEND"
+      else
+          ESCAPED_GTOKEN=$(printf '%s' "$GTOKEN" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g')
+          printf '%sGITEA_TOKEN="%s"\n' "$KEY_PREFIX" "$ESCAPED_GTOKEN" >> "$APPEND"
+      fi
       PUSHED=$((PUSHED+1))
   fi
   
@@ -140,7 +162,191 @@
   chmod 600 "$ENV_FILE"
   WROTE=1
   
-  if [ -f "$LEGACY_ENV" ]; then
+  # Legacy-strip step: only runs when the target declared a legacy
+  # location (jupyter/marimo). Kestra targets (LEGACY_ENV=="") skip
+  # this — they write directly to .env, no migration step needed.
+  if [ -n "$LEGACY_ENV" ] && [ -f "$LEGACY_ENV" ]; then
+      LEGACY_TMP=$(mktemp -p "$(dirname "$LEGACY_ENV")" .env.XXXXXX)
+      chmod 600 "$LEGACY_TMP"
+      sed '/^# === BEGIN nexus-secret-sync/,/^# === END nexus-secret-sync/d' "$LEGACY_ENV" > "$LEGACY_TMP"
+      mv "$LEGACY_TMP" "$LEGACY_ENV"
+      # Clear the variable so the trap doesn't try to rm a path that
+      # no longer exists (mv consumes the source). `rm -f` would tolerate
+      # this anyway, but explicit > implicit.
+      LEGACY_TMP=""
+  fi
+  
+  echo "RESULT pushed=$PUSHED skipped_name=$SKIPPED_NAME skipped_multi=$SKIPPED_MULTI failed=$FAILED collisions=$COLLISIONS succeeded=$SUCCEEDED wrote=$WROTE"
+  
+  '''
+# ---
+# name: test_render_kestra_snapshot
+  '''
+  set -euo pipefail
+  
+  PID=snapshot-project
+  ITOK=snapshot-token
+  INF_ENV=dev
+  GTOKEN=snapshot-gitea-token
+  ENV_FILE=/opt/docker-server/stacks/kestra/.env
+  LEGACY_ENV=''
+  BEGIN_MARKER='# === BEGIN nexus-secret-sync (re-generated each spin-up; do not edit by hand) ==='
+  END_MARKER='# === END nexus-secret-sync ==='
+  FOLDERS_URL=http://localhost:8070/api/v1/folders
+  SECRETS_URL=http://localhost:8070/api/v3/secrets/raw
+  # Kestra format toggles: KEY_PREFIX prepends to every appended key
+  # (empty for jupyter/marimo, "SECRET_" for kestra). USE_B64=1 writes
+  # the raw base64 value (kestra's EnvVarSecretProvider decodes); =0
+  # uses the plain-escaped form (jupyter/marimo expect plaintext at
+  # runtime via process env).
+  KEY_PREFIX=SECRET_
+  USE_B64=1
+  
+  CFG=$(mktemp)
+  SEEN=$(mktemp)
+  APPEND=$(mktemp)
+  NEW_BLOCK=$(mktemp)
+  TSV=$(mktemp)
+  # Optional tmpfiles — created later in conditional branches. Initialised
+  # empty so the trap can safely reference them on early-exit paths
+  # (jq-missing, outage-gates). Removal is guarded by a non-empty check
+  # inside the trap so we don't `rm -f ""`.
+  TMP_OUT=""
+  LEGACY_TMP=""
+  chmod 600 "$CFG" "$APPEND" "$NEW_BLOCK" "$TSV"
+  trap 'rm -f "$CFG" "$SEEN" "$APPEND" "$NEW_BLOCK" "$TSV"; [ -n "$TMP_OUT" ] && rm -f "$TMP_OUT"; [ -n "$LEGACY_TMP" ] && rm -f "$LEGACY_TMP"; true' EXIT
+  printf 'header = "Authorization: Bearer %s"\n' "$ITOK" > "$CFG"
+  
+  if ! command -v jq >/dev/null 2>&1; then
+      echo "  ⚠ jq is not installed on the remote VM — Infisical sync needs jq, install with: sudo apt-get install -y jq" >&2
+      echo "RESULT pushed=0 skipped_name=0 skipped_multi=0 failed=0 collisions=0 succeeded=0 wrote=0"
+      exit 0
+  fi
+  
+  PUSHED=0; SKIPPED_NAME=0; SKIPPED_MULTI=0; FAILED=0; COLLISIONS=0; SUCCEEDED=0; WROTE=0
+  
+  FOLDERS_JSON=$(curl -sS --config "$CFG" --get \
+      --connect-timeout 5 --max-time 15 \
+      --data-urlencode "workspaceId=$PID" \
+      --data-urlencode "environment=$INF_ENV" \
+      "$FOLDERS_URL" || echo '{}')
+  FOLDERS=$(printf '%s' "$FOLDERS_JSON" | jq -r '.folders[]?.name' | LC_ALL=C sort || true)
+  FOLDERS=$(printf '%s\n/\n' "$FOLDERS")
+  
+  while IFS= read -r FOLDER; do
+      [ -z "$FOLDER" ] && continue
+      if [ "$FOLDER" = "/" ]; then
+          SECRET_PATH="/"; FOLDER_LABEL="<root>"
+      else
+          SECRET_PATH="/$FOLDER"; FOLDER_LABEL="$FOLDER"
+      fi
+      SECRETS_JSON=$(curl -sS --config "$CFG" --get \
+          --connect-timeout 5 --max-time 30 \
+          --data-urlencode "workspaceId=$PID" \
+          --data-urlencode "environment=$INF_ENV" \
+          --data-urlencode "secretPath=$SECRET_PATH" \
+          "$SECRETS_URL" || true)
+      if ! printf '%s' "$SECRETS_JSON" | jq -e '.secrets | type == "array"' >/dev/null; then
+          FAILED=$((FAILED+1))
+          echo "  ⚠ Infisical fetch '$FOLDER_LABEL' returned bad shape, skipping" >&2
+          continue
+      fi
+      if ! printf '%s' "$SECRETS_JSON" | jq -r '.secrets[]? | [.secretKey, (.secretValue | @base64)] | @tsv' > "$TSV"; then
+          FAILED=$((FAILED+1))
+          echo "  ⚠ jq TSV extraction failed for folder '$FOLDER_LABEL' — skipping" >&2
+          continue
+      fi
+      SUCCEEDED=$((SUCCEEDED+1))
+      while IFS=$'\t' read -r KEY VALUE_B64; do
+          [ -z "$KEY" ] && continue
+          if ! printf '%s' "$KEY" | grep -qE '^[A-Za-z_][A-Za-z0-9_]*$'; then
+              SKIPPED_NAME=$((SKIPPED_NAME+1)); continue
+          fi
+          VALUE=$(printf '%s' "$VALUE_B64" | base64 -d || true)
+          # Multi-line guard: bash glob match, NOT `grep -q $'\n'`. The
+          # legacy deploy.sh form processed input line-by-line where the
+          # implicit line-terminator could match the pattern, so EVERY
+          # non-empty single-line value falsely triggered the skip
+          # (resulting in only GITEA_TOKEN ever landing in .infisical.env).
+          # bash's case glob compares the variable's bytes directly and
+          # only matches genuine embedded newlines.
+          case "$VALUE" in
+              *$'\n'*)
+                  SKIPPED_MULTI=$((SKIPPED_MULTI+1))
+                  echo "  ⚠ Skipping multi-line secret '$KEY' (folder '$FOLDER_LABEL')" >&2
+                  continue
+                  ;;
+          esac
+          EXISTING=$(awk -F'\t' -v k="$KEY" '$1 == k {print $2; exit}' "$SEEN")
+          if [ -n "$EXISTING" ]; then
+              COLLISIONS=$((COLLISIONS+1))
+              echo "  ⚠ Key collision: '$KEY' in folder '$FOLDER_LABEL' shadowed by earlier value from '$EXISTING' (first-wins)" >&2
+              continue
+          fi
+          printf '%s\t%s\n' "$KEY" "$FOLDER_LABEL" >> "$SEEN"
+          if [ "$USE_B64" = "1" ]; then
+              # Kestra: SECRET_<KEY>=<base64-value>. EnvVarSecretProvider
+              # decodes server-side. Newlines / binary content survive
+              # the env var via base64.
+              printf '%s%s=%s\n' "$KEY_PREFIX" "$KEY" "$VALUE_B64" >> "$APPEND"
+          else
+              # Jupyter/Marimo: <KEY>="<escaped-value>". Plain text at
+              # runtime via process env; double-backslash + double-quote
+              # escapes preserve dotenv-parser semantics.
+              ESCAPED_VALUE=$(printf '%s' "$VALUE" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g')
+              printf '%s%s="%s"\n' "$KEY_PREFIX" "$KEY" "$ESCAPED_VALUE" >> "$APPEND"
+          fi
+          PUSHED=$((PUSHED+1))
+      done < "$TSV"
+  done <<< "$FOLDERS"
+  
+  if [ -n "$GTOKEN" ] && ! grep -qE "^${KEY_PREFIX}GITEA_TOKEN=" "$APPEND"; then
+      if [ "$USE_B64" = "1" ]; then
+          GTOKEN_B64=$(printf '%s' "$GTOKEN" | base64 | tr -d '\n')
+          printf '%sGITEA_TOKEN=%s\n' "$KEY_PREFIX" "$GTOKEN_B64" >> "$APPEND"
+      else
+          ESCAPED_GTOKEN=$(printf '%s' "$GTOKEN" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g')
+          printf '%sGITEA_TOKEN="%s"\n' "$KEY_PREFIX" "$ESCAPED_GTOKEN" >> "$APPEND"
+      fi
+      PUSHED=$((PUSHED+1))
+  fi
+  
+  if [ "$SUCCEEDED" -eq 0 ]; then
+      echo "  ⚠ No Infisical folder fetch succeeded — leaving existing $ENV_FILE untouched" >&2
+      echo "RESULT pushed=0 skipped_name=$SKIPPED_NAME skipped_multi=$SKIPPED_MULTI failed=$FAILED collisions=$COLLISIONS succeeded=0 wrote=0"
+      exit 0
+  fi
+  
+  if [ "$PUSHED" -eq 0 ]; then
+      echo "  ⚠ Infisical returned $SUCCEEDED folder(s) but zero usable secrets — leaving existing $ENV_FILE untouched" >&2
+      echo "RESULT pushed=0 skipped_name=$SKIPPED_NAME skipped_multi=$SKIPPED_MULTI failed=$FAILED collisions=$COLLISIONS succeeded=$SUCCEEDED wrote=0"
+      exit 0
+  fi
+  
+  {
+      printf '%s\n' "$BEGIN_MARKER"
+      LC_ALL=C sort -t= -k1,1 "$APPEND"
+      printf '%s\n' "$END_MARKER"
+  } > "$NEW_BLOCK"
+  
+  [ -f "$ENV_FILE" ] || touch "$ENV_FILE"
+  chmod 600 "$ENV_FILE"
+  
+  TMP_OUT=$(mktemp -p "$(dirname "$ENV_FILE")" .infisical.env.XXXXXX)
+  chmod 600 "$TMP_OUT"
+  # Strip any existing block, then append the new one. Same anchored
+  # regex deploy.sh used; markers are interpolated as fixed strings so
+  # operator-edited content above/below stays put.
+  sed '/^# === BEGIN nexus-secret-sync/,/^# === END nexus-secret-sync/d' "$ENV_FILE" > "$TMP_OUT"
+  cat "$NEW_BLOCK" >> "$TMP_OUT"
+  mv "$TMP_OUT" "$ENV_FILE"
+  chmod 600 "$ENV_FILE"
+  WROTE=1
+  
+  # Legacy-strip step: only runs when the target declared a legacy
+  # location (jupyter/marimo). Kestra targets (LEGACY_ENV=="") skip
+  # this — they write directly to .env, no migration step needed.
+  if [ -n "$LEGACY_ENV" ] && [ -f "$LEGACY_ENV" ]; then
       LEGACY_TMP=$(mktemp -p "$(dirname "$LEGACY_ENV")" .env.XXXXXX)
       chmod 600 "$LEGACY_TMP"
       sed '/^# === BEGIN nexus-secret-sync/,/^# === END nexus-secret-sync/d' "$LEGACY_ENV" > "$LEGACY_TMP"
@@ -169,6 +375,13 @@
   END_MARKER='# === END nexus-secret-sync ==='
   FOLDERS_URL=http://localhost:8070/api/v1/folders
   SECRETS_URL=http://localhost:8070/api/v3/secrets/raw
+  # Kestra format toggles: KEY_PREFIX prepends to every appended key
+  # (empty for jupyter/marimo, "SECRET_" for kestra). USE_B64=1 writes
+  # the raw base64 value (kestra's EnvVarSecretProvider decodes); =0
+  # uses the plain-escaped form (jupyter/marimo expect plaintext at
+  # runtime via process env).
+  KEY_PREFIX=''
+  USE_B64=0
   
   CFG=$(mktemp)
   SEEN=$(mktemp)
@@ -251,16 +464,31 @@
               echo "  ⚠ Key collision: '$KEY' in folder '$FOLDER_LABEL' shadowed by earlier value from '$EXISTING' (first-wins)" >&2
               continue
           fi
-          ESCAPED_VALUE=$(printf '%s' "$VALUE" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g')
           printf '%s\t%s\n' "$KEY" "$FOLDER_LABEL" >> "$SEEN"
-          printf '%s="%s"\n' "$KEY" "$ESCAPED_VALUE" >> "$APPEND"
+          if [ "$USE_B64" = "1" ]; then
+              # Kestra: SECRET_<KEY>=<base64-value>. EnvVarSecretProvider
+              # decodes server-side. Newlines / binary content survive
+              # the env var via base64.
+              printf '%s%s=%s\n' "$KEY_PREFIX" "$KEY" "$VALUE_B64" >> "$APPEND"
+          else
+              # Jupyter/Marimo: <KEY>="<escaped-value>". Plain text at
+              # runtime via process env; double-backslash + double-quote
+              # escapes preserve dotenv-parser semantics.
+              ESCAPED_VALUE=$(printf '%s' "$VALUE" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g')
+              printf '%s%s="%s"\n' "$KEY_PREFIX" "$KEY" "$ESCAPED_VALUE" >> "$APPEND"
+          fi
           PUSHED=$((PUSHED+1))
       done < "$TSV"
   done <<< "$FOLDERS"
   
-  if [ -n "$GTOKEN" ] && ! grep -qE '^GITEA_TOKEN=' "$APPEND"; then
-      ESCAPED_GTOKEN=$(printf '%s' "$GTOKEN" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g')
-      printf 'GITEA_TOKEN="%s"\n' "$ESCAPED_GTOKEN" >> "$APPEND"
+  if [ -n "$GTOKEN" ] && ! grep -qE "^${KEY_PREFIX}GITEA_TOKEN=" "$APPEND"; then
+      if [ "$USE_B64" = "1" ]; then
+          GTOKEN_B64=$(printf '%s' "$GTOKEN" | base64 | tr -d '\n')
+          printf '%sGITEA_TOKEN=%s\n' "$KEY_PREFIX" "$GTOKEN_B64" >> "$APPEND"
+      else
+          ESCAPED_GTOKEN=$(printf '%s' "$GTOKEN" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g')
+          printf '%sGITEA_TOKEN="%s"\n' "$KEY_PREFIX" "$ESCAPED_GTOKEN" >> "$APPEND"
+      fi
       PUSHED=$((PUSHED+1))
   fi
   
@@ -296,7 +524,10 @@
   chmod 600 "$ENV_FILE"
   WROTE=1
   
-  if [ -f "$LEGACY_ENV" ]; then
+  # Legacy-strip step: only runs when the target declared a legacy
+  # location (jupyter/marimo). Kestra targets (LEGACY_ENV=="") skip
+  # this — they write directly to .env, no migration step needed.
+  if [ -n "$LEGACY_ENV" ] && [ -f "$LEGACY_ENV" ]; then
       LEGACY_TMP=$(mktemp -p "$(dirname "$LEGACY_ENV")" .env.XXXXXX)
       chmod 600 "$LEGACY_TMP"
       sed '/^# === BEGIN nexus-secret-sync/,/^# === END nexus-secret-sync/d' "$LEGACY_ENV" > "$LEGACY_TMP"

--- a/tests/unit/test_infisical.py
+++ b/tests/unit/test_infisical.py
@@ -966,3 +966,109 @@ def test_provision_admin_unparseable_stdout_returns_not_ready() -> None:
     )
     assert result.status == "not-ready"
     assert result.token is None
+
+
+def test_cli_infisical_provision_admin_returns_1_when_creds_dropped(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """R-creds-required-for-rc-0 (#530 R2 #4): a `loaded-existing` /
+    `freshly-bootstrapped` status with token=None (e.g. invalid-UTF8
+    base64 decode dropped the token) MUST be reported as rc=1, not
+    rc=0. Otherwise deploy.sh prints '✓ Infisical provisioned' while
+    eval'ing empty INFISICAL_TOKEN= / PROJECT_ID= lines that
+    downstream consumers treat as legitimate."""
+    import nexus_deploy.__main__ as main_mod
+    from nexus_deploy.infisical import ProvisionResult
+
+    class _FakeSSH:
+        def __init__(self, _alias: str) -> None:
+            del _alias
+
+        def __enter__(self) -> _FakeSSH:
+            return self
+
+        def __exit__(self, *_a: object) -> None:
+            return None
+
+        def run_script(self, _s: str, *, check: bool = False) -> subprocess.CompletedProcess[str]:
+            del check
+            return subprocess.CompletedProcess(args=["ssh"], returncode=0, stdout="", stderr="")
+
+    # Bypass the real provision_admin: simulate the dropped-token case
+    def _fake_provision(
+        *,
+        admin_email: str,
+        admin_password: str,
+        **_kwargs: object,
+    ) -> ProvisionResult:
+        del admin_email, admin_password
+        return ProvisionResult(
+            status="loaded-existing",
+            token=None,  # dropped (invalid utf-8 etc.)
+            project_id=None,
+        )
+
+    monkeypatch.setenv("ADMIN_EMAIL", "ops@example.com")
+    monkeypatch.setenv("INFISICAL_PASS", "pw")
+    monkeypatch.setattr(main_mod, "SSHClient", _FakeSSH)
+    monkeypatch.setattr(main_mod, "provision_admin", _fake_provision)
+
+    rc = main_mod._infisical_provision_admin([])
+    assert rc == 1, "loaded-existing without credentials must be soft-fail"
+    captured = capsys.readouterr()
+    # The handler still writes the eval lines (deploy.sh's eval needs to
+    # CLEAR stale values from prior runs), but the rc=1 signals the
+    # soft-fail so deploy.sh skips the "✓ Infisical provisioned" branch.
+    # Critically the values must be EMPTY-quoted, not stale or garbage.
+    assert "INFISICAL_TOKEN=''" in captured.out
+    assert "PROJECT_ID=''" in captured.out
+
+
+def test_cli_infisical_provision_admin_returns_0_with_full_creds(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Happy path: token + project_id both populated → rc=0 + eval
+    lines on stdout."""
+    import nexus_deploy.__main__ as main_mod
+    from nexus_deploy.infisical import ProvisionResult
+
+    class _FakeSSH:
+        def __init__(self, _alias: str) -> None:
+            del _alias
+
+        def __enter__(self) -> _FakeSSH:
+            return self
+
+        def __exit__(self, *_a: object) -> None:
+            return None
+
+        def run_script(self, _s: str, *, check: bool = False) -> subprocess.CompletedProcess[str]:
+            del check
+            return subprocess.CompletedProcess(args=["ssh"], returncode=0, stdout="", stderr="")
+
+    def _fake_provision(
+        *,
+        admin_email: str,
+        admin_password: str,
+        **_kwargs: object,
+    ) -> ProvisionResult:
+        del admin_email, admin_password
+        return ProvisionResult(
+            status="freshly-bootstrapped",
+            token="real-token",
+            project_id="ws-real",
+        )
+
+    monkeypatch.setenv("ADMIN_EMAIL", "ops@example.com")
+    monkeypatch.setenv("INFISICAL_PASS", "pw")
+    monkeypatch.setattr(main_mod, "SSHClient", _FakeSSH)
+    monkeypatch.setattr(main_mod, "provision_admin", _fake_provision)
+
+    rc = main_mod._infisical_provision_admin([])
+    assert rc == 0
+    out = capsys.readouterr().out
+    # shlex.quote leaves [a-zA-Z0-9_@%+=:,./-] unquoted, wraps others.
+    assert "INFISICAL_TOKEN=" in out
+    assert "real-token" in out
+    assert "PROJECT_ID=" in out
+    assert "ws-real" in out

--- a/tests/unit/test_infisical.py
+++ b/tests/unit/test_infisical.py
@@ -31,6 +31,9 @@ from nexus_deploy.infisical import (
     InfisicalClient,
     _filter_empty,
     compute_folders,
+    parse_provision_result,
+    provision_admin,
+    render_provision_admin_script,
 )
 
 FIXTURES = Path(__file__).resolve().parents[1] / "fixtures"
@@ -760,3 +763,206 @@ class _StubStdin:
 
     def read(self) -> str:
         return self._content
+
+
+# ---------------------------------------------------------------------------
+# provision_admin — Phase 3 Modul 3.4f (#505)
+# ---------------------------------------------------------------------------
+
+
+def test_render_provision_admin_script_basic_shape() -> None:
+    """Rendered bash includes the readiness probe + the bootstrap path."""
+    script = render_provision_admin_script(
+        admin_email="ops@example.com",
+        admin_password="s3cret-Pw",
+    )
+    assert "set -euo pipefail" in script
+    # Two-stage readiness probe
+    assert "docker inspect --format='{{.State.Status}}' infisical" in script
+    assert "/api/v1/admin/config" in script
+    # Init-state branch
+    assert '"initialized":true' in script
+    # Bootstrap + project-create endpoints
+    assert "/api/v1/admin/bootstrap" in script
+    assert "/api/v2/workspace" in script
+    # Cred persistence paths
+    assert "/opt/docker-server/.infisical-token" in script
+    assert "/opt/docker-server/.infisical-project-id" in script
+
+
+def test_render_provision_admin_script_secrets_via_env_not_argv() -> None:
+    """R-secret: admin_email + admin_password embed via shlex-quoted
+    bash vars then route to jq via env vars (NEXUS_E / NEXUS_PW),
+    NOT via --arg argv. Bearer token uses mode-600 curl --config
+    tmpfile (not -H argv)."""
+    script = render_provision_admin_script(
+        admin_email="ops@example.com",
+        admin_password="s3cret-Pw",
+    )
+    # No --arg pass-through to jq
+    assert "--arg email" not in script
+    assert "--arg password" not in script
+    # Bearer token via curl --config tmpfile
+    assert "TOKEN_CFG=$(mktemp)" in script
+    assert 'chmod 600 "$TOKEN_CFG"' in script
+    assert "trap 'rm -f \"$TOKEN_CFG\"' EXIT" in script
+
+
+def test_render_provision_admin_script_emits_result_line() -> None:
+    """Every exit path emits exactly one 'RESULT status=...' line."""
+    script = render_provision_admin_script(
+        admin_email="a@b",
+        admin_password="x",
+    )
+    assert "RESULT status=not-ready" in script
+    assert "RESULT status=loaded-existing" in script
+    assert "RESULT status=loaded-existing-missing-creds" in script
+    assert "RESULT status=already-bootstrapped-no-saved-creds" in script
+    assert "RESULT status=bootstrap-failed" in script
+    assert "RESULT status=project-create-failed" in script
+    assert "RESULT status=freshly-bootstrapped" in script
+
+
+def test_parse_provision_result_freshly_bootstrapped() -> None:
+    import base64
+
+    raw_token = "test-token-value"
+    token_b64 = base64.b64encode(raw_token.encode()).decode()
+    line = f"RESULT status=freshly-bootstrapped token={token_b64} project_id=ws-abc-123"
+    result = parse_provision_result(line)
+    assert result is not None
+    assert result.status == "freshly-bootstrapped"
+    assert result.token == raw_token
+    assert result.project_id == "ws-abc-123"
+    assert result.has_credentials is True
+
+
+def test_parse_provision_result_loaded_existing() -> None:
+    import base64
+
+    token_b64 = base64.b64encode(b"existing-token").decode()
+    line = f"RESULT status=loaded-existing token={token_b64} project_id=ws-existing"
+    result = parse_provision_result(line)
+    assert result is not None
+    assert result.status == "loaded-existing"
+    assert result.has_credentials is True
+
+
+def test_parse_provision_result_not_ready_no_creds() -> None:
+    """The not-ready / bootstrap-failed / etc. branches emit just the
+    status, no token + project_id. has_credentials must be False."""
+    for status_line in (
+        "RESULT status=not-ready",
+        "RESULT status=loaded-existing-missing-creds",
+        "RESULT status=already-bootstrapped-no-saved-creds",
+        "RESULT status=bootstrap-failed",
+        "RESULT status=project-create-failed",
+    ):
+        result = parse_provision_result(status_line)
+        assert result is not None, f"failed to parse: {status_line!r}"
+        assert result.token is None
+        assert result.project_id is None
+        assert result.has_credentials is False
+
+
+def test_parse_provision_result_no_match_returns_none() -> None:
+    """Garbage stdout → None; CLI maps that to a not-ready ProvisionResult."""
+    assert parse_provision_result("") is None
+    assert parse_provision_result("garbage") is None
+    assert parse_provision_result("RESULT something_else") is None
+
+
+def test_parse_provision_result_invalid_utf8_drops_token() -> None:
+    """If the base64-decoded bytes are not valid UTF-8 (which a real
+    Infisical token never would be — they're all ASCII / hex chars),
+    the parser drops the token but keeps the status. Defence-in-depth
+    against a malicious / truncated RESULT line."""
+    # 'ZZZ=' decodes to a single non-ASCII byte that's not valid UTF-8
+    line = "RESULT status=freshly-bootstrapped token=ZZZ= project_id=ws-abc"
+    result = parse_provision_result(line)
+    assert result is not None
+    assert result.status == "freshly-bootstrapped"
+    assert result.token is None  # invalid utf-8 → dropped
+    assert result.project_id == "ws-abc"
+
+
+def test_provision_admin_returns_not_ready_when_email_or_password_missing() -> None:
+    """Don't even try the SSH script if we don't have credentials."""
+    runner_calls: list[str] = []
+
+    def runner(script: str) -> subprocess.CompletedProcess[str]:
+        runner_calls.append(script)
+        return subprocess.CompletedProcess(args=["ssh"], returncode=0, stdout="", stderr="")
+
+    result = provision_admin(
+        admin_email="",
+        admin_password="x",
+        script_runner=runner,
+    )
+    assert result.status == "not-ready"
+    assert result.has_credentials is False
+    assert runner_calls == []
+
+
+def test_provision_admin_freshly_bootstrapped_path() -> None:
+    """Mock the SSH runner to return a freshly-bootstrapped RESULT."""
+    import base64
+
+    token = "fresh-token"
+    token_b64 = base64.b64encode(token.encode()).decode()
+
+    def runner(_script: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(
+            args=["ssh"],
+            returncode=0,
+            stdout=f"RESULT status=freshly-bootstrapped token={token_b64} project_id=ws-new",
+            stderr="",
+        )
+
+    result = provision_admin(
+        admin_email="ops@example.com",
+        admin_password="pw",
+        script_runner=runner,
+    )
+    assert result.status == "freshly-bootstrapped"
+    assert result.token == token
+    assert result.project_id == "ws-new"
+
+
+def test_provision_admin_loaded_existing_path() -> None:
+    import base64
+
+    token_b64 = base64.b64encode(b"saved-token").decode()
+
+    def runner(_script: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(
+            args=["ssh"],
+            returncode=0,
+            stdout=f"RESULT status=loaded-existing token={token_b64} project_id=ws-saved",
+            stderr="",
+        )
+
+    result = provision_admin(
+        admin_email="ops@example.com",
+        admin_password="pw",
+        script_runner=runner,
+    )
+    assert result.status == "loaded-existing"
+    assert result.token == "saved-token"
+    assert result.project_id == "ws-saved"
+
+
+def test_provision_admin_unparseable_stdout_returns_not_ready() -> None:
+    """Garbage stdout (e.g. SSH succeeded but the script crashed before
+    emitting RESULT) → ProvisionResult.not-ready instead of None."""
+
+    def runner(_script: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(args=["ssh"], returncode=0, stdout="oops", stderr="")
+
+    result = provision_admin(
+        admin_email="ops@example.com",
+        admin_password="pw",
+        script_runner=runner,
+    )
+    assert result.status == "not-ready"
+    assert result.token is None

--- a/tests/unit/test_r2_tokens.py
+++ b/tests/unit/test_r2_tokens.py
@@ -1,0 +1,423 @@
+"""Tests for nexus_deploy.r2_tokens — Phase 3 Modul 3.4f (#530).
+
+Covers the orphan-R2-API-token bug from PR #530 R2:
+
+- Pagination invariant: list_user_tokens walks ``result_info.total_pages``
+  so the matching-name lookup doesn't miss tokens past page 1.
+- Per-name + per-prefix filtering returns ALL matches (not just first).
+- cleanup_orphan_tokens refuses prefixes outside ``nexus-r2-`` (defence
+  against wiping the protected ``Nexus-Stack`` / ``Nexus2`` tokens).
+- Dry-run is the default; --apply path actually deletes.
+- Inventory's ``near_cap`` flag fires before the 50-token hard cap.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from nexus_deploy.r2_tokens import (
+    ACCOUNT_TOKEN_HARD_CAP,
+    DEFAULT_NEXUS_R2_PREFIX,
+    CleanupResult,
+    DeleteResult,
+    TokenInfo,
+    build_inventory,
+    cleanup_orphan_tokens,
+    delete_token,
+    find_tokens_by_name,
+    find_tokens_by_prefix,
+    list_user_tokens,
+)
+
+
+def _mock_response(json_body: dict[str, Any], *, status_code: int = 200) -> MagicMock:
+    """Stand-in for a `requests.Response` object."""
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = json_body
+    resp.raise_for_status = MagicMock()
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# TokenInfo.from_api — lenient parse
+# ---------------------------------------------------------------------------
+
+
+def test_token_info_from_api_minimal_fields() -> None:
+    info = TokenInfo.from_api({"id": "abc", "name": "nexus-r2-foo"})
+    assert info.id == "abc"
+    assert info.name == "nexus-r2-foo"
+    assert info.issued_on == ""
+
+
+def test_token_info_from_api_with_issued_on() -> None:
+    info = TokenInfo.from_api(
+        {"id": "abc", "name": "x", "issued_on": "2026-04-19T00:00:00Z"},
+    )
+    assert info.issued_on == "2026-04-19T00:00:00Z"
+
+
+def test_token_info_from_api_missing_fields_returns_empty_strings() -> None:
+    """Future Cloudflare API additions / removals shouldn't break parsing."""
+    info = TokenInfo.from_api({})
+    assert info.id == ""
+    assert info.name == ""
+    assert info.issued_on == ""
+
+
+# ---------------------------------------------------------------------------
+# list_user_tokens — pagination
+# ---------------------------------------------------------------------------
+
+
+def test_list_user_tokens_single_page() -> None:
+    client = MagicMock()
+    client.get.return_value = _mock_response(
+        {
+            "success": True,
+            "result": [
+                {"id": "a", "name": "nexus-r2-foo"},
+                {"id": "b", "name": "nexus-r2-bar"},
+            ],
+            "result_info": {"total_pages": 1},
+        },
+    )
+    tokens = list_user_tokens(api_token="t", client=client)
+    assert len(tokens) == 2
+    assert tokens[0].id == "a"
+    assert tokens[1].name == "nexus-r2-bar"
+    # Used per_page=100 by default
+    call = client.get.call_args
+    assert call.kwargs["params"]["per_page"] == 100
+    assert call.kwargs["params"]["page"] == 1
+
+
+def test_list_user_tokens_walks_multiple_pages() -> None:
+    """R-pagination: even if Cloudflare's per_page=100 already covers
+    the 50-token cap, we walk total_pages defensively. This was the
+    bug class: the legacy unpaginated lookup missed tokens past page 1
+    when default per_page=25 truncated the response."""
+    client = MagicMock()
+    client.get.side_effect = [
+        _mock_response(
+            {
+                "success": True,
+                "result": [{"id": "a", "name": "n1"}, {"id": "b", "name": "n2"}],
+                "result_info": {"total_pages": 2},
+            },
+        ),
+        _mock_response(
+            {
+                "success": True,
+                "result": [{"id": "c", "name": "n3"}],
+                "result_info": {"total_pages": 2},
+            },
+        ),
+    ]
+    tokens = list_user_tokens(api_token="t", client=client)
+    assert len(tokens) == 3
+    assert [t.id for t in tokens] == ["a", "b", "c"]
+    # Page 1 then page 2
+    assert client.get.call_args_list[0].kwargs["params"]["page"] == 1
+    assert client.get.call_args_list[1].kwargs["params"]["page"] == 2
+
+
+def test_list_user_tokens_unsuccessful_response_raises() -> None:
+    client = MagicMock()
+    client.get.return_value = _mock_response(
+        {"success": False, "errors": [{"message": "Auth invalid"}]},
+    )
+    with pytest.raises(RuntimeError, match="Auth invalid"):
+        list_user_tokens(api_token="t", client=client)
+
+
+def test_list_user_tokens_skips_non_dict_results() -> None:
+    """Lenient parse: a string / int / None in the result array
+    is skipped instead of crashing."""
+    client = MagicMock()
+    client.get.return_value = _mock_response(
+        {
+            "success": True,
+            "result": [
+                {"id": "a", "name": "valid"},
+                "garbage",
+                None,
+                42,
+            ],
+            "result_info": {"total_pages": 1},
+        },
+    )
+    tokens = list_user_tokens(api_token="t", client=client)
+    assert len(tokens) == 1
+    assert tokens[0].id == "a"
+
+
+# ---------------------------------------------------------------------------
+# find_tokens_by_name / find_tokens_by_prefix
+# ---------------------------------------------------------------------------
+
+
+def test_find_tokens_by_name_returns_all_duplicates() -> None:
+    """If the account ended up with multiple same-name tokens (e.g.
+    from an earlier API behavior change or race during re-setup),
+    we return ALL of them so caller can clean them up uniformly."""
+    tokens = [
+        TokenInfo(id="a", name="nexus-r2-foo"),
+        TokenInfo(id="b", name="nexus-r2-bar"),
+        TokenInfo(id="c", name="nexus-r2-foo"),  # duplicate name
+    ]
+    matched = find_tokens_by_name(tokens, "nexus-r2-foo")
+    assert {t.id for t in matched} == {"a", "c"}
+
+
+def test_find_tokens_by_prefix_excludes_non_matches() -> None:
+    tokens = [
+        TokenInfo(id="a", name="nexus-r2-foo"),
+        TokenInfo(id="b", name="Nexus-Stack"),
+        TokenInfo(id="c", name="nexus-r2-bar"),
+        TokenInfo(id="d", name="nexus2-something"),
+    ]
+    matched = find_tokens_by_prefix(tokens, "nexus-r2-")
+    assert {t.id for t in matched} == {"a", "c"}
+
+
+# ---------------------------------------------------------------------------
+# delete_token
+# ---------------------------------------------------------------------------
+
+
+def test_delete_token_success() -> None:
+    client = MagicMock()
+    client.delete.return_value = _mock_response({"success": True, "result": {"id": "abc"}})
+    result = delete_token("abc", api_token="t", name="x", client=client)
+    assert result.id == "abc"
+    assert result.name == "x"
+    assert result.deleted is True
+    assert result.error == ""
+
+
+def test_delete_token_failure_extracts_error_message() -> None:
+    client = MagicMock()
+    client.delete.return_value = _mock_response(
+        {"success": False, "errors": [{"message": "Not allowed"}]},
+        status_code=403,
+    )
+    result = delete_token("abc", api_token="t", client=client)
+    assert result.deleted is False
+    assert "Not allowed" in result.error
+
+
+def test_delete_token_non_json_response_falls_back_to_status_code() -> None:
+    client = MagicMock()
+    resp = MagicMock()
+    resp.status_code = 502
+    resp.json.side_effect = ValueError("not json")
+    client.delete.return_value = resp
+    result = delete_token("abc", api_token="t", client=client)
+    assert result.deleted is False
+    assert "HTTP 502" in result.error
+
+
+# ---------------------------------------------------------------------------
+# cleanup_orphan_tokens — name + prefix paths, dry-run, safety
+# ---------------------------------------------------------------------------
+
+
+def test_cleanup_requires_exactly_one_filter() -> None:
+    with pytest.raises(ValueError, match="exactly one"):
+        cleanup_orphan_tokens(api_token="t")
+    with pytest.raises(ValueError, match="exactly one"):
+        cleanup_orphan_tokens(api_token="t", name="x", prefix="nexus-r2-x")
+
+
+def test_cleanup_refuses_prefix_outside_nexus_r2() -> None:
+    """R-safety: prefix MUST start with `nexus-r2-`. Without this guard,
+    an operator typo could wipe the protected Nexus-Stack / Nexus2 /
+    build tokens documented in CLAUDE.md."""
+    for bad_prefix in ("Nexus-Stack", "nexus", "nexus-r", "n3xus-r2-foo"):
+        with pytest.raises(ValueError, match="must start with"):
+            cleanup_orphan_tokens(api_token="t", prefix=bad_prefix, dry_run=True)
+
+
+def test_cleanup_dry_run_lists_but_doesnt_delete() -> None:
+    client = MagicMock()
+    client.get.return_value = _mock_response(
+        {
+            "success": True,
+            "result": [
+                {"id": "a", "name": "nexus-r2-foo"},
+                {"id": "b", "name": "nexus-r2-bar"},
+            ],
+            "result_info": {"total_pages": 1},
+        },
+    )
+    result = cleanup_orphan_tokens(
+        api_token="t",
+        prefix="nexus-r2-",
+        dry_run=True,
+        client=client,
+    )
+    assert result.dry_run is True
+    assert result.total_tokens_before == 2
+    assert len(result.matched) == 2
+    assert result.deletions == ()
+    # Delete was NOT called
+    client.delete.assert_not_called()
+
+
+def test_cleanup_apply_deletes_each_matched_token() -> None:
+    client = MagicMock()
+    client.get.return_value = _mock_response(
+        {
+            "success": True,
+            "result": [
+                {"id": "a", "name": "nexus-r2-foo"},
+                {"id": "b", "name": "nexus-r2-foo"},  # duplicate name
+                {"id": "c", "name": "nexus-r2-other"},
+            ],
+            "result_info": {"total_pages": 1},
+        },
+    )
+    client.delete.return_value = _mock_response({"success": True})
+    result = cleanup_orphan_tokens(
+        api_token="t",
+        name="nexus-r2-foo",
+        dry_run=False,
+        client=client,
+    )
+    assert result.dry_run is False
+    # Both duplicate-named tokens deleted; the third (different name) untouched
+    assert len(result.matched) == 2
+    assert len(result.deletions) == 2
+    assert result.deleted_count == 2
+    assert result.failed_count == 0
+    assert result.is_success is True
+
+
+def test_cleanup_apply_partial_failure_records_per_token() -> None:
+    client = MagicMock()
+    client.get.return_value = _mock_response(
+        {
+            "success": True,
+            "result": [
+                {"id": "a", "name": "nexus-r2-x"},
+                {"id": "b", "name": "nexus-r2-x"},
+            ],
+            "result_info": {"total_pages": 1},
+        },
+    )
+    # First delete succeeds, second fails
+    client.delete.side_effect = [
+        _mock_response({"success": True}),
+        _mock_response(
+            {"success": False, "errors": [{"message": "Locked"}]},
+            status_code=423,
+        ),
+    ]
+    result = cleanup_orphan_tokens(
+        api_token="t",
+        name="nexus-r2-x",
+        dry_run=False,
+        client=client,
+    )
+    assert result.deleted_count == 1
+    assert result.failed_count == 1
+    assert result.is_success is False
+    failures = [d for d in result.deletions if not d.deleted]
+    assert "Locked" in failures[0].error
+
+
+# ---------------------------------------------------------------------------
+# build_inventory — audit shape
+# ---------------------------------------------------------------------------
+
+
+def test_build_inventory_remaining_slots() -> None:
+    client = MagicMock()
+    # 3 tokens total, 2 of them nexus-r2-*
+    client.get.return_value = _mock_response(
+        {
+            "success": True,
+            "result": [
+                {"id": "a", "name": "nexus-r2-foo"},
+                {"id": "b", "name": "nexus-r2-bar"},
+                {"id": "c", "name": "Nexus-Stack"},  # protected, NOT matched
+            ],
+            "result_info": {"total_pages": 1},
+        },
+    )
+    inv = build_inventory(api_token="t", client=client)
+    assert inv.total == 3
+    assert inv.prefix == DEFAULT_NEXUS_R2_PREFIX
+    assert len(inv.matched) == 2
+    assert inv.remaining_slots == ACCOUNT_TOKEN_HARD_CAP - 3
+    assert inv.near_cap is False  # 47 slots free
+
+
+def test_build_inventory_near_cap_threshold() -> None:
+    """near_cap fires when fewer than 5 slots remain (matches the
+    bug-report's 'Should' criterion: cron warns before the wall)."""
+    client = MagicMock()
+    # 46 tokens → 4 free slots → near_cap=True
+    client.get.return_value = _mock_response(
+        {
+            "success": True,
+            "result": [{"id": f"id-{i}", "name": f"nexus-r2-x{i}"} for i in range(46)],
+            "result_info": {"total_pages": 1},
+        },
+    )
+    inv = build_inventory(api_token="t", client=client)
+    assert inv.total == 46
+    assert inv.remaining_slots == 4
+    assert inv.near_cap is True
+
+
+def test_build_inventory_excludes_non_matching_prefix() -> None:
+    """Token total counts ALL tokens; matched only counts the prefix."""
+    client = MagicMock()
+    client.get.return_value = _mock_response(
+        {
+            "success": True,
+            "result": [
+                {"id": "a", "name": "nexus-r2-foo"},
+                {"id": "b", "name": "Nexus-Stack"},
+                {"id": "c", "name": "Nexus2"},
+                {"id": "d", "name": "nexus-stack-ch build token"},
+            ],
+            "result_info": {"total_pages": 1},
+        },
+    )
+    inv = build_inventory(api_token="t", client=client, prefix="nexus-r2-")
+    assert inv.total == 4
+    assert len(inv.matched) == 1
+    assert inv.matched[0].id == "a"
+
+
+# ---------------------------------------------------------------------------
+# Aggregate result fields
+# ---------------------------------------------------------------------------
+
+
+def test_cleanup_result_field_consistency() -> None:
+    """deletion counts match what's in the deletions tuple."""
+    deletions = (
+        DeleteResult(id="a", name="x", deleted=True),
+        DeleteResult(id="b", name="y", deleted=False, error="boom"),
+        DeleteResult(id="c", name="z", deleted=True),
+    )
+    result = CleanupResult(
+        total_tokens_before=10,
+        matched=(
+            TokenInfo(id="a", name="x"),
+            TokenInfo(id="b", name="y"),
+            TokenInfo(id="c", name="z"),
+        ),
+        deletions=deletions,
+    )
+    assert result.deleted_count == 2
+    assert result.failed_count == 1
+    assert result.is_success is False

--- a/tests/unit/test_secret_sync.py
+++ b/tests/unit/test_secret_sync.py
@@ -802,6 +802,47 @@ def test_render_jupyter_branch_unchanged_for_gitea_token() -> None:
     assert 'printf \'%sGITEA_TOKEN="%s"\\n\' "$KEY_PREFIX" "$ESCAPED_GTOKEN"' in script
 
 
+def test_render_kestra_skips_multiline_guard() -> None:
+    """R-multi-line-base64 (Kestra-specific): the multi-line skip
+    must NOT run in USE_B64=1 mode. Multi-line PEMs / certs / multi-
+    line tokens transit as single-line base64 to Kestra's
+    EnvVarSecretProvider, which decodes them server-side. Legacy
+    Kestra-secret-sync had no multi-line guard at all (it wrote
+    SECRET_<KEY>=<base64> directly without decoding); my migration
+    erroneously inherited Jupyter/Marimo's plain-text guard.
+    Regression caught in PR #530 R1."""
+    script = render_remote_script(
+        target=_kestra_target(),
+        project_id="p",
+        infisical_token="t",
+        infisical_env="dev",
+    )
+    # The multi-line guard must be gated on USE_B64=0
+    assert 'if [ "$USE_B64" = "0" ]; then' in script
+    # And the case statement that does the actual skip lives inside
+    # that conditional
+    multiline_idx = script.index('case "$VALUE" in')
+    use_b64_idx = script.index('if [ "$USE_B64" = "0" ]; then')
+    assert use_b64_idx < multiline_idx, (
+        "multi-line guard's case statement must come AFTER the USE_B64=0 conditional opens"
+    )
+
+
+def test_render_jupyter_marimo_keep_multiline_guard() -> None:
+    """Defence in depth: USE_B64=0 mode (Jupyter/Marimo) MUST still
+    skip multi-line values — they can't survive the dotenv KEY="value"
+    encoding without escaping."""
+    for name in ("jupyter", "marimo"):
+        script = render_remote_script(
+            target=StackTarget(name=name),
+            project_id="p",
+            infisical_token="t",
+            infisical_env="dev",
+        )
+        assert 'if [ "$USE_B64" = "0" ]; then' in script
+        assert "SKIPPED_MULTI=$((SKIPPED_MULTI+1))" in script
+
+
 # ---------------------------------------------------------------------------
 # CLI — `nexus-deploy secret-sync --stack <jupyter|marimo>`
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_secret_sync.py
+++ b/tests/unit/test_secret_sync.py
@@ -62,6 +62,56 @@ def test_stack_target_begin_marker_capitalised() -> None:
     assert "Infisical → Marimo env" in StackTarget(name="marimo").begin_marker
 
 
+def _kestra_target() -> StackTarget:
+    """Helper: the Kestra-style StackTarget. Matches the construction
+    in __main__._secret_sync (CLI dispatcher) — keep them in sync."""
+    return StackTarget(
+        name="kestra",
+        key_prefix="SECRET_",
+        use_base64_values=True,
+        env_file_basename=".env",
+        legacy_env_file_basename=None,
+        force_recreate=True,
+    )
+
+
+def test_stack_target_kestra_paths() -> None:
+    """Kestra writes to .env (the main stack file), not a separate
+    .infisical.env. No legacy_env_file (kestra never had one)."""
+    target = _kestra_target()
+    assert target.env_file == "/opt/docker-server/stacks/kestra/.env"
+    assert target.legacy_env_file is None
+    assert target.compose_dir == "/opt/docker-server/stacks/kestra"
+
+
+def test_stack_target_kestra_begin_marker_matches_legacy() -> None:
+    """Kestra marker matches legacy deploy.sh:1513 wording byte-for-byte."""
+    assert StackTarget(name="kestra").begin_marker == (
+        "# === BEGIN nexus-secret-sync (re-generated each spin-up; do not edit by hand) ==="
+    )
+
+
+def test_stack_target_kestra_format_toggles() -> None:
+    """The 5 fields that parameterise the Kestra variant."""
+    target = _kestra_target()
+    assert target.key_prefix == "SECRET_"
+    assert target.use_base64_values is True
+    assert target.env_file_basename == ".env"
+    assert target.legacy_env_file_basename is None
+    assert target.force_recreate is True
+
+
+def test_stack_target_jupyter_marimo_defaults_unchanged() -> None:
+    """Defaults preserve the original Jupyter/Marimo behavior."""
+    for name in ("jupyter", "marimo"):
+        target = StackTarget(name=name)
+        assert target.key_prefix == ""
+        assert target.use_base64_values is False
+        assert target.env_file_basename == ".infisical.env"
+        assert target.legacy_env_file_basename == ".env"
+        assert target.force_recreate is False
+
+
 # ---------------------------------------------------------------------------
 # Pure-logic helpers — direct tests
 # ---------------------------------------------------------------------------
@@ -655,6 +705,101 @@ def test_render_marimo_snapshot(snapshot: SnapshotAssertion) -> None:
         gitea_token="snapshot-gitea-token",
     )
     assert script == snapshot
+
+
+def test_render_kestra_snapshot(snapshot: SnapshotAssertion) -> None:
+    """Full rendered script for the Kestra variant — pins:
+    - KEY_PREFIX=SECRET_, USE_B64=1
+    - ENV_FILE=.../kestra/.env (NOT .infisical.env)
+    - LEGACY_ENV='' (no separate legacy file)
+    - the begin-marker matches legacy deploy.sh:1513 byte-for-byte
+    """
+    script = render_remote_script(
+        target=_kestra_target(),
+        project_id="snapshot-project",
+        infisical_token="snapshot-token",
+        infisical_env="dev",
+        gitea_token="snapshot-gitea-token",
+    )
+    assert script == snapshot
+
+
+def test_render_kestra_uses_secret_prefix() -> None:
+    """Kestra appends rows like 'SECRET_<KEY>=<base64>' (NOT
+    '<KEY>=value' like Jupyter/Marimo)."""
+    script = render_remote_script(
+        target=_kestra_target(),
+        project_id="p",
+        infisical_token="t",
+        infisical_env="dev",
+    )
+    # Format toggles set (shlex.quote leaves "SECRET_" + the path
+    # unquoted because no shell-special chars are present)
+    assert "KEY_PREFIX=SECRET_" in script
+    assert "USE_B64=1" in script
+    # Base64 branch present (used at runtime when USE_B64=1)
+    assert 'printf \'%s%s=%s\\n\' "$KEY_PREFIX" "$KEY" "$VALUE_B64"' in script
+
+
+def test_render_kestra_writes_to_env_not_infisical_env() -> None:
+    """Kestra target writes to .env directly; no separate .infisical.env."""
+    script = render_remote_script(
+        target=_kestra_target(),
+        project_id="p",
+        infisical_token="t",
+        infisical_env="dev",
+    )
+    assert "ENV_FILE=/opt/docker-server/stacks/kestra/.env" in script
+    # No legacy env-file path either (empty string after shlex.quote('') = '')
+    assert "LEGACY_ENV=''" in script
+
+
+def test_render_kestra_skips_legacy_strip_when_no_legacy_file() -> None:
+    """Kestra's LEGACY_ENV is empty → the legacy-strip block is gated
+    on '[ -n \"$LEGACY_ENV\" ]' so it doesn't try to strip a nonexistent
+    file. Mirrors deploy.sh's lack of a legacy .infisical.env for kestra."""
+    script = render_remote_script(
+        target=_kestra_target(),
+        project_id="p",
+        infisical_token="t",
+        infisical_env="dev",
+    )
+    assert 'if [ -n "$LEGACY_ENV" ] && [ -f "$LEGACY_ENV" ]' in script
+
+
+def test_render_kestra_gitea_token_in_base64() -> None:
+    """When gitea_token is set, the SECRET_GITEA_TOKEN line is also
+    base64-encoded (not the plaintext-escaped form Jupyter/Marimo use)."""
+    script = render_remote_script(
+        target=_kestra_target(),
+        project_id="p",
+        infisical_token="t",
+        infisical_env="dev",
+        gitea_token="my-gitea-token",
+    )
+    # Kestra branch base64-encodes the token before appending.
+    assert "GTOKEN_B64=$(printf '%s' \"$GTOKEN\" | base64 | tr -d '\\n')" in script
+    assert 'printf \'%sGITEA_TOKEN=%s\\n\' "$KEY_PREFIX" "$GTOKEN_B64"' in script
+    # And the dedup-grep uses the prefix
+    assert 'grep -qE "^${KEY_PREFIX}GITEA_TOKEN="' in script
+
+
+def test_render_jupyter_branch_unchanged_for_gitea_token() -> None:
+    """Defence in depth: Jupyter/Marimo gitea-token path stays plain-
+    escaped (regression check that the new Kestra branch didn't break
+    the original behavior)."""
+    script = render_remote_script(
+        target=StackTarget(name="jupyter"),
+        project_id="p",
+        infisical_token="t",
+        infisical_env="dev",
+        gitea_token="my-gitea-token",
+    )
+    # No base64-encode of GTOKEN in the jupyter branch
+    assert "GTOKEN_B64=$(printf" in script  # both branches render
+    # But the actual emit uses ESCAPED_GTOKEN (plain-escaped) inside the USE_B64=0 branch
+    assert "ESCAPED_GTOKEN=" in script
+    assert 'printf \'%sGITEA_TOKEN="%s"\\n\' "$KEY_PREFIX" "$ESCAPED_GTOKEN"' in script
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -42,6 +42,7 @@ from nexus_deploy.services import (
     render_metabase_hook,
     render_n8n_hook,
     render_openmetadata_hook,
+    render_pg_ducklake_hook,
     render_portainer_hook,
     render_redpanda_hook,
     render_remote_script,
@@ -123,6 +124,8 @@ def test_supported_hooks_contains_all_specs() -> None:
         "dify",
         "windmill",
         "sftpgo",
+        # 3.4f — pg-ducklake bootstrap-SQL re-apply
+        "pg-ducklake",
     }
 
 
@@ -808,6 +811,31 @@ def test_render_sftpgo_hook_secrets_via_base64_env_not_argv() -> None:
     # No -H Authorization argv (we use mode-600 curl --config tmpfile instead)
     assert '-H "Authorization' not in script
     assert "-H 'Authorization" not in script
+
+
+def test_render_pg_ducklake_hook_basic() -> None:
+    """pg-ducklake re-apply hook: pg_isready probe + psql -f exec."""
+    script = render_pg_ducklake_hook(_make_config(), _make_env())
+    assert "pg_ducklake_hook()" in script
+    # Two-stage: readiness probe then exec
+    assert "pg_isready -U nexus-pgducklake -d ducklake" in script
+    assert "/docker-entrypoint-initdb.d/00-ducklake-bootstrap.sql" in script
+    assert "psql -U nexus-pgducklake -d ducklake" in script
+
+
+def test_render_pg_ducklake_hook_status_dispatch() -> None:
+    """Three branches: skipped-not-ready / configured / failed."""
+    script = render_pg_ducklake_hook(_make_config(), _make_env())
+    assert "RESULT hook=pg-ducklake status=skipped-not-ready" in script
+    assert "RESULT hook=pg-ducklake status=configured" in script
+    assert "RESULT hook=pg-ducklake status=failed" in script
+
+
+def test_render_pg_ducklake_hook_uses_wall_clock_bound_for_readiness() -> None:
+    """R-bounded-wait: 30s wall-clock cap (NOT iteration-counted), so a
+    stalled pg_isready can't blow the wait past the documented timeout."""
+    script = render_pg_ducklake_hook(_make_config(), _make_env())
+    assert 'while [ "$SECONDS" -lt 30 ]' in script
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_setup.py
+++ b/tests/unit/test_setup.py
@@ -1197,6 +1197,35 @@ def test_setup_wetty_ssh_agent_returns_none_on_unparseable_stdout() -> None:
     assert result is None
 
 
+def test_setup_wetty_ssh_agent_propagates_transport_failure() -> None:
+    """R-transport-failure-as-rc-2 (#530 R4 #1): SSH transport
+    failure (rc=255, connection drop) must propagate as
+    CalledProcessError so the CLI maps it to rc=2 ('transport
+    failure'), not silently to None → rc=1 ('soft fail'). The
+    rendered script always ends with exit 0, so a non-zero rc from
+    run_script can only mean the transport broke."""
+    import subprocess
+
+    from nexus_deploy.setup import setup_wetty_ssh_agent
+
+    class _BrokenSSH:
+        def run_script(
+            self, _script: str, *, check: bool = False
+        ) -> subprocess.CompletedProcess[str]:
+            # check=True is what the wrapper now passes; mimic the
+            # behaviour of subprocess.run(check=True) on rc != 0.
+            assert check is True, "wrapper must pass check=True"
+            raise subprocess.CalledProcessError(
+                returncode=255,
+                cmd=["ssh", "nexus", "bash"],
+                output="kex_exchange_identification: Connection closed",
+            )
+
+    with pytest.raises(subprocess.CalledProcessError) as exc_info:
+        setup_wetty_ssh_agent(_BrokenSSH())  # type: ignore[arg-type]
+    assert exc_info.value.returncode == 255
+
+
 def test_render_wetty_agent_script_regenerates_on_half_present_keypair() -> None:
     """R-half-keypair (#530 R3 #4): the keygen-skip gate must check
     BOTH $KEY_PATH and $KEY_PATH.pub. If only one exists (manual

--- a/tests/unit/test_setup.py
+++ b/tests/unit/test_setup.py
@@ -1027,8 +1027,11 @@ def test_render_wetty_agent_script_basic_shape() -> None:
     assert "ssh-agent -a" in script
     assert "ssh-add" in script
     assert "SSH_AUTH_SOCK=" in script
-    # Single RESULT_WETTY line at the end
-    assert script.count("RESULT_WETTY ") == 1
+    # The happy-path RESULT_WETTY line is present. Multiple
+    # RESULT_WETTY lines exist in the script (each fail-fast path
+    # emits its own, all-zero, then exit 0) — we just check the
+    # all-success shape lands in there.
+    assert "RESULT_WETTY keypair_generated=$KEYPAIR_GEN" in script
 
 
 def test_render_wetty_agent_script_uses_quoted_paths() -> None:
@@ -1042,6 +1045,25 @@ def test_render_wetty_agent_script_uses_quoted_paths() -> None:
     )
     assert "'/tmp/with space/id_test'" in script
     assert "'/tmp/sock with space.sock'" in script
+
+
+def test_render_wetty_agent_script_fail_fast_on_keygen_failure() -> None:
+    """R-fail-fast: ssh-keygen non-zero OR missing output files emits
+    an all-zero RESULT_WETTY + exit 0. Without this, downstream steps
+    would silently fail and we'd produce a misleading
+    'keypair_generated=1' while Wetty can't actually SSH."""
+    from nexus_deploy.setup import render_wetty_agent_script
+
+    script = render_wetty_agent_script()
+    # The fail-fast RESULT line emits all-zero flags + bails
+    assert (
+        "RESULT_WETTY keypair_generated=0 pubkey_added=0 agent_started=0 "
+        "key_added_to_agent=0 auth_sock_written=0"
+    ) in script
+    # Both check paths present: ssh-keygen exit-status check + post-keygen
+    # output-files-exist check
+    assert "if ! ssh-keygen -t ed25519" in script
+    assert '[ ! -f "$KEY_PATH" ] || [ ! -f "$KEY_PATH.pub" ]' in script
 
 
 def test_render_wetty_agent_script_dead_socket_cleanup() -> None:

--- a/tests/unit/test_setup.py
+++ b/tests/unit/test_setup.py
@@ -1009,3 +1009,167 @@ def test_cli_subprocess_setup_unknown_returns_2() -> None:
     )
     assert proc.returncode == 2
     assert "subcommand required" in proc.stderr
+
+
+# ---------------------------------------------------------------------------
+# Wetty SSH-Agent setup (Phase 3 Modul 3.4f, #505)
+# ---------------------------------------------------------------------------
+
+
+def test_render_wetty_agent_script_basic_shape() -> None:
+    from nexus_deploy.setup import render_wetty_agent_script
+
+    script = render_wetty_agent_script()
+    assert "set -uo pipefail" in script
+    # All 5 idempotent steps present
+    assert "ssh-keygen -t ed25519" in script
+    assert "authorized_keys" in script
+    assert "ssh-agent -a" in script
+    assert "ssh-add" in script
+    assert "SSH_AUTH_SOCK=" in script
+    # Single RESULT_WETTY line at the end
+    assert script.count("RESULT_WETTY ") == 1
+
+
+def test_render_wetty_agent_script_uses_quoted_paths() -> None:
+    """Non-default paths are shlex-quoted into the rendered script."""
+    from nexus_deploy.setup import render_wetty_agent_script
+
+    script = render_wetty_agent_script(
+        key_path="/tmp/with space/id_test",  # noqa: S108 — synthetic test path
+        agent_socket="/tmp/sock with space.sock",  # noqa: S108
+        wetty_env_file="/tmp/wetty.env",  # noqa: S108
+    )
+    assert "'/tmp/with space/id_test'" in script
+    assert "'/tmp/sock with space.sock'" in script
+
+
+def test_render_wetty_agent_script_dead_socket_cleanup() -> None:
+    """R-stale-socket: a socket file that exists but isn't responsive
+    must be removed before forking a fresh agent (otherwise ssh-agent
+    fails with 'address already in use')."""
+    from nexus_deploy.setup import render_wetty_agent_script
+
+    script = render_wetty_agent_script()
+    assert 'if [ -S "$SOCKET" ]' in script
+    # Probe + cleanup-on-dead-socket
+    assert "ssh-add -l >/dev/null 2>&1 && AGENT_OK=1" in script
+    assert 'rm -f "$SOCKET"' in script
+
+
+def test_render_wetty_agent_script_authorized_keys_full_line_match() -> None:
+    """R-pubkey-dedup: full-line grep -qF (NOT a substring grep) so a
+    partial / shorter prefix doesn't false-positive. The pubkey line
+    is fixed-string compared against the file."""
+    from nexus_deploy.setup import render_wetty_agent_script
+
+    script = render_wetty_agent_script()
+    assert 'grep -qF "$PUBKEY" /root/.ssh/authorized_keys' in script
+
+
+def test_render_wetty_agent_script_strips_existing_auth_sock_line() -> None:
+    """R-idempotent-env: re-runs strip any prior SSH_AUTH_SOCK= line
+    before re-appending. Without this, every spin-up would leave
+    multiple SSH_AUTH_SOCK= lines in wetty/.env (last-wins for
+    docker-compose, but still messy)."""
+    from nexus_deploy.setup import render_wetty_agent_script
+
+    script = render_wetty_agent_script()
+    assert "sed -i '/^SSH_AUTH_SOCK=/d' \"$ENV_FILE\"" in script
+
+
+def test_parse_wetty_agent_result_all_changed() -> None:
+    from nexus_deploy.setup import parse_wetty_agent_result
+
+    line = (
+        "RESULT_WETTY keypair_generated=1 pubkey_added=1 "
+        "agent_started=1 key_added_to_agent=1 auth_sock_written=1"
+    )
+    result = parse_wetty_agent_result(line)
+    assert result is not None
+    assert result.keypair_generated is True
+    assert result.pubkey_added is True
+    assert result.agent_started is True
+    assert result.key_added_to_agent is True
+    assert result.auth_sock_written is True
+
+
+def test_parse_wetty_agent_result_all_noop() -> None:
+    """Idempotent re-run: every step finds nothing to do, only the
+    final auth_sock write is unconditional (always 1)."""
+    from nexus_deploy.setup import parse_wetty_agent_result
+
+    line = (
+        "RESULT_WETTY keypair_generated=0 pubkey_added=0 "
+        "agent_started=0 key_added_to_agent=0 auth_sock_written=1"
+    )
+    result = parse_wetty_agent_result(line)
+    assert result is not None
+    assert result.keypair_generated is False
+    assert result.pubkey_added is False
+    assert result.agent_started is False
+    assert result.key_added_to_agent is False
+    assert result.auth_sock_written is True
+
+
+def test_parse_wetty_agent_result_no_match_returns_none() -> None:
+    from nexus_deploy.setup import parse_wetty_agent_result
+
+    assert parse_wetty_agent_result("") is None
+    assert parse_wetty_agent_result("garbage") is None
+    # Wrong prefix
+    assert parse_wetty_agent_result("RESULT keypair_generated=1") is None
+
+
+def test_setup_wetty_ssh_agent_parses_result_via_mocked_ssh() -> None:
+    """End-to-end happy-path: mocked SSHClient returns canned stdout
+    with a RESULT_WETTY line; setup_wetty_ssh_agent parses it back."""
+    import subprocess
+
+    from nexus_deploy.setup import setup_wetty_ssh_agent
+
+    class _FakeSSH:
+        def run_script(
+            self, _script: str, *, check: bool = False
+        ) -> subprocess.CompletedProcess[str]:
+            del check
+            return subprocess.CompletedProcess(
+                args=["ssh"],
+                returncode=0,
+                stdout=(
+                    "RESULT_WETTY keypair_generated=1 pubkey_added=0 "
+                    "agent_started=1 key_added_to_agent=1 auth_sock_written=1\n"
+                ),
+                stderr="",
+            )
+
+    result = setup_wetty_ssh_agent(_FakeSSH())  # type: ignore[arg-type]
+    assert result is not None
+    assert result.keypair_generated is True
+    assert result.pubkey_added is False
+    assert result.agent_started is True
+    assert result.key_added_to_agent is True
+    assert result.auth_sock_written is True
+
+
+def test_setup_wetty_ssh_agent_returns_none_on_unparseable_stdout() -> None:
+    """If the script produces no RESULT_WETTY line, the wrapper returns
+    None — caller maps to rc=1 (soft failure)."""
+    import subprocess
+
+    from nexus_deploy.setup import setup_wetty_ssh_agent
+
+    class _FakeSSH:
+        def run_script(
+            self, _script: str, *, check: bool = False
+        ) -> subprocess.CompletedProcess[str]:
+            del check
+            return subprocess.CompletedProcess(
+                args=["ssh"],
+                returncode=0,
+                stdout="some other output, no RESULT_WETTY here\n",
+                stderr="",
+            )
+
+    result = setup_wetty_ssh_agent(_FakeSSH())  # type: ignore[arg-type]
+    assert result is None

--- a/tests/unit/test_setup.py
+++ b/tests/unit/test_setup.py
@@ -1197,6 +1197,23 @@ def test_setup_wetty_ssh_agent_returns_none_on_unparseable_stdout() -> None:
     assert result is None
 
 
+def test_render_wetty_agent_script_regenerates_on_half_present_keypair() -> None:
+    """R-half-keypair (#530 R3 #4): the keygen-skip gate must check
+    BOTH $KEY_PATH and $KEY_PATH.pub. If only one exists (manual
+    cleanup, partial write, fs corruption), regenerate — otherwise
+    a stale private key + missing .pub would yield empty PUBKEY +
+    silently broken authorized_keys append."""
+    from nexus_deploy.setup import render_wetty_agent_script
+
+    script = render_wetty_agent_script()
+    # Gate is OR-of-missing, not just $KEY_PATH-missing
+    assert 'if [ ! -f "$KEY_PATH" ] || [ ! -f "$KEY_PATH.pub" ]; then' in script
+    # Half-present case must rm -f BOTH before calling ssh-keygen
+    # (ssh-keygen refuses to overwrite an existing $KEY_PATH).
+    assert 'if [ -f "$KEY_PATH" ] || [ -f "$KEY_PATH.pub" ]; then' in script
+    assert 'rm -f "$KEY_PATH" "$KEY_PATH.pub"' in script
+
+
 def test_render_wetty_agent_script_validates_agent_responsiveness() -> None:
     """R-agent-validate (#530 R2 #1): after `ssh-agent -a SOCKET -s`
     we must validate that the spawned agent is actually responsive

--- a/tests/unit/test_setup.py
+++ b/tests/unit/test_setup.py
@@ -1080,13 +1080,18 @@ def test_render_wetty_agent_script_dead_socket_cleanup() -> None:
 
 
 def test_render_wetty_agent_script_authorized_keys_full_line_match() -> None:
-    """R-pubkey-dedup: full-line grep -qF (NOT a substring grep) so a
-    partial / shorter prefix doesn't false-positive. The pubkey line
-    is fixed-string compared against the file."""
+    """R-pubkey-dedup (#530 R5 #2): -F (fixed string) AND -x (whole
+    line) together. -F alone is a substring match — a longer line in
+    authorized_keys containing $PUBKEY as substring would false-
+    positive (skip the append) AND vice-versa. The actual invariant
+    the comment claims is whole-line equality, which only -Fx
+    delivers."""
     from nexus_deploy.setup import render_wetty_agent_script
 
     script = render_wetty_agent_script()
-    assert 'grep -qF "$PUBKEY" /root/.ssh/authorized_keys' in script
+    assert 'grep -qFx "$PUBKEY" /root/.ssh/authorized_keys' in script
+    # Must NOT be the substring-only -F form
+    assert 'grep -qF "$PUBKEY" /root/.ssh/authorized_keys' not in script
 
 
 def test_render_wetty_agent_script_strips_existing_auth_sock_line() -> None:

--- a/tests/unit/test_setup.py
+++ b/tests/unit/test_setup.py
@@ -1195,3 +1195,144 @@ def test_setup_wetty_ssh_agent_returns_none_on_unparseable_stdout() -> None:
 
     result = setup_wetty_ssh_agent(_FakeSSH())  # type: ignore[arg-type]
     assert result is None
+
+
+def test_render_wetty_agent_script_validates_agent_responsiveness() -> None:
+    """R-agent-validate (#530 R2 #1): after `ssh-agent -a SOCKET -s`
+    we must validate that the spawned agent is actually responsive
+    (socket present + `ssh-add -l` not rc=2). Without this validation
+    a silent ssh-agent failure would still set AGENT_STARTED=1 and we'd
+    falsely report success on a broken socket."""
+    from nexus_deploy.setup import render_wetty_agent_script
+
+    script = render_wetty_agent_script()
+    # Must wrap the ssh-agent eval in a conditional (not `|| true`)
+    assert 'if eval "$(ssh-agent -a "$SOCKET" -s)"' in script
+    # Must check both the socket file AND ssh-add response
+    assert 'if [ -S "$SOCKET" ] && SSH_AUTH_SOCK="$SOCKET" ssh-add -l' in script
+    # rc=1 (no keys loaded) is still OK; only rc>=2 (can't connect) bails
+    assert 'if [ "$ADD_RC" = "1" ]' in script
+
+
+def test_render_wetty_agent_script_fail_fast_on_env_append_failure() -> None:
+    """R-env-write-guarded (#530 R2 #2): the .env append must be
+    conditionally guarded; on failure emit RESULT_WETTY with
+    auth_sock_written=0 + bail. Legacy unconditional `>> $ENV_FILE`
+    + `AUTH_SOCK_WROTE=1` lied about the write succeeding when the
+    file/dir was unwritable."""
+    from nexus_deploy.setup import render_wetty_agent_script
+
+    script = render_wetty_agent_script()
+    # printf must be wrapped in `if ... 2>/dev/null; then` not unconditional
+    assert 'if printf \'SSH_AUTH_SOCK=%s\\n\' "$SSH_AUTH_SOCK" >> "$ENV_FILE"' in script
+    # The else-branch emits a parseable RESULT_WETTY with auth_sock_written=0
+    assert "auth_sock_written=0" in script
+
+
+def test_render_wetty_agent_script_ssh_add_failure_leaves_key_added_zero() -> None:
+    """R-ssh-add-non-fatal (#530 R2 #2 part b): ssh-add failure should
+    NOT bail (key file + agent socket still exist; operator can retry)
+    but MUST leave KEY_ADDED=0 so the operator sees the discrepancy
+    in RESULT_WETTY rather than a misleading 1."""
+    from nexus_deploy.setup import render_wetty_agent_script
+
+    script = render_wetty_agent_script()
+    # ssh-add wrapped in `if ... ; then KEY_ADDED=1` (no unconditional set)
+    assert 'if ssh-add "$KEY_PATH" >/dev/null 2>&1; then' in script
+    # Legacy unconditional pattern must be gone
+    assert 'ssh-add "$KEY_PATH" >/dev/null 2>&1 || true' not in script
+
+
+def test_render_wetty_agent_script_step_numbering_aligns_with_docstring() -> None:
+    """R-step-numbering (#530 R2 #3): inline step comments use 2-6
+    (not 1-5) so they align with the docstring's '1. mkdir + chmod 700'
+    precondition + 'steps 2-6 produce a 0/1 in RESULT_WETTY' framing."""
+    from nexus_deploy.setup import render_wetty_agent_script
+
+    script = render_wetty_agent_script()
+    assert "# Step 2: ssh-keygen" in script
+    assert "# Step 3: append pubkey" in script
+    assert "# Step 4: ssh-agent" in script
+    assert "# Step 5: ssh-add" in script
+    assert "# Step 6: write SSH_AUTH_SOCK=" in script
+    # Old numbering is gone
+    assert "# Step 1: ssh-keygen" not in script
+
+
+def test_cli_setup_wetty_ssh_agent_returns_1_when_auth_sock_not_written(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """R-soft-fail-on-missing-env-write (#530 R2 #6): when the
+    fail-fast paths in render_wetty_agent_script emit a parseable
+    RESULT_WETTY with auth_sock_written=0, the CLI handler must
+    surface rc=1 (not rc=0). Without this, deploy.sh would log a
+    misleading 'all 5 steps ok' for a Wetty container that won't
+    actually see the agent socket."""
+    import subprocess as _sp
+
+    from nexus_deploy.__main__ import _setup_wetty_ssh_agent
+
+    class _FakeSSH:
+        def __init__(self, _alias: str) -> None:
+            del _alias
+
+        def __enter__(self) -> _FakeSSH:
+            return self
+
+        def __exit__(self, *_a: object) -> None:
+            return None
+
+        def run_script(self, _script: str, *, check: bool = False) -> _sp.CompletedProcess[str]:
+            del check
+            return _sp.CompletedProcess(
+                args=["ssh"],
+                returncode=0,
+                stdout=(
+                    "RESULT_WETTY keypair_generated=1 pubkey_added=1 "
+                    "agent_started=0 key_added_to_agent=0 auth_sock_written=0\n"
+                ),
+                stderr="",
+            )
+
+    monkeypatch.setattr("nexus_deploy.__main__.SSHClient", _FakeSSH)
+    rc = _setup_wetty_ssh_agent([])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "soft-fail" in err
+    assert "SSH_AUTH_SOCK not written" in err
+
+
+def test_cli_setup_wetty_ssh_agent_happy_path_returns_0(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Happy path: auth_sock_written=1 → rc=0 even when other flags
+    are mixed (idempotent re-run)."""
+    import subprocess as _sp
+
+    from nexus_deploy.__main__ import _setup_wetty_ssh_agent
+
+    class _FakeSSH:
+        def __init__(self, _alias: str) -> None:
+            del _alias
+
+        def __enter__(self) -> _FakeSSH:
+            return self
+
+        def __exit__(self, *_a: object) -> None:
+            return None
+
+        def run_script(self, _script: str, *, check: bool = False) -> _sp.CompletedProcess[str]:
+            del check
+            return _sp.CompletedProcess(
+                args=["ssh"],
+                returncode=0,
+                stdout=(
+                    "RESULT_WETTY keypair_generated=0 pubkey_added=0 "
+                    "agent_started=0 key_added_to_agent=0 auth_sock_written=1\n"
+                ),
+                stderr="",
+            )
+
+    monkeypatch.setattr("nexus_deploy.__main__.SSHClient", _FakeSSH)
+    rc = _setup_wetty_ssh_agent([])
+    assert rc == 0


### PR DESCRIPTION
## Summary

Migrates the **last four substantive bash blocks** from `scripts/deploy.sh` into Python modules. **deploy.sh: 1979 → 1516 lines (−463 LoC, ~23% in this PR).** Cumulative migration: 5539 → 1516, **~73% migrated.**

After this PR, what remains in deploy.sh is mostly thin glue: phase headers, eval-handoffs between Python CLIs, the workspace-seed-restart loop, and the gitea-token+auth dispatch. Phase 4 (deploy.sh removal) becomes the natural follow-up.

**Round-2 update**: also includes a fix for the **R2 orphan-token leak** discovered separately during this PR's review window. Adds a new `nexus_deploy.r2_tokens` module + CLI subcommand for proactive cleanup. See the [R2-token bug fix](#r2-token-orphan-leak-round-2) section below.

### Migrations

| Block | Bash LoC | Target | New CLI |
|---|---|---|---|
| **Kestra-secret-sync** | ~340 | `secret_sync.py` extension | `secret-sync --stack kestra` |
| **Infisical bootstrap** | ~150 | `infisical.py` extension (`provision_admin`) | `infisical provision-admin` |
| **Wetty SSH-Agent** | ~100 | `setup.py` extension (`setup_wetty_ssh_agent`) | `setup wetty-ssh-agent` |
| **pg_ducklake re-apply** | ~30 | `services.py` hook | (folded into `services configure`) |

### Architecture decisions

#### Kestra-secret-sync — parameterise existing render pipeline (vs duplicate)

The Jupyter/Marimo secret-sync render in `secret_sync.py` and the Kestra equivalent in deploy.sh shared 95% of the logic (Infisical fetch loop, dedup, JSON validation, atomic write). Only ~5 lines differed: output format (`SECRET_<KEY>=<base64>` vs `<KEY>="<escaped>"`), target file (`.env` vs `.infisical.env`), restart flag (`--force-recreate` vs plain `up -d`), and the absence of a separate legacy file for Kestra.

`StackTarget` was extended with 5 new fields (defaults match the original Jupyter/Marimo behavior so existing call sites stay untouched):

```python
key_prefix: str = ""           # "SECRET_" for kestra
use_base64_values: bool = False  # True for kestra
env_file_basename: str = ".infisical.env"  # ".env" for kestra
legacy_env_file_basename: str | None = ".env"  # None for kestra
force_recreate: bool = False    # True for kestra
```

The render pipeline branches on `USE_B64` for the APPEND-line format and the GITEA_TOKEN special-case; the legacy-strip is gated on `[ -n "$LEGACY_ENV" ]`. One render function, three stack flavors, snapshot-pinned.

#### Infisical provision-admin — eval-handoff to deploy.sh

The bootstrap block split into two responsibilities:
1. **Provision** (admin user + workspace creation, save creds to disk for reuse) — handled by the new `provision_admin()`.
2. **Push secrets** (already migrated to `infisical bootstrap` in Phase 1).

The new CLI emits two eval-able lines (`INFISICAL_TOKEN=...; PROJECT_ID=...`) — same eval-handoff pattern as `gitea configure`. Both lines are always emitted (even on the soft-fail / not-ready paths, with empty values) so deploy.sh's `eval` clears any stale shell vars from a previous run.

The token is base64-encoded in the RESULT line (server → runner transport) and decoded Python-side; never embedded in jq's `--arg` argv.

#### Wetty SSH-Agent — setup-family adopter

Naturally fits the `setup.py` family (`configure_ssh`, `wait_for_ssh`, `ensure_jq`, `mount_persistent_volume`). New `setup_wetty_ssh_agent()` function + `setup wetty-ssh-agent` CLI subcommand.

5 idempotent steps, each emits a 0/1 flag in the final RESULT_WETTY line:

1. ssh-keygen if absent
2. authorized_keys append (full-line `grep -qF` dedup)
3. ssh-agent start (with dead-socket detection: if socket exists but `ssh-add -l` doesn't respond, clean up before forking a fresh agent)
4. ssh-add by fingerprint check
5. SSH_AUTH_SOCK injection into `stacks/wetty/.env` (always — the socket path is part of Wetty's contract)

#### pg_ducklake re-apply — joining the unified hook registry

The legacy `( ... ) &` background-subshell block became another bash-render hook in `_HOOK_REGISTRY`. Now 15 admin-setup hooks dispatched from a single `services configure` SSH round-trip per spin-up.

Adds `pg-ducklake` to the registry; same 30-second `pg_isready` probe + idempotent `psql -f /docker-entrypoint-initdb.d/00-ducklake-bootstrap.sql` exec.

### R-tagged invariants

| Tag | Hook / function | Test |
|---|---|---|
| R-secret | All four migrations route bearer tokens via `curl --config tmpfile` (mode 600 + RETURN trap), NEVER via `-H Authorization` argv | `test_render_provision_admin_script_secrets_via_env_not_argv`, `test_render_kestra_uses_secret_prefix`, etc. |
| R-tmpfile | Every server-side script uses `mktemp` + `chmod 600` + `EXIT/RETURN trap 'rm -f ...'` for tempfile cleanup | snapshot pins |
| R-status-codes | RESULT lines parse back to typed dataclasses; non-ASCII / malformed inputs gracefully degrade (e.g. `parse_provision_result` drops invalid-UTF8 token but keeps status) | `test_parse_provision_result_invalid_utf8_drops_token` |
| R-stale-socket | Wetty agent block detects + removes a dead socket file before forking a fresh agent (legacy bug class) | `test_render_wetty_agent_script_dead_socket_cleanup` |
| R-idempotent-env | Wetty's `SSH_AUTH_SOCK=` line is stripped + re-appended on every spin-up so wetty/.env doesn't accumulate stale lines | `test_render_wetty_agent_script_strips_existing_auth_sock_line` |
| R-secret-rotation | Kestra `--force-recreate` (NOT plain `up -d`) so EnvVarSecretProvider re-loads SECRET_* on every spin-up | `test_stack_target_kestra_format_toggles` |
| R-jupyter-marimo-unchanged | Existing Jupyter/Marimo behavior preserved by the StackTarget defaults | `test_stack_target_jupyter_marimo_defaults_unchanged` + snapshot diffs that only show the new bash variable definitions |

## R2-token orphan leak (round 2)

Bug surfaced via production audit: 8 orphaned `nexus-r2-<slug>` API tokens dated 2026-04-19/20 alongside matching newer ones from 2026-04-22+. Each forklike spin-up created a fresh token while the previous one survived, eating slots against the **50-token-per-account hard cap** (account at 38/50, hitting the wall imminent).

### Root cause

`scripts/init-r2-state.sh` looks up an existing token via Cloudflare's `/user/tokens` endpoint **without `?per_page=`** — defaults to per_page=25. Once an account holds >25 tokens, the matching same-name token may sit on page 2 → script returns empty `EXISTING_TOKEN_ID` → bails with `"Token exists but could not find its ID"`. Without manual intervention, a stale token survives forever.

### Fix

1. **Proactive pre-create cleanup** in `init-r2-state.sh`: lists all tokens with `?per_page=100`, deletes ANY matching the target name (handles same-name duplicates if the API ever allowed them) BEFORE the create call. Idempotent regardless of conflict-detection behavior. Best-effort: list failures fall back to the legacy "already exists → delete + retry" path.
2. **Pagination fix** in the legacy fallback path (line 256): `?per_page=100` so the post-conflict lookup doesn't miss the existing token.
3. **New module** `src/nexus_deploy/r2_tokens.py` with typed functions (`list_user_tokens` walks `result_info.total_pages`, `cleanup_orphan_tokens`, `build_inventory`). Module is independent of CLI dispatch — testable surface.
4. **New CLI**: `nexus-deploy r2-tokens list` (audit + remaining-slots summary, fires near-cap warning when <5 free) and `nexus-deploy r2-tokens cleanup --name|--prefix VALUE [--apply]` (one-shot reconciliation; dry-run by default). The `--prefix` form refuses anything not starting with `nexus-r2-` — defence against operator typos wiping the protected `Nexus-Stack` / `Nexus2` / build tokens documented in CLAUDE.md.

The module is Python (not bash) per the migration's overall direction; introduces 21 unit tests pinning pagination, prefix-safety, dry-run-default, and partial-failure aggregation.

## Test plan

- [x] `uv run ruff format --check .` passes
- [x] `uv run ruff check .` passes
- [x] `uv run mypy --strict src/nexus_deploy` passes
- [x] `uv run pytest --cov=src/nexus_deploy --cov-fail-under=80` passes (96% project; **1007 tests pass**, 51 new + 21 R2-token + 5 R1 fix tests)
- [x] `uv run python -m nexus_deploy r2-tokens list` (smoke-tested with mocked Cloudflare client)
- [x] `bash -n scripts/deploy.sh` parses
- [ ] **Spin-up gate:** `gh workflow run initial-setup.yaml --ref feat/python-migration-phase-3-4f-final-blocks` — must walk through every new CLI:
  - `setup wetty-ssh-agent` (only if wetty enabled)
  - `infisical provision-admin` (eval-handoff to deploy.sh)
  - `services configure` (now includes pg-ducklake hook)
  - `secret-sync --stack kestra` (only if kestra enabled, replaces the 340-line bash heredoc)
  - Existing `secret-sync --stack {jupyter,marimo}` regression check (StackTarget defaults must produce byte-identical output)

## Coverage caveats

- **infisical.py: 100%** ; **secret_sync.py: 100%** ; **services.py: 99%** ; **setup.py: 92%**.
- The 8% gap on setup.py is the new `setup_wetty_ssh_agent()` function's exception-handling lines (transport / OS errors) — covered by happy-path + None-return tests via mocked SSHClient, but the `subprocess.CalledProcessError` / `OSError` / catch-all branches in the CLI handler aren't yet exercised. Will follow up if codecov flags.

## Out of scope (deferred)

- **Orchestrator wiring in deploy.sh's [7/7]** — defer to Phase 4 entry. The orchestrator code from #527 is still live (unused). This PR adds two more phases worth of ground-truth (Infisical-provision + Kestra-secret-sync), but the [7/7] interleaving with the unmigrated workspace-seed-restart loop and the post-Kestra-restart auth probe means `run-all` wiring would need its own PR to rationalize the dispatch order. Doing it here would balloon the diff into review territory similar to PR #527 (1633 lines, 7 review rounds).
- **Modul 3.4e** — firewall-override docker-compose generation (~207 LoC bash). Self-contained; small follow-up.
- **Phase 4** — deploy.sh removal + spin-up.yml direct python invocation + 3 doc-update tasks.
- **Issue #526** — Sling multi-arch Dockerfile (orthogonal).

## Note on deploy.sh indentation drift

The Kestra-secret-sync deletion left the post-restart auth-probe block (lines ~1089-1144 of the new deploy.sh) with stale 8-spaces-extra indentation from when it lived inside a now-removed nested `if` block. Bash treats indentation as cosmetic, so the script parses and runs correctly. Fixing it would produce a much larger review-noisy diff (every line of that 50-line probe block re-indented); kept as-is for this PR. Will be cleaned up automatically in Phase 4 when [7/7] is fully restructured for the orchestrator wiring.

## Risk

**Medium-high** (combined PR is larger than #527).

- **Kestra StackTarget parameterisation drift** — Jupyter/Marimo behavior is preserved by defaults but a future refactor could break that promise silently. Pinned via `test_stack_target_jupyter_marimo_defaults_unchanged` + snapshot diffs.
- **Infisical provision token transport** — the freshly-minted bearer token transits the RESULT line as base64; if the line ever contained shell-special chars (it can't, by construction — base64 alphabet is `[A-Za-z0-9+/=]`), the runner-side `eval` would break. Pinned by anchored regex `_PROVISION_RESULT_RE`.
- **Wetty dead-socket race** — a process holding the old socket open while we `rm -f` it could leave the new ssh-agent unable to bind. Mitigated by `ssh-add -l >/dev/null 2>&1 && AGENT_OK=1` probe before cleanup; in practice only matters if a previous deploy was killed mid-handshake.
- **PR size** — 11 files changed, ~1660 LoC added, ~573 removed (net +1090). Larger than PR #527 (~1633 lines diff). Expect 6-9 review rounds.

