### PR TITLE
docs(tutorials): Add dlt tutorial series for Postgres ingestion

### DIFF
--- a/docs/tutorials/dlt/index.md
+++ b/docs/tutorials/dlt/index.md
@@ -1,0 +1,17 @@
+---
+title: "dlt"
+description: "Ingest data from public APIs into Postgres using dlt"
+order: 1
+---
+
+# dlt tutorials
+
+**dlt** (Data Load Tool) is an open-source Python library for loading data from public APIs, databases, and files into Postgres. You run it directly inside `code-server` — no extra container, no deployment step.
+
+## Tutorials
+
+1. **[Setup: environment and dependencies](./setup.md)** — Create a `uv` virtualenv, install `dlt[postgres]`, and wire up your Nexus Postgres credentials.
+2. **[Wikipedia pageviews pipeline](./wikipedia-pipeline.md)** — Your first pipeline: a `@dlt.resource` generator, `pipeline.run()`, and automatic schema inference.
+3. **[Incremental loading with state](./wikipedia-incremental.md)** — Add a cursor so each run only fetches months that aren't in Postgres yet.
+4. **[Two resources, one pipeline: Pegel Online](./pegel-online.md)** — Chunked pagination, mixed write strategies, and automatic nested-JSON unpacking into a child table.
+5. **[Write your own source](./your-own-source.md)** — Find a public API, point an LLM at it, and generate a working dlt pipeline in minutes.

--- a/docs/tutorials/dlt/pegel-online.md
+++ b/docs/tutorials/dlt/pegel-online.md
@@ -1,0 +1,313 @@
+---
+title: "Two resources, one pipeline: Pegel Online"
+description: "Load water-level measurements and station metadata from a public REST API into Postgres — two resources, two write strategies, chunked pagination, and automatic nested-JSON unpacking"
+order: 4
+---
+
+# Two resources, one pipeline: Pegel Online
+
+The Wikipedia tutorials used a single resource fetching from a single endpoint. Real-world pipelines usually need more: a primary time-series resource plus a metadata resource, pagination to handle large date ranges, and APIs that return nested JSON. This tutorial covers all of that with [Pegel Online](https://www.pegelonline.wsv.de/), a public German water-level monitoring service with a clean, no-auth REST API.
+
+## What you'll build
+
+Two resources in one pipeline:
+
+| Resource | Strategy | Why |
+|---|---|---|
+| `measurements` | `merge` — incremental | High-frequency time-series; only fetch what's new |
+| `stations` | `replace` — full snapshot | 700+ station records; stable reference data |
+
+dlt loads them into the same Postgres schema. The stations resource returns nested JSON that dlt automatically unpacks into a child table — no extra code.
+
+## Prerequisites
+
+- [Setup complete](./setup.md)
+- [Incremental loading tutorial](./wikipedia-incremental.md) completed — you understand `dlt.current.resource_state()` and `write_disposition="merge"`
+
+## The script
+
+Create `pegel_online_pipeline.py`:
+
+```python
+import dlt
+from dlt.sources.helpers import requests
+from datetime import datetime, timedelta, timezone
+from typing import Iterator
+
+STATION_ID = "aa9179c1-17ef-4c61-a48a-74193fa7bfdf"  # Lake Constance (Bodensee)
+TIMESERIES = "W"                                        # Wasserstand (water level, cm)
+INITIAL_START = "2024-01-01T00:00:00+00:00"
+CHUNK_DAYS = 30
+
+BASE_URL = "https://www.pegelonline.wsv.de/webservices/rest-api/v2"
+HEADERS = {"accept": "application/json"}
+
+_metrics = {"api_calls": 0, "records_received": 0, "start": "", "end": ""}
+
+
+@dlt.resource(
+    name="measurements",
+    primary_key=["station_id", "timestamp"],
+    write_disposition="merge",
+)
+def pegel_measurements(
+    end: str = None,
+    full_refresh: bool = False,
+) -> Iterator[dict]:
+    _metrics["api_calls"] = 0
+    _metrics["records_received"] = 0
+
+    if end is None:
+        end = datetime.now(timezone.utc).isoformat()
+
+    state = dlt.current.resource_state()
+    last_timestamp = state.get("last_timestamp", INITIAL_START)
+
+    start = INITIAL_START if full_refresh else last_timestamp
+    _metrics["start"] = start
+    _metrics["end"] = end
+
+    start_dt = datetime.fromisoformat(start).astimezone(timezone.utc)
+    end_dt = datetime.fromisoformat(end).astimezone(timezone.utc)
+    max_ts_dt = start_dt
+
+    chunk_start = start_dt
+    while chunk_start < end_dt:
+        chunk_end = min(chunk_start + timedelta(days=CHUNK_DAYS), end_dt)
+        url = (
+            f"{BASE_URL}/stations/{STATION_ID}/{TIMESERIES}/measurements.json"
+            f"?start={chunk_start.isoformat()}&end={chunk_end.isoformat()}"
+        )
+        response = requests.get(url, headers=HEADERS)
+        response.raise_for_status()
+        items = response.json()
+        _metrics["api_calls"] += 1
+        _metrics["records_received"] += len(items)
+
+        for item in items:
+            item_ts_dt = datetime.fromisoformat(item["timestamp"]).astimezone(timezone.utc)
+            if item_ts_dt > max_ts_dt:
+                max_ts_dt = item_ts_dt
+            yield {
+                "station_id": STATION_ID,
+                "timeseries": TIMESERIES,
+                "timestamp": item["timestamp"],
+                "value_cm": item["value"],
+            }
+
+        chunk_start = chunk_end
+
+    state["last_timestamp"] = max_ts_dt.isoformat()
+
+
+@dlt.resource(
+    name="stations",
+    primary_key="uuid",
+    write_disposition="replace",
+)
+def pegel_stations() -> Iterator[dict]:
+    url = (
+        f"{BASE_URL}/stations.json"
+        "?includeTimeseries=true"
+        "&includeCurrentMeasurement=false"
+        "&includeCharacteristicValues=false"
+    )
+    response = requests.get(url, headers=HEADERS)
+    response.raise_for_status()
+    yield from response.json()
+
+
+if __name__ == "__main__":
+    import sys
+    full_refresh = "--full-refresh" in sys.argv
+    run_stations = "--stations" in sys.argv
+
+    pipeline = dlt.pipeline(
+        pipeline_name="pegel_online_pipeline",
+        destination="postgres",
+        dataset_name="pegel_online",
+    )
+
+    if run_stations:
+        info = pipeline.run(pegel_stations())
+        status = info.load_packages[0].state if info.load_packages else "N/A"
+        print(f"\n{'='*42}")
+        print(f"  Pegel Online — Stations Refresh")
+        print(f"{'='*42}")
+        print(f"  Load status:      {status}")
+        print(f"{'='*42}\n")
+    else:
+        info = pipeline.run(pegel_measurements(full_refresh=full_refresh))
+
+        load_id = info.load_packages[0].load_id if info.load_packages else None
+        records_written = 0
+        if load_id:
+            with pipeline.sql_client() as client:
+                with client.execute_query(
+                    "SELECT count(*) FROM pegel_online.measurements WHERE _dlt_load_id = %s",
+                    load_id,
+                ) as cursor:
+                    records_written = cursor.fetchone()[0]
+
+        status = info.load_packages[0].state if info.load_packages else "N/A"
+        print(f"\n{'='*42}")
+        print(f"  Pegel Online — Run Summary")
+        print(f"{'='*42}")
+        print(f"  Date range:       {_metrics['start'][:10]} → {_metrics['end'][:10]}")
+        print(f"  API calls made:   {_metrics['api_calls']}")
+        print(f"  Records received: {_metrics['records_received']}")
+        print(f"  Records written:  {records_written}")
+        print(f"  Load status:      {status}")
+        print(f"{'='*42}\n")
+```
+
+## Run it
+
+**Step 1 — full refresh of measurements** (loads all 15-minute readings since January 2024):
+
+```bash
+python pegel_online_pipeline.py --full-refresh
+```
+
+```
+==========================================
+  Pegel Online — Run Summary
+==========================================
+  Date range:       2024-01-01 → 2026-05-10
+  API calls made:   29
+  Records received: 3047
+  Records written:  3046
+  Load status:      loaded
+==========================================
+```
+
+29 API calls for 29 chunks of 30 days each. The API has a per-request size limit — chunking is what makes a 16-month backfill possible without timeouts.
+
+**Step 2 — incremental run** (fetches only since the last measurement):
+
+```bash
+python pegel_online_pipeline.py
+```
+
+```
+==========================================
+  Pegel Online — Run Summary
+==========================================
+  Date range:       2026-05-10 → 2026-05-10
+  API calls made:   1
+  Records received: 2
+  Records written:  2
+  Load status:      loaded
+==========================================
+```
+
+One call, a handful of new 15-minute readings. Run it again a few minutes later and you'll see a new record arrive — the cursor advances with each run.
+
+**Step 3 — load station metadata** (one-off or periodic refresh):
+
+```bash
+python pegel_online_pipeline.py --stations
+```
+
+```
+==========================================
+  Pegel Online — Stations Refresh
+==========================================
+  Load status:      loaded
+==========================================
+```
+
+## Verify the tables
+
+Check what dlt created in the `pegel_online` schema:
+
+```bash
+PGPASSWORD="your_password" psql -h postgres -U nexus-postgres -d postgres -c "\dt pegel_online.*"
+```
+
+```
+    Schema    |         Name         | Type  |     Owner
+--------------+----------------------+-------+----------------
+ pegel_online | _dlt_loads           | table | nexus-postgres
+ pegel_online | _dlt_pipeline_state  | table | nexus-postgres
+ pegel_online | _dlt_version         | table | nexus-postgres
+ pegel_online | measurements         | table | nexus-postgres
+ pegel_online | stations             | table | nexus-postgres
+ pegel_online | stations__timeseries | table | nexus-postgres
+```
+
+Six tables — note `stations__timeseries`. The stations API response looks like this (abbreviated):
+
+```json
+{
+  "uuid": "aa9179c1-...",
+  "shortname": "BODMAN-LUDWIGSHAFEN",
+  "timeseries": [
+    { "shortname": "W", "unit": "cm" },
+    { "shortname": "WT", "unit": "°C" }
+  ]
+}
+```
+
+dlt sees the nested `timeseries` array and automatically creates a child table — `stations__timeseries` — with a `_dlt_parent_id` column that links back to the parent row in `stations`. No extra code, no flattening logic.
+
+Row counts:
+
+```bash
+PGPASSWORD="your_password" psql -h postgres -U nexus-postgres -d postgres \
+  -c "SELECT count(*) FROM pegel_online.stations;" \
+  -c "SELECT count(*) FROM pegel_online.stations__timeseries;"
+```
+
+```
+ count
+-------
+   785
+
+ count
+-------
+  1186
+```
+
+785 gauging stations across Germany, 1186 individual timeseries (each station can have water level, water temperature, flow rate, etc.).
+
+## What's new in this pipeline
+
+**Chunked pagination** — the measurements API returns at most a few hundred records per request and rejects very long date ranges. The while loop splits the full window into 30-day chunks and advances `chunk_start` until it reaches `end_dt`. A full refresh from January 2024 takes 29 requests instead of one huge one that would time out.
+
+**Timezone-aware cursor** — the API returns CET/CEST timestamps that shift between `+01:00` and `+02:00` depending on the season. If you stored those strings as-is and compared them lexicographically, the cursor would jump backwards when DST switches. Converting everything to UTC on the way in (`astimezone(timezone.utc)`) keeps the cursor monotonically increasing regardless of season.
+
+**Two resources, two strategies** — `pegel_measurements` uses `merge` because new readings arrive constantly and you only want to fetch what's new. `pegel_stations` uses `replace` because station metadata rarely changes and a full refresh is cheaper than tracking diffs for 785 stations. Both resources live in the same pipeline and write to the same schema.
+
+**Schema enrichment** — the measurements endpoint returns only `{"timestamp": "...", "value": 47.0}`. The station ID and timeseries type aren't in the response, so the resource adds them during the yield: `"station_id": STATION_ID, "timeseries": TIMESERIES`. This is the standard pattern when the API puts context in the URL rather than the response body.
+
+**Automatic nested JSON unpacking** — `pegel_stations` is six lines of code. It yields raw dicts straight from the API. dlt inspects the first record, finds the nested `timeseries` array, and creates `stations__timeseries` automatically. The double underscore (`__`) is dlt's naming convention for nested tables.
+
+## Explore in CloudBeaver
+
+Open `https://cloudbeaver.<your-domain>` and run a query that joins measurements to their station:
+
+```sql
+SELECT
+    s.shortname,
+    s.longname,
+    m.timestamp,
+    m.value_cm
+FROM pegel_online.measurements m
+JOIN pegel_online.stations s ON s.uuid = m.station_id
+ORDER BY m.timestamp DESC
+LIMIT 20;
+```
+
+Or browse all available timeseries for a station:
+
+```sql
+SELECT s.shortname, t.shortname AS timeseries, t.unit
+FROM pegel_online.stations s
+JOIN pegel_online.stations__timeseries t ON t._dlt_parent_id = s._dlt_id
+ORDER BY s.shortname, t.shortname;
+```
+
+## What's next
+
+Both pipelines so far were written by hand with a known API. The next tutorial — [Write your own source](./your-own-source.md) — shows a faster path: point an LLM at a public API endpoint, let it inspect the response, and generate the dlt resource for you.

--- a/docs/tutorials/dlt/pegel-online.md
+++ b/docs/tutorials/dlt/pegel-online.md
@@ -222,7 +222,7 @@ python pegel_online_pipeline.py --stations
 Check what dlt created in the `pegel_online` schema:
 
 ```bash
-PGPASSWORD="your_password" psql -h postgres -U nexus-postgres -d postgres -c "\dt pegel_online.*"
+psql -h postgres -U nexus-postgres -d postgres -c "\dt pegel_online.*"
 ```
 
 ```
@@ -254,7 +254,7 @@ dlt sees the nested `timeseries` array and automatically creates a child table �
 Row counts:
 
 ```bash
-PGPASSWORD="your_password" psql -h postgres -U nexus-postgres -d postgres \
+psql -h postgres -U nexus-postgres -d postgres \
   -c "SELECT count(*) FROM pegel_online.stations;" \
   -c "SELECT count(*) FROM pegel_online.stations__timeseries;"
 ```
@@ -275,7 +275,7 @@ PGPASSWORD="your_password" psql -h postgres -U nexus-postgres -d postgres \
 
 **Chunked pagination** — the measurements API returns at most a few hundred records per request and rejects very long date ranges. The while loop splits the full window into 30-day chunks and advances `chunk_start` until it reaches `end_dt`. A full refresh from January 2024 takes 29 requests instead of one huge one that would time out.
 
-**Timezone-aware cursor** — the API returns CET/CEST timestamps that shift between `+01:00` and `+02:00` depending on the season. If you stored those strings as-is and compared them lexicographically, the cursor would jump backwards when DST switches. Converting everything to UTC on the way in (`astimezone(timezone.utc)`) keeps the cursor monotonically increasing regardless of season.
+**Timezone-aware cursor** — the API returns CET/CEST timestamps that shift between `+01:00` and `+02:00` depending on the season. Each `item["timestamp"]` is parsed into a `datetime` and converted to UTC via `astimezone(timezone.utc)` before being compared to `max_ts_dt`, so the comparison stays in a stable timezone and remains monotonic across DST changes. The stored cursor (`state["last_timestamp"]`) is also written as a UTC ISO string for the same reason. The yielded `timestamp` field keeps the original API representation — only the internal bookkeeping is normalized, not the payload.
 
 **Two resources, two strategies** — `pegel_measurements` uses `merge` because new readings arrive constantly and you only want to fetch what's new. `pegel_stations` uses `replace` because station metadata rarely changes and a full refresh is cheaper than tracking diffs for 785 stations. Both resources live in the same pipeline and write to the same schema.
 

--- a/docs/tutorials/dlt/setup.md
+++ b/docs/tutorials/dlt/setup.md
@@ -1,0 +1,85 @@
+---
+title: "Setup: dlt environment and Postgres credentials"
+description: "Create an isolated Python environment with uv, install dlt, and wire up your Nexus Postgres credentials"
+order: 1
+---
+
+# Setup: dlt environment and Postgres credentials
+
+Before writing any pipeline, you need a working Python environment inside code-server and a credentials file that tells dlt how to reach the Nexus Postgres database. This page covers both — it takes about 5 minutes and you only do it once.
+
+## Prerequisites
+
+- Nexus-Stack deployment with `code-server` and `postgres` enabled
+- Familiarity with opening a terminal in code-server — see [Run curl in the code-server terminal](/docs/tutorials/code-server/terminal-curl/) if this is your first time
+
+## 1. Create a working directory
+
+All dlt tutorials live inside your workspace repo so your scripts survive container restarts and teardowns. Open a terminal in code-server and run:
+
+```bash
+cd ~/nexus-<your-domain>-gitea
+mkdir dlt && cd dlt
+```
+
+Replace `nexus-<your-domain>-gitea` with your actual repo name — it follows the pattern `nexus-<domain-with-hyphens>-gitea`. For a domain `odeslab.com` it would be `nexus-odeslab-com-gitea`.
+
+## 2. Create a virtual environment
+
+```bash
+uv venv .venv
+source .venv/bin/activate
+```
+
+Your prompt now shows `(.venv)`. The environment is isolated — packages installed here don't affect anything else on the server.
+
+## 3. Install dlt with the Postgres plugin
+
+```bash
+uv pip install "dlt[postgres]"
+```
+
+This installs dlt and `psycopg2-binary`, the driver dlt uses to talk to Postgres. Verify:
+
+```bash
+dlt --version
+```
+
+Expected output: `dlt version 1.x.x` (exact version may vary).
+
+## 4. Configure Postgres credentials
+
+dlt reads credentials from a file called `secrets.toml` inside a `.dlt/` directory next to your scripts.
+
+```bash
+mkdir .dlt
+```
+
+Open the **Secrets** page in your Control Plane, expand the `postgres` entry, and copy the value of `POSTGRES_PASSWORD`. Then create the file:
+
+```bash
+cat > .dlt/secrets.toml << 'EOF'
+[destination.postgres.credentials]
+host = "postgres"
+port = 5432
+database = "postgres"
+username = "nexus-postgres"
+password = "YOUR_POSTGRES_PASSWORD"
+EOF
+```
+
+Replace `YOUR_POSTGRES_PASSWORD` with the value you copied from Infisical.
+
+The host `postgres` is the Docker service name — it resolves inside the server's network and is only reachable from code-server, not from your laptop.
+
+## 5. Protect your credentials
+
+`secrets.toml` contains your database password. Add it to `.gitignore` so it's never committed to your workspace repo:
+
+```bash
+echo '.dlt/secrets.toml' > .gitignore
+```
+
+## What's next
+
+Your environment is ready. The next tutorial builds your first pipeline: [Wikipedia pageviews → Postgres](./wikipedia-pipeline.md) — a single resource, a single table, and a first look at how dlt handles schema inference automatically.

--- a/docs/tutorials/dlt/setup.md
+++ b/docs/tutorials/dlt/setup.md
@@ -77,7 +77,7 @@ The host `postgres` is the Docker service name — it resolves inside the server
 `secrets.toml` contains your database password. Add it to `.gitignore` so it's never committed to your workspace repo:
 
 ```bash
-echo '.dlt/secrets.toml' > .gitignore
+grep -qxF '.dlt/secrets.toml' .gitignore 2>/dev/null || echo '.dlt/secrets.toml' >> .gitignore
 ```
 
 ## What's next

--- a/docs/tutorials/dlt/wikipedia-incremental.md
+++ b/docs/tutorials/dlt/wikipedia-incremental.md
@@ -173,7 +173,7 @@ sudo apt-get update && sudo apt-get install -y postgresql-client
 Then query:
 
 ```bash
-PGPASSWORD="your_password" psql -h postgres -U nexus-postgres -d postgres \
+psql -h postgres -U nexus-postgres -d postgres \
   -c "SELECT article, timestamp, views FROM wikipedia.pageviews ORDER BY article, timestamp LIMIT 10;"
 ```
 

--- a/docs/tutorials/dlt/wikipedia-incremental.md
+++ b/docs/tutorials/dlt/wikipedia-incremental.md
@@ -1,0 +1,202 @@
+---
+title: "Incremental loading with state"
+description: "Add a cursor to your Wikipedia pipeline so each run only fetches months that aren't in Postgres yet"
+order: 3
+---
+
+# Incremental loading with state
+
+The previous tutorial used `write_disposition="replace"`, which drops and recreates the table on every run. That's fine for a handful of articles, but it re-fetches years of data each time. This tutorial rewrites the pipeline to fetch only what's new since the last run.
+
+## Prerequisites
+
+- [Setup complete](./setup.md)
+- [Wikipedia pipeline tutorial](./wikipedia-pipeline.md) completed — you understand resources and `pipeline.run()`
+
+## The script
+
+Create `wikipedia_incremental.py`:
+
+```python
+import dlt
+from dlt.sources.helpers import requests
+from datetime import datetime
+from typing import Iterator
+
+ARTICLES = [
+    "Data_engineering",
+    "Data_science",
+    "Large_language_model",
+]
+
+BASE_URL = "https://wikimedia.org/api/rest_v1/metrics/pageviews/per-article"
+HEADERS = {"User-Agent": "dlt-nexus-pipeline/1.0"}
+
+_metrics = {"api_calls": 0, "records_received": 0, "start": "", "end": ""}
+
+
+@dlt.resource(
+    name="pageviews",
+    primary_key=["article", "timestamp"],
+    write_disposition="merge",
+)
+def wikipedia_pageviews(
+    end: str = None,
+    full_refresh: bool = False,
+    granularity: str = "monthly",
+) -> Iterator[dict]:
+    _metrics["api_calls"] = 0
+    _metrics["records_received"] = 0
+
+    if end is None:
+        # Cap at the first of the current month — only fetch complete months
+        end = datetime.now().replace(day=1).strftime("%Y%m%d")
+
+    state = dlt.current.resource_state()
+    last_timestamp = state.get("last_timestamp", "2024010100")
+
+    start = "20240101" if full_refresh else last_timestamp[:8]
+    _metrics["start"] = start
+    _metrics["end"] = end
+
+    # Cursor has caught up — nothing new to fetch this month
+    if start >= end:
+        return
+
+    max_timestamp = last_timestamp
+
+    for article in ARTICLES:
+        url = f"{BASE_URL}/en.wikipedia/all-access/all-agents/{article}/{granularity}/{start}/{end}"
+        response = requests.get(url, headers=HEADERS)
+        response.raise_for_status()
+        items = response.json().get("items", [])
+        _metrics["api_calls"] += 1
+        _metrics["records_received"] += len(items)
+        for item in items:
+            if item["timestamp"] > max_timestamp:
+                max_timestamp = item["timestamp"]
+            yield item
+
+    state["last_timestamp"] = max_timestamp
+
+
+if __name__ == "__main__":
+    import sys
+    full_refresh = "--full-refresh" in sys.argv
+
+    pipeline = dlt.pipeline(
+        pipeline_name="wikipedia_incremental",
+        destination="postgres",
+        dataset_name="wikipedia",
+    )
+    info = pipeline.run(wikipedia_pageviews(full_refresh=full_refresh))
+
+    load_id = info.load_packages[0].load_id if info.load_packages else None
+    records_written = 0
+    if load_id:
+        with pipeline.sql_client() as client:
+            with client.execute_query(
+                "SELECT count(*) FROM wikipedia.pageviews WHERE _dlt_load_id = %s", load_id
+            ) as cursor:
+                records_written = cursor.fetchone()[0]
+
+    status = info.load_packages[0].state if info.load_packages else "N/A"
+    print(f"\n{'='*42}")
+    print(f"  Wikipedia Pageviews — Run Summary")
+    print(f"{'='*42}")
+    print(f"  Date range:       {_metrics['start']} → {_metrics['end']}")
+    print(f"  API calls made:   {_metrics['api_calls']}")
+    print(f"  Records received: {_metrics['records_received']}")
+    print(f"  Records written:  {records_written}")
+    print(f"  Load status:      {status}")
+    print(f"{'='*42}\n")
+```
+
+## Run it
+
+First run — loads all complete months since January 2024:
+
+```bash
+python wikipedia_incremental.py --full-refresh
+```
+
+```
+==========================================
+  Wikipedia Pageviews — Run Summary
+==========================================
+  Date range:       20240101 → 20260501
+  API calls made:   3
+  Records received: 87
+  Records written:  87
+  Load status:      loaded
+==========================================
+```
+
+Second run — the cursor is already at the current month boundary, nothing to fetch:
+
+```bash
+python wikipedia_incremental.py
+```
+
+```
+==========================================
+  Wikipedia Pageviews — Run Summary
+==========================================
+  Date range:       20260501 → 20260501
+  API calls made:   0
+  Records received: 0
+  Records written:  0
+  Load status:      N/A
+==========================================
+```
+
+Zero API calls, zero records — the pipeline detected that the cursor has caught up and returned early without touching the database. Next month's run will fetch only that month's data for each article.
+
+## Optional: Verify the data
+
+**Option A — CloudBeaver (recommended):** Open `https://cloudbeaver.<your-domain>` in your browser. Connect to the Nexus Postgres database if you haven't already (host `postgres`, port `5432`, database `postgres`, user `nexus-postgres`), then expand **postgres → wikipedia → Tables → pageviews** in the left panel. Right-click the table and choose **View data** to browse rows and filter by `article` or `timestamp`.
+
+You can also run SQL directly — open a new SQL script and try:
+
+```sql
+SELECT article, timestamp, views
+FROM wikipedia.pageviews
+ORDER BY article, timestamp;
+```
+
+**Option B — psql in the terminal:** If you installed `postgresql-client` in the [Wikipedia pipeline tutorial](./wikipedia-pipeline.md), it's gone after a container restart. Reinstall with:
+
+```bash
+sudo apt-get update && sudo apt-get install -y postgresql-client
+```
+
+Then query:
+
+```bash
+PGPASSWORD="your_password" psql -h postgres -U nexus-postgres -d postgres \
+  -c "SELECT article, timestamp, views FROM wikipedia.pageviews ORDER BY article, timestamp LIMIT 10;"
+```
+
+Either way you should see 87 rows spread across three articles, each with a `YYYYMMDD00` timestamp and a monthly view count.
+
+## What changed from the simple pipeline
+
+**`write_disposition="merge"`** — instead of replacing the table, dlt upserts each row using the `primary_key`. Running the pipeline twice on the same data produces the same table: no duplicates.
+
+**`dlt.current.resource_state()`** — a dict that dlt persists to Postgres after each successful load (in `wikipedia._dlt_pipeline_state`). It's how the pipeline remembers where it left off between runs. The cursor is stored as the latest `timestamp` string seen across all articles.
+
+**`start >= end` guard** — the Wikimedia API rejects requests where the date range is zero or covers only part of a month. When the cursor has already reached the first of the current month, we return early before making any API calls.
+
+**`end` capped at the first of the current month** — the API sometimes returns data for the ongoing (incomplete) month. If that timestamp were stored as the cursor, the next run would request a date range of a few days into the current month, which the API rejects. Capping `end` at `YYYY-MM-01` means we only ever store complete months in the cursor.
+
+## When to use `--full-refresh`
+
+```bash
+python wikipedia_incremental.py --full-refresh
+```
+
+Use this when you add a new article to `ARTICLES`. Without it, the new article would only be fetched from the current cursor position forward — you'd be missing all its history. Full refresh re-fetches everything from the beginning and upserts into the existing table, so existing rows are updated and the new article's history is backfilled in one run.
+
+## What's next
+
+Both Wikipedia pipelines fetch from a single flat endpoint. The next tutorial — [Pegel Online](./pegel-online.md) — introduces a more realistic source: two separate resources (measurements and station metadata), a chunked API to handle large date ranges, and nested JSON that dlt automatically unpacks into a child table.

--- a/docs/tutorials/dlt/wikipedia-pipeline.md
+++ b/docs/tutorials/dlt/wikipedia-pipeline.md
@@ -1,0 +1,150 @@
+---
+title: "Your first dlt pipeline: Wikipedia pageviews"
+description: "Build a pipeline that fetches monthly Wikipedia pageview counts from a public API and loads them into Postgres"
+order: 2
+---
+
+# Your first dlt pipeline: Wikipedia pageviews
+
+This tutorial builds a complete dlt pipeline from scratch. You'll fetch monthly pageview counts for a handful of Wikipedia articles from the free Wikimedia API and load them into your Nexus Postgres database. By the end you'll understand the three building blocks every dlt pipeline is made of.
+
+## Prerequisites
+
+- [Setup complete](./setup.md) — virtual environment active, dlt installed, Postgres credentials in `.dlt/secrets.toml`
+- `code-server` terminal open, working directory `~/nexus-<your-domain>-gitea/dlt`
+
+## Install psql for verification
+
+psql is not pre-installed on the code-server container. Install it once per session:
+
+```bash
+sudo apt-get update && sudo apt-get install -y postgresql-client
+```
+
+This is session-only — it won't survive a container restart, but you only need it to inspect results.
+
+## The script
+
+Create `wikipedia_pipeline.py` in your `dlt/` directory:
+
+```python
+import dlt
+from dlt.sources.helpers import requests
+from datetime import datetime
+from typing import Iterator
+
+ARTICLES = [
+    "Data_engineering",
+    "Data_science",
+    "Large_language_model",
+]
+
+BASE_URL = "https://wikimedia.org/api/rest_v1/metrics/pageviews/per-article"
+HEADERS = {"User-Agent": "dlt-nexus-pipeline/1.0"}
+
+
+@dlt.resource(
+    name="pageviews",
+    primary_key=["article", "timestamp"],
+    write_disposition="replace",
+)
+def wikipedia_pageviews(
+    start: str = "20240101",
+    end: str = None,
+    granularity: str = "monthly",
+) -> Iterator[dict]:
+    if end is None:
+        end = datetime.now().strftime("%Y%m%d")
+    for article in ARTICLES:
+        url = f"{BASE_URL}/en.wikipedia/all-access/all-agents/{article}/{granularity}/{start}/{end}"
+        response = requests.get(url, headers=HEADERS)
+        response.raise_for_status()
+        for item in response.json().get("items", []):
+            yield item
+
+
+if __name__ == "__main__":
+    pipeline = dlt.pipeline(
+        pipeline_name="wikipedia_pipeline",
+        destination="postgres",
+        dataset_name="wikipedia",
+    )
+    info = pipeline.run(wikipedia_pageviews())
+    print(info)
+```
+
+## Run it
+
+```bash
+python wikipedia_pipeline.py
+```
+
+Expected output:
+
+```
+Pipeline wikipedia_pipeline load step completed in 0.15 seconds
+1 load package(s) were loaded to destination postgres and into dataset wikipedia
+The postgres destination used postgresql://nexus-postgres:***@postgres:5432/postgres location to store data
+Load package 1778429304.0475023 is LOADED and contains no failed jobs
+```
+
+## Verify the data
+
+Check which tables dlt created:
+
+```bash
+PGPASSWORD="your_password" psql -h postgres -U nexus-postgres -d postgres -c "\dt wikipedia.*"
+```
+
+```
+   Schema   |        Name         | Type  |     Owner
+-----------+---------------------+-------+----------------
+ wikipedia | _dlt_loads          | table | nexus-postgres
+ wikipedia | _dlt_pipeline_state | table | nexus-postgres
+ wikipedia | _dlt_version        | table | nexus-postgres
+ wikipedia | pageviews           | table | nexus-postgres
+```
+
+Query the first few rows:
+
+```bash
+PGPASSWORD="your_password" psql -h postgres -U nexus-postgres -d postgres \
+  -c "SELECT article, timestamp, views FROM wikipedia.pageviews ORDER BY article, timestamp LIMIT 10;"
+```
+
+```
+     article      | timestamp  | views
+------------------+------------+-------
+ Data_engineering | 2024010100 |  7454
+ Data_engineering | 2024020100 |  6273
+ Data_engineering | 2024030100 |  6732
+ ...
+```
+
+The `timestamp` format is `YYYYMMDD00` — a Wikimedia convention where the trailing `00` is always a placeholder for the hour field in monthly aggregates.
+
+## What just happened
+
+Three pieces make every dlt pipeline:
+
+**1. The resource** — `@dlt.resource` turns a Python generator into an extractable data source. The function `yield`s one dict per row. dlt infers the table schema automatically from the first yielded record: column names come from dict keys, types from the values.
+
+**2. The pipeline** — `dlt.pipeline(...)` wires a source to a destination. `dataset_name="wikipedia"` becomes a Postgres schema. The `pipeline_name` is used to store pipeline state between runs (relevant in the next tutorial).
+
+**3. `pipeline.run()`** — pulls every record from the generator, creates `wikipedia.pageviews` if it doesn't exist, and loads all rows. Takes a few seconds for a few hundred rows.
+
+The three `_dlt_*` tables are dlt's own bookkeeping: `_dlt_loads` logs every run, `_dlt_version` records the dlt version that wrote the schema, and `_dlt_pipeline_state` stores the incremental cursor (covered in the next tutorial).
+
+## Customise the articles
+
+Edit the `ARTICLES` list at the top of the script to track any Wikipedia article. The article name must match the URL slug exactly — copy it from the Wikipedia address bar:
+
+```
+https://en.wikipedia.org/wiki/Apache_Kafka  →  "Apache_Kafka"
+```
+
+`write_disposition="replace"` drops and recreates `pageviews` on every run, so adding or removing articles takes effect immediately on the next run.
+
+## What's next
+
+`replace` is fine for exploration but wasteful: every run re-fetches all history just to overwrite the same rows. The next tutorial adds a **state cursor** so each run only fetches months that aren't in the database yet — [Wikipedia pipeline with incremental loading](./wikipedia-incremental.md).

--- a/docs/tutorials/dlt/wikipedia-pipeline.md
+++ b/docs/tutorials/dlt/wikipedia-pipeline.md
@@ -93,8 +93,10 @@ Load package 1778429304.0475023 is LOADED and contains no failed jobs
 Check which tables dlt created:
 
 ```bash
-PGPASSWORD="your_password" psql -h postgres -U nexus-postgres -d postgres -c "\dt wikipedia.*"
+psql -h postgres -U nexus-postgres -d postgres -c "\dt wikipedia.*"
 ```
+
+psql will prompt for the password. If you prefer to skip the prompt in your session, run `export PGPASSWORD="your_password"` once in the terminal first — but never inline it in a committed script.
 
 ```
    Schema   |        Name         | Type  |     Owner
@@ -108,7 +110,7 @@ PGPASSWORD="your_password" psql -h postgres -U nexus-postgres -d postgres -c "\d
 Query the first few rows:
 
 ```bash
-PGPASSWORD="your_password" psql -h postgres -U nexus-postgres -d postgres \
+psql -h postgres -U nexus-postgres -d postgres \
   -c "SELECT article, timestamp, views FROM wikipedia.pageviews ORDER BY article, timestamp LIMIT 10;"
 ```
 

--- a/docs/tutorials/dlt/your-own-source.md
+++ b/docs/tutorials/dlt/your-own-source.md
@@ -1,0 +1,209 @@
+---
+title: "Write your own source with an LLM"
+description: "Find a public API, point Claude at it, and have a working dlt pipeline running in minutes"
+order: 5
+---
+
+# Write your own source with an LLM
+
+The previous tutorials built pipelines by hand, which is fine for learning. In practice, dlt pipelines are one of the best things to generate with an LLM: the structure is always the same, the API response tells you everything you need to know about the schema, and the output is verifiable by running it. An LLM with tool access can fetch the endpoint itself, read the response, and write the resource — no manual JSON spelunking required.
+
+This tutorial shows the workflow: where to find APIs, what to tell the LLM, and what to watch for in the generated code.
+
+## Where to find public APIs: BundesAPI
+
+[github.com/bundesAPI](https://github.com/bundesAPI) is a community collection of unofficial wrappers and documentation for German federal government APIs. Many are openly accessible with no authentication. A few worth exploring:
+
+| Repo | What it exposes |
+|---|---|
+| `autobahn-api` | Road works, closures, and webcams on German motorways |
+| `bundestag-api` | Parliamentary proceedings, votes, members |
+| `jobsuche-api` | Federal Employment Agency job listings |
+| `plz-api` | Postal codes with coordinates |
+| `nina-api` | Civil protection warnings (floods, weather) |
+| `deutschland` | Umbrella repo with links to many more |
+
+Browse the org, open any repo's README, and look for the base URL and a few example endpoints. That's all you need to hand to an LLM.
+
+## The workflow
+
+### 1. Pick an endpoint and inspect it
+
+Open the API's README and find a concrete endpoint. For the Autobahn API, the roads listing is:
+
+```
+GET https://verkehr.autobahn.de/o/autobahn/
+```
+
+Paste this URL into a browser or run it with curl to see what the response looks like:
+
+```bash
+curl -s https://verkehr.autobahn.de/o/autobahn/ | head -c 500
+```
+
+```json
+{
+  "roads": ["A1", "A2", "A3", "A4", ...]
+}
+```
+
+The roadworks for a specific road:
+
+```bash
+curl -s "https://verkehr.autobahn.de/o/autobahn/A1/services/roadworks" | head -c 1000
+```
+
+```json
+{
+  "roadworks": [
+    {
+      "identifier": "...",
+      "title": "Baustelle A1",
+      "startTimestamp": "2025-01-15T06:00:00+01:00",
+      "endTimestamp": "2025-08-31T18:00:00+01:00",
+      "coordinate": { "lat": "53.5", "long": "9.9" },
+      "extent": "..."
+    }
+  ]
+}
+```
+
+Two minutes of curl gives you the full picture: field names, types, whether timestamps are ISO strings, whether there are nested objects.
+
+### 2. Write the prompt
+
+Open Claude (or any LLM with web/tool access) and give it all of this in one message. Be specific about what you want:
+
+> I want to build a dlt pipeline that loads current roadworks from the German Autobahn API into a Postgres database.
+>
+> Base URL: `https://verkehr.autobahn.de/o/autobahn/`
+>
+> The API first requires a call to `/` to get a list of roads (returns `{"roads": ["A1", "A2", ...]}`). For each road, roadworks are at `/{road}/services/roadworks` (returns `{"roadworks": [{identifier, title, startTimestamp, endTimestamp, coordinate, ...}]}`).
+>
+> Please write a dlt resource that:
+> - Iterates over all roads and fetches their current roadworks
+> - Uses `write_disposition="replace"` (roadworks change daily, a full snapshot is fine)
+> - Uses `identifier` as the primary key
+> - Flattens `coordinate` into `lat` and `lon` columns rather than leaving it nested
+>
+> Target: `destination="postgres"`, `dataset_name="autobahn"`.
+>
+> Follow the same pattern as the other resources in this project: `@dlt.resource`, yield dicts, `dlt.sources.helpers.requests` for HTTP.
+
+Key things to include in your prompt:
+- The base URL and the shape of 1–2 sample responses
+- Which field is the natural primary key
+- Whether you want `merge` (incremental) or `replace` (full snapshot)
+- Any transformations you want (flatten nested fields, rename columns, add constants)
+- The destination and dataset name
+
+### 3. Review the output
+
+The LLM will produce something like:
+
+```python
+import dlt
+from dlt.sources.helpers import requests
+from typing import Iterator
+
+BASE_URL = "https://verkehr.autobahn.de/o/autobahn"
+HEADERS = {"accept": "application/json"}
+
+
+@dlt.resource(
+    name="roadworks",
+    primary_key="identifier",
+    write_disposition="replace",
+)
+def autobahn_roadworks() -> Iterator[dict]:
+    roads_response = requests.get(f"{BASE_URL}/", headers=HEADERS)
+    roads_response.raise_for_status()
+    roads = roads_response.json().get("roads", [])
+
+    for road in roads:
+        rw_response = requests.get(
+            f"{BASE_URL}/{road}/services/roadworks", headers=HEADERS
+        )
+        rw_response.raise_for_status()
+        for item in rw_response.json().get("roadworks", []):
+            coord = item.pop("coordinate", {})
+            yield {
+                **item,
+                "road": road,
+                "lat": coord.get("lat"),
+                "lon": coord.get("long"),
+            }
+
+
+if __name__ == "__main__":
+    pipeline = dlt.pipeline(
+        pipeline_name="autobahn_pipeline",
+        destination="postgres",
+        dataset_name="autobahn",
+    )
+    info = pipeline.run(autobahn_roadworks())
+    print(info)
+```
+
+**What to check before running:**
+
+- Does it handle the case where an endpoint returns an empty list? (`roadworks` may be empty for quiet roads — the generator should just yield nothing and continue.)
+- Does it handle HTTP errors gracefully? A single 404 for one road shouldn't crash the whole run. Ask the LLM to wrap the per-road request in a try/except if needed.
+- Are timestamps stored as strings or converted? dlt will infer the type from the first record — ISO strings become `text` columns unless you parse them. That's usually fine.
+- Does anything need a cursor? If you want only new records on the next run, you need `write_disposition="merge"` and a state cursor (see the [incremental loading tutorial](./wikipedia-incremental.md)).
+
+Run it, check `print(info)` for errors, then inspect the table in CloudBeaver or psql. Iterate from there.
+
+## Tips for agentic LLMs
+
+If you're using Claude Code or another agent with tool access, you can skip the manual curl step entirely. A prompt like:
+
+> Fetch `https://verkehr.autobahn.de/o/autobahn/` and `https://verkehr.autobahn.de/o/autobahn/A1/services/roadworks`, examine the response structure, and write a dlt resource that loads all roadworks into Postgres.
+
+The agent will make the HTTP calls itself, read the response, identify the primary key, spot any nested structures, and write the resource with the right field names. You get a working script without opening a browser.
+
+This works especially well when:
+- The API docs are sparse or outdated but the endpoint itself is live
+- The response has 20+ fields and you don't want to type them all out
+- You want the agent to decide whether nested objects should be flattened or left for dlt to unpack into child tables
+
+## What to do next with your data
+
+You now have real-world data in Postgres. Here's where the rest of Nexus-Stack picks it up.
+
+### Visualize in Grafana
+
+Grafana connects to Postgres as a data source. Once connected, build a **Time series** panel over `wikipedia.pageviews` to plot monthly article views for each article side-by-side, or a **Gauge** panel showing the current Bodensee water level from `pegel_online.measurements`. Time-series data with a timestamp column lands directly in Grafana's native panel type with no transformation needed.
+
+Open `https://grafana.<your-domain>` → **Connections → Add new data source → PostgreSQL**.
+
+### Build dashboards in Superset or Metabase
+
+For exploration and sharing, Superset and Metabase both connect to Postgres and let you build charts without writing SQL. Superset's SQL Lab is particularly useful while iterating — you can query `wikipedia.pageviews`, spot outliers, and turn the query directly into a saved chart.
+
+Open `https://superset.<your-domain>` or `https://metabase.<your-domain>` → add a PostgreSQL database connection → start exploring.
+
+### Model with dbt in Meltano
+
+Raw API data rarely lands in the shape you want for analysis. dbt lets you define SQL transformations as versioned models. For the Pegel Online data, a useful first model joins `measurements` to `stations` and calculates daily averages:
+
+```sql
+-- models/pegel_daily_avg.sql
+select
+    s.shortname as station,
+    date_trunc('day', m.timestamp::timestamptz) as day,
+    avg(m.value_cm) as avg_water_level_cm,
+    min(m.value_cm) as min_water_level_cm,
+    max(m.value_cm) as max_water_level_cm
+from pegel_online.measurements m
+join pegel_online.stations s on s.uuid = m.station_id
+group by 1, 2
+```
+
+Meltano bundles dbt and connects it to your Nexus Postgres. Open `https://meltano.<your-domain>` to get started.
+
+### Schedule with Kestra
+
+Running pipelines by hand doesn't scale. Kestra can trigger your dlt scripts on a schedule — daily incremental runs for measurements, a weekly stations refresh. Create a flow in the Kestra UI that runs `python pegel_online_pipeline.py` inside code-server via a Script task, or use Kestra's Python task runner directly.
+
+Open `https://kestra.<your-domain>` → **Flows → New flow**.


### PR DESCRIPTION
## Description

Five end-to-end tutorials for using dlt (Data Load Tool) from code-server to load public API data into Nexus Postgres. All tutorials were written alongside live testing in a running Nexus-Stack deployment.

| Tutorial | What it teaches |
|---|---|
| Setup | `uv` virtualenv, `dlt[postgres]`, `secrets.toml` |
| Wikipedia pipeline | `@dlt.resource`, `pipeline.run()`, schema inference |
| Incremental loading | State cursor, `merge` disposition, `--full-refresh` |
| Pegel Online | Two resources, chunked pagination, nested JSON → child table |
| Write your own source | BundesAPI catalog, LLM-assisted pipeline generation, what to do next |

## Motivation and Context

Rather than adding dlt as a separate Docker stack, these tutorials show how to use dlt natively inside `code-server` — the environment every Nexus-Stack user already has. No extra container needed.

Related: #34, #315

## How Has This Been Tested

Every script was run live in code-server against a real Nexus-Stack deployment (Postgres destination). Both Wikipedia pipelines, the full Pegel Online pipeline (full refresh + incremental + stations), and all SQL verification queries were executed and their output is reproduced verbatim in the tutorials.

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes. *(documentation only)*
- [ ] All new and existing tests passed. *(documentation only)*
