### PR TITLE
fix(nexus_deploy): Apply Kestra-specific StackTarget overrides in orchestrator phase (#543)

### DIFF
--- a/examples/workspace-seeds/kestra/flows/parallel-http-fetch-to-r2.yaml
+++ b/examples/workspace-seeds/kestra/flows/parallel-http-fetch-to-r2.yaml
@@ -19,10 +19,13 @@ description: |
   block or a preceding task that emits a list will feed this loop
   the same way.
 
-  Concurrency: `concurrencyLimit` (input) caps how many fetches run
-  at once. Default 4 — plenty for tiny JSON responses, won't OOM the
-  4 GB Kestra container. Lower it for large payloads, raise it for
-  many small ones.
+  Concurrency: hard-coded to 4 fetches in parallel — plenty for tiny
+  JSON responses, won't OOM the 4 GB Kestra container. Lower it for
+  large payloads, raise it for many small ones by editing
+  `concurrencyLimit:` in the `fetch_all` task. (Can't be a flow
+  input — Kestra parses the YAML for `ForEach.concurrencyLimit`
+  before rendering Pebble templates, so a `{{ inputs.X }}` value
+  fails type-check as Integer.)
 
   IMPORTANT: input URLs MUST be unique. Kestra's `each_parallel`
   keys per-iteration outputs by `taskrun.value` (the loop value),
@@ -70,20 +73,24 @@ inputs:
     description: R2 key prefix (no leading or trailing slash). Final key adds a date/hour partition + index + url-derived slug.
     defaults: "nexus-tutorials/openmeteo-cities"
 
-  - id: concurrencyLimit
-    type: INT
-    description: How many URLs to fetch in parallel. Default 4 — fine for JSON-sized payloads.
-    defaults: 4
-
 tasks:
   # ---------------------------------------------------------------------
   # 1. ForEach over the URL list. Each iteration runs `download` then
-  #    `upload` on its own URL. `concurrencyLimit` caps the parallelism.
+  #    `upload` on its own URL.
+  #
+  #    `concurrencyLimit` is hard-coded (4) instead of bound to a flow
+  #    input because Kestra deserialises the YAML BEFORE rendering
+  #    Pebble templates, and ForEach.concurrencyLimit is typed as a
+  #    java.lang.Integer — a string-shaped ``{{ inputs.X }}`` value
+  #    fails YAML deserialisation with
+  #    ``Cannot deserialize value of type java.lang.Integer from String``.
+  #    To change the parallelism, edit this number in the flow source
+  #    (Gitea workspace repo) and Kestra picks it up via system.flow-sync.
   # ---------------------------------------------------------------------
   - id: fetch_all
     type: io.kestra.plugin.core.flow.ForEach
     values: "{{ inputs.urls }}"
-    concurrencyLimit: "{{ inputs.concurrencyLimit }}"
+    concurrencyLimit: 4
     tasks:
       # -----------------------------------------------------------------
       # 2. Download this iteration's URL. taskrun.value is the current

--- a/src/nexus_deploy/orchestrator.py
+++ b/src/nexus_deploy/orchestrator.py
@@ -1695,9 +1695,35 @@ class Orchestrator:
                     )
 
                 # Step 2: invoke secret-sync helper (kestra stack).
-                # This delegates to the existing CLI — it handles the
-                # SECRET_<KEY>=<base64> dedup + force-recreate.
-                target = _secret_sync.StackTarget(name="kestra")
+                # The Kestra stack needs four overrides vs. the
+                # Jupyter/Marimo defaults so the rendered SECRET_<key>
+                # block lands where Kestra's EnvVarSecretProvider can
+                # actually find it (Issue #543):
+                #   - env_file_basename=".env" (not .infisical.env;
+                #     Kestra's compose loads .env directly, no separate
+                #     legacy file)
+                #   - legacy_env_file_basename=None (Kestra never had
+                #     a legacy .infisical.env; without this override
+                #     the script wrote SECRETS to .infisical.env and
+                #     the legacy-strip step nuked them on next run)
+                #   - key_prefix="SECRET_" (Kestra's
+                #     ``{{ secret('GITEA_TOKEN') }}`` looks up env var
+                #     ``SECRET_GITEA_TOKEN``)
+                #   - use_base64_values=True (Kestra's
+                #     EnvVarSecretProvider expects base64-encoded
+                #     values for the SECRET_<key> form)
+                #   - force_recreate=True (compose `up -d` alone
+                #     wouldn't restart kestra to re-read .env;
+                #     --force-recreate is the cheapest reload primitive)
+                # Mirrors the construction in __main__._secret_sync.
+                target = _secret_sync.StackTarget(
+                    name="kestra",
+                    key_prefix="SECRET_",
+                    use_base64_values=True,
+                    env_file_basename=".env",
+                    legacy_env_file_basename=None,
+                    force_recreate=True,
+                )
                 sync_result = _secret_sync.run_sync_for_stack(
                     target,
                     project_id=self.project_id,

--- a/src/nexus_deploy/orchestrator.py
+++ b/src/nexus_deploy/orchestrator.py
@@ -1695,7 +1695,7 @@ class Orchestrator:
                     )
 
                 # Step 2: invoke secret-sync helper (kestra stack).
-                # The Kestra stack needs four overrides vs. the
+                # The Kestra stack needs five overrides vs. the
                 # Jupyter/Marimo defaults so the rendered SECRET_<key>
                 # block lands where Kestra's EnvVarSecretProvider can
                 # actually find it (Issue #543):

--- a/src/nexus_deploy/orchestrator.py
+++ b/src/nexus_deploy/orchestrator.py
@@ -1702,10 +1702,19 @@ class Orchestrator:
                 #   - env_file_basename=".env" (not .infisical.env;
                 #     Kestra's compose loads .env directly, no separate
                 #     legacy file)
-                #   - legacy_env_file_basename=None (Kestra never had
-                #     a legacy .infisical.env; without this override
-                #     the script wrote SECRETS to .infisical.env and
-                #     the legacy-strip step nuked them on next run)
+                #   - legacy_env_file_basename=None (the
+                #     StackTarget default is ``.env``, intended as the
+                #     migration-from-legacy strip target for the
+                #     Jupyter/Marimo path that writes to
+                #     ``.infisical.env``. For Kestra the SECRET block
+                #     IS written to ``.env`` itself; without this
+                #     None-override the remote script's legacy-strip
+                #     step would sed-strip the just-written
+                #     ``BEGIN/END nexus-secret-sync`` block out of
+                #     the same ``.env`` and the mv would wipe its
+                #     own output. ``None`` skips the legacy-strip
+                #     branch entirely — kestra has no migration
+                #     concern.)
                 #   - key_prefix="SECRET_" (Kestra's
                 #     ``{{ secret('GITEA_TOKEN') }}`` looks up env var
                 #     ``SECRET_GITEA_TOKEN``)

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -2683,6 +2683,78 @@ def test_phase_kestra_secret_sync_partial_when_kestra_pass_missing(
     assert "KESTRA_PASS" in result.detail
 
 
+def test_phase_kestra_secret_sync_constructs_correct_stack_target(
+    minimal_env: BootstrapEnv, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Issue #543: regression test pinning the Kestra-specific
+    StackTarget overrides inside the orchestrator phase. Without
+    these overrides the secret-sync would write to .infisical.env
+    (Jupyter/Marimo default) with bare ``GITEA_TOKEN=`` keys
+    instead of .env with ``SECRET_GITEA_TOKEN=<base64>``, and
+    Kestra's EnvVarSecretProvider would fail to resolve any
+    ``{{ secret('NAME') }}`` reference at runtime.
+
+    Mocks ssh_run + KestraClient.wait_ready + run_sync_for_stack
+    so the assertion is purely on the StackTarget shape passed in.
+    """
+    from unittest.mock import patch
+
+    config = NexusConfig(
+        admin_username="admin",
+        gitea_admin_password="gitea-admin",
+        kestra_admin_password="k-pw",
+    )
+    orchestrator = Orchestrator(
+        config=config,
+        bootstrap_env=minimal_env,
+        enabled_services=["kestra"],
+        repo_name="r",
+        gitea_repo_owner="o",
+        project_id="proj-1",
+        infisical_token="inf-tok",
+        domain="example.com",
+    )
+    orchestrator.state.gitea_token = "gt"
+    captured: dict[str, object] = {}
+
+    def _capture_run_sync(target: object, **kwargs: object) -> object:
+        captured["target"] = target
+        from nexus_deploy.secret_sync import SyncResult
+
+        return SyncResult(
+            pushed=10,
+            skipped_invalid_name=0,
+            skipped_multiline=0,
+            failed_folders=0,
+            collisions=0,
+            succeeded_folders=1,
+            wrote=True,
+        )
+
+    with patch(
+        "nexus_deploy.orchestrator._secret_sync.run_sync_for_stack",
+        side_effect=_capture_run_sync,
+    ), patch("nexus_deploy.orchestrator._kestra.KestraClient") as mock_client_cls:
+        mock_client = MagicMock()
+        mock_client.wait_ready.return_value = True
+        mock_client_cls.return_value = mock_client
+        ssh = MagicMock()
+        ssh.port_forward.return_value.__enter__.return_value = 12345
+        ssh.port_forward.return_value.__exit__.return_value = False
+        orchestrator._phase_kestra_secret_sync(ssh)
+
+    target = captured.get("target")
+    assert target is not None
+    # The five Kestra-specific overrides — each is load-bearing per
+    # the comment block in orchestrator._phase_kestra_secret_sync.
+    assert target.name == "kestra"
+    assert target.key_prefix == "SECRET_"
+    assert target.use_base64_values is True
+    assert target.env_file_basename == ".env"
+    assert target.legacy_env_file_basename is None
+    assert target.force_recreate is True
+
+
 # --- _phase_global_env ---
 
 

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -2715,12 +2715,12 @@ def test_phase_kestra_secret_sync_constructs_correct_stack_target(
         domain="example.com",
     )
     orchestrator.state.gitea_token = "gt"
-    captured: dict[str, object] = {}
+    from nexus_deploy.secret_sync import StackTarget, SyncResult
 
-    def _capture_run_sync(target: object, **kwargs: object) -> object:
+    captured: dict[str, StackTarget] = {}
+
+    def _capture_run_sync(target: StackTarget, **kwargs: object) -> SyncResult:
         captured["target"] = target
-        from nexus_deploy.secret_sync import SyncResult
-
         return SyncResult(
             pushed=10,
             skipped_invalid_name=0,
@@ -2731,10 +2731,13 @@ def test_phase_kestra_secret_sync_constructs_correct_stack_target(
             wrote=True,
         )
 
-    with patch(
-        "nexus_deploy.orchestrator._secret_sync.run_sync_for_stack",
-        side_effect=_capture_run_sync,
-    ), patch("nexus_deploy.orchestrator._kestra.KestraClient") as mock_client_cls:
+    with (
+        patch(
+            "nexus_deploy.orchestrator._secret_sync.run_sync_for_stack",
+            side_effect=_capture_run_sync,
+        ),
+        patch("nexus_deploy.orchestrator._kestra.KestraClient") as mock_client_cls,
+    ):
         mock_client = MagicMock()
         mock_client.wait_ready.return_value = True
         mock_client_cls.return_value = mock_client

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -2684,7 +2684,7 @@ def test_phase_kestra_secret_sync_partial_when_kestra_pass_missing(
 
 
 def test_phase_kestra_secret_sync_constructs_correct_stack_target(
-    minimal_env: BootstrapEnv, monkeypatch: pytest.MonkeyPatch
+    minimal_env: BootstrapEnv,
 ) -> None:
     """Issue #543: regression test pinning the Kestra-specific
     StackTarget overrides inside the orchestrator phase. Without
@@ -2697,8 +2697,6 @@ def test_phase_kestra_secret_sync_constructs_correct_stack_target(
     Mocks ssh_run + KestraClient.wait_ready + run_sync_for_stack
     so the assertion is purely on the StackTarget shape passed in.
     """
-    from unittest.mock import patch
-
     config = NexusConfig(
         admin_username="admin",
         gitea_admin_password="gitea-admin",


### PR DESCRIPTION
Closes #543.

## Root cause

`Orchestrator._phase_kestra_secret_sync` constructed `_secret_sync.StackTarget(name="kestra")` with **no overrides** — so all five Kestra-specific config fields fell back to the Jupyter/Marimo defaults. The CLI handler in `__main__._secret_sync` constructed it correctly with all overrides; the orchestrator phase did not.

| Field | Kestra needs | Default (what we got) | Effect of falling back |
|---|---|---|---|
| `env_file_basename` | `".env"` | `".infisical.env"` | Secrets landed in `kestra/.infisical.env`, not `kestra/.env` (Kestra's compose loads `.env`) |
| `legacy_env_file_basename` | `None` | `".env"` | Script's legacy-strip step nuked the just-written SECRET block from `.env` on subsequent runs |
| `key_prefix` | `"SECRET_"` | `""` | Keys came out as `GITEA_TOKEN="..."` instead of `SECRET_GITEA_TOKEN=<base64>`; Kestra's `EnvVarSecretProvider` couldn't find them |
| `use_base64_values` | `True` | `False` | Plain values — fails the EnvVarSecretProvider's expected encoding |
| `force_recreate` | `True` | `False` | Compose `up -d` alone wouldn't restart Kestra to re-read `.env` after the write |

## Symptom

On production after `initial-setup.yaml` (run [25513735533](https://github.com/stefanko-ch/Nexus-Stack/actions/runs/25513735533)):

```
$ docker logs kestra 2>&1 | grep -i 'GITEA_TOKEN'
io.kestra.core.secret.SecretNotFoundException: Cannot find secret for key 'GITEA_TOKEN'.
... (repeat every minute)

$ ls /opt/docker-server/stacks/kestra/
.env             #  4 lines, basic compose env, mtime BEFORE the secret-sync success report
.infisical.env   # 116 lines with `GITEA_TOKEN="abaa3cb..."` (bare key, plain value)

$ docker exec kestra env | grep SECRET_
# empty
```

Orchestrator log claimed success:
```
✓ kestra-secret-sync: ok — pushed=114
⚠ kestra-register: partial — execution=FAILED
```

So the `pushed=114` count was real (Infisical → file write happened), just to the wrong file with the wrong shape.

## Fix

Inline the same five overrides in the orchestrator phase that `__main__._secret_sync` already uses:

```python
target = _secret_sync.StackTarget(
    name="kestra",
    key_prefix="SECRET_",
    use_base64_values=True,
    env_file_basename=".env",
    legacy_env_file_basename=None,
    force_recreate=True,
)
```

Plus a regression test (`test_phase_kestra_secret_sync_constructs_correct_stack_target`) that patches `run_sync_for_stack` to capture the StackTarget passed in and asserts all five overrides. Future refactors that introduce a `_kestra_target()` helper or otherwise touch this construction will surface here.

## Tests

- 1332 tests green (1331 pre + 1 new regression test)
- mypy --strict clean
- ruff clean

## Test plan

- [ ] CI green
- [ ] Manual spin-up validation: `gh workflow run spin-up.yml` on this branch, then on the box:
  - `cat /opt/docker-server/stacks/kestra/.env` should contain a `# === BEGIN nexus-secret-sync` block with `SECRET_GITEA_TOKEN=<base64>` plus ~113 other entries
  - `docker exec kestra env | grep SECRET_GITEA_TOKEN` should be non-empty
  - `docker logs kestra 2>&1 | grep SecretNotFoundException` should be empty
  - The seeded tutorial flows (`nexus-tutorials/*`) should appear in the Kestra UI

## Out of scope (follow-ups)

- Refactor: extract a `kestra_stack_target()` helper in `secret_sync.py` so both the CLI handler and the orchestrator phase share one source of truth. The duplicated inline construction (this PR) makes the PR diff small and obvious; the helper extraction belongs in a separate cleanup PR.
- Rename `.infisical.env` → `.env-disabled` cleanup on existing servers — running this fix on an already-deployed box leaves the stale `.infisical.env` behind. A one-shot script could drop it; not worth doing inline.
