### PR TITLE
feat(nexus_deploy): Phase 4a — extend orchestrator with 5 pre-bootstrap phases

### DIFF
--- a/src/nexus_deploy/__main__.py
+++ b/src/nexus_deploy/__main__.py
@@ -2548,6 +2548,152 @@ def _run_all(args: list[str]) -> int:
     return 0
 
 
+def _run_pre_bootstrap(args: list[str]) -> int:
+    """`nexus-deploy run-pre-bootstrap`.
+
+    Phase 4a (#505) — runs the pre-bootstrap pipeline (service-env →
+    stack-sync → firewall-configure → compose-up → infisical-provision)
+    in a single Python invocation, replacing the per-CLI calls in
+    deploy.sh's [3/7]-[7/7-start] section.
+
+    Reads ``SECRETS_JSON`` from stdin (Tofu output). Reads workspace
+    coords + firewall_rules + admin password from env vars (deploy.sh
+    derives them in bash and exports them).
+
+    On rc=0 emits eval-able stdout for deploy.sh's surviving glue:
+    ``INFISICAL_TOKEN=<token>`` + ``PROJECT_ID=<id>`` (the two values
+    that downstream non-migrated bash blocks still need). Empty values
+    on rc=1 (provision soft-fail) so eval clears any stale value.
+
+    Required env: ``ADMIN_EMAIL``, ``REPO_NAME``, ``GITEA_REPO_OWNER``,
+    ``ENABLED_SERVICES``, ``DOMAIN``, ``INFISICAL_PASS``.
+    Optional env: ``WORKSPACE_BRANCH`` (default ``main``),
+    ``GITEA_USER_USERNAME``, ``GITEA_USER_EMAIL``, ``GITEA_USER_PASS``,
+    ``OM_PRINCIPAL_DOMAIN``, ``SSH_HOST_ALIAS`` (default ``nexus``),
+    ``FIREWALL_RULES_JSON`` (default ``{}``), ``STACKS_DIR`` (default
+    ``$PWD``).
+
+    Exit codes:
+    - 0: every phase ok or skipped.
+    - 1: at least one phase produced status='partial' (deploy.sh
+         continues — operator sees the per-phase log).
+    - 2: at least one phase failed (orchestrator aborted; subsequent
+         deploy.sh steps that depend on Infisical/etc must abort too).
+    """
+    if args:
+        print(f"run-pre-bootstrap: unknown args {args!r}", file=sys.stderr)
+        return 2
+
+    admin_email = os.environ.get("ADMIN_EMAIL") or ""
+    repo_name = os.environ.get("REPO_NAME") or ""
+    gitea_repo_owner = os.environ.get("GITEA_REPO_OWNER") or ""
+    enabled_str = os.environ.get("ENABLED_SERVICES") or ""
+    domain = os.environ.get("DOMAIN") or ""
+    admin_password_infisical = os.environ.get("INFISICAL_PASS") or ""
+
+    missing = [
+        name
+        for name, val in (
+            ("ADMIN_EMAIL", admin_email),
+            ("REPO_NAME", repo_name),
+            ("GITEA_REPO_OWNER", gitea_repo_owner),
+            ("ENABLED_SERVICES", enabled_str),
+            ("DOMAIN", domain),
+            ("INFISICAL_PASS", admin_password_infisical),
+        )
+        if not val
+    ]
+    if missing:
+        print(
+            f"run-pre-bootstrap: missing required env: {', '.join(missing)}",
+            file=sys.stderr,
+        )
+        return 2
+
+    enabled = [s.strip() for s in enabled_str.replace(",", " ").split() if s.strip()]
+    workspace_branch = os.environ.get("WORKSPACE_BRANCH") or "main"
+    gitea_user_username = os.environ.get("GITEA_USER_USERNAME") or None
+    gitea_user_email = os.environ.get("GITEA_USER_EMAIL") or None
+    gitea_user_password = os.environ.get("GITEA_USER_PASS") or None
+    ssh_host = os.environ.get("SSH_HOST_ALIAS") or "nexus"
+    firewall_json = os.environ.get("FIREWALL_RULES_JSON") or "{}"
+    stacks_dir = (
+        Path(os.environ.get("STACKS_DIR") or "") if os.environ.get("STACKS_DIR") else Path.cwd()
+    )
+
+    try:
+        config = NexusConfig.from_secrets_json(sys.stdin.read())
+    except ConfigError as exc:
+        print(f"run-pre-bootstrap: {exc}", file=sys.stderr)
+        return 2
+
+    bootstrap_env = BootstrapEnv(
+        domain=domain,
+        admin_email=admin_email,
+        gitea_user_email=gitea_user_email,
+        gitea_user_username=gitea_user_username,
+        gitea_repo_owner=gitea_repo_owner,
+        repo_name=repo_name,
+        om_principal_domain=os.environ.get("OM_PRINCIPAL_DOMAIN") or None,
+    )
+
+    orchestrator = Orchestrator(
+        config=config,
+        bootstrap_env=bootstrap_env,
+        enabled_services=enabled,
+        repo_name=repo_name,
+        gitea_repo_owner=gitea_repo_owner,
+        workspace_branch=workspace_branch,
+        gitea_user_username=gitea_user_username,
+        gitea_user_email=gitea_user_email,
+        gitea_user_password=gitea_user_password,
+        ssh_host=ssh_host,
+        domain=domain,
+        firewall_json=firewall_json,
+        stacks_dir=stacks_dir,
+        admin_password_infisical=admin_password_infisical,
+    )
+
+    try:
+        result = orchestrator.run_pre_bootstrap()
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError) as exc:
+        print(
+            f"run-pre-bootstrap: transport failure ({type(exc).__name__})",
+            file=sys.stderr,
+        )
+        return 2
+    except Exception as exc:
+        print(
+            f"run-pre-bootstrap: unexpected error ({type(exc).__name__})",
+            file=sys.stderr,
+        )
+        return 2
+
+    # Per-phase log to stderr.
+    for phase in result.phases:
+        marker = {"ok": "✓", "partial": "⚠", "failed": "✗", "skipped": "—"}.get(phase.status, "?")
+        detail = f" — {phase.detail}" if phase.detail else ""
+        sys.stderr.write(f"  {marker} {phase.name}: {phase.status}{detail}\n")
+
+    # Eval-able stdout: 2 values for deploy.sh's surviving glue. Always
+    # emit (with empty values when not populated) so eval clears stale
+    # shell vars from prior runs.
+    import shlex as _shlex
+
+    sys.stdout.write(
+        f"INFISICAL_TOKEN={_shlex.quote(result.state.infisical_token or '')}\n",
+    )
+    sys.stdout.write(
+        f"PROJECT_ID={_shlex.quote(result.state.project_id or '')}\n",
+    )
+
+    if result.has_hard_failure:
+        return 2
+    if result.has_partial:
+        return 1
+    return 0
+
+
 def _allocate_free_port() -> int:
     """Ask the kernel for a free IPv4 ephemeral port on the loopback.
 
@@ -2646,6 +2792,8 @@ def main() -> int:
         return _service_env(args[1:])
     if args[:1] == ["run-all"]:
         return _run_all(args[1:])
+    if args[:1] == ["run-pre-bootstrap"]:
+        return _run_pre_bootstrap(args[1:])
     if args[:1] == ["r2-tokens"]:
         return _r2_tokens(args[1:])
     if args[:2] == ["firewall", "configure"]:
@@ -2673,6 +2821,9 @@ def main() -> int:
         "service-env --enabled <comma-list> [--stacks-dir PATH] (reads SECRETS_JSON from stdin), "
         "run-all (reads SECRETS_JSON from stdin + env vars; emits eval-able stdout: "
         "RESTART_SERVICES + WOODPECKER_GITEA_CLIENT + WOODPECKER_GITEA_SECRET), "
+        "run-pre-bootstrap (Phase 4a: service-env → stack-sync → firewall-configure → "
+        "compose-up → infisical-provision; reads SECRETS_JSON from stdin + env vars "
+        "incl. INFISICAL_PASS; emits eval-able stdout: INFISICAL_TOKEN + PROJECT_ID), "
         "r2-tokens list [--prefix STR] | cleanup --name|--prefix VALUE [--apply] "
         "(env: TF_VAR_cloudflare_api_token), "
         "firewall configure [--project-root PATH] [--domain DOMAIN] "

--- a/src/nexus_deploy/__main__.py
+++ b/src/nexus_deploy/__main__.py
@@ -2580,16 +2580,20 @@ def _run_pre_bootstrap(args: list[str]) -> int:
     ``infisical provision-admin`` CLI (#530).
 
     Required env: ``ADMIN_EMAIL``, ``REPO_NAME``, ``GITEA_REPO_OWNER``,
-    ``ENABLED_SERVICES``, ``DOMAIN``, ``INFISICAL_PASS``.
+    ``ENABLED_SERVICES``, ``DOMAIN``, ``INFISICAL_PASS``,
+    ``FIREWALL_RULES_JSON`` — explicit, NOT defaulted (PR #532 R5 #2):
+    a missing/empty value would otherwise be silently treated as
+    zero-entry mode by the firewall module and trigger destructive
+    cleanup of existing override files. Operators MUST pass an
+    explicit ``"{}"`` to opt into zero-entry mode.
     Optional env: ``WORKSPACE_BRANCH`` (default ``main``),
     ``GITEA_USER_USERNAME``, ``GITEA_USER_EMAIL``, ``GITEA_USER_PASS``,
     ``OM_PRINCIPAL_DOMAIN``, ``SSH_HOST_ALIAS`` (default ``nexus``),
-    ``FIREWALL_RULES_JSON`` (default ``{}``), ``PROJECT_ROOT`` (default
-    ``$PWD``) — the repo checkout root; phases derive
-    ``$PROJECT_ROOT/stacks`` for per-service compose paths. (Renamed
-    from ``STACKS_DIR`` in PR #532 R2 #1: deploy.sh's ``STACKS_DIR``
-    is the actual stacks dir, so reusing the name produced
-    ``.../stacks/stacks/...``.)
+    ``PROJECT_ROOT`` (default ``$PWD``) — the repo checkout root;
+    phases derive ``$PROJECT_ROOT/stacks`` for per-service compose paths.
+    (Renamed from ``STACKS_DIR`` in PR #532 R2 #1: deploy.sh's
+    ``STACKS_DIR`` is the actual stacks dir, so reusing the name
+    produced ``.../stacks/stacks/...``.)
 
     Exit codes:
     - 0: every phase ok or skipped.
@@ -2608,6 +2612,12 @@ def _run_pre_bootstrap(args: list[str]) -> int:
     enabled_str = os.environ.get("ENABLED_SERVICES") or ""
     domain = os.environ.get("DOMAIN") or ""
     admin_password_infisical = os.environ.get("INFISICAL_PASS") or ""
+    # PR #532 R5 #2: FIREWALL_RULES_JSON is required (no default).
+    # An accidental empty value would be treated by the firewall module
+    # as intentional zero-entry mode and trigger destructive cleanup of
+    # existing override files on disk. Operators must pass "{}" explicitly
+    # to opt into zero-entry mode.
+    firewall_json = os.environ.get("FIREWALL_RULES_JSON") or ""
 
     # Build a list of variable NAMES that are missing/empty. CodeQL's
     # 'clear-text logging of sensitive information' rule scans for
@@ -2622,6 +2632,7 @@ def _run_pre_bootstrap(args: list[str]) -> int:
         ("ENABLED_SERVICES", enabled_str),
         ("DOMAIN", domain),
         ("INFISICAL_PASS", admin_password_infisical),
+        ("FIREWALL_RULES_JSON", firewall_json),
     )
     missing_names = [name for name, val in required_env if not val]
     if missing_names:
@@ -2637,7 +2648,6 @@ def _run_pre_bootstrap(args: list[str]) -> int:
     gitea_user_email = os.environ.get("GITEA_USER_EMAIL") or None
     gitea_user_password = os.environ.get("GITEA_USER_PASS") or None
     ssh_host = os.environ.get("SSH_HOST_ALIAS") or "nexus"
-    firewall_json = os.environ.get("FIREWALL_RULES_JSON") or "{}"
     project_root_env = os.environ.get("PROJECT_ROOT")
     project_root = Path(project_root_env) if project_root_env else Path.cwd()
 

--- a/src/nexus_deploy/__main__.py
+++ b/src/nexus_deploy/__main__.py
@@ -2584,8 +2584,12 @@ def _run_pre_bootstrap(args: list[str]) -> int:
     Optional env: ``WORKSPACE_BRANCH`` (default ``main``),
     ``GITEA_USER_USERNAME``, ``GITEA_USER_EMAIL``, ``GITEA_USER_PASS``,
     ``OM_PRINCIPAL_DOMAIN``, ``SSH_HOST_ALIAS`` (default ``nexus``),
-    ``FIREWALL_RULES_JSON`` (default ``{}``), ``STACKS_DIR`` (default
-    ``$PWD``).
+    ``FIREWALL_RULES_JSON`` (default ``{}``), ``PROJECT_ROOT`` (default
+    ``$PWD``) — the repo checkout root; phases derive
+    ``$PROJECT_ROOT/stacks`` for per-service compose paths. (Renamed
+    from ``STACKS_DIR`` in PR #532 R2 #1: deploy.sh's ``STACKS_DIR``
+    is the actual stacks dir, so reusing the name produced
+    ``.../stacks/stacks/...``.)
 
     Exit codes:
     - 0: every phase ok or skipped.
@@ -2634,9 +2638,8 @@ def _run_pre_bootstrap(args: list[str]) -> int:
     gitea_user_password = os.environ.get("GITEA_USER_PASS") or None
     ssh_host = os.environ.get("SSH_HOST_ALIAS") or "nexus"
     firewall_json = os.environ.get("FIREWALL_RULES_JSON") or "{}"
-    stacks_dir = (
-        Path(os.environ.get("STACKS_DIR") or "") if os.environ.get("STACKS_DIR") else Path.cwd()
-    )
+    project_root_env = os.environ.get("PROJECT_ROOT")
+    project_root = Path(project_root_env) if project_root_env else Path.cwd()
 
     try:
         config = NexusConfig.from_secrets_json(sys.stdin.read())
@@ -2667,7 +2670,7 @@ def _run_pre_bootstrap(args: list[str]) -> int:
         ssh_host=ssh_host,
         domain=domain,
         firewall_json=firewall_json,
-        stacks_dir=stacks_dir,
+        project_root=project_root,
         admin_password_infisical=admin_password_infisical,
     )
 

--- a/src/nexus_deploy/__main__.py
+++ b/src/nexus_deploy/__main__.py
@@ -2565,6 +2565,20 @@ def _run_pre_bootstrap(args: list[str]) -> int:
     that downstream non-migrated bash blocks still need). Empty values
     on rc=1 (provision soft-fail) so eval clears any stale value.
 
+    SECURITY: stdout carries an Infisical bearer token. The CALLER
+    MUST redirect stdout to a file (or pipe through ``eval``) so the
+    token doesn't end up in workflow logs / terminal scrollback. The
+    established deploy.sh pattern is::
+
+        OUT=$(mktemp); echo "$OUT" >> "$RUNNER_CLEANUP_PATHS"
+        run-pre-bootstrap > "$OUT" || RC=$?
+        eval "$(cat "$OUT")"
+
+    The mktemp tempfile is auto-cleaned by the global EXIT trap.
+    DON'T invoke this command interactively without a redirection.
+    Same eval-pattern + redirection conventions as the legacy
+    ``infisical provision-admin`` CLI (#530).
+
     Required env: ``ADMIN_EMAIL``, ``REPO_NAME``, ``GITEA_REPO_OWNER``,
     ``ENABLED_SERVICES``, ``DOMAIN``, ``INFISICAL_PASS``.
     Optional env: ``WORKSPACE_BRANCH`` (default ``main``),
@@ -2591,21 +2605,24 @@ def _run_pre_bootstrap(args: list[str]) -> int:
     domain = os.environ.get("DOMAIN") or ""
     admin_password_infisical = os.environ.get("INFISICAL_PASS") or ""
 
-    missing = [
-        name
-        for name, val in (
-            ("ADMIN_EMAIL", admin_email),
-            ("REPO_NAME", repo_name),
-            ("GITEA_REPO_OWNER", gitea_repo_owner),
-            ("ENABLED_SERVICES", enabled_str),
-            ("DOMAIN", domain),
-            ("INFISICAL_PASS", admin_password_infisical),
-        )
-        if not val
-    ]
-    if missing:
+    # Build a list of variable NAMES that are missing/empty. CodeQL's
+    # 'clear-text logging of sensitive information' rule scans for
+    # password-typed values reaching log statements; rename to
+    # `missing_names` so the comprehension makes it obvious that only
+    # the (name) projection — not the (val) — gets emitted to stderr.
+    # Caught in PR #532 R1 #1 (CodeQL false positive).
+    required_env = (
+        ("ADMIN_EMAIL", admin_email),
+        ("REPO_NAME", repo_name),
+        ("GITEA_REPO_OWNER", gitea_repo_owner),
+        ("ENABLED_SERVICES", enabled_str),
+        ("DOMAIN", domain),
+        ("INFISICAL_PASS", admin_password_infisical),
+    )
+    missing_names = [name for name, val in required_env if not val]
+    if missing_names:
         print(
-            f"run-pre-bootstrap: missing required env: {', '.join(missing)}",
+            f"run-pre-bootstrap: missing required env: {', '.join(missing_names)}",
             file=sys.stderr,
         )
         return 2

--- a/src/nexus_deploy/__main__.py
+++ b/src/nexus_deploy/__main__.py
@@ -2552,9 +2552,11 @@ def _run_pre_bootstrap(args: list[str]) -> int:
     """`nexus-deploy run-pre-bootstrap`.
 
     Phase 4a (#505) — runs the pre-bootstrap pipeline (service-env →
-    stack-sync → firewall-configure → compose-up → infisical-provision)
+    firewall-configure → stack-sync → compose-up → infisical-provision)
     in a single Python invocation, replacing the per-CLI calls in
-    deploy.sh's [3/7]-[7/7-start] section.
+    deploy.sh's [3/7]-[7/7-start] section. (Phase order corrected in
+    PR #532 R5 #1 so firewall overrides are part of what stack-sync
+    rsyncs to the server.)
 
     Reads ``SECRETS_JSON`` from stdin (Tofu output). Reads workspace
     coords + firewall_rules + admin password from env vars (deploy.sh
@@ -2851,7 +2853,7 @@ def main() -> int:
         "service-env --enabled <comma-list> [--stacks-dir PATH] (reads SECRETS_JSON from stdin), "
         "run-all (reads SECRETS_JSON from stdin + env vars; emits eval-able stdout: "
         "RESTART_SERVICES + WOODPECKER_GITEA_CLIENT + WOODPECKER_GITEA_SECRET), "
-        "run-pre-bootstrap (Phase 4a: service-env → stack-sync → firewall-configure → "
+        "run-pre-bootstrap (Phase 4a: service-env → firewall-configure → stack-sync → "
         "compose-up → infisical-provision; reads SECRETS_JSON from stdin + env vars "
         "incl. INFISICAL_PASS; emits eval-able stdout: INFISICAL_TOKEN + PROJECT_ID), "
         "r2-tokens list [--prefix STR] | cleanup --name|--prefix VALUE [--apply] "

--- a/src/nexus_deploy/compose_runner.py
+++ b/src/nexus_deploy/compose_runner.py
@@ -319,6 +319,7 @@ ScriptRunner = Callable[[str], subprocess.CompletedProcess[str]]
 def run_compose_up(
     enabled: list[str],
     *,
+    host: str = "nexus",
     dify_storage_prep: bool | None = None,
     script_runner: ScriptRunner | None = None,
 ) -> ComposeUpResult:
@@ -327,6 +328,11 @@ def run_compose_up(
     ``dify_storage_prep`` defaults to True iff ``"dify"`` is in
     ``enabled`` — caller can override (tests pass False to skip the
     chown block, production lets the default fire).
+
+    ``host`` selects which ssh-config alias the remote script runs
+    against. Defaults to ``"nexus"`` for back-compat with existing
+    callers; orchestrator passes its ``self.ssh_host`` so a non-default
+    ``SSH_HOST_ALIAS`` reaches every phase uniformly (PR #532 R2 #2).
 
     Returns ``ComposeUpResult(started=0, failed=len(enabled))`` if the
     remote script produced no parseable RESULT line — same defensive
@@ -340,7 +346,7 @@ def run_compose_up(
 
     script = render_remote_script(parents=parents, leaves=leaves, dify_storage_prep=actual_dify)
 
-    run_script = script_runner or (lambda s: _remote.ssh_run_script(s))
+    run_script = script_runner or (lambda s: _remote.ssh_run_script(s, host=host))
     completed = run_script(script)
 
     # Forward remote per-service ✓/✗ + warnings to local stderr (Modul-1.2

--- a/src/nexus_deploy/infisical.py
+++ b/src/nexus_deploy/infisical.py
@@ -394,9 +394,16 @@ def provision_admin(
     admin_password: str,
     organization_name: str = "Nexus",
     project_name: str = "Nexus Stack",
+    host: str = "nexus",
     script_runner: Callable[[str], subprocess.CompletedProcess[str]] | None = None,
 ) -> ProvisionResult:
     """Render + run the provision script via SSH, parse result.
+
+    ``host`` selects which ssh-config alias the remote script runs
+    against. Defaults to ``"nexus"`` for back-compat with existing
+    callers; orchestrator passes its ``self.ssh_host`` so a non-default
+    ``SSH_HOST_ALIAS`` reaches every pre-bootstrap phase uniformly
+    (PR #532 R2 #2).
 
     ``script_runner`` is a DI seam for tests; production callers pass
     None and get :func:`_remote.ssh_run_script` (script-via-stdin so
@@ -404,7 +411,7 @@ def provision_admin(
     """
     if not admin_email or not admin_password:
         return ProvisionResult(status="not-ready", token=None, project_id=None)
-    runner = script_runner or (lambda s: _remote.ssh_run_script(s))
+    runner = script_runner or (lambda s: _remote.ssh_run_script(s, host=host))
     script = render_provision_admin_script(
         admin_email=admin_email,
         admin_password=admin_password,

--- a/src/nexus_deploy/orchestrator.py
+++ b/src/nexus_deploy/orchestrator.py
@@ -1093,10 +1093,22 @@ class Orchestrator:
         self.state.project_id = None
         self.infisical_token = None
         self.project_id = None
+        # Phase order matters (PR #532 R5 #1):
+        #   service-env  — writes per-stack .env files locally
+        #   firewall     — writes per-stack docker-compose.firewall.yml
+        #                  overrides locally (must be BEFORE stack-sync
+        #                  so rsync picks them up)
+        #   stack-sync   — rsyncs everything in stacks/<svc>/ to the
+        #                  server (without --delete; remote orphan
+        #                  cleanup of stale firewall overrides stays in
+        #                  deploy.sh's bash for Phase 4b)
+        #   compose-up   — sees the synced overrides → containers start
+        #                  with correct firewall exposure
+        #   infisical    — bootstraps Infisical admin + workspace last
         phases: list[Callable[[], PhaseResult]] = [
             self._phase_service_env,
-            self._phase_stack_sync,
             self._phase_firewall_configure,
+            self._phase_stack_sync,
             self._phase_compose_up,
             self._phase_infisical_provision,
         ]

--- a/src/nexus_deploy/orchestrator.py
+++ b/src/nexus_deploy/orchestrator.py
@@ -52,12 +52,16 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Literal
 
+from nexus_deploy import compose_runner as _compose_runner
+from nexus_deploy import firewall as _firewall
 from nexus_deploy import gitea as _gitea
 from nexus_deploy import infisical as _infisical
 from nexus_deploy import kestra as _kestra
 from nexus_deploy import secret_sync as _secret_sync
 from nexus_deploy import seeder as _seeder
+from nexus_deploy import service_env as _service_env
 from nexus_deploy import services as _services
+from nexus_deploy import stack_sync as _stack_sync
 from nexus_deploy.config import NexusConfig
 from nexus_deploy.infisical import BootstrapEnv
 from nexus_deploy.ssh import SSHClient
@@ -83,6 +87,16 @@ class OrchestratorState:
     woodpecker_client_secret: str | None = None
     fork_name: str | None = None
     fork_owner: str | None = None
+    # Phase 4a (#505): infisical_token + project_id are now POPULATED by
+    # _phase_infisical_provision (running BEFORE _phase_infisical_bootstrap)
+    # instead of being inherited as orchestrator inputs. Pre-bootstrap
+    # callers don't need to pass them in the constructor; the post-bootstrap
+    # phases read from state. The Orchestrator.infisical_token /
+    # .project_id constructor fields stay as fallbacks for callers that
+    # already have the credentials (e.g. testing the post-bootstrap path
+    # in isolation).
+    infisical_token: str | None = None
+    project_id: str | None = None
 
 
 @dataclass(frozen=True)
@@ -151,6 +165,18 @@ class Orchestrator:
     project_id: str | None = None
     infisical_token: str | None = None
     infisical_env: str = "dev"
+
+    # Phase 4a (#505) — additions for the pre-bootstrap pipeline.
+    # All optional to keep back-compat with existing post-bootstrap-only
+    # callers (run_all). When unset, phases that need them surface as
+    # status='skipped' with a clear detail.
+    cf_client_id: str | None = None  # Cloudflare Access Service Token id
+    cf_client_secret: str | None = None  # Cloudflare Access Service Token secret
+    persistent_volume_id: str = "0"  # Hetzner Cloud volume id; "0" = no volume
+    stacks_dir: Path = field(default_factory=lambda: Path.cwd())
+    firewall_json: str = "{}"  # raw `tofu output -json firewall_rules` body
+    domain: str = ""  # for firewall RedPanda rendering
+    admin_password_infisical: str | None = None  # for infisical provision-admin
 
     state: OrchestratorState = field(default_factory=OrchestratorState)
     results: list[PhaseResult] = field(default_factory=list)
@@ -635,6 +661,406 @@ class Orchestrator:
 
     def _phase_secret_sync_marimo(self, ssh: SSHClient) -> PhaseResult:
         return self._phase_secret_sync(ssh, "marimo")
+
+    # ---------------------------------------------------------------------
+    # Phase 4a (#505) — pre-bootstrap pipeline.
+    #
+    # These phases run BEFORE the existing infisical-bootstrap phase and
+    # collectively replace deploy.sh's [0/7]-[7/7] CLI invocations + the
+    # interleaved bash glue. Each wraps an already-migrated module's
+    # public function and converts its result/exception into a PhaseResult.
+    # No new logic — just a unified place to chain them with state-handoff.
+    #
+    # The pre-bootstrap phases come in two clusters:
+    #
+    # 1. **Local-only** (don't need an SSHClient): service-env render,
+    #    firewall override generation. They're declared with an ``ssh``
+    #    parameter for signature consistency with the existing phases
+    #    (so the run_pre_bootstrap loop can call them uniformly), but
+    #    the parameter goes unused.
+    #
+    # 2. **Server-side** (use the wrapped helper's own ssh.run_script
+    #    plumbing): stack-sync, compose up, infisical provision-admin.
+    #    These don't need the orchestrator's shared SSHClient because
+    #    their helper functions invoke ``ssh nexus`` via subprocess
+    #    independently (legacy compatibility — we don't refactor those
+    #    helpers in this PR).
+    # ---------------------------------------------------------------------
+
+    def _phase_service_env(self, ssh: SSHClient) -> PhaseResult:
+        """Render per-service ``stacks/<svc>/.env`` files locally + (when
+        Gitea is enabled) append the Gitea workspace block to the
+        Gitea-integrated stacks. Replaces deploy.sh's
+        ``service-env --enabled`` invocation (Modul 3.4c, #527).
+
+        Local-only: no SSH calls. The ``ssh`` parameter is present for
+        signature consistency with the run_pre_bootstrap loop; unused
+        here.
+        """
+        del ssh  # unused — local-only phase
+        try:
+            result = _service_env.render_all_env_files(
+                self.config,
+                self.bootstrap_env,
+                self.enabled_services,
+                stacks_dir=self.stacks_dir / "stacks",
+            )
+        except _service_env.ServiceEnvError as exc:
+            # Hard-fail conditions (e.g. SFTPGo with empty password) —
+            # the legacy bash exits 1 with a red banner; the Python
+            # equivalent raises so we surface it here.
+            return PhaseResult(
+                name="service-env",
+                status="failed",
+                detail=str(exc),
+            )
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError) as exc:
+            return PhaseResult(
+                name="service-env",
+                status="failed",
+                detail=f"transport ({type(exc).__name__})",
+            )
+        except Exception as exc:
+            return PhaseResult(
+                name="service-env",
+                status="failed",
+                detail=f"unexpected ({type(exc).__name__})",
+            )
+
+        # Optionally append the Gitea workspace block. Mirrors the CLI
+        # handler's logic: only when ALL the workspace coords are present
+        # AND gitea is enabled.
+        gitea_appended_count = 0
+        if "gitea" in self.enabled_services and all(
+            (
+                self.bootstrap_env.gitea_repo_owner,
+                self.repo_name,
+            ),
+        ):
+            gitea_repo_url = (
+                f"http://gitea:3000/{self.bootstrap_env.gitea_repo_owner}/{self.repo_name}.git"
+            )
+            try:
+                cfg = _service_env.GiteaWorkspaceConfig(
+                    gitea_repo_url=gitea_repo_url,
+                    gitea_username=self.gitea_user_username or "",
+                    gitea_password=self.gitea_user_password or "",
+                    git_author_name=self.gitea_user_username or "",
+                    git_author_email=self.gitea_user_email or "",
+                    repo_name=self.repo_name,
+                    workspace_branch=self.workspace_branch,
+                )
+                appended = _service_env.append_gitea_workspace_block(
+                    cfg,
+                    self.enabled_services,
+                    stacks_dir=self.stacks_dir / "stacks",
+                )
+                gitea_appended_count = len(appended)
+            except OSError as exc:
+                return PhaseResult(
+                    name="service-env",
+                    status="partial",
+                    detail=(
+                        f"rendered={result.rendered} but gitea-block append "
+                        f"failed: {type(exc).__name__}"
+                    ),
+                )
+
+        if result.failed > 0:
+            if result.rendered == 0:
+                return PhaseResult(
+                    name="service-env",
+                    status="failed",
+                    detail=f"rendered=0 failed={result.failed}",
+                )
+            return PhaseResult(
+                name="service-env",
+                status="partial",
+                detail=(
+                    f"rendered={result.rendered} skipped={result.skipped} "
+                    f"failed={result.failed} gitea_appended={gitea_appended_count}"
+                ),
+            )
+        return PhaseResult(
+            name="service-env",
+            status="ok",
+            detail=(
+                f"rendered={result.rendered} skipped={result.skipped} "
+                f"gitea_appended={gitea_appended_count}"
+            ),
+        )
+
+    def _phase_stack_sync(self, ssh: SSHClient) -> PhaseResult:
+        """Rsync each enabled stack to ``/opt/docker-server/stacks/<svc>/``
+        and clean up disabled stack directories on the server. Replaces
+        deploy.sh's ``stack-sync --enabled`` invocation (Modul 3.3, #523).
+
+        Uses ``run_stack_sync`` which manages its own rsync subprocess
+        + cleanup ssh.run_script invocation independently — the
+        orchestrator's shared SSHClient is not consumed here.
+        """
+        del ssh  # run_stack_sync manages its own subprocess invocations
+        try:
+            result = _stack_sync.run_stack_sync(
+                self.stacks_dir / "stacks",
+                self.enabled_services,
+                host=self.ssh_host,
+            )
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError) as exc:
+            return PhaseResult(
+                name="stack-sync",
+                status="failed",
+                detail=f"transport ({type(exc).__name__})",
+            )
+        except Exception as exc:
+            return PhaseResult(
+                name="stack-sync",
+                status="failed",
+                detail=f"unexpected ({type(exc).__name__})",
+            )
+        cleanup_failed = result.cleanup.failed if result.cleanup is not None else 0
+        cleanup_removed = result.cleanup.removed if result.cleanup is not None else 0
+        cleanup_missing_or_unparseable = result.cleanup is None
+        if cleanup_missing_or_unparseable:
+            # No parseable RESULT from the cleanup script — same hard-fail
+            # contract as the per-CLI handler maps to rc=2.
+            return PhaseResult(
+                name="stack-sync",
+                status="failed",
+                detail=(
+                    f"rsync_synced={result.synced} rsync_failed={result.failed_rsync} "
+                    "cleanup script produced no parseable RESULT"
+                ),
+            )
+        if result.failed_rsync > 0 or cleanup_failed > 0:
+            return PhaseResult(
+                name="stack-sync",
+                status="partial",
+                detail=(
+                    f"rsync_synced={result.synced} rsync_failed={result.failed_rsync} "
+                    f"cleanup_removed={cleanup_removed} cleanup_failed={cleanup_failed}"
+                ),
+            )
+        return PhaseResult(
+            name="stack-sync",
+            status="ok",
+            detail=(f"rsync_synced={result.synced} cleanup_removed={cleanup_removed}"),
+        )
+
+    def _phase_firewall_configure(self, ssh: SSHClient) -> PhaseResult:
+        """Generate per-service ``docker-compose.firewall.yml`` overrides
+        and (when RedPanda has firewall ports) the dual-listener override
+        + substituted ``redpanda-firewall.yaml``. Replaces deploy.sh's
+        ``firewall configure --domain`` invocation (Modul 3.4e, #531).
+
+        Local-only — the rendered files are written to ``stacks/<svc>/``
+        on the runner. The subsequent server-side scp + orphan-cleanup
+        loop stays in deploy.sh for now (Phase 4b will migrate it).
+        """
+        del ssh  # local-only phase
+        try:
+            gen, write = _firewall.configure(
+                firewall_json=self.firewall_json,
+                stacks_dir=self.stacks_dir,
+                domain=self.domain,
+            )
+        except (ValueError, FileNotFoundError) as exc:
+            return PhaseResult(
+                name="firewall-configure",
+                status="failed",
+                detail=str(exc),
+            )
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError) as exc:
+            return PhaseResult(
+                name="firewall-configure",
+                status="failed",
+                detail=f"transport ({type(exc).__name__})",
+            )
+        except Exception as exc:
+            return PhaseResult(
+                name="firewall-configure",
+                status="failed",
+                detail=f"unexpected ({type(exc).__name__})",
+            )
+
+        if gen.zero_entry:
+            if write.failed:
+                return PhaseResult(
+                    name="firewall-configure",
+                    status="partial",
+                    detail=(
+                        f"zero-entry mode but stale-cleanup had {len(write.failed)} failure(s)"
+                    ),
+                )
+            return PhaseResult(
+                name="firewall-configure",
+                status="ok",
+                detail="zero-entry (no rules)",
+            )
+
+        if gen.skipped:
+            # Per #531 R7 #4: skipped services mean Tofu requested a rule
+            # but compose.yml was unparseable → existing override stays
+            # in place but state may be inconsistent with Tofu.
+            return PhaseResult(
+                name="firewall-configure",
+                status="partial",
+                detail=(
+                    f"rendered={len(gen.compiled)} skipped={len(gen.skipped)} "
+                    f"redpanda={'yes' if gen.redpanda else 'no'}"
+                ),
+            )
+        if write.failed:
+            return PhaseResult(
+                name="firewall-configure",
+                status="partial",
+                detail=(
+                    f"rendered={len(gen.compiled)} written={len(write.written)} "
+                    f"failed={len(write.failed)}"
+                ),
+            )
+        return PhaseResult(
+            name="firewall-configure",
+            status="ok",
+            detail=(f"rendered={len(gen.compiled)} redpanda={'yes' if gen.redpanda else 'no'}"),
+        )
+
+    def _phase_compose_up(self, ssh: SSHClient) -> PhaseResult:
+        """Start containers in parallel via
+        :func:`compose_runner.run_compose_up`. Replaces deploy.sh's
+        ``compose up --enabled`` invocation (Modul 2.2a, #505).
+
+        ``run_compose_up`` invokes ``ssh nexus 'bash -s'`` via
+        subprocess internally — the orchestrator's shared SSHClient
+        is not consumed here.
+        """
+        del ssh  # run_compose_up manages its own ssh script invocation
+        try:
+            result = _compose_runner.run_compose_up(self.enabled_services)
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError) as exc:
+            return PhaseResult(
+                name="compose-up",
+                status="failed",
+                detail=f"transport ({type(exc).__name__})",
+            )
+        except Exception as exc:
+            return PhaseResult(
+                name="compose-up",
+                status="failed",
+                detail=f"unexpected ({type(exc).__name__})",
+            )
+        if result.failed > 0:
+            return PhaseResult(
+                name="compose-up",
+                status="partial",
+                detail=f"started={result.started} failed={result.failed}",
+            )
+        return PhaseResult(
+            name="compose-up",
+            status="ok",
+            detail=f"started={result.started}",
+        )
+
+    def _phase_infisical_provision(self, ssh: SSHClient) -> PhaseResult:
+        """Bootstrap the Infisical admin + workspace. Replaces deploy.sh's
+        ``infisical provision-admin`` invocation (Modul 3.4f, #530).
+
+        Populates ``self.state.infisical_token`` and ``self.state.project_id``
+        on success — those values are then consumed by the existing
+        ``_phase_infisical_bootstrap`` phase. Read the constructor's
+        ``project_id`` / ``infisical_token`` fields as fallback (so a
+        post-bootstrap-only test can still bypass this phase).
+        """
+        del ssh  # provision_admin manages its own ssh.run_script call
+        admin_email = self.bootstrap_env.admin_email or ""
+        admin_password = self.admin_password_infisical or ""
+        if not admin_email or not admin_password:
+            return PhaseResult(
+                name="infisical-provision",
+                status="skipped",
+                detail="ADMIN_EMAIL or admin_password_infisical missing",
+            )
+        try:
+            result = _infisical.provision_admin(
+                admin_email=admin_email,
+                admin_password=admin_password,
+            )
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError) as exc:
+            return PhaseResult(
+                name="infisical-provision",
+                status="failed",
+                detail=f"transport ({type(exc).__name__})",
+            )
+        except Exception as exc:
+            return PhaseResult(
+                name="infisical-provision",
+                status="failed",
+                detail=f"unexpected ({type(exc).__name__})",
+            )
+
+        if not result.has_credentials:
+            # Same contract as #530 R2 #4: rc=1 (soft-fail) when the
+            # provision didn't produce usable credentials. Pre-bootstrap
+            # caller should treat this as 'continue without secret push'.
+            return PhaseResult(
+                name="infisical-provision",
+                status="partial",
+                detail=f"status={result.status} (no usable credentials)",
+            )
+
+        # Populate state for downstream phases.
+        self.state.infisical_token = result.token
+        self.state.project_id = result.project_id
+        # Also populate the orchestrator's input fields so the existing
+        # _phase_infisical_bootstrap (which reads self.project_id /
+        # self.infisical_token) finds the values.
+        self.project_id = result.project_id
+        self.infisical_token = result.token
+
+        return PhaseResult(
+            name="infisical-provision",
+            status="ok",
+            detail=f"status={result.status}",
+        )
+
+    def run_pre_bootstrap(self) -> OrchestratorResult:
+        """Run the pre-bootstrap pipeline: service-env → stack-sync →
+        firewall-configure → compose-up → infisical-provision.
+
+        Resets ``self.results`` so re-invoking the same instance does
+        not duplicate prior phase outputs. ``self.state`` is left as-is
+        (production callers create a fresh ``Orchestrator`` per run).
+
+        Failure of any phase aborts the run; partial-success phases
+        continue. Same rc=0/1/2 dispatch contract as :meth:`run_all`.
+
+        The phases here don't need the orchestrator's shared SSHClient
+        — the wrapped helpers each manage their own subprocess / ssh
+        invocations independently. That's why this method doesn't
+        open an ExitStack-managed ssh context (in contrast to
+        :meth:`run_all`).
+        """
+        self.results = []
+        # ssh arg is unused by every pre-bootstrap phase but kept for
+        # signature consistency. Pass a None placeholder cast for type-
+        # checker; phases that *would* use it get their own context
+        # internally via the wrapped helper.
+        from typing import cast as _cast
+
+        ssh_placeholder = _cast("SSHClient", None)
+        phases: list[Callable[[SSHClient], PhaseResult]] = [
+            self._phase_service_env,
+            self._phase_stack_sync,
+            self._phase_firewall_configure,
+            self._phase_compose_up,
+            self._phase_infisical_provision,
+        ]
+        for phase in phases:
+            result = phase(ssh_placeholder)
+            self.results.append(result)
+            if result.status == "failed":
+                break
+        return OrchestratorResult(phases=tuple(self.results), state=self.state)
 
 
 # Module-level helper so the CLI handler can shell out cleanly.

--- a/src/nexus_deploy/orchestrator.py
+++ b/src/nexus_deploy/orchestrator.py
@@ -957,9 +957,12 @@ class Orchestrator:
         :func:`compose_runner.run_compose_up`. Replaces deploy.sh's
         ``compose up --enabled`` invocation (Modul 2.2a, #505).
 
-        ``run_compose_up`` invokes ``ssh nexus 'bash -s'`` via
-        subprocess internally — the orchestrator's shared SSHClient
-        is not consumed here, so the signature drops the ``ssh`` arg.
+        ``run_compose_up`` invokes ``ssh <host> 'bash -s'`` via
+        subprocess internally, where ``<host>`` is ``self.ssh_host``
+        (default ``"nexus"``, override via ``SSH_HOST_ALIAS``). The
+        orchestrator's shared SSHClient is not consumed here, so the
+        signature drops the ``ssh`` arg. Docstring updated in PR #532
+        R7 #1 — was 'ssh nexus' before R2 #2 plumbed host through.
         """
         try:
             result = _compose_runner.run_compose_up(
@@ -994,14 +997,23 @@ class Orchestrator:
         """Bootstrap the Infisical admin + workspace. Replaces deploy.sh's
         ``infisical provision-admin`` invocation (Modul 3.4f, #530).
 
-        Populates ``self.state.infisical_token`` and ``self.state.project_id``
-        on success — those values are then consumed by the existing
-        ``_phase_infisical_bootstrap`` phase. Read the constructor's
-        ``project_id`` / ``infisical_token`` fields as fallback (so a
-        post-bootstrap-only test can still bypass this phase).
+        On success, populates BOTH the state mirrors
+        (``self.state.infisical_token`` + ``self.state.project_id``,
+        for the CLI's stdout emission) AND the orchestrator's own
+        fields (``self.infisical_token`` + ``self.project_id``, which
+        the post-bootstrap phases gate on). On a partial/failed
+        outcome, the fields stay None — ``run_pre_bootstrap`` zeros
+        BOTH surfaces at start so a re-run can't carry stale creds
+        (PR #532 R1 #4 + R2 #3). Note: there is NO read-fallback to
+        constructor-provided creds — callers wanting to bypass this
+        phase should use ``run_all`` directly with ``infisical_token``
+        + ``project_id`` set in the constructor (docstring corrected
+        in PR #532 R7 #2; previously claimed a fallback that didn't
+        exist).
 
         ``provision_admin`` manages its own ssh.run_script call —
         no shared SSHClient context, so the signature drops ``ssh``.
+        ``host=self.ssh_host`` is passed through (PR #532 R2 #2).
         """
         admin_email = self.bootstrap_env.admin_email or ""
         admin_password = self.admin_password_infisical or ""

--- a/src/nexus_deploy/orchestrator.py
+++ b/src/nexus_deploy/orchestrator.py
@@ -742,12 +742,15 @@ class Orchestrator:
             )
 
         # Optionally append the Gitea workspace block. Mirrors the CLI
-        # handler's `workspace_coords_complete` check exactly — ALL six
-        # coords (repo_url, username, password, author_name, author_email,
-        # repo_name) must be non-empty, otherwise we'd write a
-        # broken Gitea block (empty PASSWORD/AUTHOR fields) that's
-        # harder to diagnose than a missing block. Caught in PR #532
-        # R1 #3.
+        # handler's `workspace_coords_complete` check exactly — the 5
+        # input coords (repo_owner, repo_name, gitea_user_username,
+        # gitea_user_password, gitea_user_email) must all be non-empty.
+        # The remaining GiteaWorkspaceConfig fields (gitea_repo_url,
+        # git_author_name) are derived from these inputs, so they don't
+        # need a separate guard. Otherwise we'd write a broken Gitea
+        # block (empty PASSWORD/AUTHOR fields) that's harder to diagnose
+        # than a missing block. Caught in PR #532 R1 #3, comment
+        # corrected in R4 #2.
         gitea_appended_count = 0
         gitea_user_email_value = self.gitea_user_email or self.bootstrap_env.gitea_user_email
         # Single source of truth: self.gitea_repo_owner (required

--- a/src/nexus_deploy/orchestrator.py
+++ b/src/nexus_deploy/orchestrator.py
@@ -1056,8 +1056,11 @@ class Orchestrator:
         )
 
     def run_pre_bootstrap(self) -> OrchestratorResult:
-        """Run the pre-bootstrap pipeline: service-env → stack-sync →
-        firewall-configure → compose-up → infisical-provision.
+        """Run the pre-bootstrap pipeline: service-env →
+        firewall-configure → stack-sync → compose-up →
+        infisical-provision. (Order corrected in PR #532 R5 #1 so
+        firewall overrides are part of what stack-sync rsyncs to the
+        server.)
 
         Resets ``self.results`` AND the credentials on BOTH
         ``self.state`` (``infisical_token`` + ``project_id``) and the

--- a/src/nexus_deploy/orchestrator.py
+++ b/src/nexus_deploy/orchestrator.py
@@ -687,17 +687,17 @@ class Orchestrator:
     #    helpers in this PR).
     # ---------------------------------------------------------------------
 
-    def _phase_service_env(self, ssh: SSHClient) -> PhaseResult:
+    def _phase_service_env(self) -> PhaseResult:
         """Render per-service ``stacks/<svc>/.env`` files locally + (when
         Gitea is enabled) append the Gitea workspace block to the
         Gitea-integrated stacks. Replaces deploy.sh's
         ``service-env --enabled`` invocation (Modul 3.4c, #527).
 
-        Local-only: no SSH calls. The ``ssh`` parameter is present for
-        signature consistency with the run_pre_bootstrap loop; unused
-        here.
+        Local-only — no SSH context needed. Pre-bootstrap phases drop
+        the ``ssh`` arg from their signature (caught in PR #532 R1 #2:
+        passing a None-cast-as-SSHClient is a runtime-contract footgun
+        even if the current body uses ``del ssh``).
         """
-        del ssh  # unused — local-only phase
         try:
             result = _service_env.render_all_env_files(
                 self.config,
@@ -728,15 +728,24 @@ class Orchestrator:
             )
 
         # Optionally append the Gitea workspace block. Mirrors the CLI
-        # handler's logic: only when ALL the workspace coords are present
-        # AND gitea is enabled.
+        # handler's `workspace_coords_complete` check exactly — ALL six
+        # coords (repo_url, username, password, author_name, author_email,
+        # repo_name) must be non-empty, otherwise we'd write a
+        # broken Gitea block (empty PASSWORD/AUTHOR fields) that's
+        # harder to diagnose than a missing block. Caught in PR #532
+        # R1 #3.
         gitea_appended_count = 0
-        if "gitea" in self.enabled_services and all(
+        gitea_user_email_value = self.gitea_user_email or self.bootstrap_env.gitea_user_email
+        workspace_coords_complete = all(
             (
                 self.bootstrap_env.gitea_repo_owner,
                 self.repo_name,
+                self.gitea_user_username,
+                self.gitea_user_password,
+                gitea_user_email_value,
             ),
-        ):
+        )
+        if "gitea" in self.enabled_services and workspace_coords_complete:
             gitea_repo_url = (
                 f"http://gitea:3000/{self.bootstrap_env.gitea_repo_owner}/{self.repo_name}.git"
             )
@@ -746,7 +755,7 @@ class Orchestrator:
                     gitea_username=self.gitea_user_username or "",
                     gitea_password=self.gitea_user_password or "",
                     git_author_name=self.gitea_user_username or "",
-                    git_author_email=self.gitea_user_email or "",
+                    git_author_email=gitea_user_email_value or "",
                     repo_name=self.repo_name,
                     workspace_branch=self.workspace_branch,
                 )
@@ -790,16 +799,16 @@ class Orchestrator:
             ),
         )
 
-    def _phase_stack_sync(self, ssh: SSHClient) -> PhaseResult:
+    def _phase_stack_sync(self) -> PhaseResult:
         """Rsync each enabled stack to ``/opt/docker-server/stacks/<svc>/``
         and clean up disabled stack directories on the server. Replaces
         deploy.sh's ``stack-sync --enabled`` invocation (Modul 3.3, #523).
 
         Uses ``run_stack_sync`` which manages its own rsync subprocess
         + cleanup ssh.run_script invocation independently — the
-        orchestrator's shared SSHClient is not consumed here.
+        orchestrator's shared SSHClient is not consumed here, so the
+        signature drops the ``ssh`` arg.
         """
-        del ssh  # run_stack_sync manages its own subprocess invocations
         try:
             result = _stack_sync.run_stack_sync(
                 self.stacks_dir / "stacks",
@@ -847,7 +856,7 @@ class Orchestrator:
             detail=(f"rsync_synced={result.synced} cleanup_removed={cleanup_removed}"),
         )
 
-    def _phase_firewall_configure(self, ssh: SSHClient) -> PhaseResult:
+    def _phase_firewall_configure(self) -> PhaseResult:
         """Generate per-service ``docker-compose.firewall.yml`` overrides
         and (when RedPanda has firewall ports) the dual-listener override
         + substituted ``redpanda-firewall.yaml``. Replaces deploy.sh's
@@ -857,7 +866,6 @@ class Orchestrator:
         on the runner. The subsequent server-side scp + orphan-cleanup
         loop stays in deploy.sh for now (Phase 4b will migrate it).
         """
-        del ssh  # local-only phase
         try:
             gen, write = _firewall.configure(
                 firewall_json=self.firewall_json,
@@ -925,16 +933,15 @@ class Orchestrator:
             detail=(f"rendered={len(gen.compiled)} redpanda={'yes' if gen.redpanda else 'no'}"),
         )
 
-    def _phase_compose_up(self, ssh: SSHClient) -> PhaseResult:
+    def _phase_compose_up(self) -> PhaseResult:
         """Start containers in parallel via
         :func:`compose_runner.run_compose_up`. Replaces deploy.sh's
         ``compose up --enabled`` invocation (Modul 2.2a, #505).
 
         ``run_compose_up`` invokes ``ssh nexus 'bash -s'`` via
         subprocess internally — the orchestrator's shared SSHClient
-        is not consumed here.
+        is not consumed here, so the signature drops the ``ssh`` arg.
         """
-        del ssh  # run_compose_up manages its own ssh script invocation
         try:
             result = _compose_runner.run_compose_up(self.enabled_services)
         except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError) as exc:
@@ -961,7 +968,7 @@ class Orchestrator:
             detail=f"started={result.started}",
         )
 
-    def _phase_infisical_provision(self, ssh: SSHClient) -> PhaseResult:
+    def _phase_infisical_provision(self) -> PhaseResult:
         """Bootstrap the Infisical admin + workspace. Replaces deploy.sh's
         ``infisical provision-admin`` invocation (Modul 3.4f, #530).
 
@@ -970,8 +977,10 @@ class Orchestrator:
         ``_phase_infisical_bootstrap`` phase. Read the constructor's
         ``project_id`` / ``infisical_token`` fields as fallback (so a
         post-bootstrap-only test can still bypass this phase).
+
+        ``provision_admin`` manages its own ssh.run_script call —
+        no shared SSHClient context, so the signature drops ``ssh``.
         """
-        del ssh  # provision_admin manages its own ssh.run_script call
         admin_email = self.bootstrap_env.admin_email or ""
         admin_password = self.admin_password_infisical or ""
         if not admin_email or not admin_password:
@@ -1027,9 +1036,13 @@ class Orchestrator:
         """Run the pre-bootstrap pipeline: service-env → stack-sync →
         firewall-configure → compose-up → infisical-provision.
 
-        Resets ``self.results`` so re-invoking the same instance does
-        not duplicate prior phase outputs. ``self.state`` is left as-is
-        (production callers create a fresh ``Orchestrator`` per run).
+        Resets ``self.results`` AND the credentials slice of
+        ``self.state`` (``infisical_token`` + ``project_id``) so a
+        re-invocation on the same instance can't leak stale credentials
+        from a prior run into the current rc=1 stdout emission. Caught
+        in PR #532 R1 #4. Other state fields stay (gitea_token /
+        woodpecker_* / fork_*) since they're populated by post-bootstrap
+        phases and a re-run would naturally re-set them.
 
         Failure of any phase aborts the run; partial-success phases
         continue. Same rc=0/1/2 dispatch contract as :meth:`run_all`.
@@ -1038,17 +1051,16 @@ class Orchestrator:
         — the wrapped helpers each manage their own subprocess / ssh
         invocations independently. That's why this method doesn't
         open an ExitStack-managed ssh context (in contrast to
-        :meth:`run_all`).
+        :meth:`run_all`), and why pre-bootstrap phases drop the ``ssh``
+        arg from their signature (per PR #532 R1 #2 — passing a
+        None-cast-as-SSHClient is a runtime-contract footgun).
         """
         self.results = []
-        # ssh arg is unused by every pre-bootstrap phase but kept for
-        # signature consistency. Pass a None placeholder cast for type-
-        # checker; phases that *would* use it get their own context
-        # internally via the wrapped helper.
-        from typing import cast as _cast
-
-        ssh_placeholder = _cast("SSHClient", None)
-        phases: list[Callable[[SSHClient], PhaseResult]] = [
+        # Reset credentials so a re-run can't carry over stale token/
+        # project_id from a previous invocation that produced rc=1.
+        self.state.infisical_token = None
+        self.state.project_id = None
+        phases: list[Callable[[], PhaseResult]] = [
             self._phase_service_env,
             self._phase_stack_sync,
             self._phase_firewall_configure,
@@ -1056,7 +1068,7 @@ class Orchestrator:
             self._phase_infisical_provision,
         ]
         for phase in phases:
-            result = phase(ssh_placeholder)
+            result = phase()
             self.results.append(result)
             if result.status == "failed":
                 break

--- a/src/nexus_deploy/orchestrator.py
+++ b/src/nexus_deploy/orchestrator.py
@@ -750,9 +750,13 @@ class Orchestrator:
         # R1 #3.
         gitea_appended_count = 0
         gitea_user_email_value = self.gitea_user_email or self.bootstrap_env.gitea_user_email
+        # Single source of truth: self.gitea_repo_owner (required
+        # constructor field). The bootstrap_env mirror exists for the
+        # in-script seeder/secret-sync path but should NOT diverge from
+        # the orchestrator's own field. Caught in PR #532 R3 #1.
         workspace_coords_complete = all(
             (
-                self.bootstrap_env.gitea_repo_owner,
+                self.gitea_repo_owner,
                 self.repo_name,
                 self.gitea_user_username,
                 self.gitea_user_password,
@@ -760,9 +764,7 @@ class Orchestrator:
             ),
         )
         if "gitea" in self.enabled_services and workspace_coords_complete:
-            gitea_repo_url = (
-                f"http://gitea:3000/{self.bootstrap_env.gitea_repo_owner}/{self.repo_name}.git"
-            )
+            gitea_repo_url = f"http://gitea:3000/{self.gitea_repo_owner}/{self.repo_name}.git"
             try:
                 cfg = _service_env.GiteaWorkspaceConfig(
                     gitea_repo_url=gitea_repo_url,

--- a/src/nexus_deploy/orchestrator.py
+++ b/src/nexus_deploy/orchestrator.py
@@ -90,11 +90,14 @@ class OrchestratorState:
     # Phase 4a (#505): infisical_token + project_id are now POPULATED by
     # _phase_infisical_provision (running BEFORE _phase_infisical_bootstrap)
     # instead of being inherited as orchestrator inputs. Pre-bootstrap
-    # callers don't need to pass them in the constructor; the post-bootstrap
-    # phases read from state. The Orchestrator.infisical_token /
-    # .project_id constructor fields stay as fallbacks for callers that
-    # already have the credentials (e.g. testing the post-bootstrap path
-    # in isolation).
+    # callers don't need to pass them in the constructor.
+    #
+    # Note: post-bootstrap phases currently gate on the
+    # ``self.infisical_token`` / ``self.project_id`` orchestrator fields,
+    # not on these state mirrors. ``_phase_infisical_provision`` writes
+    # to BOTH (state + self.field) so a single full-pipeline run sees
+    # the values everywhere. State stays as the canonical record for
+    # the CLI's stdout emission. Caught in PR #532 R2 #5.
     infisical_token: str | None = None
     project_id: str | None = None
 
@@ -173,7 +176,14 @@ class Orchestrator:
     cf_client_id: str | None = None  # Cloudflare Access Service Token id
     cf_client_secret: str | None = None  # Cloudflare Access Service Token secret
     persistent_volume_id: str = "0"  # Hetzner Cloud volume id; "0" = no volume
-    stacks_dir: Path = field(default_factory=lambda: Path.cwd())
+    # Repository checkout root on the runner — phases derive
+    # ``project_root / "stacks"`` for per-service compose/.env paths.
+    # Renamed from ``stacks_dir`` in PR #532 R2 #1: deploy.sh defines
+    # ``STACKS_DIR=$PROJECT_ROOT/stacks`` (the actual stacks dir), so
+    # wiring that env var into a field of the same name and then
+    # appending ``/"stacks"`` produced a broken ``.../stacks/stacks/...``
+    # path. The CLI handler now reads ``PROJECT_ROOT`` instead.
+    project_root: Path = field(default_factory=lambda: Path.cwd())
     firewall_json: str = "{}"  # raw `tofu output -json firewall_rules` body
     domain: str = ""  # for firewall RedPanda rendering
     admin_password_infisical: str | None = None  # for infisical provision-admin
@@ -674,17 +684,21 @@ class Orchestrator:
     # The pre-bootstrap phases come in two clusters:
     #
     # 1. **Local-only** (don't need an SSHClient): service-env render,
-    #    firewall override generation. They're declared with an ``ssh``
-    #    parameter for signature consistency with the existing phases
-    #    (so the run_pre_bootstrap loop can call them uniformly), but
-    #    the parameter goes unused.
+    #    firewall override generation.
     #
     # 2. **Server-side** (use the wrapped helper's own ssh.run_script
     #    plumbing): stack-sync, compose up, infisical provision-admin.
     #    These don't need the orchestrator's shared SSHClient because
-    #    their helper functions invoke ``ssh nexus`` via subprocess
-    #    independently (legacy compatibility — we don't refactor those
-    #    helpers in this PR).
+    #    their helper functions invoke ``ssh <host>`` via subprocess
+    #    independently — they accept ``host=self.ssh_host`` so a
+    #    non-default ``SSH_HOST_ALIAS`` reaches every phase uniformly
+    #    (caught in PR #532 R2 #2).
+    #
+    # Both clusters' phase methods take no parameters (no shared
+    # SSHClient, no ssh arg) — the run_pre_bootstrap loop calls them as
+    # ``phase()``. The previous design passed a None-cast-as-SSHClient
+    # for signature consistency with the existing phases; that was a
+    # runtime-contract footgun and was removed in PR #532 R1 #2.
     # ---------------------------------------------------------------------
 
     def _phase_service_env(self) -> PhaseResult:
@@ -703,7 +717,7 @@ class Orchestrator:
                 self.config,
                 self.bootstrap_env,
                 self.enabled_services,
-                stacks_dir=self.stacks_dir / "stacks",
+                stacks_dir=self.project_root / "stacks",
             )
         except _service_env.ServiceEnvError as exc:
             # Hard-fail conditions (e.g. SFTPGo with empty password) —
@@ -762,7 +776,7 @@ class Orchestrator:
                 appended = _service_env.append_gitea_workspace_block(
                     cfg,
                     self.enabled_services,
-                    stacks_dir=self.stacks_dir / "stacks",
+                    stacks_dir=self.project_root / "stacks",
                 )
                 gitea_appended_count = len(appended)
             except OSError as exc:
@@ -811,7 +825,7 @@ class Orchestrator:
         """
         try:
             result = _stack_sync.run_stack_sync(
-                self.stacks_dir / "stacks",
+                self.project_root / "stacks",
                 self.enabled_services,
                 host=self.ssh_host,
             )
@@ -869,7 +883,7 @@ class Orchestrator:
         try:
             gen, write = _firewall.configure(
                 firewall_json=self.firewall_json,
-                stacks_dir=self.stacks_dir,
+                stacks_dir=self.project_root,
                 domain=self.domain,
             )
         except (ValueError, FileNotFoundError) as exc:
@@ -943,7 +957,10 @@ class Orchestrator:
         is not consumed here, so the signature drops the ``ssh`` arg.
         """
         try:
-            result = _compose_runner.run_compose_up(self.enabled_services)
+            result = _compose_runner.run_compose_up(
+                self.enabled_services,
+                host=self.ssh_host,
+            )
         except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError) as exc:
             return PhaseResult(
                 name="compose-up",
@@ -993,6 +1010,7 @@ class Orchestrator:
             result = _infisical.provision_admin(
                 admin_email=admin_email,
                 admin_password=admin_password,
+                host=self.ssh_host,
             )
         except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError) as exc:
             return PhaseResult(
@@ -1036,13 +1054,17 @@ class Orchestrator:
         """Run the pre-bootstrap pipeline: service-env → stack-sync →
         firewall-configure → compose-up → infisical-provision.
 
-        Resets ``self.results`` AND the credentials slice of
-        ``self.state`` (``infisical_token`` + ``project_id``) so a
-        re-invocation on the same instance can't leak stale credentials
-        from a prior run into the current rc=1 stdout emission. Caught
-        in PR #532 R1 #4. Other state fields stay (gitea_token /
-        woodpecker_* / fork_*) since they're populated by post-bootstrap
-        phases and a re-run would naturally re-set them.
+        Resets ``self.results`` AND the credentials on BOTH
+        ``self.state`` (``infisical_token`` + ``project_id``) and the
+        orchestrator's own ``self.infisical_token`` / ``self.project_id``
+        fields, so a re-invocation on the same instance can't leak
+        stale credentials from a prior run — neither into the current
+        rc=1 stdout emission (state) nor into a downstream call to
+        :meth:`run_all` whose post-bootstrap phases gate on the fields.
+        Caught in PR #532 R1 #4 (state) and R2 #3 (fields). Other state
+        slots (gitea_token / woodpecker_* / fork_*) stay because they're
+        populated by post-bootstrap phases and a re-run would naturally
+        re-set them.
 
         Failure of any phase aborts the run; partial-success phases
         continue. Same rc=0/1/2 dispatch contract as :meth:`run_all`.
@@ -1056,10 +1078,16 @@ class Orchestrator:
         None-cast-as-SSHClient is a runtime-contract footgun).
         """
         self.results = []
-        # Reset credentials so a re-run can't carry over stale token/
-        # project_id from a previous invocation that produced rc=1.
+        # Reset credentials on BOTH state mirrors and the orchestrator's
+        # own fields so a re-run can't carry over stale token / project_id
+        # from a previous invocation that produced rc=1. State guards the
+        # rc=1 stdout emission; the self.fields guard the post-bootstrap
+        # phases (infisical-bootstrap, secret-sync) when the same instance
+        # is later passed to run_all. Caught in PR #532 R2 #3.
         self.state.infisical_token = None
         self.state.project_id = None
+        self.infisical_token = None
+        self.project_id = None
         phases: list[Callable[[], PhaseResult]] = [
             self._phase_service_env,
             self._phase_stack_sync,

--- a/src/nexus_deploy/stack_sync.py
+++ b/src/nexus_deploy/stack_sync.py
@@ -370,6 +370,7 @@ def rsync_enabled_stacks(
 def cleanup_disabled_stacks(
     enabled: list[str],
     *,
+    host: str = "nexus",
     script_runner: ScriptRunner | None = None,
     remote_stacks_dir: str = _REMOTE_STACKS_DIR,
 ) -> CleanupResult | None:
@@ -382,11 +383,16 @@ def cleanup_disabled_stacks(
     enabled list is itself a configuration error, not a hint to
     preserve folders that match it).
 
+    ``host`` selects which ssh-config alias the cleanup script runs
+    against; defaults to ``"nexus"`` for back-compat. ``run_stack_sync``
+    passes its own ``host`` so rsync + cleanup target the same alias
+    (PR #532 R4 #1).
+
     Returns None on transport failure or unparseable RESULT line.
     """
     safe_enabled = [s for s in enabled if _is_safe_name(s)]
     script = render_cleanup_script(safe_enabled, stacks_dir=remote_stacks_dir)
-    runner = script_runner or (lambda s: _remote.ssh_run_script(s))
+    runner = script_runner or (lambda s: _remote.ssh_run_script(s, host=host))
     completed = runner(script)
 
     # Forward per-stack diagnostics ("Stopping foo...", "Removing
@@ -426,6 +432,7 @@ def run_stack_sync(
     )
     cleanup = cleanup_disabled_stacks(
         enabled,
+        host=host,
         script_runner=script_runner,
         remote_stacks_dir=remote_stacks_dir,
     )

--- a/src/nexus_deploy/stack_sync.py
+++ b/src/nexus_deploy/stack_sync.py
@@ -388,7 +388,17 @@ def cleanup_disabled_stacks(
     passes its own ``host`` so rsync + cleanup target the same alias
     (PR #532 R4 #1).
 
-    Returns None on transport failure or unparseable RESULT line.
+    Returns None only when the script produced no parseable RESULT
+    line (unparseable / missing). Transport-level failures
+    (``subprocess.CalledProcessError`` from a non-zero ssh exit,
+    ``subprocess.TimeoutExpired`` from a hung connection) propagate
+    to the caller — the default runner uses
+    :func:`_remote.ssh_run_script` with ``check=True``. The orchestrator
+    wraps the call in a try/except and converts those into a
+    ``status='failed'`` PhaseResult; direct callers should do the same.
+    Docstring corrected in PR #532 R6 #4 (was: "Returns None on
+    transport failure or unparseable RESULT line", which falsely
+    promised exception-to-None coercion).
     """
     safe_enabled = [s for s in enabled if _is_safe_name(s)]
     script = render_cleanup_script(safe_enabled, stacks_dir=remote_stacks_dir)

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -1568,3 +1568,542 @@ def test_phase_secret_sync_partial_when_no_usable_result(
     )
     result = orchestrator._phase_secret_sync(MagicMock(), "jupyter")
     assert result.status == "partial"
+
+
+# ---------------------------------------------------------------------------
+# Phase 4a (#505) — pre-bootstrap pipeline phases.
+# Each new phase is exercised with a happy path + at least one failure
+# / partial path to lock the PhaseResult contract.
+# ---------------------------------------------------------------------------
+
+
+def test_phase_service_env_happy_path(
+    orchestrator: Orchestrator,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Any,
+) -> None:
+    """All renders ok → status=ok with the rendered/skipped counts in detail."""
+    from nexus_deploy.service_env import ServiceEnvResult, ServiceRenderResult
+
+    fake_result = ServiceEnvResult(
+        services=(
+            ServiceRenderResult(service="postgres", status="rendered"),
+            ServiceRenderResult(service="kestra", status="rendered"),
+        ),
+    )
+    monkeypatch.setattr(
+        "nexus_deploy.orchestrator._service_env.render_all_env_files",
+        lambda *_a, **_kw: fake_result,
+    )
+    # Skip the gitea-block append branch by clearing the bootstrap env's
+    # repo_owner so the workspace_coords_complete check fails.
+    orchestrator.bootstrap_env = type(orchestrator.bootstrap_env)(
+        domain="example.com",
+        admin_email="admin@example.com",
+        gitea_repo_owner=None,
+    )
+    orchestrator.stacks_dir = tmp_path
+    result = orchestrator._phase_service_env(MagicMock())
+    assert result.status == "ok"
+    assert "rendered=2" in result.detail
+
+
+def test_phase_service_env_partial_when_failures(
+    orchestrator: Orchestrator,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Any,
+) -> None:
+    """Some renders failed but at least one succeeded → status=partial."""
+    from nexus_deploy.service_env import ServiceEnvResult, ServiceRenderResult
+
+    fake_result = ServiceEnvResult(
+        services=(
+            ServiceRenderResult(service="postgres", status="rendered"),
+            ServiceRenderResult(service="kestra", status="failed", detail="oops"),
+        ),
+    )
+    monkeypatch.setattr(
+        "nexus_deploy.orchestrator._service_env.render_all_env_files",
+        lambda *_a, **_kw: fake_result,
+    )
+    orchestrator.bootstrap_env = type(orchestrator.bootstrap_env)(
+        domain="example.com",
+        admin_email="admin@example.com",
+        gitea_repo_owner=None,
+    )
+    orchestrator.stacks_dir = tmp_path
+    result = orchestrator._phase_service_env(MagicMock())
+    assert result.status == "partial"
+    assert "rendered=1" in result.detail
+    assert "failed=1" in result.detail
+
+
+def test_phase_service_env_failed_on_service_env_error(
+    orchestrator: Orchestrator,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Any,
+) -> None:
+    """ServiceEnvError (e.g. SFTPGo with empty password) → status=failed."""
+    from nexus_deploy.service_env import ServiceEnvError
+
+    def _raises(*_a: Any, **_kw: Any) -> None:
+        raise ServiceEnvError("SFTPGo password is empty")
+
+    monkeypatch.setattr(
+        "nexus_deploy.orchestrator._service_env.render_all_env_files",
+        _raises,
+    )
+    orchestrator.stacks_dir = tmp_path
+    result = orchestrator._phase_service_env(MagicMock())
+    assert result.status == "failed"
+    assert "SFTPGo" in result.detail
+
+
+def test_phase_stack_sync_happy_path(
+    orchestrator: Orchestrator,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Any,
+) -> None:
+    """rsync ok + cleanup ok → status=ok."""
+    from nexus_deploy.stack_sync import CleanupResult, RsyncResult, StackSyncResult
+
+    fake = StackSyncResult(
+        rsync=(
+            RsyncResult(service="postgres", status="synced"),
+            RsyncResult(service="kestra", status="synced"),
+        ),
+        cleanup=CleanupResult(stopped=0, removed=3, failed=0),
+    )
+    monkeypatch.setattr(
+        "nexus_deploy.orchestrator._stack_sync.run_stack_sync",
+        lambda *_a, **_kw: fake,
+    )
+    orchestrator.stacks_dir = tmp_path
+    result = orchestrator._phase_stack_sync(MagicMock())
+    assert result.status == "ok"
+    assert "rsync_synced=2" in result.detail
+    assert "cleanup_removed=3" in result.detail
+
+
+def test_phase_stack_sync_failed_when_cleanup_unparseable(
+    orchestrator: Orchestrator,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Any,
+) -> None:
+    """cleanup is None (no parseable RESULT) → status=failed."""
+    from nexus_deploy.stack_sync import RsyncResult, StackSyncResult
+
+    fake = StackSyncResult(
+        rsync=(RsyncResult(service="postgres", status="synced"),),
+        cleanup=None,
+    )
+    monkeypatch.setattr(
+        "nexus_deploy.orchestrator._stack_sync.run_stack_sync",
+        lambda *_a, **_kw: fake,
+    )
+    orchestrator.stacks_dir = tmp_path
+    result = orchestrator._phase_stack_sync(MagicMock())
+    assert result.status == "failed"
+    assert "no parseable RESULT" in result.detail
+
+
+def test_phase_firewall_configure_zero_entry(
+    orchestrator: Orchestrator,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Any,
+) -> None:
+    """Empty firewall_rules → zero-entry mode → status=ok."""
+    from nexus_deploy.firewall import GenerateResult, WriteResult
+
+    monkeypatch.setattr(
+        "nexus_deploy.orchestrator._firewall.configure",
+        lambda *_a, **_kw: (
+            GenerateResult(compiled=(), redpanda=None, zero_entry=True),
+            WriteResult(written=()),
+        ),
+    )
+    orchestrator.firewall_json = "{}"
+    orchestrator.stacks_dir = tmp_path
+    result = orchestrator._phase_firewall_configure(MagicMock())
+    assert result.status == "ok"
+    assert "zero-entry" in result.detail
+
+
+def test_phase_firewall_configure_partial_when_skipped(
+    orchestrator: Orchestrator,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Any,
+) -> None:
+    """Skipped services → status=partial (per #531 R7 #4)."""
+    from nexus_deploy.firewall import (
+        CompiledOverride,
+        GenerateResult,
+        WriteResult,
+    )
+
+    fake_compiled = CompiledOverride(
+        service="postgres",
+        target_path=tmp_path / "postgres" / "docker-compose.firewall.yml",
+        yaml_content="services: {}\n",
+    )
+    monkeypatch.setattr(
+        "nexus_deploy.orchestrator._firewall.configure",
+        lambda *_a, **_kw: (
+            GenerateResult(
+                compiled=(fake_compiled,),
+                redpanda=None,
+                skipped=("kestra",),
+                zero_entry=False,
+            ),
+            WriteResult(written=(fake_compiled.target_path,)),
+        ),
+    )
+    orchestrator.firewall_json = '{"postgres-1": {"port": 5432}, "kestra-1": {"port": 8080}}'
+    orchestrator.stacks_dir = tmp_path
+    result = orchestrator._phase_firewall_configure(MagicMock())
+    assert result.status == "partial"
+    assert "skipped=1" in result.detail
+
+
+def test_phase_firewall_configure_failed_on_value_error(
+    orchestrator: Orchestrator,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Any,
+) -> None:
+    """ValueError (e.g. missing template token) → status=failed."""
+
+    def _raises(**_kw: Any) -> None:
+        raise ValueError("RedPanda template missing __REDPANDA_KAFKA_DOMAIN__")
+
+    monkeypatch.setattr(
+        "nexus_deploy.orchestrator._firewall.configure",
+        _raises,
+    )
+    orchestrator.stacks_dir = tmp_path
+    result = orchestrator._phase_firewall_configure(MagicMock())
+    assert result.status == "failed"
+    assert "REDPANDA_KAFKA_DOMAIN" in result.detail
+
+
+def test_phase_compose_up_happy_path(
+    orchestrator: Orchestrator,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """All containers started → status=ok."""
+    from nexus_deploy.compose_runner import ComposeUpResult
+
+    monkeypatch.setattr(
+        "nexus_deploy.orchestrator._compose_runner.run_compose_up",
+        lambda *_a, **_kw: ComposeUpResult(started=10, failed=0),
+    )
+    result = orchestrator._phase_compose_up(MagicMock())
+    assert result.status == "ok"
+    assert "started=10" in result.detail
+
+
+def test_phase_compose_up_partial_on_failures(
+    orchestrator: Orchestrator,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Some containers failed → status=partial."""
+    from nexus_deploy.compose_runner import ComposeUpResult
+
+    monkeypatch.setattr(
+        "nexus_deploy.orchestrator._compose_runner.run_compose_up",
+        lambda *_a, **_kw: ComposeUpResult(started=8, failed=2),
+    )
+    result = orchestrator._phase_compose_up(MagicMock())
+    assert result.status == "partial"
+    assert "started=8" in result.detail
+    assert "failed=2" in result.detail
+
+
+def test_phase_infisical_provision_happy_path(
+    orchestrator: Orchestrator,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Provision returns usable creds → state populated, status=ok."""
+    from nexus_deploy.infisical import ProvisionResult
+
+    monkeypatch.setattr(
+        "nexus_deploy.orchestrator._infisical.provision_admin",
+        lambda *_a, **_kw: ProvisionResult(
+            status="freshly-bootstrapped",
+            token="real-token",
+            project_id="proj-real",
+        ),
+    )
+    orchestrator.admin_password_infisical = "pw"
+    result = orchestrator._phase_infisical_provision(MagicMock())
+    assert result.status == "ok"
+    assert orchestrator.state.infisical_token == "real-token"
+    assert orchestrator.state.project_id == "proj-real"
+    assert orchestrator.infisical_token == "real-token"
+    assert orchestrator.project_id == "proj-real"
+
+
+def test_phase_infisical_provision_partial_on_dropped_creds(
+    orchestrator: Orchestrator,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """has_credentials=False → partial."""
+    from nexus_deploy.infisical import ProvisionResult
+
+    monkeypatch.setattr(
+        "nexus_deploy.orchestrator._infisical.provision_admin",
+        lambda *_a, **_kw: ProvisionResult(status="loaded-existing", token=None, project_id=None),
+    )
+    # Reset to None so the post-bootstrap fallback doesn't mask the
+    # partial result.
+    orchestrator.state.infisical_token = None
+    orchestrator.admin_password_infisical = "pw"
+    result = orchestrator._phase_infisical_provision(MagicMock())
+    assert result.status == "partial"
+    assert "no usable credentials" in result.detail
+    assert orchestrator.state.infisical_token is None
+
+
+def test_phase_infisical_provision_skipped_when_password_missing(
+    orchestrator: Orchestrator,
+) -> None:
+    """No admin password → status=skipped."""
+    orchestrator.admin_password_infisical = None
+    result = orchestrator._phase_infisical_provision(MagicMock())
+    assert result.status == "skipped"
+    assert "admin_password_infisical" in result.detail
+
+
+def test_run_pre_bootstrap_runs_phases_in_order(
+    orchestrator: Orchestrator,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """All 5 pre-bootstrap phases run in deterministic order."""
+    invocation_order: list[str] = []
+
+    def _make_phase(name: str) -> Any:
+        def _phase(self: Any, _ssh: Any) -> PhaseResult:
+            invocation_order.append(name)
+            return PhaseResult(name=name, status="ok")
+
+        return _phase
+
+    monkeypatch.setattr(Orchestrator, "_phase_service_env", _make_phase("service-env"))
+    monkeypatch.setattr(Orchestrator, "_phase_stack_sync", _make_phase("stack-sync"))
+    monkeypatch.setattr(
+        Orchestrator,
+        "_phase_firewall_configure",
+        _make_phase("firewall-configure"),
+    )
+    monkeypatch.setattr(Orchestrator, "_phase_compose_up", _make_phase("compose-up"))
+    monkeypatch.setattr(
+        Orchestrator,
+        "_phase_infisical_provision",
+        _make_phase("infisical-provision"),
+    )
+    result = orchestrator.run_pre_bootstrap()
+    assert invocation_order == [
+        "service-env",
+        "stack-sync",
+        "firewall-configure",
+        "compose-up",
+        "infisical-provision",
+    ]
+    assert [p.name for p in result.phases] == invocation_order
+    assert result.is_success
+
+
+def test_run_pre_bootstrap_aborts_on_failure(
+    orchestrator: Orchestrator,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A phase with status='failed' aborts the run; downstream phases skipped."""
+    invocation_order: list[str] = []
+
+    def _make_phase(name: str, status: Literal["ok", "failed"]) -> Any:
+        def _phase(self: Any, _ssh: Any) -> PhaseResult:
+            invocation_order.append(name)
+            return PhaseResult(name=name, status=status)
+
+        return _phase
+
+    monkeypatch.setattr(Orchestrator, "_phase_service_env", _make_phase("service-env", "ok"))
+    monkeypatch.setattr(
+        Orchestrator,
+        "_phase_stack_sync",
+        _make_phase("stack-sync", "failed"),
+    )
+    monkeypatch.setattr(
+        Orchestrator,
+        "_phase_firewall_configure",
+        _make_phase("firewall-configure", "ok"),
+    )
+    result = orchestrator.run_pre_bootstrap()
+    assert invocation_order == ["service-env", "stack-sync"]
+    assert result.has_hard_failure
+
+
+def test_run_pre_bootstrap_partial_continues_to_downstream(
+    orchestrator: Orchestrator,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Partial-success phase doesn't abort — all 5 phases still run."""
+    invocation_order: list[str] = []
+
+    def _make_phase(name: str, status: Literal["ok", "partial"]) -> Any:
+        def _phase(self: Any, _ssh: Any) -> PhaseResult:
+            invocation_order.append(name)
+            return PhaseResult(name=name, status=status)
+
+        return _phase
+
+    monkeypatch.setattr(Orchestrator, "_phase_service_env", _make_phase("service-env", "ok"))
+    monkeypatch.setattr(
+        Orchestrator,
+        "_phase_stack_sync",
+        _make_phase("stack-sync", "partial"),
+    )
+    monkeypatch.setattr(
+        Orchestrator,
+        "_phase_firewall_configure",
+        _make_phase("firewall-configure", "ok"),
+    )
+    monkeypatch.setattr(Orchestrator, "_phase_compose_up", _make_phase("compose-up", "ok"))
+    monkeypatch.setattr(
+        Orchestrator,
+        "_phase_infisical_provision",
+        _make_phase("infisical-provision", "ok"),
+    )
+    result = orchestrator.run_pre_bootstrap()
+    assert len(invocation_order) == 5
+    assert result.has_partial
+    assert not result.has_hard_failure
+
+
+# ---------------------------------------------------------------------------
+# Phase 4a — `nexus-deploy run-pre-bootstrap` CLI handler tests.
+# ---------------------------------------------------------------------------
+
+
+def _setup_pre_bootstrap_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Set the 6 required env vars for run-pre-bootstrap."""
+    for var, val in (
+        ("ADMIN_EMAIL", "admin@example.com"),
+        ("REPO_NAME", "nexus-example-com-gitea"),
+        ("GITEA_REPO_OWNER", "admin"),
+        ("ENABLED_SERVICES", "gitea,kestra"),
+        ("DOMAIN", "example.com"),
+        ("INFISICAL_PASS", "pw"),
+    ):
+        monkeypatch.setenv(var, val)
+    monkeypatch.setattr("sys.stdin.read", lambda: "{}")
+
+
+def test_cli_run_pre_bootstrap_unknown_arg_returns_2(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from nexus_deploy.__main__ import _run_pre_bootstrap
+
+    rc = _run_pre_bootstrap(["--unknown"])
+    assert rc == 2
+    assert "unknown args" in capsys.readouterr().err
+
+
+def test_cli_run_pre_bootstrap_missing_env_returns_2(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from nexus_deploy.__main__ import _run_pre_bootstrap
+
+    # ADMIN_EMAIL deliberately missing; set the rest.
+    for var, val in (
+        ("REPO_NAME", "r"),
+        ("GITEA_REPO_OWNER", "o"),
+        ("ENABLED_SERVICES", "gitea"),
+        ("DOMAIN", "example.com"),
+        ("INFISICAL_PASS", "pw"),
+    ):
+        monkeypatch.setenv(var, val)
+    monkeypatch.delenv("ADMIN_EMAIL", raising=False)
+    monkeypatch.setattr("sys.stdin.read", lambda: "{}")
+    rc = _run_pre_bootstrap([])
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "missing required env" in err
+    assert "ADMIN_EMAIL" in err
+
+
+def test_cli_run_pre_bootstrap_rc0_emits_credentials_to_stdout(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Happy path: orchestrator returns ok with populated creds → rc=0
+    AND INFISICAL_TOKEN + PROJECT_ID on stdout (eval-able)."""
+    from nexus_deploy.__main__ import _run_pre_bootstrap
+
+    _setup_pre_bootstrap_env(monkeypatch)
+    fake_result = OrchestratorResult(
+        phases=(PhaseResult("p1", "ok"),),
+        state=OrchestratorState(
+            infisical_token="real-token",
+            project_id="proj-real",
+        ),
+    )
+    with patch.object(Orchestrator, "run_pre_bootstrap", return_value=fake_result):
+        rc = _run_pre_bootstrap([])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "INFISICAL_TOKEN=real-token" in out
+    assert "PROJECT_ID=proj-real" in out
+
+
+def test_cli_run_pre_bootstrap_rc1_on_partial_emits_empty_creds(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Partial: e.g. infisical-provision dropped creds → rc=1 with
+    empty INFISICAL_TOKEN + PROJECT_ID (eval clears stale values)."""
+    from nexus_deploy.__main__ import _run_pre_bootstrap
+
+    _setup_pre_bootstrap_env(monkeypatch)
+    fake_result = OrchestratorResult(
+        phases=(PhaseResult("infisical-provision", "partial"),),
+        state=OrchestratorState(),  # empty token/project_id
+    )
+    with patch.object(Orchestrator, "run_pre_bootstrap", return_value=fake_result):
+        rc = _run_pre_bootstrap([])
+    assert rc == 1
+    out = capsys.readouterr().out
+    # shlex.quote of empty string → ''
+    assert "INFISICAL_TOKEN=''" in out
+    assert "PROJECT_ID=''" in out
+
+
+def test_cli_run_pre_bootstrap_rc2_on_hard_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from nexus_deploy.__main__ import _run_pre_bootstrap
+
+    _setup_pre_bootstrap_env(monkeypatch)
+    fake_result = OrchestratorResult(
+        phases=(PhaseResult("stack-sync", "failed"),),
+        state=OrchestratorState(),
+    )
+    with patch.object(Orchestrator, "run_pre_bootstrap", return_value=fake_result):
+        rc = _run_pre_bootstrap([])
+    assert rc == 2
+
+
+def test_cli_run_pre_bootstrap_transport_failure_returns_2(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """SSH/transport failure mid-run → rc=2 with stderr explanation."""
+    from nexus_deploy.__main__ import _run_pre_bootstrap
+
+    _setup_pre_bootstrap_env(monkeypatch)
+
+    def _raises(self: Any) -> Any:
+        import subprocess
+
+        raise subprocess.TimeoutExpired(cmd=["ssh"], timeout=30)
+
+    with patch.object(Orchestrator, "run_pre_bootstrap", _raises):
+        rc = _run_pre_bootstrap([])
+    assert rc == 2
+    assert "transport failure" in capsys.readouterr().err

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -1602,7 +1602,7 @@ def test_phase_service_env_happy_path(
         admin_email="admin@example.com",
         gitea_repo_owner=None,
     )
-    orchestrator.stacks_dir = tmp_path
+    orchestrator.project_root = tmp_path
     result = orchestrator._phase_service_env()
     assert result.status == "ok"
     assert "rendered=2" in result.detail
@@ -1631,7 +1631,7 @@ def test_phase_service_env_partial_when_failures(
         admin_email="admin@example.com",
         gitea_repo_owner=None,
     )
-    orchestrator.stacks_dir = tmp_path
+    orchestrator.project_root = tmp_path
     result = orchestrator._phase_service_env()
     assert result.status == "partial"
     assert "rendered=1" in result.detail
@@ -1653,7 +1653,7 @@ def test_phase_service_env_failed_on_service_env_error(
         "nexus_deploy.orchestrator._service_env.render_all_env_files",
         _raises,
     )
-    orchestrator.stacks_dir = tmp_path
+    orchestrator.project_root = tmp_path
     result = orchestrator._phase_service_env()
     assert result.status == "failed"
     assert "SFTPGo" in result.detail
@@ -1678,7 +1678,7 @@ def test_phase_stack_sync_happy_path(
         "nexus_deploy.orchestrator._stack_sync.run_stack_sync",
         lambda *_a, **_kw: fake,
     )
-    orchestrator.stacks_dir = tmp_path
+    orchestrator.project_root = tmp_path
     result = orchestrator._phase_stack_sync()
     assert result.status == "ok"
     assert "rsync_synced=2" in result.detail
@@ -1701,7 +1701,7 @@ def test_phase_stack_sync_failed_when_cleanup_unparseable(
         "nexus_deploy.orchestrator._stack_sync.run_stack_sync",
         lambda *_a, **_kw: fake,
     )
-    orchestrator.stacks_dir = tmp_path
+    orchestrator.project_root = tmp_path
     result = orchestrator._phase_stack_sync()
     assert result.status == "failed"
     assert "no parseable RESULT" in result.detail
@@ -1723,7 +1723,7 @@ def test_phase_firewall_configure_zero_entry(
         ),
     )
     orchestrator.firewall_json = "{}"
-    orchestrator.stacks_dir = tmp_path
+    orchestrator.project_root = tmp_path
     result = orchestrator._phase_firewall_configure()
     assert result.status == "ok"
     assert "zero-entry" in result.detail
@@ -1759,7 +1759,7 @@ def test_phase_firewall_configure_partial_when_skipped(
         ),
     )
     orchestrator.firewall_json = '{"postgres-1": {"port": 5432}, "kestra-1": {"port": 8080}}'
-    orchestrator.stacks_dir = tmp_path
+    orchestrator.project_root = tmp_path
     result = orchestrator._phase_firewall_configure()
     assert result.status == "partial"
     assert "skipped=1" in result.detail
@@ -1779,7 +1779,7 @@ def test_phase_firewall_configure_failed_on_value_error(
         "nexus_deploy.orchestrator._firewall.configure",
         _raises,
     )
-    orchestrator.stacks_dir = tmp_path
+    orchestrator.project_root = tmp_path
     result = orchestrator._phase_firewall_configure()
     assert result.status == "failed"
     assert "REDPANDA_KAFKA_DOMAIN" in result.detail
@@ -1989,9 +1989,15 @@ def test_run_pre_bootstrap_resets_stale_credentials(
     Reset happens at the top of run_pre_bootstrap before any phase
     fires."""
 
-    # Simulate a first run that left stale credentials on state.
+    # Simulate a first run that left stale credentials on BOTH state
+    # mirrors and the orchestrator's own fields. Both must be cleared
+    # (R1 #4 cleared state; R2 #3 also clears self.fields so a follow-on
+    # run_all() can't pick up stale creds via the post-bootstrap phase
+    # gating).
     orchestrator.state.infisical_token = "stale-token-from-prior-run"
     orchestrator.state.project_id = "stale-proj-from-prior-run"
+    orchestrator.infisical_token = "stale-token-from-prior-run"
+    orchestrator.project_id = "stale-proj-from-prior-run"
 
     # Mock all phases to ok except infisical-provision which produces
     # status='partial' WITHOUT populating state (simulating the bug
@@ -2010,10 +2016,12 @@ def test_run_pre_bootstrap_resets_stale_credentials(
 
     result = orchestrator.run_pre_bootstrap()
     assert result.has_partial
-    # Stale credentials MUST be cleared, even though the
-    # infisical-provision phase didn't populate fresh ones.
+    # Stale credentials MUST be cleared on BOTH surfaces, even though
+    # the infisical-provision phase didn't populate fresh ones.
     assert orchestrator.state.infisical_token is None
     assert orchestrator.state.project_id is None
+    assert orchestrator.infisical_token is None
+    assert orchestrator.project_id is None
 
 
 def test_phase_service_env_skips_gitea_block_on_incomplete_coords(
@@ -2059,7 +2067,7 @@ def test_phase_service_env_skips_gitea_block_on_incomplete_coords(
     )
     orchestrator.gitea_user_username = "ops"
     orchestrator.gitea_user_password = None  # missing — must skip the append
-    orchestrator.stacks_dir = tmp_path
+    orchestrator.project_root = tmp_path
 
     result = orchestrator._phase_service_env()
     assert result.status == "ok"

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -1901,10 +1901,14 @@ def test_run_pre_bootstrap_runs_phases_in_order(
         _make_phase("infisical-provision"),
     )
     result = orchestrator.run_pre_bootstrap()
+    # PR #532 R5 #1: firewall-configure must run BEFORE stack-sync so
+    # the per-stack docker-compose.firewall.yml overrides are part of
+    # what rsync pushes to the server, before compose-up brings the
+    # containers up.
     assert invocation_order == [
         "service-env",
-        "stack-sync",
         "firewall-configure",
+        "stack-sync",
         "compose-up",
         "infisical-provision",
     ]
@@ -1938,7 +1942,9 @@ def test_run_pre_bootstrap_aborts_on_failure(
         _make_phase("firewall-configure", "ok"),
     )
     result = orchestrator.run_pre_bootstrap()
-    assert invocation_order == ["service-env", "stack-sync"]
+    # service-env (ok) → firewall-configure (ok) → stack-sync (failed)
+    # → abort. compose-up + infisical-provision must NOT run.
+    assert invocation_order == ["service-env", "firewall-configure", "stack-sync"]
     assert result.has_hard_failure
 
 
@@ -2083,7 +2089,7 @@ def test_phase_service_env_skips_gitea_block_on_incomplete_coords(
 
 
 def _setup_pre_bootstrap_env(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Set the 6 required env vars for run-pre-bootstrap."""
+    """Set the 7 required env vars for run-pre-bootstrap."""
     for var, val in (
         ("ADMIN_EMAIL", "admin@example.com"),
         ("REPO_NAME", "nexus-example-com-gitea"),
@@ -2091,6 +2097,7 @@ def _setup_pre_bootstrap_env(monkeypatch: pytest.MonkeyPatch) -> None:
         ("ENABLED_SERVICES", "gitea,kestra"),
         ("DOMAIN", "example.com"),
         ("INFISICAL_PASS", "pw"),
+        ("FIREWALL_RULES_JSON", "{}"),  # explicit zero-entry mode
     ):
         monkeypatch.setenv(var, val)
     monkeypatch.setattr("sys.stdin.read", lambda: "{}")
@@ -2118,6 +2125,7 @@ def test_cli_run_pre_bootstrap_missing_env_returns_2(
         ("ENABLED_SERVICES", "gitea"),
         ("DOMAIN", "example.com"),
         ("INFISICAL_PASS", "pw"),
+        ("FIREWALL_RULES_JSON", "{}"),
     ):
         monkeypatch.setenv(var, val)
     monkeypatch.delenv("ADMIN_EMAIL", raising=False)
@@ -2127,6 +2135,35 @@ def test_cli_run_pre_bootstrap_missing_env_returns_2(
     err = capsys.readouterr().err
     assert "missing required env" in err
     assert "ADMIN_EMAIL" in err
+
+
+def test_cli_run_pre_bootstrap_missing_firewall_rules_returns_2(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """R-firewall-required (PR #532 R5 #2): FIREWALL_RULES_JSON is now
+    required and has NO default. A missing/empty value must abort with
+    rc=2 — falling back to "{}" silently triggers destructive cleanup
+    of existing override files via the firewall module's zero-entry
+    mode. Operators must pass "{}" explicitly to opt in."""
+    from nexus_deploy.__main__ import _run_pre_bootstrap
+
+    # All other required vars set; FIREWALL_RULES_JSON deliberately missing.
+    for var, val in (
+        ("ADMIN_EMAIL", "admin@example.com"),
+        ("REPO_NAME", "r"),
+        ("GITEA_REPO_OWNER", "o"),
+        ("ENABLED_SERVICES", "gitea"),
+        ("DOMAIN", "example.com"),
+        ("INFISICAL_PASS", "pw"),
+    ):
+        monkeypatch.setenv(var, val)
+    monkeypatch.delenv("FIREWALL_RULES_JSON", raising=False)
+    monkeypatch.setattr("sys.stdin.read", lambda: "{}")
+    rc = _run_pre_bootstrap([])
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "missing required env" in err
+    assert "FIREWALL_RULES_JSON" in err
 
 
 def test_cli_run_pre_bootstrap_rc0_emits_credentials_to_stdout(

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -2062,9 +2062,17 @@ def test_phase_service_env_skips_gitea_block_on_incomplete_coords(
         _spy_append,
     )
 
-    # Set repo_owner + repo_name (the original lax check would've
-    # passed) but leave gitea_user_password=None — the new full check
-    # must catch this.
+    # The orchestrator fixture already sets self.gitea_repo_owner +
+    # self.repo_name (the canonical sources of truth post-R3 #1). We
+    # override the user-cred coords here: username + email are present
+    # but gitea_user_password=None. Since the workspace_coords_complete
+    # check requires ALL 5 inputs (repo_owner, repo_name,
+    # gitea_user_username, gitea_user_password, gitea_user_email) to
+    # be non-empty, the missing password alone must skip the append —
+    # otherwise we'd write an .env block with PASSWORD="" which breaks
+    # the workspace git_clone at runtime. Comment updated in PR #532
+    # R7 #3 to reflect the post-R3 source-of-truth + the actual coord
+    # being missing.
     orchestrator.bootstrap_env = type(orchestrator.bootstrap_env)(
         domain="example.com",
         admin_email="admin@example.com",
@@ -2072,7 +2080,7 @@ def test_phase_service_env_skips_gitea_block_on_incomplete_coords(
         gitea_user_email="ops@example.com",
     )
     orchestrator.gitea_user_username = "ops"
-    orchestrator.gitea_user_password = None  # missing — must skip the append
+    orchestrator.gitea_user_password = None  # missing → workspace_coords_complete=False
     orchestrator.project_root = tmp_path
 
     result = orchestrator._phase_service_env()

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -1595,8 +1595,16 @@ def test_phase_service_env_happy_path(
         "nexus_deploy.orchestrator._service_env.render_all_env_files",
         lambda *_a, **_kw: fake_result,
     )
-    # Skip the gitea-block append branch by clearing the bootstrap env's
-    # repo_owner so the workspace_coords_complete check fails.
+    # Skip the gitea-block append branch. Post-R3 #1 the
+    # workspace_coords_complete check uses self.gitea_repo_owner (set
+    # to "admin" by the fixture), so clearing the bootstrap_env mirror
+    # alone wouldn't fail the guard. The actual skip happens because
+    # the orchestrator fixture leaves gitea_user_username, _password,
+    # _email at None — those three coords fail the all() check, which
+    # is what we want here (this test focuses on the happy path of
+    # render_all_env_files, not the gitea-append branch). The minimal
+    # bootstrap_env is kept for hygiene. Comment corrected in PR #532
+    # R8 #1.
     orchestrator.bootstrap_env = type(orchestrator.bootstrap_env)(
         domain="example.com",
         admin_email="admin@example.com",

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -1603,7 +1603,7 @@ def test_phase_service_env_happy_path(
         gitea_repo_owner=None,
     )
     orchestrator.stacks_dir = tmp_path
-    result = orchestrator._phase_service_env(MagicMock())
+    result = orchestrator._phase_service_env()
     assert result.status == "ok"
     assert "rendered=2" in result.detail
 
@@ -1632,7 +1632,7 @@ def test_phase_service_env_partial_when_failures(
         gitea_repo_owner=None,
     )
     orchestrator.stacks_dir = tmp_path
-    result = orchestrator._phase_service_env(MagicMock())
+    result = orchestrator._phase_service_env()
     assert result.status == "partial"
     assert "rendered=1" in result.detail
     assert "failed=1" in result.detail
@@ -1654,7 +1654,7 @@ def test_phase_service_env_failed_on_service_env_error(
         _raises,
     )
     orchestrator.stacks_dir = tmp_path
-    result = orchestrator._phase_service_env(MagicMock())
+    result = orchestrator._phase_service_env()
     assert result.status == "failed"
     assert "SFTPGo" in result.detail
 
@@ -1679,7 +1679,7 @@ def test_phase_stack_sync_happy_path(
         lambda *_a, **_kw: fake,
     )
     orchestrator.stacks_dir = tmp_path
-    result = orchestrator._phase_stack_sync(MagicMock())
+    result = orchestrator._phase_stack_sync()
     assert result.status == "ok"
     assert "rsync_synced=2" in result.detail
     assert "cleanup_removed=3" in result.detail
@@ -1702,7 +1702,7 @@ def test_phase_stack_sync_failed_when_cleanup_unparseable(
         lambda *_a, **_kw: fake,
     )
     orchestrator.stacks_dir = tmp_path
-    result = orchestrator._phase_stack_sync(MagicMock())
+    result = orchestrator._phase_stack_sync()
     assert result.status == "failed"
     assert "no parseable RESULT" in result.detail
 
@@ -1724,7 +1724,7 @@ def test_phase_firewall_configure_zero_entry(
     )
     orchestrator.firewall_json = "{}"
     orchestrator.stacks_dir = tmp_path
-    result = orchestrator._phase_firewall_configure(MagicMock())
+    result = orchestrator._phase_firewall_configure()
     assert result.status == "ok"
     assert "zero-entry" in result.detail
 
@@ -1760,7 +1760,7 @@ def test_phase_firewall_configure_partial_when_skipped(
     )
     orchestrator.firewall_json = '{"postgres-1": {"port": 5432}, "kestra-1": {"port": 8080}}'
     orchestrator.stacks_dir = tmp_path
-    result = orchestrator._phase_firewall_configure(MagicMock())
+    result = orchestrator._phase_firewall_configure()
     assert result.status == "partial"
     assert "skipped=1" in result.detail
 
@@ -1780,7 +1780,7 @@ def test_phase_firewall_configure_failed_on_value_error(
         _raises,
     )
     orchestrator.stacks_dir = tmp_path
-    result = orchestrator._phase_firewall_configure(MagicMock())
+    result = orchestrator._phase_firewall_configure()
     assert result.status == "failed"
     assert "REDPANDA_KAFKA_DOMAIN" in result.detail
 
@@ -1796,7 +1796,7 @@ def test_phase_compose_up_happy_path(
         "nexus_deploy.orchestrator._compose_runner.run_compose_up",
         lambda *_a, **_kw: ComposeUpResult(started=10, failed=0),
     )
-    result = orchestrator._phase_compose_up(MagicMock())
+    result = orchestrator._phase_compose_up()
     assert result.status == "ok"
     assert "started=10" in result.detail
 
@@ -1812,7 +1812,7 @@ def test_phase_compose_up_partial_on_failures(
         "nexus_deploy.orchestrator._compose_runner.run_compose_up",
         lambda *_a, **_kw: ComposeUpResult(started=8, failed=2),
     )
-    result = orchestrator._phase_compose_up(MagicMock())
+    result = orchestrator._phase_compose_up()
     assert result.status == "partial"
     assert "started=8" in result.detail
     assert "failed=2" in result.detail
@@ -1834,7 +1834,7 @@ def test_phase_infisical_provision_happy_path(
         ),
     )
     orchestrator.admin_password_infisical = "pw"
-    result = orchestrator._phase_infisical_provision(MagicMock())
+    result = orchestrator._phase_infisical_provision()
     assert result.status == "ok"
     assert orchestrator.state.infisical_token == "real-token"
     assert orchestrator.state.project_id == "proj-real"
@@ -1857,7 +1857,7 @@ def test_phase_infisical_provision_partial_on_dropped_creds(
     # partial result.
     orchestrator.state.infisical_token = None
     orchestrator.admin_password_infisical = "pw"
-    result = orchestrator._phase_infisical_provision(MagicMock())
+    result = orchestrator._phase_infisical_provision()
     assert result.status == "partial"
     assert "no usable credentials" in result.detail
     assert orchestrator.state.infisical_token is None
@@ -1868,7 +1868,7 @@ def test_phase_infisical_provision_skipped_when_password_missing(
 ) -> None:
     """No admin password → status=skipped."""
     orchestrator.admin_password_infisical = None
-    result = orchestrator._phase_infisical_provision(MagicMock())
+    result = orchestrator._phase_infisical_provision()
     assert result.status == "skipped"
     assert "admin_password_infisical" in result.detail
 
@@ -1881,7 +1881,7 @@ def test_run_pre_bootstrap_runs_phases_in_order(
     invocation_order: list[str] = []
 
     def _make_phase(name: str) -> Any:
-        def _phase(self: Any, _ssh: Any) -> PhaseResult:
+        def _phase(self: Any) -> PhaseResult:
             invocation_order.append(name)
             return PhaseResult(name=name, status="ok")
 
@@ -1920,7 +1920,7 @@ def test_run_pre_bootstrap_aborts_on_failure(
     invocation_order: list[str] = []
 
     def _make_phase(name: str, status: Literal["ok", "failed"]) -> Any:
-        def _phase(self: Any, _ssh: Any) -> PhaseResult:
+        def _phase(self: Any) -> PhaseResult:
             invocation_order.append(name)
             return PhaseResult(name=name, status=status)
 
@@ -1950,7 +1950,7 @@ def test_run_pre_bootstrap_partial_continues_to_downstream(
     invocation_order: list[str] = []
 
     def _make_phase(name: str, status: Literal["ok", "partial"]) -> Any:
-        def _phase(self: Any, _ssh: Any) -> PhaseResult:
+        def _phase(self: Any) -> PhaseResult:
             invocation_order.append(name)
             return PhaseResult(name=name, status=status)
 
@@ -1977,6 +1977,96 @@ def test_run_pre_bootstrap_partial_continues_to_downstream(
     assert len(invocation_order) == 5
     assert result.has_partial
     assert not result.has_hard_failure
+
+
+def test_run_pre_bootstrap_resets_stale_credentials(
+    orchestrator: Orchestrator,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """R-state-reset (PR #532 R1 #4): re-running on the same instance
+    after a previous run that produced partial credentials must NOT
+    leak the stale token/project_id into the second run's stdout.
+    Reset happens at the top of run_pre_bootstrap before any phase
+    fires."""
+
+    # Simulate a first run that left stale credentials on state.
+    orchestrator.state.infisical_token = "stale-token-from-prior-run"
+    orchestrator.state.project_id = "stale-proj-from-prior-run"
+
+    # Mock all phases to ok except infisical-provision which produces
+    # status='partial' WITHOUT populating state (simulating the bug
+    # condition: dropped credentials).
+    def _ok_phase(_self: Any) -> PhaseResult:
+        return PhaseResult(name="ok-phase", status="ok")
+
+    def _partial_no_creds(_self: Any) -> PhaseResult:
+        return PhaseResult(name="infisical-provision", status="partial", detail="dropped")
+
+    monkeypatch.setattr(Orchestrator, "_phase_service_env", _ok_phase)
+    monkeypatch.setattr(Orchestrator, "_phase_stack_sync", _ok_phase)
+    monkeypatch.setattr(Orchestrator, "_phase_firewall_configure", _ok_phase)
+    monkeypatch.setattr(Orchestrator, "_phase_compose_up", _ok_phase)
+    monkeypatch.setattr(Orchestrator, "_phase_infisical_provision", _partial_no_creds)
+
+    result = orchestrator.run_pre_bootstrap()
+    assert result.has_partial
+    # Stale credentials MUST be cleared, even though the
+    # infisical-provision phase didn't populate fresh ones.
+    assert orchestrator.state.infisical_token is None
+    assert orchestrator.state.project_id is None
+
+
+def test_phase_service_env_skips_gitea_block_on_incomplete_coords(
+    orchestrator: Orchestrator,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Any,
+) -> None:
+    """R-gitea-guard (PR #532 R1 #3): when ANY workspace coord is
+    empty (e.g. gitea_user_password=None), the Gitea workspace block
+    is NOT appended — refuses to write a broken block with empty
+    PASSWORD/AUTHOR fields. Mirrors the CLI handler's
+    workspace_coords_complete check."""
+    from nexus_deploy.service_env import ServiceEnvResult, ServiceRenderResult
+
+    fake_result = ServiceEnvResult(
+        services=(ServiceRenderResult(service="postgres", status="rendered"),),
+    )
+    monkeypatch.setattr(
+        "nexus_deploy.orchestrator._service_env.render_all_env_files",
+        lambda *_a, **_kw: fake_result,
+    )
+
+    append_called = False
+
+    def _spy_append(*_a: Any, **_kw: Any) -> tuple[str, ...]:
+        nonlocal append_called
+        append_called = True
+        return ()
+
+    monkeypatch.setattr(
+        "nexus_deploy.orchestrator._service_env.append_gitea_workspace_block",
+        _spy_append,
+    )
+
+    # Set repo_owner + repo_name (the original lax check would've
+    # passed) but leave gitea_user_password=None — the new full check
+    # must catch this.
+    orchestrator.bootstrap_env = type(orchestrator.bootstrap_env)(
+        domain="example.com",
+        admin_email="admin@example.com",
+        gitea_repo_owner="owner",
+        gitea_user_email="ops@example.com",
+    )
+    orchestrator.gitea_user_username = "ops"
+    orchestrator.gitea_user_password = None  # missing — must skip the append
+    orchestrator.stacks_dir = tmp_path
+
+    result = orchestrator._phase_service_env()
+    assert result.status == "ok"
+    assert "gitea_appended=0" in result.detail
+    assert append_called is False, (
+        "append_gitea_workspace_block must NOT be called when any coord is empty"
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Phase 4a (#505) of the deploy.sh → Python migration. Purely **additive** — extends `Orchestrator` with the 5 pre-bootstrap phases that today live as separate `python -m nexus_deploy <subcommand>` invocations in `scripts/deploy.sh`. New `run-pre-bootstrap` CLI subcommand exposes them as a single Python invocation.

`scripts/deploy.sh` is **unchanged** in this PR. Phase 4b will wire deploy.sh to call `run-pre-bootstrap` instead of the 5 per-CLI calls (saving ~80 LoC bash). Phase 4c removes deploy.sh entirely.

## Why this PR is small + low-risk

- Each new phase is a thin wrapper around an already-tested module function (`service_env.render_all_env_files`, `stack_sync.run_stack_sync`, `firewall.configure`, `compose_runner.run_compose_up`, `infisical.provision_admin`). No new domain logic.
- All wrapped functions already have their own test suites (~1000 existing tests). The new phases just convert their results into `PhaseResult` objects.
- No changes to `run_all()` or any existing phase — those keep their post-bootstrap-only semantics. Pure code addition.
- Tests cover per-phase happy-path + at least one failure/partial path + the orchestration `run_pre_bootstrap()` method + the new CLI handler.

## Changes

### `src/nexus_deploy/orchestrator.py` (+426 LoC)

5 new `_phase_*` methods + `run_pre_bootstrap()` method.

| Phase | Wraps | deploy.sh block replaced |
|---|---|---|
| `_phase_service_env` | `service_env.render_all_env_files` + `append_gitea_workspace_block` | `python -m nexus_deploy service-env --enabled ...` |
| `_phase_stack_sync` | `stack_sync.run_stack_sync` | `python -m nexus_deploy stack-sync --enabled ...` |
| `_phase_firewall_configure` | `firewall.configure` | `echo "$FIREWALL_JSON" \| python -m nexus_deploy firewall configure --domain ...` |
| `_phase_compose_up` | `compose_runner.run_compose_up` | `python -m nexus_deploy compose up --enabled ...` |
| `_phase_infisical_provision` | `infisical.provision_admin` | `python -m nexus_deploy infisical provision-admin` |

New `OrchestratorState` fields: `infisical_token`, `project_id` — populated by `_phase_infisical_provision`, consumed by the existing `_phase_infisical_bootstrap` (in-process state-handoff replaces the bash `eval`).

New `Orchestrator` constructor fields: `stacks_dir`, `firewall_json`, `domain`, `admin_password_infisical` (plus `cf_client_id` / `cf_client_secret` / `persistent_volume_id` reserved for Phase 4b's setup-cluster phases).

### `src/nexus_deploy/__main__.py` (+151 LoC)

New `_run_pre_bootstrap` CLI handler. Same 0/1/2 exit-code contract as the other CLIs. Reads `SECRETS_JSON` from stdin + 6 required env vars; emits `INFISICAL_TOKEN=...` + `PROJECT_ID=...` to stdout (eval-able by deploy.sh).

### `tests/unit/test_orchestrator.py` (+539 LoC, +22 tests)

- Per-phase tests: happy-path + failure/partial paths
- `run_pre_bootstrap` tests: deterministic order, fail-fast on `failed`, partial-continues, all-skipped
- CLI handler tests: rc=0/1/2 contract + missing-env + unknown-arg + transport-failure

## Test plan

- [x] `uv run pytest --no-header -q` — **1090 passed** (was 1068, +22)
- [x] `uv run mypy --strict src/nexus_deploy` — clean
- [x] `uv run ruff format --check . && uv run ruff check .` — clean
- [ ] Manual sanity-check: invoke `nexus-deploy run-pre-bootstrap` against a synthetic env — defer until Phase 4b wires it in
- [ ] End-to-end spin-up via `gh workflow run initial-setup.yaml --ref feat/phase-4a-orchestrator-pre-bootstrap` — defer until Phase 4b actually replaces the per-CLI calls in deploy.sh

## Out of scope

- Wiring deploy.sh to call `run-pre-bootstrap` (Phase 4b)
- The 5 ssh-context-needing phases (`setup-ssh`, `wait-ssh`, `ensure-jq`, `mount-volume`, `setup-wetty`) — Phase 4b
- The remaining bash-only blocks in deploy.sh (firewall scp loop, RedPanda config sync, Kestra HTTP probes, finalization banner) — Phase 4b/4c
- deploy.sh removal — Phase 4c
