### PR TITLE
fix(nexus_deploy): Hetzner capacity charset gate + tfvars whitespace strip (#537 R8 follow-up)

### DIFF
--- a/src/nexus_deploy/__main__.py
+++ b/src/nexus_deploy/__main__.py
@@ -2604,8 +2604,14 @@ def _read_single_pair_from_tfvars(text: str) -> _hetzner.ServerSpec | None:
     # PR #537 R2 #3: use the named ``value`` capture group instead of
     # ``match.group(0).split('"', 2)[1]`` — same semantics, but the
     # intent (extract the quoted value) is now explicit in the regex.
-    type_value = type_match.group("value")
-    loc_value = loc_match.group("value")
+    # PR #537 R8 #3: ``.strip()`` before ``.lower()``. A hand-edited
+    # tfvars like ``server_location = "hel1 "`` (with stray trailing
+    # whitespace inside the quotes) would otherwise produce a
+    # ServerSpec with location='hel1 ' that never matches the
+    # whitespace-stripped Hetzner location keys → confusing 'unknown
+    # location' diagnostic for what is actually a copy-paste artefact.
+    type_value = type_match.group("value").strip()
+    loc_value = loc_match.group("value").strip()
     if not type_value or not loc_value:
         return None
     return _hetzner.ServerSpec(

--- a/src/nexus_deploy/hetzner_capacity.py
+++ b/src/nexus_deploy/hetzner_capacity.py
@@ -142,11 +142,16 @@ def parse_preferences(value: str) -> tuple[ServerSpec, ...]:
         # and inject extra keys). Hetzner's own identifiers are
         # lowercase ``[a-z0-9-]+`` so the gate is conservative on
         # legitimate input.
+        # PR #538 R1 #1: error wording — input is already ``.lower()``'d
+        # before this charset check, so saying "expected lowercase" is
+        # misleading (the operator could pass ``Cx43:Fsn1`` and it would
+        # pass; a Unicode-letter token like ``cx43:fsñ1`` would lowercase
+        # cleanly but still fail charset). The real constraint is ASCII.
         for half_name, half_value in (("type", server_type), ("location", location)):
             if not _HETZNER_IDENT.fullmatch(half_value):
                 raise ValueError(
                     f"server_preferences {half_name} has invalid characters "
-                    f"(expected lowercase alphanumeric / dash): {token!r}",
+                    f"(expected ASCII letters, digits, or dash): {token!r}",
                 )
         key = (server_type, location)
         if key in seen:

--- a/src/nexus_deploy/hetzner_capacity.py
+++ b/src/nexus_deploy/hetzner_capacity.py
@@ -30,11 +30,23 @@ trip is small (a few KB each).
 from __future__ import annotations
 
 import json
+import re
 import urllib.error
 import urllib.request
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
+
+# Hetzner identifier shape — server-type names (``cx43``, ``ccx33``,
+# ``cax31``, ``cpx51``) and location names (``fsn1``, ``nbg1``,
+# ``hel1``, ``ash``, ``hil``) are all lowercase alphanumeric with
+# optional dashes (no real-world example uses one but the API spec
+# allows it). This regex is the safety gate at the parser boundary:
+# anything outside this character set could break the downstream
+# tfvars rewrite (a value containing ``"`` would close the HCL
+# string early and effectively inject additional keys; embedded
+# newlines would split the value across multiple HCL lines).
+_HETZNER_IDENT = re.compile(r"^[a-z0-9-]+$")
 
 _API_BASE = "https://api.hetzner.cloud/v1"
 _DEFAULT_TIMEOUT = 30.0
@@ -123,6 +135,19 @@ def parse_preferences(value: str) -> tuple[ServerSpec, ...]:
             raise ValueError(
                 f"server_preferences token has empty type or location: {token!r}",
             )
+        # PR #537 R8 #1: defensive charset gate. ``server_type`` and
+        # ``location`` are interpolated as ``"{value}"`` into HCL by
+        # the downstream tfvars rewrite; a value containing ``"`` or
+        # a newline would break the file (close the HCL string early
+        # and inject extra keys). Hetzner's own identifiers are
+        # lowercase ``[a-z0-9-]+`` so the gate is conservative on
+        # legitimate input.
+        for half_name, half_value in (("type", server_type), ("location", location)):
+            if not _HETZNER_IDENT.fullmatch(half_value):
+                raise ValueError(
+                    f"server_preferences {half_name} has invalid characters "
+                    f"(expected lowercase alphanumeric / dash): {token!r}",
+                )
         key = (server_type, location)
         if key in seen:
             raise ValueError(

--- a/tests/unit/test_hetzner_capacity.py
+++ b/tests/unit/test_hetzner_capacity.py
@@ -108,6 +108,34 @@ def test_parse_preferences_rejects_duplicate_pair() -> None:
         parse_preferences("cx43:fsn1, cx43:fsn1")
 
 
+def test_parse_preferences_rejects_quote_in_value() -> None:
+    """PR #537 R8 #1: a value containing ``"`` would break the
+    downstream tfvars rewrite (close the HCL string early). Reject
+    at the parser boundary before it can reach the rewriter."""
+    with pytest.raises(ValueError, match="invalid characters"):
+        parse_preferences('cx43:fsn1", server_type = "evil')
+
+
+def test_parse_preferences_rejects_newline_in_value() -> None:
+    """Embedded newline would split the HCL value across multiple
+    lines on rewrite. Defensive — the env var pipeline shouldn't
+    emit newlines but a hand-edited config.tfvars could.
+    (Input keeps a single colon so the charset check fires; a
+    multi-colon input would short-circuit to the colon-count error
+    instead — see test_parse_preferences_rejects_token_with_multiple_colons.)"""
+    with pytest.raises(ValueError, match="invalid characters"):
+        parse_preferences("cx43:fsn1\nbreakout")
+
+
+def test_parse_preferences_accepts_dash_in_identifier() -> None:
+    """Hetzner's identifier shape is ``[a-z0-9-]+``; no current name
+    uses a dash but the API spec allows it. Don't over-constrain."""
+    # Synthetic — no real Hetzner type uses this shape, but the
+    # parser must not preemptively reject it.
+    result = parse_preferences("cx-future:fsn1")
+    assert result == (ServerSpec("cx-future", "fsn1"),)
+
+
 def test_parse_preferences_rejects_only_commas() -> None:
     """``,,,`` parses to all-empty tokens (skipped) → no specs."""
     with pytest.raises(ValueError, match="no valid entries"):

--- a/tests/unit/test_select_capacity_cli.py
+++ b/tests/unit/test_select_capacity_cli.py
@@ -175,6 +175,31 @@ def test_select_capacity_uses_server_preferences_from_tfvars(
     assert 'server_location    = "hel1"' in rewritten
 
 
+def test_select_capacity_strips_whitespace_in_legacy_pair(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """PR #537 R8 #3: a hand-edited config.tfvars with whitespace
+    INSIDE the quoted value (``server_location = "hel1 "``) used to
+    produce a ServerSpec with location='hel1 ' that never matched
+    the Hetzner availability keys → confusing 'unknown location'
+    error. Now ``_read_single_pair_from_tfvars`` strips before
+    lowercasing, so the lookup succeeds."""
+    path = tmp_path / "config.tfvars"
+    path.write_text(
+        'server_type = " cx43 "\nserver_location = "hel1 "\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HCLOUD_TOKEN", "t")
+    monkeypatch.setattr(
+        _hetzner,
+        "fetch_availability",
+        lambda _t, http_get=None: {"hel1": {"cx43"}},
+    )
+    rc = _select_capacity(["--tfvars", str(path)])
+    assert rc == 0
+
+
 def test_select_capacity_falls_back_to_legacy_single_pair(
     tfvars_with_legacy_pair: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
Follow-up to merged PR #537. Two R8 review-round findings landed on the feature branch *after* it was merged into main, so they didn't make it into the merge commit. This PR cherry-picks those two fixes onto main.

## Summary

1. **`parse_preferences` charset validation (real bug — defensive injection guard).** A `SERVER_PREFERENCES` value containing `"` or an embedded newline would have flowed through the parser unchanged and into the f-string-based `config.tfvars` rewrite, where it could close the HCL string early and inject extra keys. Added a `[a-z0-9-]+` charset gate at the parser boundary — Hetzner's own identifiers are lowercase alphanumeric (with optional dash), so the gate is conservative on legitimate input.
2. **`_read_single_pair_from_tfvars` whitespace strip (UX bug).** A hand-edited `config.tfvars` like `server_location = "hel1 "` (with stray whitespace inside the quotes) used to produce a `ServerSpec` with `location='hel1 '` that never matched the Hetzner availability map → confusing "unknown location" diagnostic for what is actually a copy-paste artefact. Added `.strip()` before `.lower()`.

## Tests

Four new unit tests pin both fixes — quote rejection, newline rejection, dash-allowed positively, whitespace-stripped legacy pair. 1308 total green, mypy --strict clean, ruff clean, codecov/patch should pass (parse_preferences was already at 100% line coverage; new branches add to that count).

## Test plan

- [ ] CI green (Lint / Typecheck / Test / CodeQL).
- [ ] No manual spin-up gate needed — both fixes are pure-Python pre-flight logic; no production behaviour change beyond rejecting invalid input that previously parsed silently.

## Refs

- Original PR: #537
- Original issue: #536
- R8 review comments on #537: 3199749668 (charset) + 3199749748 (whitespace) — both replied to in the cherry-picked commit's body.
