### PR TITLE
feat(deploy): RFC 0001 PR-1 of 7 — s3_persistence foundation (module + scripts + tests)

### DIFF
--- a/scripts/cleanup-s3-bucket.sh
+++ b/scripts/cleanup-s3-bucket.sh
@@ -68,6 +68,15 @@ BUCKET="$STACK_SLUG"
 if ! command -v aws >/dev/null 2>&1; then
   err "aws CLI not found in PATH"
 fi
+# The pagination loop below parses ``list-object-versions`` JSON
+# output via python3. Check up-front so a missing interpreter
+# fails the script BEFORE we start deleting; without the check, the
+# loop would tear through one page of versions, then error half-way
+# with ``python3: command not found`` leaving the bucket in a
+# partially-emptied state.
+if ! command -v python3 >/dev/null 2>&1; then
+  err "python3 not found in PATH — needed for paginated version-list parsing. Install Python 3 or use a runner image that includes it."
+fi
 
 export AWS_ACCESS_KEY_ID="$R2_ACCESS_KEY_ID"
 export AWS_SECRET_ACCESS_KEY="$R2_SECRET_ACCESS_KEY"

--- a/scripts/cleanup-s3-bucket.sh
+++ b/scripts/cleanup-s3-bucket.sh
@@ -1,22 +1,22 @@
 #!/bin/bash
 # =============================================================================
-# Nexus-Stack - Hetzner Object Storage bucket cleanup (RFC 0001)
+# Nexus-Stack - Cloudflare R2 persistence bucket cleanup (RFC 0001)
 # =============================================================================
-# Deletes a per-stack persistence bucket on Hetzner Object Storage.
-# Called from `destroy-all.yml` workflow ONLY when the operator
-# explicitly opted in via `--delete-data` (see RFC 0001 decision #6).
+# Deletes a per-stack R2 persistence bucket. Called from
+# `destroy-all.yml` workflow ONLY when the operator explicitly opted in
+# via `--delete-data` (see RFC 0001 decision #6).
 #
 # Default behaviour: PRESERVE the bucket. The script is a no-op
 # unless the operator passes the explicit confirmation environment
 # variable, mirroring the existing `confirm=DESTROY` pattern.
 #
 # Required environment variables:
-#   HETZNER_S3_ACCESS_KEY   - Project-level access key
-#   HETZNER_S3_SECRET_KEY   - Matching secret
-#   HETZNER_S3_LOCATION     - fsn1 / hel1 / nbg1
-#   STACK_SLUG              - Per-stack slug (used as bucket name)
-#   CONFIRM_DELETE_DATA     - Must equal 'DESTROY' for the script to act.
-#                             Anything else (including unset) → no-op.
+#   CLOUDFLARE_ACCOUNT_ID    - Cloudflare account ID
+#   R2_ACCESS_KEY_ID         - R2 S3-API access key (shared project token)
+#   R2_SECRET_ACCESS_KEY     - matching secret
+#   STACK_SLUG               - Per-stack slug (used as bucket name)
+#   CONFIRM_DELETE_DATA      - Must equal 'DESTROY' for the script to act.
+#                              Anything else (including unset) → no-op.
 # =============================================================================
 
 set -euo pipefail
@@ -27,10 +27,10 @@ YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
 NC='\033[0m'
 
-log() { echo -e "${BLUE}[cleanup-s3-bucket]${NC} $*" >&2; }
-ok()  { echo -e "${GREEN}[cleanup-s3-bucket] ✓${NC} $*" >&2; }
+log()  { echo -e "${BLUE}[cleanup-s3-bucket]${NC} $*" >&2; }
+ok()   { echo -e "${GREEN}[cleanup-s3-bucket] ✓${NC} $*" >&2; }
 warn() { echo -e "${YELLOW}[cleanup-s3-bucket] ⚠${NC}  $*" >&2; }
-err() { echo -e "${RED}[cleanup-s3-bucket] ✗${NC}  $*" >&2; exit 1; }
+err()  { echo -e "${RED}[cleanup-s3-bucket] ✗${NC}  $*" >&2; exit 1; }
 
 # -----------------------------------------------------------------------------
 # Safety gate (decision #6 — opt-in delete)
@@ -53,32 +53,27 @@ fi
 # Argument validation (only run when actually deleting)
 # -----------------------------------------------------------------------------
 
-: "${HETZNER_S3_ACCESS_KEY:?HETZNER_S3_ACCESS_KEY is required}"
-: "${HETZNER_S3_SECRET_KEY:?HETZNER_S3_SECRET_KEY is required}"
-: "${HETZNER_S3_LOCATION:?HETZNER_S3_LOCATION is required (fsn1 / hel1 / nbg1)}"
+: "${CLOUDFLARE_ACCOUNT_ID:?CLOUDFLARE_ACCOUNT_ID is required}"
+: "${R2_ACCESS_KEY_ID:?R2_ACCESS_KEY_ID is required (reuse the one from init-r2-state.sh)}"
+: "${R2_SECRET_ACCESS_KEY:?R2_SECRET_ACCESS_KEY is required}"
 : "${STACK_SLUG:?STACK_SLUG is required (used as bucket name)}"
 
 if ! [[ "$STACK_SLUG" =~ ^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$ ]]; then
-  err "STACK_SLUG '$STACK_SLUG' is not a valid S3 bucket name"
+  err "STACK_SLUG '$STACK_SLUG' is not a valid R2 bucket name"
 fi
 
-case "$HETZNER_S3_LOCATION" in
-  fsn1|hel1|nbg1) ;;
-  *) err "HETZNER_S3_LOCATION must be one of fsn1, hel1, nbg1 (got '$HETZNER_S3_LOCATION')" ;;
-esac
-
-ENDPOINT="https://${HETZNER_S3_LOCATION}.your-objectstorage.com"
+ENDPOINT="https://${CLOUDFLARE_ACCOUNT_ID}.r2.cloudflarestorage.com"
 BUCKET="$STACK_SLUG"
 
 if ! command -v aws >/dev/null 2>&1; then
   err "aws CLI not found in PATH"
 fi
 
-export AWS_ACCESS_KEY_ID="$HETZNER_S3_ACCESS_KEY"
-export AWS_SECRET_ACCESS_KEY="$HETZNER_S3_SECRET_KEY"
-export AWS_DEFAULT_REGION="$HETZNER_S3_LOCATION"
+export AWS_ACCESS_KEY_ID="$R2_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$R2_SECRET_ACCESS_KEY"
+export AWS_DEFAULT_REGION="auto"
 
-aws_s3() {
+r2_s3() {
   aws --endpoint-url "$ENDPOINT" s3api "$@"
 }
 
@@ -87,7 +82,7 @@ aws_s3() {
 # -----------------------------------------------------------------------------
 
 log "Checking bucket '$BUCKET' on $ENDPOINT"
-if ! aws_s3 head-bucket --bucket "$BUCKET" 2>/dev/null; then
+if ! r2_s3 head-bucket --bucket "$BUCKET" 2>/dev/null; then
   warn "Bucket '$BUCKET' does not exist — nothing to clean up"
   exit 0
 fi
@@ -106,16 +101,16 @@ log "Listing object versions to delete"
 TMP_VERSIONS=$(mktemp)
 trap 'rm -f "$TMP_VERSIONS"' EXIT
 
-# Paginate via aws_s3's built-in `--max-items` cursor. Hetzner's
-# Object Storage caps a single ListObjectVersions response at 1000
-# entries (matching AWS's documented limit), so we paginate.
+# Paginate via aws_s3's built-in `--max-items` cursor. R2 caps a
+# single ListObjectVersions response at 1000 entries (matching AWS's
+# documented limit), so we paginate.
 NEXT_TOKEN=""
 DELETED_COUNT=0
 while :; do
   if [ -z "$NEXT_TOKEN" ]; then
-    PAGE=$(aws_s3 list-object-versions --bucket "$BUCKET" --max-items 1000 --output json)
+    PAGE=$(r2_s3 list-object-versions --bucket "$BUCKET" --max-items 1000 --output json)
   else
-    PAGE=$(aws_s3 list-object-versions --bucket "$BUCKET" --max-items 1000 \
+    PAGE=$(r2_s3 list-object-versions --bucket "$BUCKET" --max-items 1000 \
       --starting-token "$NEXT_TOKEN" --output json)
   fi
 
@@ -134,7 +129,7 @@ print(json.dumps({"Objects": to_delete, "Quiet": True}))
 ' > "$TMP_VERSIONS"
 
   if [ -s "$TMP_VERSIONS" ]; then
-    aws_s3 delete-objects --bucket "$BUCKET" --delete "file://$TMP_VERSIONS" >/dev/null
+    r2_s3 delete-objects --bucket "$BUCKET" --delete "file://$TMP_VERSIONS" >/dev/null
     BATCH=$(grep -c '"Key"' "$TMP_VERSIONS" || true)
     DELETED_COUNT=$((DELETED_COUNT + BATCH))
   fi
@@ -156,5 +151,5 @@ ok "Deleted $DELETED_COUNT object versions"
 # -----------------------------------------------------------------------------
 
 log "Deleting bucket '$BUCKET'"
-aws_s3 delete-bucket --bucket "$BUCKET" >/dev/null
+r2_s3 delete-bucket --bucket "$BUCKET" >/dev/null
 ok "Bucket '$BUCKET' deleted"

--- a/scripts/cleanup-s3-bucket.sh
+++ b/scripts/cleanup-s3-bucket.sh
@@ -1,0 +1,160 @@
+#!/bin/bash
+# =============================================================================
+# Nexus-Stack - Hetzner Object Storage bucket cleanup (RFC 0001)
+# =============================================================================
+# Deletes a per-stack persistence bucket on Hetzner Object Storage.
+# Called from `destroy-all.yml` workflow ONLY when the operator
+# explicitly opted in via `--delete-data` (see RFC 0001 decision #6).
+#
+# Default behaviour: PRESERVE the bucket. The script is a no-op
+# unless the operator passes the explicit confirmation environment
+# variable, mirroring the existing `confirm=DESTROY` pattern.
+#
+# Required environment variables:
+#   HETZNER_S3_ACCESS_KEY   - Project-level access key
+#   HETZNER_S3_SECRET_KEY   - Matching secret
+#   HETZNER_S3_LOCATION     - fsn1 / hel1 / nbg1
+#   STACK_SLUG              - Per-stack slug (used as bucket name)
+#   CONFIRM_DELETE_DATA     - Must equal 'DESTROY' for the script to act.
+#                             Anything else (including unset) → no-op.
+# =============================================================================
+
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+log() { echo -e "${BLUE}[cleanup-s3-bucket]${NC} $*" >&2; }
+ok()  { echo -e "${GREEN}[cleanup-s3-bucket] ✓${NC} $*" >&2; }
+warn() { echo -e "${YELLOW}[cleanup-s3-bucket] ⚠${NC}  $*" >&2; }
+err() { echo -e "${RED}[cleanup-s3-bucket] ✗${NC}  $*" >&2; exit 1; }
+
+# -----------------------------------------------------------------------------
+# Safety gate (decision #6 — opt-in delete)
+# -----------------------------------------------------------------------------
+#
+# The bucket holds the only copy of the stack's persistent data
+# under the v1.0 architecture (no Hetzner volume to fall back on).
+# Deleting it without explicit confirmation would silently destroy
+# student work — the same pattern as `destroy-all.yml -f
+# confirm=DESTROY`, just with a per-data-store gate.
+
+if [ "${CONFIRM_DELETE_DATA:-}" != "DESTROY" ]; then
+  warn "CONFIRM_DELETE_DATA != 'DESTROY' — preserving bucket"
+  warn "Pass CONFIRM_DELETE_DATA=DESTROY to actually delete the bucket and its contents"
+  log "No-op (this is the default safety behaviour)"
+  exit 0
+fi
+
+# -----------------------------------------------------------------------------
+# Argument validation (only run when actually deleting)
+# -----------------------------------------------------------------------------
+
+: "${HETZNER_S3_ACCESS_KEY:?HETZNER_S3_ACCESS_KEY is required}"
+: "${HETZNER_S3_SECRET_KEY:?HETZNER_S3_SECRET_KEY is required}"
+: "${HETZNER_S3_LOCATION:?HETZNER_S3_LOCATION is required (fsn1 / hel1 / nbg1)}"
+: "${STACK_SLUG:?STACK_SLUG is required (used as bucket name)}"
+
+if ! [[ "$STACK_SLUG" =~ ^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$ ]]; then
+  err "STACK_SLUG '$STACK_SLUG' is not a valid S3 bucket name"
+fi
+
+case "$HETZNER_S3_LOCATION" in
+  fsn1|hel1|nbg1) ;;
+  *) err "HETZNER_S3_LOCATION must be one of fsn1, hel1, nbg1 (got '$HETZNER_S3_LOCATION')" ;;
+esac
+
+ENDPOINT="https://${HETZNER_S3_LOCATION}.your-objectstorage.com"
+BUCKET="$STACK_SLUG"
+
+if ! command -v aws >/dev/null 2>&1; then
+  err "aws CLI not found in PATH"
+fi
+
+export AWS_ACCESS_KEY_ID="$HETZNER_S3_ACCESS_KEY"
+export AWS_SECRET_ACCESS_KEY="$HETZNER_S3_SECRET_KEY"
+export AWS_DEFAULT_REGION="$HETZNER_S3_LOCATION"
+
+aws_s3() {
+  aws --endpoint-url "$ENDPOINT" s3api "$@"
+}
+
+# -----------------------------------------------------------------------------
+# Bucket existence probe
+# -----------------------------------------------------------------------------
+
+log "Checking bucket '$BUCKET' on $ENDPOINT"
+if ! aws_s3 head-bucket --bucket "$BUCKET" 2>/dev/null; then
+  warn "Bucket '$BUCKET' does not exist — nothing to clean up"
+  exit 0
+fi
+
+# -----------------------------------------------------------------------------
+# Empty the bucket (versioning means we need to delete every version)
+# -----------------------------------------------------------------------------
+#
+# `aws s3 rb --force` only deletes current versions; with versioning
+# enabled (which init-s3-bucket.sh turned on) we'd be left with a
+# bucket that's "empty" but still has thousands of noncurrent
+# versions, and the bucket-delete call would 409. The robust path is
+# to enumerate every (key, version-id) pair and delete in batches.
+
+log "Listing object versions to delete"
+TMP_VERSIONS=$(mktemp)
+trap 'rm -f "$TMP_VERSIONS"' EXIT
+
+# Paginate via aws_s3's built-in `--max-items` cursor. Hetzner's
+# Object Storage caps a single ListObjectVersions response at 1000
+# entries (matching AWS's documented limit), so we paginate.
+NEXT_TOKEN=""
+DELETED_COUNT=0
+while :; do
+  if [ -z "$NEXT_TOKEN" ]; then
+    PAGE=$(aws_s3 list-object-versions --bucket "$BUCKET" --max-items 1000 --output json)
+  else
+    PAGE=$(aws_s3 list-object-versions --bucket "$BUCKET" --max-items 1000 \
+      --starting-token "$NEXT_TOKEN" --output json)
+  fi
+
+  # Two collections to delete: live `Versions` and tombstone `DeleteMarkers`
+  echo "$PAGE" | python3 -c '
+import json, sys
+page = json.load(sys.stdin)
+to_delete = []
+for v in (page.get("Versions") or []):
+    to_delete.append({"Key": v["Key"], "VersionId": v["VersionId"]})
+for m in (page.get("DeleteMarkers") or []):
+    to_delete.append({"Key": m["Key"], "VersionId": m["VersionId"]})
+if not to_delete:
+    sys.exit(0)
+print(json.dumps({"Objects": to_delete, "Quiet": True}))
+' > "$TMP_VERSIONS"
+
+  if [ -s "$TMP_VERSIONS" ]; then
+    aws_s3 delete-objects --bucket "$BUCKET" --delete "file://$TMP_VERSIONS" >/dev/null
+    BATCH=$(grep -c '"Key"' "$TMP_VERSIONS" || true)
+    DELETED_COUNT=$((DELETED_COUNT + BATCH))
+  fi
+
+  NEXT_TOKEN=$(echo "$PAGE" | python3 -c '
+import json, sys
+page = json.load(sys.stdin)
+print(page.get("NextToken") or "")
+')
+  if [ -z "$NEXT_TOKEN" ]; then
+    break
+  fi
+done
+
+ok "Deleted $DELETED_COUNT object versions"
+
+# -----------------------------------------------------------------------------
+# Delete the bucket itself
+# -----------------------------------------------------------------------------
+
+log "Deleting bucket '$BUCKET'"
+aws_s3 delete-bucket --bucket "$BUCKET" >/dev/null
+ok "Bucket '$BUCKET' deleted"

--- a/scripts/init-s3-bucket.sh
+++ b/scripts/init-s3-bucket.sh
@@ -1,0 +1,223 @@
+#!/bin/bash
+# =============================================================================
+# Nexus-Stack - Hetzner Object Storage bucket bootstrap (RFC 0001)
+# =============================================================================
+# Creates the per-stack persistence bucket on Hetzner Object Storage,
+# enables versioning, sets a lifecycle policy that retains the last 7
+# daily + 4 weekly snapshots, and pushes the access credentials to
+# Infisical so the stack's spinup pipeline can read them.
+#
+# Called once per stack, either:
+#   - by the operator from their workstation during initial setup
+#   - by the Education repo's setup.ts during fork creation
+#
+# Idempotent: running it twice with the same arguments produces no
+# changes after the first run. The bucket-exists check lets a
+# re-trigger after a partial failure (e.g. lifecycle policy didn't
+# stick) succeed cleanly.
+#
+# Required environment variables:
+#   HETZNER_S3_ACCESS_KEY    - Project-level access key with create-bucket scope
+#   HETZNER_S3_SECRET_KEY    - Matching secret
+#   HETZNER_S3_LOCATION      - fsn1 / hel1 / nbg1 (must match the project)
+#   STACK_SLUG               - Per-stack slug, e.g. "nexus-stefan-hslu"
+#                              (used as bucket name; must match S3 naming rules)
+#   INFISICAL_PROJECT_ID     - Where to push the bucket creds (optional;
+#                              skipped with a warning if unset)
+#   INFISICAL_TOKEN          - Infisical service-account token (optional)
+#
+# Outputs (on stdout):
+#   BUCKET=<bucket-name>
+#   ENDPOINT=<https://<location>.your-objectstorage.com>
+#   REGION=<location>
+#
+# The Education repo's setup.ts captures these and writes them as
+# GitHub Actions secrets on the per-stack fork.
+# =============================================================================
+
+set -euo pipefail
+
+# Colors for human output. Logs to stderr (so the stdout-parsable
+# KEY=VALUE block at the end isn't polluted).
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+log() { echo -e "${BLUE}[init-s3-bucket]${NC} $*" >&2; }
+ok()  { echo -e "${GREEN}[init-s3-bucket] ✓${NC} $*" >&2; }
+warn() { echo -e "${YELLOW}[init-s3-bucket] ⚠${NC}  $*" >&2; }
+err() { echo -e "${RED}[init-s3-bucket] ✗${NC}  $*" >&2; exit 1; }
+
+# -----------------------------------------------------------------------------
+# Argument validation
+# -----------------------------------------------------------------------------
+
+: "${HETZNER_S3_ACCESS_KEY:?HETZNER_S3_ACCESS_KEY is required}"
+: "${HETZNER_S3_SECRET_KEY:?HETZNER_S3_SECRET_KEY is required}"
+: "${HETZNER_S3_LOCATION:?HETZNER_S3_LOCATION is required (fsn1 / hel1 / nbg1)}"
+: "${STACK_SLUG:?STACK_SLUG is required (used as bucket name)}"
+
+# Validate STACK_SLUG against S3 bucket-name rules — same regex as
+# the s3_persistence Python module so a slug rejected here would
+# also be rejected at script-render time.
+if ! [[ "$STACK_SLUG" =~ ^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$ ]]; then
+  err "STACK_SLUG '$STACK_SLUG' is not a valid S3 bucket name (3-63 chars, lowercase, digits, hyphens, dots)"
+fi
+
+case "$HETZNER_S3_LOCATION" in
+  fsn1|hel1|nbg1) ;;
+  *) err "HETZNER_S3_LOCATION must be one of fsn1, hel1, nbg1 (got '$HETZNER_S3_LOCATION')" ;;
+esac
+
+ENDPOINT="https://${HETZNER_S3_LOCATION}.your-objectstorage.com"
+BUCKET="$STACK_SLUG"
+
+log "Stack: $STACK_SLUG"
+log "Bucket: $BUCKET"
+log "Endpoint: $ENDPOINT"
+
+# -----------------------------------------------------------------------------
+# Tooling check
+# -----------------------------------------------------------------------------
+
+if ! command -v aws >/dev/null 2>&1; then
+  err "aws CLI not found in PATH. Install from https://aws.amazon.com/cli/"
+fi
+
+# We rely on the v2 CLI's --endpoint-url flag, which has been stable
+# since 2020. v1 is technically supported but quirky on signed-URL
+# generation; nudge the operator if they're on an old build.
+AWS_VERSION=$(aws --version 2>&1 | head -1)
+log "Using $AWS_VERSION"
+
+# Per-call AWS config. We avoid touching the operator's ~/.aws/
+# directory so the init-bucket script doesn't overwrite an existing
+# personal AWS profile.
+export AWS_ACCESS_KEY_ID="$HETZNER_S3_ACCESS_KEY"
+export AWS_SECRET_ACCESS_KEY="$HETZNER_S3_SECRET_KEY"
+export AWS_DEFAULT_REGION="$HETZNER_S3_LOCATION"
+
+aws_s3() {
+  aws --endpoint-url "$ENDPOINT" s3api "$@"
+}
+
+# -----------------------------------------------------------------------------
+# Create bucket (idempotent)
+# -----------------------------------------------------------------------------
+
+log "Checking if bucket '$BUCKET' already exists"
+if aws_s3 head-bucket --bucket "$BUCKET" 2>/dev/null; then
+  ok "Bucket '$BUCKET' already exists — skipping create"
+else
+  log "Creating bucket '$BUCKET' in $HETZNER_S3_LOCATION"
+  # Hetzner Object Storage requires the LocationConstraint even
+  # though the endpoint URL already encodes the location — leaving
+  # it out gets a 400 with an unhelpful "InvalidLocationConstraint"
+  # error. Pin it explicitly.
+  aws_s3 create-bucket \
+    --bucket "$BUCKET" \
+    --create-bucket-configuration "LocationConstraint=$HETZNER_S3_LOCATION" \
+    >/dev/null
+  ok "Bucket '$BUCKET' created"
+fi
+
+# -----------------------------------------------------------------------------
+# Enable versioning (required for the lifecycle retention policy below)
+# -----------------------------------------------------------------------------
+
+log "Enabling versioning on '$BUCKET'"
+aws_s3 put-bucket-versioning \
+  --bucket "$BUCKET" \
+  --versioning-configuration "Status=Enabled" \
+  >/dev/null
+ok "Versioning enabled"
+
+# -----------------------------------------------------------------------------
+# Lifecycle policy: retain last 7 daily + 4 weekly snapshots
+# -----------------------------------------------------------------------------
+#
+# Per RFC 0001 decision #5: snapshots-per-stack are written under
+# `snapshots/<timestamp>/`. We treat every non-current version of
+# the manifest.json + payload tree as a "previous snapshot". The
+# rule below evicts non-current versions older than 30 days, which
+# covers the 7-daily + 4-weekly window with a generous buffer.
+#
+# More granular retention (exactly 7+4) requires either tag-based
+# rules or a separate cleanup cron — out of scope for v1.0. The
+# 30-day cap is the safety net; a follow-up PR can refine it.
+
+log "Setting 30-day lifecycle policy for noncurrent versions"
+LIFECYCLE_POLICY=$(cat <<'EOF'
+{
+  "Rules": [
+    {
+      "ID": "nexus-snapshot-retention-v1",
+      "Status": "Enabled",
+      "Filter": { "Prefix": "snapshots/" },
+      "NoncurrentVersionExpiration": {
+        "NoncurrentDays": 30
+      }
+    }
+  ]
+}
+EOF
+)
+TMP_LIFECYCLE=$(mktemp)
+trap 'rm -f "$TMP_LIFECYCLE"' EXIT
+echo "$LIFECYCLE_POLICY" > "$TMP_LIFECYCLE"
+aws_s3 put-bucket-lifecycle-configuration \
+  --bucket "$BUCKET" \
+  --lifecycle-configuration "file://$TMP_LIFECYCLE" \
+  >/dev/null
+ok "Lifecycle policy applied"
+
+# -----------------------------------------------------------------------------
+# Push credentials to Infisical (optional)
+# -----------------------------------------------------------------------------
+#
+# When INFISICAL_PROJECT_ID + INFISICAL_TOKEN are set, push the per-stack
+# credentials into the stack's Infisical folder so the spinup pipeline
+# can read them via the existing `infisical.py` machinery. We push the
+# project-level access key as-is — per-bucket sub-keys are a v1.1
+# refinement that needs Hetzner's sub-user API, not yet implemented.
+
+if [ -n "${INFISICAL_PROJECT_ID:-}" ] && [ -n "${INFISICAL_TOKEN:-}" ]; then
+  if ! command -v infisical >/dev/null 2>&1; then
+    warn "infisical CLI not found — skipping credential push to Infisical"
+    warn "Install from https://infisical.com/docs/cli/overview"
+  else
+    log "Pushing bucket credentials to Infisical project '$INFISICAL_PROJECT_ID'"
+    # The folder per stack matches the existing convention used by
+    # the secret-sync pipeline (`secret_sync.py`). We push 5 keys:
+    # endpoint, region, access_key, secret_key, bucket name.
+    infisical secrets set \
+      --token "$INFISICAL_TOKEN" \
+      --projectId "$INFISICAL_PROJECT_ID" \
+      --path "/persistence/$STACK_SLUG" \
+      "S3_ENDPOINT=$ENDPOINT" \
+      "S3_REGION=$HETZNER_S3_LOCATION" \
+      "S3_BUCKET=$BUCKET" \
+      "S3_ACCESS_KEY=$HETZNER_S3_ACCESS_KEY" \
+      "S3_SECRET_KEY=$HETZNER_S3_SECRET_KEY" \
+      >/dev/null 2>&1 || warn "infisical secrets set returned non-zero (may already exist)"
+    ok "Credentials pushed to Infisical"
+  fi
+else
+  warn "INFISICAL_PROJECT_ID/INFISICAL_TOKEN not set — credentials NOT pushed automatically"
+  warn "The caller is responsible for getting them to the per-stack fork's secrets"
+fi
+
+# -----------------------------------------------------------------------------
+# Output (parseable by setup.ts / GitHub Actions)
+# -----------------------------------------------------------------------------
+
+ok "init-s3-bucket complete"
+# Single trailing block on stdout in `KEY=VALUE` form. This is what
+# the calling automation parses; everything else above went to stderr.
+cat <<EOF
+BUCKET=$BUCKET
+ENDPOINT=$ENDPOINT
+REGION=$HETZNER_S3_LOCATION
+EOF

--- a/scripts/init-s3-bucket.sh
+++ b/scripts/init-s3-bucket.sh
@@ -3,9 +3,12 @@
 # Nexus-Stack - Hetzner Object Storage bucket bootstrap (RFC 0001)
 # =============================================================================
 # Creates the per-stack persistence bucket on Hetzner Object Storage,
-# enables versioning, sets a lifecycle policy that retains the last 7
-# daily + 4 weekly snapshots, and pushes the access credentials to
-# Infisical so the stack's spinup pipeline can read them.
+# enables versioning, sets a 30-day NoncurrentVersionExpiration
+# lifecycle policy (the safety net that covers the eventual 7-daily +
+# 4-weekly retention window per RFC 0001 decision #5 — precise N-of-
+# each retention is enforced by a separate cleanup script in v1.1),
+# and pushes the access credentials to Infisical so the stack's
+# spinup pipeline can read them.
 #
 # Called once per stack, either:
 #   - by the operator from their workstation during initial setup
@@ -189,20 +192,36 @@ if [ -n "${INFISICAL_PROJECT_ID:-}" ] && [ -n "${INFISICAL_TOKEN:-}" ]; then
     warn "Install from https://infisical.com/docs/cli/overview"
   else
     log "Pushing bucket credentials to Infisical project '$INFISICAL_PROJECT_ID'"
-    # The folder per stack matches the existing convention used by
-    # the secret-sync pipeline (`secret_sync.py`). We push 5 keys:
-    # endpoint, region, access_key, secret_key, bucket name.
-    infisical secrets set \
-      --token "$INFISICAL_TOKEN" \
+    # Secret values must NOT appear in argv — that's visible via
+    # `ps`, in shell history, and in CI logs. We pipe a tempfile of
+    # `KEY=VALUE` lines into `infisical secrets set --read-from-file
+    # -` (or via stdin equivalent). The file lives in $TMPDIR with
+    # mode 600 and is removed via the EXIT trap.
+    #
+    # Path: `/persistence/$STACK_SLUG` matches the existing
+    # `secret_sync.py` folder convention. We push 5 keys: endpoint,
+    # region, bucket, access_key, secret_key.
+    SECRETS_FILE=$(mktemp)
+    chmod 600 "$SECRETS_FILE"
+    # Append to the existing trap so we don't clobber the lifecycle
+    # tempfile cleanup set earlier in the script.
+    trap 'rm -f "$TMP_LIFECYCLE" "$SECRETS_FILE"' EXIT
+    cat > "$SECRETS_FILE" <<EOF
+S3_ENDPOINT=$ENDPOINT
+S3_REGION=$HETZNER_S3_LOCATION
+S3_BUCKET=$BUCKET
+S3_ACCESS_KEY=$HETZNER_S3_ACCESS_KEY
+S3_SECRET_KEY=$HETZNER_S3_SECRET_KEY
+EOF
+    # Pass the token via env, not argv, for the same reason. The
+    # CLI honours `INFISICAL_TOKEN` from the environment per its
+    # docs, so we just unset the explicit `--token` flag.
+    INFISICAL_TOKEN="$INFISICAL_TOKEN" infisical secrets set \
       --projectId "$INFISICAL_PROJECT_ID" \
       --path "/persistence/$STACK_SLUG" \
-      "S3_ENDPOINT=$ENDPOINT" \
-      "S3_REGION=$HETZNER_S3_LOCATION" \
-      "S3_BUCKET=$BUCKET" \
-      "S3_ACCESS_KEY=$HETZNER_S3_ACCESS_KEY" \
-      "S3_SECRET_KEY=$HETZNER_S3_SECRET_KEY" \
-      >/dev/null 2>&1 || warn "infisical secrets set returned non-zero (may already exist)"
-    ok "Credentials pushed to Infisical"
+      --file "$SECRETS_FILE" \
+      >/dev/null 2>&1 || warn "infisical secrets set returned non-zero (values may already exist)"
+    ok "Credentials pushed to Infisical (via stdin file, not argv)"
   fi
 else
   warn "INFISICAL_PROJECT_ID/INFISICAL_TOKEN not set — credentials NOT pushed automatically"

--- a/scripts/init-s3-bucket.sh
+++ b/scripts/init-s3-bucket.sh
@@ -20,15 +20,17 @@
 # partial failure (e.g. lifecycle policy didn't stick) succeed cleanly.
 #
 # Required environment variables:
-#   CLOUDFLARE_API_TOKEN     - Cloudflare API token with R2:Edit scope
 #   CLOUDFLARE_ACCOUNT_ID    - Cloudflare account ID
+#                              (used to derive the R2 endpoint URL:
+#                              https://<account_id>.r2.cloudflarestorage.com)
 #   R2_ACCESS_KEY_ID         - R2 S3-API access key (from init-r2-state.sh
 #                              output; reused across all R2 buckets in the
 #                              project)
 #   R2_SECRET_ACCESS_KEY     - matching secret
 #   STACK_SLUG               - Per-stack slug, e.g. "nexus-stefan-hslu"
 #                              (used as bucket name; must match R2 naming
-#                              rules: lowercase alnum + hyphen, 3-63 chars)
+#                              rules: lowercase alnum + hyphens + dots,
+#                              3-63 chars, must start/end with alnum)
 #   INFISICAL_PROJECT_ID     - Where to push the bucket coordinates (optional;
 #                              skipped with a warning if unset)
 #   INFISICAL_TOKEN          - Infisical service-account token (optional)
@@ -61,7 +63,14 @@ err()  { echo -e "${RED}[init-s3-bucket] ✗${NC}  $*" >&2; exit 1; }
 # Argument validation
 # -----------------------------------------------------------------------------
 
-: "${CLOUDFLARE_API_TOKEN:?CLOUDFLARE_API_TOKEN is required}"
+# Note: CLOUDFLARE_API_TOKEN is NOT required here — all operations
+# go through the S3-compatible API at the R2 endpoint with the
+# R2_ACCESS_KEY_ID + R2_SECRET_ACCESS_KEY pair. The token would be
+# needed for non-S3 Cloudflare API operations (e.g. minting a new
+# R2 token, configuring buckets via the CF management API), but
+# v1.0 doesn't do any of that — the token from init-r2-state.sh
+# already exists and is reused. Requiring an unused token here
+# would just make the script harder to call.
 : "${CLOUDFLARE_ACCOUNT_ID:?CLOUDFLARE_ACCOUNT_ID is required}"
 : "${R2_ACCESS_KEY_ID:?R2_ACCESS_KEY_ID is required (reuse the one from init-r2-state.sh)}"
 : "${R2_SECRET_ACCESS_KEY:?R2_SECRET_ACCESS_KEY is required}"

--- a/scripts/init-s3-bucket.sh
+++ b/scripts/init-s3-bucket.sh
@@ -1,38 +1,42 @@
 #!/bin/bash
 # =============================================================================
-# Nexus-Stack - Hetzner Object Storage bucket bootstrap (RFC 0001)
+# Nexus-Stack - Cloudflare R2 persistence bucket bootstrap (RFC 0001)
 # =============================================================================
-# Creates the per-stack persistence bucket on Hetzner Object Storage,
-# enables versioning, sets a 30-day NoncurrentVersionExpiration
-# lifecycle policy (the safety net that covers the eventual 7-daily +
-# 4-weekly retention window per RFC 0001 decision #5 — precise N-of-
-# each retention is enforced by a separate cleanup script in v1.1),
-# and pushes the access credentials to Infisical so the stack's
-# spinup pipeline can read them.
+# Creates the per-stack R2 persistence bucket, enables versioning, sets a
+# 30-day NoncurrentVersionExpiration lifecycle policy (the safety net that
+# covers the eventual 7-daily + 4-weekly retention window per RFC 0001
+# decision #5 — precise N-of-each retention is enforced by a v1.1 cleanup
+# script). Reuses the same R2 token already minted by `init-r2-state.sh` for
+# the Tofu state bucket, so this script doesn't need its own credential
+# bootstrap.
 #
 # Called once per stack, either:
 #   - by the operator from their workstation during initial setup
 #   - by the Education repo's setup.ts during fork creation
+#   - by the migration workflow during the existing-26-stacks evacuation phase
 #
-# Idempotent: running it twice with the same arguments produces no
-# changes after the first run. The bucket-exists check lets a
-# re-trigger after a partial failure (e.g. lifecycle policy didn't
-# stick) succeed cleanly.
+# Idempotent: running it twice with the same arguments produces no changes
+# after the first run. The bucket-exists check lets a re-trigger after a
+# partial failure (e.g. lifecycle policy didn't stick) succeed cleanly.
 #
 # Required environment variables:
-#   HETZNER_S3_ACCESS_KEY    - Project-level access key with create-bucket scope
-#   HETZNER_S3_SECRET_KEY    - Matching secret
-#   HETZNER_S3_LOCATION      - fsn1 / hel1 / nbg1 (must match the project)
+#   CLOUDFLARE_API_TOKEN     - Cloudflare API token with R2:Edit scope
+#   CLOUDFLARE_ACCOUNT_ID    - Cloudflare account ID
+#   R2_ACCESS_KEY_ID         - R2 S3-API access key (from init-r2-state.sh
+#                              output; reused across all R2 buckets in the
+#                              project)
+#   R2_SECRET_ACCESS_KEY     - matching secret
 #   STACK_SLUG               - Per-stack slug, e.g. "nexus-stefan-hslu"
-#                              (used as bucket name; must match S3 naming rules)
-#   INFISICAL_PROJECT_ID     - Where to push the bucket creds (optional;
+#                              (used as bucket name; must match R2 naming
+#                              rules: lowercase alnum + hyphen, 3-63 chars)
+#   INFISICAL_PROJECT_ID     - Where to push the bucket coordinates (optional;
 #                              skipped with a warning if unset)
 #   INFISICAL_TOKEN          - Infisical service-account token (optional)
 #
 # Outputs (on stdout):
 #   BUCKET=<bucket-name>
-#   ENDPOINT=<https://<location>.your-objectstorage.com>
-#   REGION=<location>
+#   ENDPOINT=<https://<account_id>.r2.cloudflarestorage.com>
+#   REGION=auto
 #
 # The Education repo's setup.ts captures these and writes them as
 # GitHub Actions secrets on the per-stack fork.
@@ -40,41 +44,38 @@
 
 set -euo pipefail
 
-# Colors for human output. Logs to stderr (so the stdout-parsable
-# KEY=VALUE block at the end isn't polluted).
+# Colors. Logs go to stderr so the trailing stdout KEY=VALUE block stays
+# clean for downstream automation.
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
 NC='\033[0m'
 
-log() { echo -e "${BLUE}[init-s3-bucket]${NC} $*" >&2; }
-ok()  { echo -e "${GREEN}[init-s3-bucket] ✓${NC} $*" >&2; }
+log()  { echo -e "${BLUE}[init-s3-bucket]${NC} $*" >&2; }
+ok()   { echo -e "${GREEN}[init-s3-bucket] ✓${NC} $*" >&2; }
 warn() { echo -e "${YELLOW}[init-s3-bucket] ⚠${NC}  $*" >&2; }
-err() { echo -e "${RED}[init-s3-bucket] ✗${NC}  $*" >&2; exit 1; }
+err()  { echo -e "${RED}[init-s3-bucket] ✗${NC}  $*" >&2; exit 1; }
 
 # -----------------------------------------------------------------------------
 # Argument validation
 # -----------------------------------------------------------------------------
 
-: "${HETZNER_S3_ACCESS_KEY:?HETZNER_S3_ACCESS_KEY is required}"
-: "${HETZNER_S3_SECRET_KEY:?HETZNER_S3_SECRET_KEY is required}"
-: "${HETZNER_S3_LOCATION:?HETZNER_S3_LOCATION is required (fsn1 / hel1 / nbg1)}"
+: "${CLOUDFLARE_API_TOKEN:?CLOUDFLARE_API_TOKEN is required}"
+: "${CLOUDFLARE_ACCOUNT_ID:?CLOUDFLARE_ACCOUNT_ID is required}"
+: "${R2_ACCESS_KEY_ID:?R2_ACCESS_KEY_ID is required (reuse the one from init-r2-state.sh)}"
+: "${R2_SECRET_ACCESS_KEY:?R2_SECRET_ACCESS_KEY is required}"
 : "${STACK_SLUG:?STACK_SLUG is required (used as bucket name)}"
 
-# Validate STACK_SLUG against S3 bucket-name rules — same regex as
-# the s3_persistence Python module so a slug rejected here would
-# also be rejected at script-render time.
+# Validate STACK_SLUG against R2 bucket-name rules — same regex as the
+# Python module (`_BUCKET_NAME`). R2 bucket names follow the AWS S3 v2
+# convention: lowercase alnum, hyphens, dots; 3-63 chars; must start
+# and end with alnum.
 if ! [[ "$STACK_SLUG" =~ ^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$ ]]; then
-  err "STACK_SLUG '$STACK_SLUG' is not a valid S3 bucket name (3-63 chars, lowercase, digits, hyphens, dots)"
+  err "STACK_SLUG '$STACK_SLUG' is not a valid R2 bucket name (3-63 chars, lowercase alnum + hyphens + dots, must start/end with alnum)"
 fi
 
-case "$HETZNER_S3_LOCATION" in
-  fsn1|hel1|nbg1) ;;
-  *) err "HETZNER_S3_LOCATION must be one of fsn1, hel1, nbg1 (got '$HETZNER_S3_LOCATION')" ;;
-esac
-
-ENDPOINT="https://${HETZNER_S3_LOCATION}.your-objectstorage.com"
+ENDPOINT="https://${CLOUDFLARE_ACCOUNT_ID}.r2.cloudflarestorage.com"
 BUCKET="$STACK_SLUG"
 
 log "Stack: $STACK_SLUG"
@@ -89,20 +90,21 @@ if ! command -v aws >/dev/null 2>&1; then
   err "aws CLI not found in PATH. Install from https://aws.amazon.com/cli/"
 fi
 
-# We rely on the v2 CLI's --endpoint-url flag, which has been stable
-# since 2020. v1 is technically supported but quirky on signed-URL
-# generation; nudge the operator if they're on an old build.
 AWS_VERSION=$(aws --version 2>&1 | head -1)
 log "Using $AWS_VERSION"
 
-# Per-call AWS config. We avoid touching the operator's ~/.aws/
-# directory so the init-bucket script doesn't overwrite an existing
-# personal AWS profile.
-export AWS_ACCESS_KEY_ID="$HETZNER_S3_ACCESS_KEY"
-export AWS_SECRET_ACCESS_KEY="$HETZNER_S3_SECRET_KEY"
-export AWS_DEFAULT_REGION="$HETZNER_S3_LOCATION"
+# Use the R2 S3-compatible access keys (same shape as AWS), but pointed
+# at the Cloudflare R2 endpoint. We avoid touching the operator's
+# ~/.aws/ so the script doesn't overwrite an existing personal profile.
+export AWS_ACCESS_KEY_ID="$R2_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$R2_SECRET_ACCESS_KEY"
+# R2 uses ``auto`` as the region (R2 is a single global namespace; the
+# SDK doesn't route based on region). The S3 v4 signing protocol still
+# requires *some* region to be set or it 400s — ``auto`` is the
+# Cloudflare-canonical value.
+export AWS_DEFAULT_REGION="auto"
 
-aws_s3() {
+r2_s3() {
   aws --endpoint-url "$ENDPOINT" s3api "$@"
 }
 
@@ -111,18 +113,14 @@ aws_s3() {
 # -----------------------------------------------------------------------------
 
 log "Checking if bucket '$BUCKET' already exists"
-if aws_s3 head-bucket --bucket "$BUCKET" 2>/dev/null; then
+if r2_s3 head-bucket --bucket "$BUCKET" 2>/dev/null; then
   ok "Bucket '$BUCKET' already exists — skipping create"
 else
-  log "Creating bucket '$BUCKET' in $HETZNER_S3_LOCATION"
-  # Hetzner Object Storage requires the LocationConstraint even
-  # though the endpoint URL already encodes the location — leaving
-  # it out gets a 400 with an unhelpful "InvalidLocationConstraint"
-  # error. Pin it explicitly.
-  aws_s3 create-bucket \
-    --bucket "$BUCKET" \
-    --create-bucket-configuration "LocationConstraint=$HETZNER_S3_LOCATION" \
-    >/dev/null
+  log "Creating bucket '$BUCKET' on R2"
+  # R2 doesn't use ``LocationConstraint`` like AWS S3 — passing it
+  # gives a 400. Just create with the default location, which for an
+  # account in the EU jurisdiction lands in an EU data centre.
+  r2_s3 create-bucket --bucket "$BUCKET" >/dev/null
   ok "Bucket '$BUCKET' created"
 fi
 
@@ -131,25 +129,21 @@ fi
 # -----------------------------------------------------------------------------
 
 log "Enabling versioning on '$BUCKET'"
-aws_s3 put-bucket-versioning \
+r2_s3 put-bucket-versioning \
   --bucket "$BUCKET" \
   --versioning-configuration "Status=Enabled" \
   >/dev/null
 ok "Versioning enabled"
 
 # -----------------------------------------------------------------------------
-# Lifecycle policy: retain last 7 daily + 4 weekly snapshots
+# Lifecycle policy: 30-day NoncurrentVersionExpiration
 # -----------------------------------------------------------------------------
 #
-# Per RFC 0001 decision #5: snapshots-per-stack are written under
-# `snapshots/<timestamp>/`. We treat every non-current version of
-# the manifest.json + payload tree as a "previous snapshot". The
-# rule below evicts non-current versions older than 30 days, which
-# covers the 7-daily + 4-weekly window with a generous buffer.
-#
-# More granular retention (exactly 7+4) requires either tag-based
-# rules or a separate cleanup cron — out of scope for v1.0. The
-# 30-day cap is the safety net; a follow-up PR can refine it.
+# Per RFC 0001 decision #5: snapshots are written under
+# `snapshots/<timestamp>/`. We retain non-current versions of any object
+# in that prefix for 30 days, which covers the 7-daily + 4-weekly
+# window with a generous buffer. Precise N-of-each retention is a v1.1
+# follow-up via a separate cleanup script.
 
 log "Setting 30-day lifecycle policy for noncurrent versions"
 LIFECYCLE_POLICY=$(cat <<'EOF'
@@ -170,61 +164,54 @@ EOF
 TMP_LIFECYCLE=$(mktemp)
 trap 'rm -f "$TMP_LIFECYCLE"' EXIT
 echo "$LIFECYCLE_POLICY" > "$TMP_LIFECYCLE"
-aws_s3 put-bucket-lifecycle-configuration \
+r2_s3 put-bucket-lifecycle-configuration \
   --bucket "$BUCKET" \
   --lifecycle-configuration "file://$TMP_LIFECYCLE" \
   >/dev/null
 ok "Lifecycle policy applied"
 
 # -----------------------------------------------------------------------------
-# Push credentials to Infisical (optional)
+# Push bucket coordinates to Infisical (optional)
 # -----------------------------------------------------------------------------
 #
 # When INFISICAL_PROJECT_ID + INFISICAL_TOKEN are set, push the per-stack
-# credentials into the stack's Infisical folder so the spinup pipeline
-# can read them via the existing `infisical.py` machinery. We push the
-# project-level access key as-is — per-bucket sub-keys are a v1.1
-# refinement that needs Hetzner's sub-user API, not yet implemented.
+# bucket coordinates into the stack's Infisical folder so the spinup
+# pipeline can read them via the existing `infisical.py` machinery. Note:
+# the *credentials* (R2_ACCESS_KEY_ID + R2_SECRET_ACCESS_KEY) are SHARED
+# across all R2 buckets in the project (same token as init-r2-state.sh),
+# so we don't push those here — they're already in Infisical from the
+# control-plane setup. We push only the bucket-specific bits (name +
+# endpoint + region).
 
 if [ -n "${INFISICAL_PROJECT_ID:-}" ] && [ -n "${INFISICAL_TOKEN:-}" ]; then
   if ! command -v infisical >/dev/null 2>&1; then
     warn "infisical CLI not found — skipping credential push to Infisical"
     warn "Install from https://infisical.com/docs/cli/overview"
   else
-    log "Pushing bucket credentials to Infisical project '$INFISICAL_PROJECT_ID'"
-    # Secret values must NOT appear in argv — that's visible via
-    # `ps`, in shell history, and in CI logs. We pipe a tempfile of
-    # `KEY=VALUE` lines into `infisical secrets set --read-from-file
-    # -` (or via stdin equivalent). The file lives in $TMPDIR with
-    # mode 600 and is removed via the EXIT trap.
-    #
-    # Path: `/persistence/$STACK_SLUG` matches the existing
-    # `secret_sync.py` folder convention. We push 5 keys: endpoint,
-    # region, bucket, access_key, secret_key.
+    log "Pushing bucket coordinates to Infisical project '$INFISICAL_PROJECT_ID'"
+    # Secret values must NOT appear in argv — that's visible via `ps`,
+    # in shell history, and in CI logs. Pipe a tempfile of
+    # KEY=VALUE lines into ``infisical secrets set --file ...``. The
+    # file lives in $TMPDIR with mode 600 and is removed via the EXIT
+    # trap.
     SECRETS_FILE=$(mktemp)
     chmod 600 "$SECRETS_FILE"
-    # Append to the existing trap so we don't clobber the lifecycle
-    # tempfile cleanup set earlier in the script.
     trap 'rm -f "$TMP_LIFECYCLE" "$SECRETS_FILE"' EXIT
     cat > "$SECRETS_FILE" <<EOF
-S3_ENDPOINT=$ENDPOINT
-S3_REGION=$HETZNER_S3_LOCATION
-S3_BUCKET=$BUCKET
-S3_ACCESS_KEY=$HETZNER_S3_ACCESS_KEY
-S3_SECRET_KEY=$HETZNER_S3_SECRET_KEY
+PERSISTENCE_S3_ENDPOINT=$ENDPOINT
+PERSISTENCE_S3_REGION=auto
+PERSISTENCE_S3_BUCKET=$BUCKET
 EOF
-    # Pass the token via env, not argv, for the same reason. The
-    # CLI honours `INFISICAL_TOKEN` from the environment per its
-    # docs, so we just unset the explicit `--token` flag.
+    # INFISICAL_TOKEN via env, not --token argv.
     INFISICAL_TOKEN="$INFISICAL_TOKEN" infisical secrets set \
       --projectId "$INFISICAL_PROJECT_ID" \
       --path "/persistence/$STACK_SLUG" \
       --file "$SECRETS_FILE" \
       >/dev/null 2>&1 || warn "infisical secrets set returned non-zero (values may already exist)"
-    ok "Credentials pushed to Infisical (via stdin file, not argv)"
+    ok "Bucket coordinates pushed to Infisical (R2 credentials reused from project-wide secrets)"
   fi
 else
-  warn "INFISICAL_PROJECT_ID/INFISICAL_TOKEN not set — credentials NOT pushed automatically"
+  warn "INFISICAL_PROJECT_ID/INFISICAL_TOKEN not set — bucket coordinates NOT pushed automatically"
   warn "The caller is responsible for getting them to the per-stack fork's secrets"
 fi
 
@@ -233,10 +220,8 @@ fi
 # -----------------------------------------------------------------------------
 
 ok "init-s3-bucket complete"
-# Single trailing block on stdout in `KEY=VALUE` form. This is what
-# the calling automation parses; everything else above went to stderr.
 cat <<EOF
 BUCKET=$BUCKET
 ENDPOINT=$ENDPOINT
-REGION=$HETZNER_S3_LOCATION
+REGION=auto
 EOF

--- a/src/nexus_deploy/s3_persistence.py
+++ b/src/nexus_deploy/s3_persistence.py
@@ -1,9 +1,15 @@
 """S3-backed persistence for stack data (RFC 0001).
 
-Replaces the per-stack Hetzner Block Storage volume with Hetzner
-Object Storage as the canonical persistence layer. Server local
-SSD becomes ephemeral cache; on spinup we restore from S3, on
-teardown we snapshot to S3 *atomically* (verify before destroy).
+Replaces the per-stack Hetzner Block Storage volume with Cloudflare
+R2 as the canonical persistence layer. Server local SSD becomes
+ephemeral cache; on spinup we restore from R2, on teardown we
+snapshot to R2 *atomically* (verify before destroy).
+
+The module itself is endpoint-agnostic — it talks to anything
+S3-compatible via the :class:`S3Endpoint` constructor argument. The
+defaults and docs reflect R2 because that's the v1.0 storage
+provider per RFC 0001 decision #1; the same module can drive
+Hetzner Object Storage or AWS S3 by passing a different endpoint.
 
 This module follows the same pattern as ``setup.py``: pure rendering
 functions that return server-side bash. Actual execution happens via
@@ -19,7 +25,7 @@ Public surface:
   secret_key, bucket)`` tuple. The credentials are intentionally
   passed in rather than read from the environment so the rendered
   script never relies on ambient state — and so unit tests can
-  inject a fixture without touching real Hetzner credentials.
+  inject a fixture without touching real R2 credentials.
 * :class:`SnapshotManifest` — Python-level dataclass + JSON
   serialiser for the snapshot metadata. The version-1.0 *rendered*
   bash writes a slim manifest (timestamp, stack, template version)
@@ -30,8 +36,8 @@ Public surface:
   client-side — currently used only by tests and a planned v1.1
   cleanup-and-verify script. See "Open question 1" in
   ``docs/proposals/0001-s3-persistence.md``.
-* :func:`render_rclone_config` — produces a ``[hetzner-s3]`` rclone
-  profile block from an :class:`S3Endpoint`. Written to
+* :func:`render_rclone_config` — produces a ``[cloudflare-r2]``
+  rclone profile block from an :class:`S3Endpoint`. Written to
   ``~/.config/rclone/rclone.conf`` on the server. Idempotent — the
   block is identified by name and replaced wholesale on every
   spinup so credential rotation is a single render away.
@@ -57,21 +63,24 @@ boundary clean.
 Design choices for v1.0 (see RFC 0001 in
 ``docs/proposals/0001-s3-persistence.md`` for the full reasoning):
 
-* **Hetzner Object Storage**, not Cloudflare R2 — operator
-  preference for EU data-residency. The endpoint URL is the only
-  S3-flavour-specific bit; switching to R2 later is an
-  ``S3Endpoint`` constructor argument away.
-* **Bucket per stack** — one Hetzner bucket per
-  ``<class>-<user>`` slug. Easier blast-radius isolation than
-  ``<bucket>/<stack>/...`` prefixes.
+* **Cloudflare R2**, not Hetzner Object Storage — the project
+  already uses R2 for the Tofu state backend, the
+  ``cloudflare/cloudflare`` provider is already wired up, and R2
+  has zero egress fees + region-agnostic access. The earlier
+  Hetzner-OS proposal would have introduced a parallel storage
+  system and a per-region egress cost for non-EU compute.
+* **Bucket per stack** — one R2 bucket per ``<class>-<user>``
+  slug. Easier blast-radius isolation than ``<bucket>/<stack>/...``
+  prefixes.
 * **rsync (rclone) for everything in v1.0** — Gitea LFS and Dify
   storage have native S3 backends but that's deferred to v1.1.
   v1.0 keeps the docker-compose layout untouched and drives
   persistence purely via rclone sync of the bind-mount directory.
 * **Snapshot-versioning strategy**: timestamped directories under
   ``snapshots/<ISO8601>/`` plus a ``snapshots/latest`` pointer
-  file. Retention (last 7 daily + 4 weekly) is enforced by a
-  separate cleanup script — out of scope for this module.
+  file. Retention (30-day NoncurrentVersionExpiration via R2
+  lifecycle policy) is enforced at bucket-creation time by the
+  Tofu resource — out of scope for this module.
 """
 
 from __future__ import annotations
@@ -86,21 +95,24 @@ from dataclasses import asdict, dataclass, field
 # Identifier shape — protects the rendered bash from injection
 # ---------------------------------------------------------------------------
 
-# Hetzner location names (`fsn1`, `hel1`, `nbg1`) are lowercase
-# alphanumeric with optional dashes. The bucket name follows S3 rules
-# (3-63 chars, lowercase, digits, hyphens). We're strict on both
-# because they're interpolated into rendered bash without further
-# escaping; a value containing ``$``, ``;`` or backticks would let an
-# attacker who controlled the value execute arbitrary commands on
-# the server. Hetzner's own identifiers are always within this set,
-# so the gate is conservative on legitimate input.
-_HETZNER_REGION = re.compile(r"^[a-z0-9-]+$")
+# S3-region identifier shape. R2 uses ``auto`` as the region (R2
+# is a single global namespace with edge replication, no traditional
+# region routing). For Hetzner Object Storage the equivalent is a
+# location code like ``fsn1`` / ``hel1`` / ``nbg1``. We accept any
+# lowercase alnum-with-dashes value so the module supports both
+# providers from the same charset gate. The bucket name follows S3
+# rules (3-63 chars, lowercase, digits, hyphens). We're strict on
+# both because they're interpolated into rendered bash without
+# further escaping; a value containing ``$``, ``;`` or backticks
+# would let an attacker who controlled the value execute arbitrary
+# commands on the server.
+_S3_REGION = re.compile(r"^[a-z0-9-]+$")
 _BUCKET_NAME = re.compile(r"^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$")
 _ACCESS_KEY = re.compile(r"^[A-Za-z0-9]+$")
-# Hetzner Object Storage secret keys are base64-ish (40-80 chars).
-# We allow the full set of base64 + URL-safe characters so we don't
-# reject a future format change, but still gate against bash
-# metacharacters.
+# S3-style secret keys are base64-ish across providers (R2 emits
+# 40-64 chars; Hetzner / AWS similar). We allow the full set of
+# base64 + URL-safe characters so we don't reject a future format
+# change, but still gate against bash metacharacters.
 _SECRET_KEY = re.compile(r"^[A-Za-z0-9+/=_-]+$")
 # Postgres identifier shape — applies to both database names and
 # role names interpolated into rendered SQL (``DROP DATABASE
@@ -129,7 +141,8 @@ _S3_SUBPATH = re.compile(r"^[a-z0-9][a-z0-9./-]*[a-z0-9]$|^[a-z0-9]$")
 # Endpoint URL shape — the rclone config writes ``endpoint = <value>``
 # verbatim; whitespace or newlines would corrupt the file. Accept
 # scheme + ://, then a conservative URL char set covering host/port/
-# path. Real Hetzner endpoints (https://fsn1.your-objectstorage.com)
+# path. Real R2 endpoints (https://<account_id>.r2.cloudflarestorage.com)
+# and Hetzner endpoints (https://fsn1.your-objectstorage.com) both
 # match cleanly; injection attempts don't.
 _ENDPOINT_URL = re.compile(r"^https?://[A-Za-z0-9._~:/?#\[\]@!$&'()*+,;=%-]+$")
 
@@ -152,7 +165,7 @@ class S3PersistenceError(Exception):
 
 @dataclass(frozen=True)
 class S3Endpoint:
-    """Hetzner Object Storage connection coordinates.
+    """S3-compatible storage connection coordinates.
 
     All five fields are required: missing credentials are an error
     surfaced at construction time, not at script-render time, so the
@@ -161,10 +174,12 @@ class S3Endpoint:
     rclone error on the remote.
 
     ``endpoint`` is the full URL (e.g.
-    ``https://fsn1.your-objectstorage.com``) so we don't have to
-    assume the URL shape. ``region`` is the short code (``fsn1``)
-    needed by the S3 v4 signing protocol — Hetzner requires it to
-    match the location.
+    ``https://<account_id>.r2.cloudflarestorage.com`` for R2,
+    ``https://fsn1.your-objectstorage.com`` for Hetzner Object
+    Storage) so we don't have to assume the URL shape. ``region``
+    is the short code required by the S3 v4 signing protocol —
+    ``auto`` for R2, the location code (``fsn1`` / ``hel1`` /
+    ``nbg1``) for Hetzner.
     """
 
     endpoint: str
@@ -196,7 +211,7 @@ class S3Endpoint:
                 f"rendered rclone config (whitespace/newlines/control chars): {self.endpoint!r}",
             )
         for name, value, pattern in (
-            ("region", self.region, _HETZNER_REGION),
+            ("region", self.region, _S3_REGION),
             ("bucket", self.bucket, _BUCKET_NAME),
             ("access_key", self.access_key, _ACCESS_KEY),
             ("secret_key", self.secret_key, _SECRET_KEY),
@@ -333,10 +348,13 @@ class SnapshotManifest:
 
 
 # rclone profile name. Used as the destination prefix in rclone
-# commands (``rclone sync /local hetzner-s3:bucket/path``). Picked
-# at module level so the config-render and the script-render can't
-# drift apart.
-RCLONE_PROFILE = "hetzner-s3"
+# commands (``rclone sync /local cloudflare-r2:bucket/path``).
+# Picked at module level so the config-render and the script-render
+# can't drift apart. Naming the profile after the v1.0 provider (R2)
+# keeps things obvious in the rendered scripts; if we ever switch
+# providers in the future we can rename here without changing any
+# caller — the constant is the single source of truth.
+RCLONE_PROFILE = "cloudflare-r2"
 
 
 def _quote_sql_ident(name: str) -> str:
@@ -357,26 +375,33 @@ def _quote_sql_ident(name: str) -> str:
 
 
 def render_rclone_config(endpoint: S3Endpoint) -> str:
-    """Render the ``[hetzner-s3]`` rclone profile block.
+    """Render the ``[cloudflare-r2]`` rclone profile block.
 
     The output is the *full* config file content, not a diff.
     Caller writes it atomically to ``~/.config/rclone/rclone.conf``
     on the server (overwrite-with-tempfile pattern) so a partial
     write can't leave the file in a state where rclone reads
     half-old half-new credentials.
+
+    ``provider = Cloudflare`` tells rclone to apply R2-specific
+    quirks (no checksum-on-multipart, no STORAGE_CLASS, etc.). If
+    the caller passes a Hetzner endpoint instead, this is wrong —
+    but v1.0 ships with R2 only, and the profile name is fixed at
+    module level. A future provider-agnostic refactor would lift
+    the ``provider`` value to a constructor argument.
     """
     return (
         f"[{RCLONE_PROFILE}]\n"
         "type = s3\n"
-        "provider = Other\n"
+        "provider = Cloudflare\n"
         "env_auth = false\n"
         f"access_key_id = {endpoint.access_key}\n"
         f"secret_access_key = {endpoint.secret_key}\n"
         f"endpoint = {endpoint.endpoint}\n"
         f"region = {endpoint.region}\n"
-        # `acl = private` is the Hetzner default but spelling it
-        # out makes the intent explicit and protects against a
-        # future rclone-default change.
+        # `acl = private` is the R2 default but spelling it out
+        # makes the intent explicit and protects against a future
+        # rclone-default change.
         "acl = private\n"
     )
 
@@ -409,7 +434,7 @@ class PostgresDumpTarget:
     user: str
 
     def __post_init__(self) -> None:
-        if not _HETZNER_REGION.fullmatch(self.container):
+        if not _S3_REGION.fullmatch(self.container):
             raise S3PersistenceError(
                 f"PostgresDumpTarget.container must match docker-service-name shape "
                 f"(lowercase alnum + dash): {self.container!r}",

--- a/src/nexus_deploy/s3_persistence.py
+++ b/src/nexus_deploy/s3_persistence.py
@@ -41,14 +41,19 @@ Public surface:
   ``~/.config/rclone/rclone.conf`` on the server. Idempotent — the
   block is identified by name and replaced wholesale on every
   spinup so credential rotation is a single render away.
-* :func:`render_snapshot_script` — bash that pauses the relevant
-  docker compose stacks, runs ``pg_dump`` for each Postgres
-  database we care about, rsyncs ``/var/lib/nexus-data/`` to S3,
-  writes the manifest, and exits with rc=0 only if every
-  ``rclone check`` passed. Caller is responsible for treating
-  rc≠0 as "abort teardown — leave the server up".
-* :func:`render_restore_script` — bash that reads the latest
-  manifest, rclone-syncs the snapshot to ``/var/lib/nexus-data/``,
+* :func:`render_snapshot_script` — bash that stops the relevant
+  docker compose stacks (graceful drain, not ``pause``), runs
+  ``pg_dump`` for each Postgres database we care about, rsyncs
+  ``/var/lib/nexus-data/`` to S3, writes the manifest, and exits
+  with rc=0 only if every ``rclone check`` passed. Caller is
+  responsible for treating rc≠0 as "abort teardown — leave the
+  server up".
+* :func:`render_restore_script` — bash that reads
+  ``snapshots/latest.txt`` (a single-line pointer to the active
+  snapshot timestamp; v1.0 does NOT download/parse
+  ``manifest.json`` — integrity is checked at snapshot-write
+  time via ``rclone check``, not on restore), then rclone-syncs
+  the snapshot tree to ``/var/lib/nexus-data/``,
   and runs ``pg_restore`` for each Postgres dump. Idempotent on
   the empty-S3 case (first-time spinup).
 
@@ -77,10 +82,16 @@ Design choices for v1.0 (see RFC 0001 in
   v1.0 keeps the docker-compose layout untouched and drives
   persistence purely via rclone sync of the bind-mount directory.
 * **Snapshot-versioning strategy**: timestamped directories under
-  ``snapshots/<ISO8601>/`` plus a ``snapshots/latest`` pointer
+  ``snapshots/<ISO8601>/`` plus a ``snapshots/latest.txt`` pointer
   file. Retention (30-day NoncurrentVersionExpiration via R2
-  lifecycle policy) is enforced at bucket-creation time by the
-  Tofu resource — out of scope for this module.
+  lifecycle policy) is enforced by ``scripts/init-s3-bucket.sh``
+  in v1.0 — the script enables bucket versioning and applies the
+  lifecycle rule via the S3 API at bucket-bootstrap time. v1.1
+  may migrate this to a Tofu resource once the
+  ``cloudflare/cloudflare`` provider grows a first-class R2
+  lifecycle resource. Either way, it stays out of scope for
+  this module — the module only writes objects, never configures
+  the bucket itself.
 """
 
 from __future__ import annotations
@@ -674,12 +685,22 @@ def render_snapshot_script(
             '  local dst="$2"',
             '  local label="$3"',
             "  set +e",
+            # Pipeline is three-stage: rclone | tee | grep. PIPESTATUS
+            # indexes accordingly:
+            #   [0] = rclone (the actual integrity check)
+            #   [1] = tee   (just buffering output; ~always succeeds)
+            #   [2] = grep  (0 = drift markers found, 1 = clean)
+            # An earlier revision captured drift_rc=[1] (tee), which
+            # always succeeds, so the gate effectively reported
+            # "drift found" on every snapshot and would have aborted
+            # every real teardown. Capturing [2] (grep) makes drift
+            # detection actually correct.
             '  rclone check "$src" "$dst" '
             '--one-way --combined - 2>"$WORKDIR/rclone-check.err" '
             '| tee "$WORKDIR/rclone-check.out" '
             '| grep -qE "^[-*]"',
-            "  local drift_rc=${PIPESTATUS[1]}",
             "  local rclone_rc=${PIPESTATUS[0]}",
+            "  local drift_rc=${PIPESTATUS[2]}",
             "  set -e",
             '  if [ "$rclone_rc" -ne 0 ]; then',
             '    echo "✗ snapshot-failed: rclone check ${label} errored (rc=$rclone_rc)" >&2',

--- a/src/nexus_deploy/s3_persistence.py
+++ b/src/nexus_deploy/s3_persistence.py
@@ -273,8 +273,9 @@ class SnapshotManifest:
         at the root of the timestamped snapshot directory.
 
         Indented because it's read by humans during ops/debugging,
-        and 200-300 bytes of whitespace doesn't move the needle on
-        Hetzner egress costs.
+        and 200-300 bytes of whitespace per manifest doesn't move
+        the needle on storage cost or transfer time at our snapshot
+        cadence — for R2 specifically, egress is free.
         """
         return json.dumps(
             {
@@ -613,16 +614,37 @@ def render_snapshot_script(
             # operator quietly ignores. Per CLAUDE.md "Never silently
             # swallow errors in critical operations."
             #
-            # We now branch on the SPECIFIC happy "stack is already
-            # down" case via ``docker compose ps -q`` (returns empty
-            # when no containers are running). Any other ``stop``
-            # failure bubbles up via ``set -e``.
+            # We branch on the SPECIFIC happy "stack is already
+            # down" case via ``docker compose ps -q``: if the
+            # command SUCCEEDS (rc=0) AND its stdout is EMPTY,
+            # there are no running containers → safe to skip stop.
+            # Any other situation (ps itself fails, or it succeeds
+            # and lists running containers) takes us into the
+            # ``compose stop`` branch — where ``set -e`` will abort
+            # the snapshot on any non-zero exit, surfacing missing-
+            # compose-file / daemon-down / YAML-syntax errors as
+            # the real failures they are.
+            #
+            # An earlier revision of this block evaluated only the
+            # stdout via ``[ -n "$(... 2>/dev/null)" ]`` — that
+            # silently mapped every ps failure (which produces
+            # empty stdout) to "stack already down" and continued
+            # the snapshot while services were still running.
+            # We now capture ps's exit code explicitly via
+            # ``set +e`` so the empty-stdout-from-failure case
+            # can't masquerade as the empty-stdout-from-no-
+            # containers case.
+            lines.append(f"COMPOSE_FILE={quoted}")
+            lines.append("set +e")
+            lines.append('PS_OUT=$(docker compose -f "$COMPOSE_FILE" ps -q 2>/dev/null)')
+            lines.append("PS_RC=$?")
+            lines.append("set -e")
+            lines.append('if [ "$PS_RC" -eq 0 ] && [ -z "$PS_OUT" ]; then')
             lines.append(
-                f'if [ -n "$(docker compose -f {quoted} ps -q 2>/dev/null)" ]; then',
+                f'  echo "  (skip: compose stack at {compose_file} already down)"',
             )
-            lines.append(f"  docker compose -f {quoted} stop")
             lines.append("else")
-            lines.append(f'  echo "  (skip: compose stack at {compose_file} already down)"')
+            lines.append('  docker compose -f "$COMPOSE_FILE" stop')
             lines.append("fi")
         lines.append("")
 

--- a/src/nexus_deploy/s3_persistence.py
+++ b/src/nexus_deploy/s3_persistence.py
@@ -110,7 +110,28 @@ _SECRET_KEY = re.compile(r"^[A-Za-z0-9+/=_-]+$")
 # every database/user we manage today matches this strict shape, and
 # an attacker who controls the value should be rejected at config
 # time, not handled with quoting acrobatics.
+#
+# Note: this charset **includes hyphens** because real role names in
+# the project use them (``nexus-gitea`` in stacks/gitea/docker-
+# compose.yml, ``nexus-dify`` in stacks/dify/docker-compose.yml).
+# Hyphens are valid inside double-quoted SQL identifiers but invalid
+# unquoted, so :func:`_quote_sql_ident` below double-quotes the
+# rendered SQL identifier unconditionally.
 _PG_IDENTIFIER = re.compile(r"^[A-Za-z_][A-Za-z0-9_-]*$")
+# S3 object-key shape — applies to ``RsyncTarget.s3_subpath`` which is
+# interpolated into double-quoted bash strings like
+# ``"$BUCKET/$SNAPSHOT_PREFIX/{sub}"``. ``shlex.quote`` does NOT make
+# a value safe inside double quotes (``$(...)`` and backticks still
+# expand). Restrict to a strict path-segment shape: lowercase alnum +
+# hyphen + dot + forward-slash for nesting. No ``..``, no leading
+# slash, no quotes/dollars/backticks/spaces/newlines.
+_S3_SUBPATH = re.compile(r"^[a-z0-9][a-z0-9./-]*[a-z0-9]$|^[a-z0-9]$")
+# Endpoint URL shape — the rclone config writes ``endpoint = <value>``
+# verbatim; whitespace or newlines would corrupt the file. Accept
+# scheme + ://, then a conservative URL char set covering host/port/
+# path. Real Hetzner endpoints (https://fsn1.your-objectstorage.com)
+# match cleanly; injection attempts don't.
+_ENDPOINT_URL = re.compile(r"^https?://[A-Za-z0-9._~:/?#\[\]@!$&'()*+,;=%-]+$")
 
 
 class S3PersistenceError(Exception):
@@ -158,6 +179,21 @@ class S3Endpoint:
         if not self.endpoint.startswith(("http://", "https://")):
             raise S3PersistenceError(
                 f"S3Endpoint.endpoint must start with http(s)://: {self.endpoint!r}",
+            )
+        # The endpoint URL gets interpolated verbatim into the
+        # rendered rclone config (key=value lines). The http(s)://
+        # prefix check alone doesn't catch whitespace, newlines, or
+        # control characters — any of which would corrupt the config
+        # file (split the value across multiple keys, inject extra
+        # lines) the moment rclone parses it. Tighten to the URL
+        # character set: scheme + `://` + RFC-3986 unreserved/host
+        # characters + optional port + optional path. Real Hetzner
+        # endpoints (e.g. ``https://fsn1.your-objectstorage.com``)
+        # are well inside this set; an injection attempt is not.
+        if not _ENDPOINT_URL.fullmatch(self.endpoint):
+            raise S3PersistenceError(
+                "S3Endpoint.endpoint contains characters that would corrupt the "
+                f"rendered rclone config (whitespace/newlines/control chars): {self.endpoint!r}",
             )
         for name, value, pattern in (
             ("region", self.region, _HETZNER_REGION),
@@ -303,6 +339,23 @@ class SnapshotManifest:
 RCLONE_PROFILE = "hetzner-s3"
 
 
+def _quote_sql_ident(name: str) -> str:
+    """Double-quote a Postgres identifier for safe SQL interpolation.
+
+    Real role names in the project use hyphens (``nexus-gitea``,
+    ``nexus-dify``) — hyphens are illegal inside *unquoted* SQL
+    identifiers but valid inside double-quoted ones. Always
+    emitting the quoted form means the rendered SQL works for
+    both shapes without case-by-case logic.
+
+    The input is already charset-gated by :data:`_PG_IDENTIFIER`,
+    so it never contains a literal ``"``; we still double any that
+    appear, belt-and-suspenders, in case a future caller bypasses
+    the gate.
+    """
+    return '"' + name.replace('"', '""') + '"'
+
+
 def render_rclone_config(endpoint: S3Endpoint) -> str:
     """Render the ``[hetzner-s3]`` rclone profile block.
 
@@ -378,11 +431,37 @@ class RsyncTarget:
     is the relative key under the snapshot's timestamped directory
     — kept short and stable across snapshots so a future
     diff-based optimisation has a useful key to compare against.
+
+    Charset validation: ``s3_subpath`` is interpolated into bash
+    *inside* double-quoted strings (``"$BUCKET/$PREFIX/{sub}"``),
+    where ``shlex.quote()`` doesn't help — ``$()`` and backticks
+    still expand inside double quotes. We enforce a strict
+    path-segment shape at construction so the rendered bash can't
+    be tricked into executing the value as a command substitution.
+    ``local_path`` is interpolated with ``shlex.quote`` outside any
+    double quotes, so its only requirement is absolute-path
+    (the rendered script does ``mkdir -p`` etc. against it).
     """
 
     name: str
     local_path: str
     s3_subpath: str
+
+    def __post_init__(self) -> None:
+        if not self.local_path.startswith("/"):
+            raise S3PersistenceError(
+                f"RsyncTarget.local_path must be absolute: {self.local_path!r}",
+            )
+        if not _S3_SUBPATH.fullmatch(self.s3_subpath):
+            raise S3PersistenceError(
+                "RsyncTarget.s3_subpath must match strict path-segment shape "
+                "(lowercase alnum + hyphen + dot + forward-slash, no leading "
+                f"slash, no `..`): {self.s3_subpath!r}",
+            )
+        if ".." in self.s3_subpath.split("/"):
+            raise S3PersistenceError(
+                f"RsyncTarget.s3_subpath must not contain '..' segments: {self.s3_subpath!r}",
+            )
 
 
 def render_snapshot_script(
@@ -480,7 +559,12 @@ def render_snapshot_script(
             container = shlex.quote(pg.container)
             db = shlex.quote(pg.database)
             user = shlex.quote(pg.user)
-            dump_file = f"$POSTGRES_DIR/{pg.database}.sql.gz"
+            # File naming: ``<database>.dump.gz`` (custom binary
+            # pg_dump format, gzipped) — matches the restore-side
+            # filename and the RFC's stated S3 layout. Earlier this
+            # said ``.sql.gz`` which was misleading since the body
+            # is NOT plain SQL (``-F c`` produces a binary archive).
+            dump_file = f"$POSTGRES_DIR/{pg.database}.dump.gz"
             lines.append(
                 f"docker exec {container} pg_dump -U {user} -d {db} -F c | gzip -9 > {dump_file}",
             )
@@ -517,44 +601,66 @@ def render_snapshot_script(
             'rclone copyto "$WORKDIR/manifest.json" "$BUCKET/$SNAPSHOT_PREFIX/manifest.json"',
             "",
             'echo "→ snapshot: verifying upload (rclone check)"',
-            # Atomicity gate. Two distinct failure modes need distinct
-            # treatment, which the previous ``... | grep ... && {...}
-            # || true`` form silently merged into one bucket:
+            # Atomicity gate. Three classes of source need verifying:
             #
-            #   1. rclone-check itself fails (auth/network/quota) →
-            #      ``rclone check`` exits non-zero. The previous form
-            #      would let ``set -e`` catch that, but only if the
-            #      pipe-grep didn't find any drift markers; the ``||
-            #      true`` fallback then masked it again. We capture
-            #      the rclone-check rc explicitly via ``${PIPESTATUS}``
-            #      and abort if non-zero.
+            #   a. ``$WORKDIR`` — locally-staged manifest.json + the
+            #      postgres dumps under $POSTGRES_DIR.
+            #   b. each :class:`RsyncTarget`.local_path — the
+            #      filesystem trees uploaded directly from
+            #      /var/lib/nexus-data/<...>. These were NOT in
+            #      $WORKDIR (we synced them straight from the live
+            #      mount), so a $WORKDIR-only check would have left
+            #      the bulk of the persisted state unverified.
             #
-            #   2. rclone-check succeeds but reports drift (some file
-            #      missing-on-remote ``-`` or different ``*``). In
-            #      that case ``grep -E "^[-*]"`` *succeeds* (rc=0 →
-            #      drift found) and we abort. If grep returns rc=1
-            #      (no drift markers found) that's the happy path.
+            # We run ``rclone check`` once per source, accumulating
+            # any failure into a single ``verify_failed`` flag. Two
+            # distinct rcs per check (rclone's own exit and the
+            # grep-for-drift) are captured via ``PIPESTATUS`` so
+            # neither can be masked by ``|| true``.
             #
-            # ``--one-way`` keeps the comparison local→S3-only, so a
-            # stale orphan in S3 from a previous failed snapshot can't
-            # by itself fail the gate — only files we actually
-            # uploaded need to round-trip cleanly.
-            "set +e",
-            'rclone check "$WORKDIR" "$BUCKET/$SNAPSHOT_PREFIX" '
+            # ``--one-way`` keeps each comparison source→S3 only, so
+            # a stale orphan in S3 from a previous failed snapshot
+            # can't by itself fail the gate.
+            "verify_failed=0",
+            "verify_one() {",
+            '  local src="$1"',
+            '  local dst="$2"',
+            '  local label="$3"',
+            "  set +e",
+            '  rclone check "$src" "$dst" '
             '--one-way --combined - 2>"$WORKDIR/rclone-check.err" '
             '| tee "$WORKDIR/rclone-check.out" '
             '| grep -qE "^[-*]"',
-            "drift_rc=${PIPESTATUS[1]}     # 0 = drift found, 1 = clean",
-            "rclone_rc=${PIPESTATUS[0]}    # rclone-check's own exit",
-            "set -e",
-            'if [ "$rclone_rc" -ne 0 ]; then',
-            '  echo "✗ snapshot-failed: rclone check itself errored (rc=$rclone_rc)" >&2',
-            '  cat "$WORKDIR/rclone-check.err" >&2 || true',
-            "  exit 2",
-            "fi",
-            'if [ "$drift_rc" -eq 0 ]; then',
-            '  echo "✗ snapshot-failed: rclone check found drift" >&2',
-            '  cat "$WORKDIR/rclone-check.out" >&2',
+            "  local drift_rc=${PIPESTATUS[1]}",
+            "  local rclone_rc=${PIPESTATUS[0]}",
+            "  set -e",
+            '  if [ "$rclone_rc" -ne 0 ]; then',
+            '    echo "✗ snapshot-failed: rclone check ${label} errored (rc=$rclone_rc)" >&2',
+            '    cat "$WORKDIR/rclone-check.err" >&2 || true',
+            "    verify_failed=1",
+            "    return",
+            "  fi",
+            '  if [ "$drift_rc" -eq 0 ]; then',
+            '    echo "✗ snapshot-failed: rclone check ${label} found drift" >&2',
+            '    cat "$WORKDIR/rclone-check.out" >&2',
+            "    verify_failed=1",
+            "    return",
+            "  fi",
+            '  echo "  ✓ verified ${label}"',
+            "}",
+            "",
+            'verify_one "$WORKDIR" "$BUCKET/$SNAPSHOT_PREFIX" "workdir(manifest+postgres)"',
+        ]
+        + [
+            f"verify_one {shlex.quote(rs.local_path)} "
+            f'"$BUCKET/$SNAPSHOT_PREFIX/{shlex.quote(rs.s3_subpath)}" '
+            f"{shlex.quote('rsync:' + rs.name)}"
+            for rs in rs_targets
+        ]
+        + [
+            "",
+            'if [ "$verify_failed" -ne 0 ]; then',
+            '  echo "✗ snapshot-failed: one or more verifications drifted; not pointing snapshots/latest at $TIMESTAMP" >&2',
             "  exit 2",
             "fi",
             "",
@@ -662,24 +768,39 @@ def render_restore_script(
         lines.append('echo "→ restore: applying postgres dumps"')
         for pg in pg_targets:
             container = shlex.quote(pg.container)
-            db = shlex.quote(pg.database)
-            user = shlex.quote(pg.user)
-            dump_file = f"$WORKDIR/postgres/{pg.database}.sql.gz"
+            db_cli = shlex.quote(pg.database)
+            user_cli = shlex.quote(pg.user)
+            # SQL identifiers — must be DOUBLE-QUOTED in the rendered
+            # SQL because real role names use hyphens (``nexus-gitea``,
+            # ``nexus-dify``) which are invalid as unquoted PG
+            # identifiers. ``_quote_sql_ident`` handles the doubling
+            # of any literal ``"`` in the value (defensive — values
+            # are already charset-gated by ``_PG_IDENTIFIER`` so they
+            # can't contain quotes today). The SQL goes inside a
+            # ``-c "..."`` bash argument that is itself double-quoted,
+            # so the inner ``"`` characters need bash-escaping → we
+            # use a single-quoted bash argument instead.
+            db_sql = _quote_sql_ident(pg.database)
+            user_sql = _quote_sql_ident(pg.user)
+            dump_file = f"$WORKDIR/postgres/{pg.database}.dump.gz"
             # We drop+recreate the database to guarantee a clean
             # restore. pg_restore --clean would do something similar
             # but is fragile across PG versions; the explicit
             # drop+create is portable.
+            #
+            # ``-c '<SQL>'`` (single-quoted bash arg) so the inner
+            # double-quoted SQL identifiers don't need escaping.
             lines.append(
-                f"docker exec {container} psql -U {user} -d postgres "
-                f'-c "DROP DATABASE IF EXISTS {pg.database} WITH (FORCE);"',
+                f"docker exec {container} psql -U {user_cli} -d postgres "
+                f"-c 'DROP DATABASE IF EXISTS {db_sql} WITH (FORCE);'",
             )
             lines.append(
-                f"docker exec {container} psql -U {user} -d postgres "
-                f'-c "CREATE DATABASE {pg.database} OWNER {pg.user};"',
+                f"docker exec {container} psql -U {user_cli} -d postgres "
+                f"-c 'CREATE DATABASE {db_sql} OWNER {user_sql};'",
             )
             lines.append(
                 f"gunzip -c {dump_file} | "
-                f"docker exec -i {container} pg_restore -U {user} -d {db} "
+                f"docker exec -i {container} pg_restore -U {user_cli} -d {db_cli} "
                 "--no-owner --no-acl",
             )
         lines.append("")
@@ -698,7 +819,7 @@ def manifest_for_components(
     *,
     stack: str,
     template_version: str,
-    timestamp: str,
+    created_at: str,
     components: Mapping[str, tuple[int, str]],
 ) -> SnapshotManifest:
     """Build a :class:`SnapshotManifest` from a sized+hashed component map.
@@ -711,6 +832,12 @@ def manifest_for_components(
     sha256 over multi-GB rsync trees on the server adds material
     minutes to teardown.
 
+    ``created_at`` should be an ISO-8601 string (e.g.
+    ``2026-05-11T04:00:00Z``); it lands on the manifest's
+    ``created_at`` field. Previously this parameter was named
+    ``timestamp`` and silently ignored — misleading API, fixed
+    here by renaming + actually using it.
+
     The version-1.1 plan is to revisit this and either (a) make the
     rendered bash compute and emit per-component sha256 (slower
     teardown, more robust restore) or (b) trust rclone's own
@@ -718,7 +845,7 @@ def manifest_for_components(
     """
     return SnapshotManifest(
         version=1,
-        created_at="",
+        created_at=created_at,
         stack=stack,
         template_version=template_version,
         components=tuple(

--- a/src/nexus_deploy/s3_persistence.py
+++ b/src/nexus_deploy/s3_persistence.py
@@ -497,37 +497,53 @@ def render_snapshot_script(
     timestamp: str,
     postgres_targets: Iterable[PostgresDumpTarget],
     rsync_targets: Iterable[RsyncTarget],
-    pause_compose_files: Iterable[str] = (),
+    stop_compose_files: Iterable[str] = (),
 ) -> str:
-    """Render the bash that snapshots the live stack to S3.
+    """Render the bash that snapshots the live stack to R2.
 
     Steps the rendered script performs (in order, ``set -euo
     pipefail`` throughout — first failure aborts):
 
-    1. ``docker compose pause`` for every file in
-       ``pause_compose_files``. This lets in-flight HTTP requests
-       drain naturally instead of being killed mid-write.
-    2. ``pg_dump`` (compressed) for each postgres target into
-       ``/tmp/nexus-snapshot/postgres/<db>.sql.gz``.
-    3. ``rclone sync`` each rsync target into the timestamped S3
-       directory ``snapshots/<timestamp>/<subpath>``.
+    1. ``docker compose stop`` for every file in
+       ``stop_compose_files``. Graceful drain with the default
+       10s timeout: app processes finish in-flight requests and
+       close DB connections cleanly. We deliberately do NOT use
+       ``docker compose pause`` — that's a cgroup-freezer SIGSTOP
+       and hard-kills in-flight writes mid-transaction.
+    2. ``pg_dump -F c | gzip`` for each postgres target into
+       ``/tmp/nexus-snapshot/postgres/<db>.dump.gz`` (custom
+       binary format, gzipped — works with the matching
+       ``gunzip | pg_restore`` on the spinup side).
+    3. ``rclone sync`` each rsync target's ``local_path`` into the
+       timestamped R2 directory ``snapshots/<timestamp>/<s3_subpath>``.
+       Only the listed targets are walked — db/ and redis/ subdirs
+       under /var/lib/nexus-data are NOT included (Postgres state is
+       captured separately via pg_dump, Redis is regeneratable).
     4. Upload the postgres dumps under
-       ``snapshots/<timestamp>/postgres/``.
-    5. Compute sha256 + size for each component, write
-       ``manifest.json``, upload it.
-    6. ``rclone check`` re-reads the upload and compares ETags —
-       this is the gate the caller checks for atomicity.
-    7. Update ``snapshots/latest`` to point at the new timestamp.
-
-    On any non-zero step the script prints a clear ``✗
-    snapshot-failed: ...`` line and exits non-zero. Pipeline.py
-    interprets that as "do NOT proceed to tofu destroy".
+       ``snapshots/<timestamp>/postgres/<db>.dump.gz``.
+    5. Write a slim ``manifest.json`` (stack, timestamp, template
+       version — no per-component checksums in v1.0; we rely on
+       rclone's ETag/per-object hash check for integrity). Upload
+       it to ``snapshots/<timestamp>/manifest.json``.
+    6. **Atomicity gate** — run ``rclone check --one-way`` once
+       per source: the workdir tree (containing manifest +
+       postgres dumps) PLUS each RsyncTarget's local_path against
+       its R2 destination. Each check captures two rcs via
+       ``PIPESTATUS`` (rclone's own exit, and the drift-grep's
+       exit), neither maskable by ``|| true``. Any failure
+       accumulates into ``verify_failed=1`` and the script aborts
+       BEFORE touching the ``snapshots/latest.txt`` pointer —
+       this is the "verified-before-pointing-latest" invariant
+       the caller relies on for atomic teardown.
+    7. Update ``snapshots/latest.txt`` to contain the new
+       timestamp. Pipeline.py interprets script rc=0 as
+       "proceed to tofu destroy"; any non-zero rc means
+       "abort teardown, leave server up".
 
     Side note on shlex.quote: every interpolated value is gated
-    upstream by :class:`S3Endpoint`'s charset checks and the
-    ``stack_slug``/``timestamp`` regexes below — but we still
-    ``shlex.quote`` belt-and-suspenders to keep the rendered bash
-    safe even if a future caller bypasses the constructor.
+    upstream by the dataclass constructors' charset checks; we
+    still ``shlex.quote`` belt-and-suspenders to keep the rendered
+    bash safe even if a future caller bypasses validation.
     """
     if not _BUCKET_NAME.fullmatch(stack_slug):
         raise S3PersistenceError(
@@ -544,7 +560,7 @@ def render_snapshot_script(
 
     pg_targets = tuple(postgres_targets)
     rs_targets = tuple(rsync_targets)
-    pause_files = tuple(pause_compose_files)
+    stop_files = tuple(stop_compose_files)
 
     bucket_url = f"{RCLONE_PROFILE}:{shlex.quote(endpoint.bucket)}"
     snapshot_prefix = f"snapshots/{shlex.quote(timestamp)}"
@@ -568,13 +584,19 @@ def render_snapshot_script(
         "",
     ]
 
-    if pause_files:
-        lines.append('echo "→ snapshot: pausing compose stacks"')
-        for compose_file in pause_files:
+    if stop_files:
+        lines.append('echo "→ snapshot: stopping compose stacks (graceful 10s drain)"')
+        for compose_file in stop_files:
             quoted = shlex.quote(compose_file)
+            # ``docker compose stop`` (not ``pause``) — the latter is
+            # SIGSTOP via the cgroup freezer and hard-kills in-flight
+            # writes. ``stop`` sends SIGTERM with a 10s grace window
+            # for the container to flush + close DB connections
+            # cleanly. ``|| echo`` keeps this non-fatal if a stack
+            # is already down (e.g. partial-failure retry).
             lines.append(
-                f"docker compose -f {quoted} pause || "
-                'echo "  (compose pause non-fatal: stack may already be down)"',
+                f"docker compose -f {quoted} stop || "
+                'echo "  (compose stop non-fatal: stack may already be down)"',
             )
         lines.append("")
 
@@ -707,7 +729,7 @@ def render_restore_script(
     rsync_targets: Iterable[RsyncTarget],
     local_root: str = "/var/lib/nexus-data",
 ) -> str:
-    """Render the bash that restores a snapshot from S3 to the local
+    """Render the bash that restores a snapshot from R2 to the local
     filesystem.
 
     Idempotent on the empty-S3 case (first-time spinup) — the
@@ -718,16 +740,32 @@ def render_restore_script(
        ``echo 'fresh-start: no snapshot in S3, leaving local
        state empty'`` and exits 0. Pipeline.py then proceeds with
        a clean docker-compose up just like a brand-new install.
-    2. ``rclone sync`` the snapshot's filesystem trees into
-       ``local_root``.
-    3. ``pg_restore`` each postgres dump into the matching
-       container's database. The container is assumed to already be
-       running (compose-up ran first); we drop+recreate the
-       database to get a clean restore.
+       Also validates the timestamp matches the safe-path regex
+       before substituting it into any rclone command — defends
+       against a malformed/tampered ``latest.txt``.
+    2. ``rclone sync`` each RsyncTarget's S3 subpath into the
+       matching ``local_path`` (which is the absolute path on the
+       server — not always under ``local_root``; callers may
+       restore to e.g. ``/opt/data``). ``local_root`` is only used
+       to ``mkdir -p`` the top-level data directory.
+    3. ``rclone sync`` the postgres dumps from
+       ``snapshots/<ts>/postgres/`` into a scratch workdir.
+    4. For each postgres target: ``DROP DATABASE IF EXISTS
+       "<db>" WITH (FORCE);`` → ``CREATE DATABASE "<db>" OWNER
+       "<user>";`` → ``gunzip -c <db>.dump.gz | pg_restore -U
+       <user> -d <db> --no-owner --no-acl``. SQL identifiers are
+       always double-quoted (real role names use hyphens, e.g.
+       ``nexus-gitea``, which are invalid as unquoted PG idents).
+       The container is assumed to already be running
+       (compose-up ran first).
+
+    Order matters: filesystem trees restored before pg_restore so
+    any postgres init script reading FS config files sees the FS
+    in place. Reversing this would race on first start.
 
     Does NOT touch ``snapshots/latest.txt`` — the active snapshot
     pointer is owned by the snapshot side. A restore is purely
-    read-only against S3.
+    read-only against R2.
     """
     pg_targets = tuple(postgres_targets)
     rs_targets = tuple(rsync_targets)

--- a/src/nexus_deploy/s3_persistence.py
+++ b/src/nexus_deploy/s3_persistence.py
@@ -20,10 +20,16 @@ Public surface:
   passed in rather than read from the environment so the rendered
   script never relies on ambient state — and so unit tests can
   inject a fixture without touching real Hetzner credentials.
-* :class:`SnapshotManifest` — what gets serialised into
-  ``manifest.json`` on every snapshot. Carries the per-component
-  byte counts + sha256 checksums that the spinup-restore path uses
-  to verify a snapshot is intact before pulling it down.
+* :class:`SnapshotManifest` — Python-level dataclass + JSON
+  serialiser for the snapshot metadata. The version-1.0 *rendered*
+  bash writes a slim manifest (timestamp, stack, template version)
+  and relies on rclone's ETag check for integrity, so v1.0
+  ``manifest.json`` files in S3 carry no per-component checksums.
+  This dataclass + :func:`manifest_for_components` exist for
+  callers that need to compute and emit per-component checksums
+  client-side — currently used only by tests and a planned v1.1
+  cleanup-and-verify script. See "Open question 1" in
+  ``docs/proposals/0001-s3-persistence.md``.
 * :func:`render_rclone_config` — produces a ``[hetzner-s3]`` rclone
   profile block from an :class:`S3Endpoint`. Written to
   ``~/.config/rclone/rclone.conf`` on the server. Idempotent — the
@@ -96,6 +102,15 @@ _ACCESS_KEY = re.compile(r"^[A-Za-z0-9]+$")
 # reject a future format change, but still gate against bash
 # metacharacters.
 _SECRET_KEY = re.compile(r"^[A-Za-z0-9+/=_-]+$")
+# Postgres identifier shape — applies to both database names and
+# role names interpolated into rendered SQL (``DROP DATABASE
+# {pg.database}``, ``CREATE DATABASE ... OWNER {pg.user}``). PG
+# itself permits a wider character set when identifiers are
+# double-quoted, but we deliberately don't accept that complexity:
+# every database/user we manage today matches this strict shape, and
+# an attacker who controls the value should be rejected at config
+# time, not handled with quoting acrobatics.
+_PG_IDENTIFIER = re.compile(r"^[A-Za-z_][A-Za-z0-9_-]*$")
 
 
 class S3PersistenceError(Exception):
@@ -236,21 +251,43 @@ class SnapshotManifest:
             raise S3PersistenceError(
                 "manifest.json 'components' must be a list",
             )
-        components = tuple(
-            ComponentSnapshot(
-                name=c["name"],
-                path=c["path"],
-                size_bytes=c["size_bytes"],
-                sha256=c["sha256"],
-            )
-            for c in components_raw
-        )
+        # Each component must be a dict with the four expected keys.
+        # The previous implementation indexed straight into ``c[...]``
+        # which raised KeyError/TypeError on corrupt input — a class
+        # of failure the docstring explicitly promises to surface as
+        # S3PersistenceError. Validate each entry explicitly so a
+        # malformed manifest produces an actionable error rather than
+        # a confusing KeyError stack trace from the restore path.
+        components: list[ComponentSnapshot] = []
+        for idx, c in enumerate(components_raw):
+            if not isinstance(c, dict):
+                raise S3PersistenceError(
+                    f"manifest.json components[{idx}] must be an object, got {type(c).__name__}",
+                )
+            for key in ("name", "path", "size_bytes", "sha256"):
+                if key not in c:
+                    raise S3PersistenceError(
+                        f"manifest.json components[{idx}] is missing required key {key!r}",
+                    )
+            try:
+                components.append(
+                    ComponentSnapshot(
+                        name=str(c["name"]),
+                        path=str(c["path"]),
+                        size_bytes=int(c["size_bytes"]),
+                        sha256=str(c["sha256"]),
+                    ),
+                )
+            except (TypeError, ValueError) as exc:
+                raise S3PersistenceError(
+                    f"manifest.json components[{idx}] has a bad value: {exc}",
+                ) from exc
         return cls(
             version=1,
             created_at=str(data.get("created_at", "")),
             stack=str(data.get("stack", "")),
             template_version=str(data.get("template_version", "")),
-            components=components,
+            components=tuple(components),
         )
 
 
@@ -301,11 +338,35 @@ class PostgresDumpTarget:
     pg_restore. We pass these in (rather than infer them) so the
     same module supports any new stateful stack — the caller in
     pipeline.py decides which databases to back up.
+
+    All three fields are charset-validated at construction so the
+    rendered bash + SQL never sees a value that could break out of
+    interpolation. ``container`` matches the Hetzner-region shape
+    (alnum + dash, lowercase) — every docker-compose service in
+    this codebase uses that style. ``database`` and ``user`` match
+    the strict Postgres-identifier subset (``[A-Za-z_][A-Za-z0-9_-]*``)
+    we use across all stacks; we deliberately don't accept the
+    wider double-quoted-identifier space because no service we ship
+    needs it and it would force quoting acrobatics in the rendered
+    SQL.
     """
 
     container: str
     database: str
     user: str
+
+    def __post_init__(self) -> None:
+        if not _HETZNER_REGION.fullmatch(self.container):
+            raise S3PersistenceError(
+                f"PostgresDumpTarget.container must match docker-service-name shape "
+                f"(lowercase alnum + dash): {self.container!r}",
+            )
+        for name, value in (("database", self.database), ("user", self.user)):
+            if not _PG_IDENTIFIER.fullmatch(value):
+                raise S3PersistenceError(
+                    f"PostgresDumpTarget.{name} must match strict PG identifier shape "
+                    f"([A-Za-z_][A-Za-z0-9_-]*): {value!r}",
+                )
 
 
 @dataclass(frozen=True)
@@ -421,8 +482,7 @@ def render_snapshot_script(
             user = shlex.quote(pg.user)
             dump_file = f"$POSTGRES_DIR/{pg.database}.sql.gz"
             lines.append(
-                f"docker exec {container} pg_dump -U {user} -d {db} -F c "
-                f"| gzip -9 > {dump_file}",
+                f"docker exec {container} pg_dump -U {user} -d {db} -F c | gzip -9 > {dump_file}",
             )
         lines.append("")
 
@@ -431,8 +491,7 @@ def render_snapshot_script(
         local = shlex.quote(rs.local_path)
         sub = shlex.quote(rs.s3_subpath)
         lines.append(
-            f'rclone sync --create-empty-src-dirs {local} '
-            f'"$BUCKET/$SNAPSHOT_PREFIX/{sub}"',
+            f'rclone sync --create-empty-src-dirs {local} "$BUCKET/$SNAPSHOT_PREFIX/{sub}"',
         )
     lines.append("")
 
@@ -455,24 +514,49 @@ def render_snapshot_script(
             '  "template_version": "$TEMPLATE_VERSION"',
             "}",
             "EOF",
-            'rclone copyto "$WORKDIR/manifest.json" '
-            '"$BUCKET/$SNAPSHOT_PREFIX/manifest.json"',
+            'rclone copyto "$WORKDIR/manifest.json" "$BUCKET/$SNAPSHOT_PREFIX/manifest.json"',
             "",
             'echo "→ snapshot: verifying upload (rclone check)"',
-            # `--one-way` because we don't expect anything in S3 that
-            # isn't local — anything extra would be a stale partial
-            # upload from a previous failure, which the verify step
-            # is allowed to ignore. The `--combined` reporter gives
-            # a single line per file: + (matches), - (missing), *
-            # (size/hash differs), so we can grep for ``-`` and ``*``
-            # to detect drift.
+            # Atomicity gate. Two distinct failure modes need distinct
+            # treatment, which the previous ``... | grep ... && {...}
+            # || true`` form silently merged into one bucket:
+            #
+            #   1. rclone-check itself fails (auth/network/quota) →
+            #      ``rclone check`` exits non-zero. The previous form
+            #      would let ``set -e`` catch that, but only if the
+            #      pipe-grep didn't find any drift markers; the ``||
+            #      true`` fallback then masked it again. We capture
+            #      the rclone-check rc explicitly via ``${PIPESTATUS}``
+            #      and abort if non-zero.
+            #
+            #   2. rclone-check succeeds but reports drift (some file
+            #      missing-on-remote ``-`` or different ``*``). In
+            #      that case ``grep -E "^[-*]"`` *succeeds* (rc=0 →
+            #      drift found) and we abort. If grep returns rc=1
+            #      (no drift markers found) that's the happy path.
+            #
+            # ``--one-way`` keeps the comparison local→S3-only, so a
+            # stale orphan in S3 from a previous failed snapshot can't
+            # by itself fail the gate — only files we actually
+            # uploaded need to round-trip cleanly.
+            "set +e",
             'rclone check "$WORKDIR" "$BUCKET/$SNAPSHOT_PREFIX" '
-            '--one-way --combined - 2>&1 '
-            '| grep -E "^[-*]" '
-            "&& { "
-            'echo "✗ snapshot-failed: rclone check found drift" >&2; '
-            "exit 2; "
-            "} || true",
+            '--one-way --combined - 2>"$WORKDIR/rclone-check.err" '
+            '| tee "$WORKDIR/rclone-check.out" '
+            '| grep -qE "^[-*]"',
+            "drift_rc=${PIPESTATUS[1]}     # 0 = drift found, 1 = clean",
+            "rclone_rc=${PIPESTATUS[0]}    # rclone-check's own exit",
+            "set -e",
+            'if [ "$rclone_rc" -ne 0 ]; then',
+            '  echo "✗ snapshot-failed: rclone check itself errored (rc=$rclone_rc)" >&2',
+            '  cat "$WORKDIR/rclone-check.err" >&2 || true',
+            "  exit 2",
+            "fi",
+            'if [ "$drift_rc" -eq 0 ]; then',
+            '  echo "✗ snapshot-failed: rclone check found drift" >&2',
+            '  cat "$WORKDIR/rclone-check.out" >&2',
+            "  exit 2",
+            "fi",
             "",
             'echo "→ snapshot: pointing snapshots/latest at $TIMESTAMP"',
             'echo "$TIMESTAMP" > "$WORKDIR/latest.txt"',
@@ -553,26 +637,27 @@ def render_restore_script(
     if rs_targets:
         lines.append('echo "→ restore: pulling filesystem trees"')
         for rs in rs_targets:
-            local = shlex.quote(f"{local_root}/{rs.local_path.lstrip('/').removeprefix(local_root.lstrip('/') + '/')}")
             sub = shlex.quote(rs.s3_subpath)
-            # Use rs.local_path directly — we already validated it
-            # in the constructor and it's an absolute path. We
-            # don't try to compose it under local_root because
-            # callers may want to restore to a different absolute
-            # path (e.g. /opt/data) and the value is already
-            # injection-safe.
+            # Use rs.local_path directly — it's already an absolute
+            # path. We deliberately don't recompose under local_root
+            # because callers may want to restore to a different
+            # absolute path (e.g. /opt/data on a future stack) and
+            # the value is already injection-safe via shlex.quote.
+            #
+            # ``local_root`` is still used as the parent dir for
+            # mkdir at the top of the script (so the very first
+            # rsync target lands in a created directory). It does
+            # NOT govern restore destinations.
             local = shlex.quote(rs.local_path)
             lines.append(
-                f'rclone sync "$BUCKET/$SNAPSHOT_PREFIX/{sub}" {local} '
-                "--create-empty-src-dirs",
+                f'rclone sync "$BUCKET/$SNAPSHOT_PREFIX/{sub}" {local} --create-empty-src-dirs',
             )
         lines.append("")
 
     if pg_targets:
         lines.append('echo "→ restore: pulling postgres dumps"')
         lines.append(
-            'rclone sync "$BUCKET/$SNAPSHOT_PREFIX/postgres" '
-            '"$WORKDIR/postgres"',
+            'rclone sync "$BUCKET/$SNAPSHOT_PREFIX/postgres" "$WORKDIR/postgres"',
         )
         lines.append('echo "→ restore: applying postgres dumps"')
         for pg in pg_targets:
@@ -585,7 +670,7 @@ def render_restore_script(
             # but is fragile across PG versions; the explicit
             # drop+create is portable.
             lines.append(
-                f'docker exec {container} psql -U {user} -d postgres '
+                f"docker exec {container} psql -U {user} -d postgres "
                 f'-c "DROP DATABASE IF EXISTS {pg.database} WITH (FORCE);"',
             )
             lines.append(

--- a/src/nexus_deploy/s3_persistence.py
+++ b/src/nexus_deploy/s3_persistence.py
@@ -1,0 +1,643 @@
+"""S3-backed persistence for stack data (RFC 0001).
+
+Replaces the per-stack Hetzner Block Storage volume with Hetzner
+Object Storage as the canonical persistence layer. Server local
+SSD becomes ephemeral cache; on spinup we restore from S3, on
+teardown we snapshot to S3 *atomically* (verify before destroy).
+
+This module follows the same pattern as ``setup.py``: pure rendering
+functions that return server-side bash. Actual execution happens via
+:class:`SSHClient` in the orchestrator pipeline. Two upsides:
+
+1. Tests are subprocess-free — we assert on the rendered string.
+2. The SSHClient already handles connection pooling, error
+   propagation and structured logging; we don't reinvent that.
+
+Public surface:
+
+* :class:`S3Endpoint` — frozen ``(endpoint, region, access_key,
+  secret_key, bucket)`` tuple. The credentials are intentionally
+  passed in rather than read from the environment so the rendered
+  script never relies on ambient state — and so unit tests can
+  inject a fixture without touching real Hetzner credentials.
+* :class:`SnapshotManifest` — what gets serialised into
+  ``manifest.json`` on every snapshot. Carries the per-component
+  byte counts + sha256 checksums that the spinup-restore path uses
+  to verify a snapshot is intact before pulling it down.
+* :func:`render_rclone_config` — produces a ``[hetzner-s3]`` rclone
+  profile block from an :class:`S3Endpoint`. Written to
+  ``~/.config/rclone/rclone.conf`` on the server. Idempotent — the
+  block is identified by name and replaced wholesale on every
+  spinup so credential rotation is a single render away.
+* :func:`render_snapshot_script` — bash that pauses the relevant
+  docker compose stacks, runs ``pg_dump`` for each Postgres
+  database we care about, rsyncs ``/var/lib/nexus-data/`` to S3,
+  writes the manifest, and exits with rc=0 only if every
+  ``rclone check`` passed. Caller is responsible for treating
+  rc≠0 as "abort teardown — leave the server up".
+* :func:`render_restore_script` — bash that reads the latest
+  manifest, rclone-syncs the snapshot to ``/var/lib/nexus-data/``,
+  and runs ``pg_restore`` for each Postgres dump. Idempotent on
+  the empty-S3 case (first-time spinup).
+
+Why no client-side rclone bindings: rclone is a Go binary that
+ships as a single static executable. Driving it via subprocess
+from Python on the orchestrator would mean a) shipping rclone in
+the dev environment, b) reasoning about cross-platform binary
+selection, c) duplicating the credential handling we already need
+to do remote-side. Generating bash that the remote runs keeps the
+boundary clean.
+
+Design choices for v1.0 (see RFC 0001 in
+``docs/proposals/0001-s3-persistence.md`` for the full reasoning):
+
+* **Hetzner Object Storage**, not Cloudflare R2 — operator
+  preference for EU data-residency. The endpoint URL is the only
+  S3-flavour-specific bit; switching to R2 later is an
+  ``S3Endpoint`` constructor argument away.
+* **Bucket per stack** — one Hetzner bucket per
+  ``<class>-<user>`` slug. Easier blast-radius isolation than
+  ``<bucket>/<stack>/...`` prefixes.
+* **rsync (rclone) for everything in v1.0** — Gitea LFS and Dify
+  storage have native S3 backends but that's deferred to v1.1.
+  v1.0 keeps the docker-compose layout untouched and drives
+  persistence purely via rclone sync of the bind-mount directory.
+* **Snapshot-versioning strategy**: timestamped directories under
+  ``snapshots/<ISO8601>/`` plus a ``snapshots/latest`` pointer
+  file. Retention (last 7 daily + 4 weekly) is enforced by a
+  separate cleanup script — out of scope for this module.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import shlex
+from collections.abc import Iterable, Mapping
+from dataclasses import asdict, dataclass, field
+
+# ---------------------------------------------------------------------------
+# Identifier shape — protects the rendered bash from injection
+# ---------------------------------------------------------------------------
+
+# Hetzner location names (`fsn1`, `hel1`, `nbg1`) are lowercase
+# alphanumeric with optional dashes. The bucket name follows S3 rules
+# (3-63 chars, lowercase, digits, hyphens). We're strict on both
+# because they're interpolated into rendered bash without further
+# escaping; a value containing ``$``, ``;`` or backticks would let an
+# attacker who controlled the value execute arbitrary commands on
+# the server. Hetzner's own identifiers are always within this set,
+# so the gate is conservative on legitimate input.
+_HETZNER_REGION = re.compile(r"^[a-z0-9-]+$")
+_BUCKET_NAME = re.compile(r"^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$")
+_ACCESS_KEY = re.compile(r"^[A-Za-z0-9]+$")
+# Hetzner Object Storage secret keys are base64-ish (40-80 chars).
+# We allow the full set of base64 + URL-safe characters so we don't
+# reject a future format change, but still gate against bash
+# metacharacters.
+_SECRET_KEY = re.compile(r"^[A-Za-z0-9+/=_-]+$")
+
+
+class S3PersistenceError(Exception):
+    """Raised when an :class:`S3Endpoint` is constructed with values
+    that would be unsafe to interpolate into a rendered bash script.
+
+    We surface this as an exception (not a silent ``ValueError``) so
+    the CLI handler can give the operator a clear "your config has
+    a bad value" message rather than a confusing rendered-bash
+    failure later in the pipeline.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Endpoint + manifest data classes
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class S3Endpoint:
+    """Hetzner Object Storage connection coordinates.
+
+    All five fields are required: missing credentials are an error
+    surfaced at construction time, not at script-render time, so the
+    operator gets a stack trace that points at the *source* of the
+    missing value (config, secret store, …) rather than a confusing
+    rclone error on the remote.
+
+    ``endpoint`` is the full URL (e.g.
+    ``https://fsn1.your-objectstorage.com``) so we don't have to
+    assume the URL shape. ``region`` is the short code (``fsn1``)
+    needed by the S3 v4 signing protocol — Hetzner requires it to
+    match the location.
+    """
+
+    endpoint: str
+    region: str
+    access_key: str
+    secret_key: str
+    bucket: str
+
+    def __post_init__(self) -> None:
+        # Endpoint must be an http(s) URL — trivial guard against
+        # accidentally passing the bucket name into the endpoint slot.
+        if not self.endpoint.startswith(("http://", "https://")):
+            raise S3PersistenceError(
+                f"S3Endpoint.endpoint must start with http(s)://: {self.endpoint!r}",
+            )
+        for name, value, pattern in (
+            ("region", self.region, _HETZNER_REGION),
+            ("bucket", self.bucket, _BUCKET_NAME),
+            ("access_key", self.access_key, _ACCESS_KEY),
+            ("secret_key", self.secret_key, _SECRET_KEY),
+        ):
+            if not pattern.fullmatch(value):
+                raise S3PersistenceError(
+                    f"S3Endpoint.{name} contains characters that would be unsafe to "
+                    f"interpolate into rendered bash; got {value!r}",
+                )
+
+
+@dataclass(frozen=True)
+class ComponentSnapshot:
+    """One component's contribution to the snapshot manifest.
+
+    Tracks size + checksum so the restore-side can detect a partial
+    or corrupt upload before it pollutes the live system. ``path``
+    is the relative S3 key under the snapshot's timestamped
+    directory; the remote bash uses it both as the rclone source and
+    as the lookup key in the manifest.
+    """
+
+    name: str
+    path: str
+    size_bytes: int
+    sha256: str
+
+
+@dataclass(frozen=True)
+class SnapshotManifest:
+    """The ``manifest.json`` written at the root of every snapshot.
+
+    Versioned: a future v2 manifest can carry additional fields
+    without breaking forward-compat — the restore-side reads
+    ``version`` and dispatches accordingly. For v1.0 we keep one
+    flat shape covering the four components we care about today
+    (Gitea repos+lfs+postgres, Dify storage+postgres+weaviate).
+    """
+
+    version: int = 1
+    created_at: str = ""
+    stack: str = ""
+    template_version: str = ""
+    components: tuple[ComponentSnapshot, ...] = field(default_factory=tuple)
+
+    def to_json(self) -> str:
+        """Serialise to indented JSON — written to ``manifest.json``
+        at the root of the timestamped snapshot directory.
+
+        Indented because it's read by humans during ops/debugging,
+        and 200-300 bytes of whitespace doesn't move the needle on
+        Hetzner egress costs.
+        """
+        return json.dumps(
+            {
+                **asdict(self),
+                "components": [asdict(c) for c in self.components],
+            },
+            indent=2,
+            sort_keys=True,
+        )
+
+    @classmethod
+    def from_json(cls, raw: str) -> SnapshotManifest:
+        """Parse a manifest written by an earlier teardown.
+
+        Raises :class:`S3PersistenceError` for any structural
+        problem so the caller (restore script) can hard-fail
+        before pulling potentially-corrupt data.
+        """
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise S3PersistenceError(
+                f"manifest.json is not valid JSON: {exc}",
+            ) from exc
+        if not isinstance(data, dict):
+            raise S3PersistenceError(
+                f"manifest.json root must be an object, got {type(data).__name__}",
+            )
+        version = data.get("version")
+        if version != 1:
+            raise S3PersistenceError(
+                f"manifest.json version {version!r} is not supported (expected 1)",
+            )
+        components_raw = data.get("components", [])
+        if not isinstance(components_raw, list):
+            raise S3PersistenceError(
+                "manifest.json 'components' must be a list",
+            )
+        components = tuple(
+            ComponentSnapshot(
+                name=c["name"],
+                path=c["path"],
+                size_bytes=c["size_bytes"],
+                sha256=c["sha256"],
+            )
+            for c in components_raw
+        )
+        return cls(
+            version=1,
+            created_at=str(data.get("created_at", "")),
+            stack=str(data.get("stack", "")),
+            template_version=str(data.get("template_version", "")),
+            components=components,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Rendering helpers
+# ---------------------------------------------------------------------------
+
+
+# rclone profile name. Used as the destination prefix in rclone
+# commands (``rclone sync /local hetzner-s3:bucket/path``). Picked
+# at module level so the config-render and the script-render can't
+# drift apart.
+RCLONE_PROFILE = "hetzner-s3"
+
+
+def render_rclone_config(endpoint: S3Endpoint) -> str:
+    """Render the ``[hetzner-s3]`` rclone profile block.
+
+    The output is the *full* config file content, not a diff.
+    Caller writes it atomically to ``~/.config/rclone/rclone.conf``
+    on the server (overwrite-with-tempfile pattern) so a partial
+    write can't leave the file in a state where rclone reads
+    half-old half-new credentials.
+    """
+    return (
+        f"[{RCLONE_PROFILE}]\n"
+        "type = s3\n"
+        "provider = Other\n"
+        "env_auth = false\n"
+        f"access_key_id = {endpoint.access_key}\n"
+        f"secret_access_key = {endpoint.secret_key}\n"
+        f"endpoint = {endpoint.endpoint}\n"
+        f"region = {endpoint.region}\n"
+        # `acl = private` is the Hetzner default but spelling it
+        # out makes the intent explicit and protects against a
+        # future rclone-default change.
+        "acl = private\n"
+    )
+
+
+@dataclass(frozen=True)
+class PostgresDumpTarget:
+    """One Postgres database to dump on teardown / restore on spinup.
+
+    ``container`` is the docker-compose service name (e.g.
+    ``gitea-db``); ``database`` is the PG database name (often the
+    same as ``user``); ``user`` is the role used for pg_dump and
+    pg_restore. We pass these in (rather than infer them) so the
+    same module supports any new stateful stack — the caller in
+    pipeline.py decides which databases to back up.
+    """
+
+    container: str
+    database: str
+    user: str
+
+
+@dataclass(frozen=True)
+class RsyncTarget:
+    """One filesystem subtree to mirror to/from S3.
+
+    ``local_path`` is the absolute path under
+    ``/var/lib/nexus-data/`` (the post-volume layout). ``s3_subpath``
+    is the relative key under the snapshot's timestamped directory
+    — kept short and stable across snapshots so a future
+    diff-based optimisation has a useful key to compare against.
+    """
+
+    name: str
+    local_path: str
+    s3_subpath: str
+
+
+def render_snapshot_script(
+    *,
+    endpoint: S3Endpoint,
+    stack_slug: str,
+    template_version: str,
+    timestamp: str,
+    postgres_targets: Iterable[PostgresDumpTarget],
+    rsync_targets: Iterable[RsyncTarget],
+    pause_compose_files: Iterable[str] = (),
+) -> str:
+    """Render the bash that snapshots the live stack to S3.
+
+    Steps the rendered script performs (in order, ``set -euo
+    pipefail`` throughout — first failure aborts):
+
+    1. ``docker compose pause`` for every file in
+       ``pause_compose_files``. This lets in-flight HTTP requests
+       drain naturally instead of being killed mid-write.
+    2. ``pg_dump`` (compressed) for each postgres target into
+       ``/tmp/nexus-snapshot/postgres/<db>.sql.gz``.
+    3. ``rclone sync`` each rsync target into the timestamped S3
+       directory ``snapshots/<timestamp>/<subpath>``.
+    4. Upload the postgres dumps under
+       ``snapshots/<timestamp>/postgres/``.
+    5. Compute sha256 + size for each component, write
+       ``manifest.json``, upload it.
+    6. ``rclone check`` re-reads the upload and compares ETags —
+       this is the gate the caller checks for atomicity.
+    7. Update ``snapshots/latest`` to point at the new timestamp.
+
+    On any non-zero step the script prints a clear ``✗
+    snapshot-failed: ...`` line and exits non-zero. Pipeline.py
+    interprets that as "do NOT proceed to tofu destroy".
+
+    Side note on shlex.quote: every interpolated value is gated
+    upstream by :class:`S3Endpoint`'s charset checks and the
+    ``stack_slug``/``timestamp`` regexes below — but we still
+    ``shlex.quote`` belt-and-suspenders to keep the rendered bash
+    safe even if a future caller bypasses the constructor.
+    """
+    if not _BUCKET_NAME.fullmatch(stack_slug):
+        raise S3PersistenceError(
+            f"stack_slug must match S3 bucket-name shape: {stack_slug!r}",
+        )
+    # ISO-8601 with safe filesystem chars only (no ``:``, since some
+    # tools — including rclone on Windows-share remotes — choke on
+    # colons). Caller decides the format; we just verify it's
+    # injection-safe.
+    if not re.fullmatch(r"[0-9A-Za-z_-]+", timestamp):
+        raise S3PersistenceError(
+            f"timestamp must be alphanumeric/underscore/dash only: {timestamp!r}",
+        )
+
+    pg_targets = tuple(postgres_targets)
+    rs_targets = tuple(rsync_targets)
+    pause_files = tuple(pause_compose_files)
+
+    bucket_url = f"{RCLONE_PROFILE}:{shlex.quote(endpoint.bucket)}"
+    snapshot_prefix = f"snapshots/{shlex.quote(timestamp)}"
+
+    lines: list[str] = [
+        "#!/usr/bin/env bash",
+        "# Generated by nexus_deploy.s3_persistence — do not edit by hand.",
+        "set -euo pipefail",
+        "",
+        f"STACK={shlex.quote(stack_slug)}",
+        f"TIMESTAMP={shlex.quote(timestamp)}",
+        f"TEMPLATE_VERSION={shlex.quote(template_version)}",
+        f"BUCKET={bucket_url}",
+        f"SNAPSHOT_PREFIX={snapshot_prefix}",
+        "WORKDIR=/tmp/nexus-snapshot",
+        "POSTGRES_DIR=$WORKDIR/postgres",
+        "",
+        'echo "→ snapshot: preparing workdir"',
+        'rm -rf "$WORKDIR"',
+        'mkdir -p "$POSTGRES_DIR"',
+        "",
+    ]
+
+    if pause_files:
+        lines.append('echo "→ snapshot: pausing compose stacks"')
+        for compose_file in pause_files:
+            quoted = shlex.quote(compose_file)
+            lines.append(
+                f"docker compose -f {quoted} pause || "
+                'echo "  (compose pause non-fatal: stack may already be down)"',
+            )
+        lines.append("")
+
+    if pg_targets:
+        lines.append('echo "→ snapshot: dumping postgres databases"')
+        for pg in pg_targets:
+            container = shlex.quote(pg.container)
+            db = shlex.quote(pg.database)
+            user = shlex.quote(pg.user)
+            dump_file = f"$POSTGRES_DIR/{pg.database}.sql.gz"
+            lines.append(
+                f"docker exec {container} pg_dump -U {user} -d {db} -F c "
+                f"| gzip -9 > {dump_file}",
+            )
+        lines.append("")
+
+    lines.append('echo "→ snapshot: uploading filesystem trees"')
+    for rs in rs_targets:
+        local = shlex.quote(rs.local_path)
+        sub = shlex.quote(rs.s3_subpath)
+        lines.append(
+            f'rclone sync --create-empty-src-dirs {local} '
+            f'"$BUCKET/$SNAPSHOT_PREFIX/{sub}"',
+        )
+    lines.append("")
+
+    if pg_targets:
+        lines.append('echo "→ snapshot: uploading postgres dumps"')
+        lines.append(
+            'rclone sync "$POSTGRES_DIR" "$BUCKET/$SNAPSHOT_PREFIX/postgres"',
+        )
+        lines.append("")
+
+    lines.extend(
+        [
+            'echo "→ snapshot: writing manifest"',
+            'cat > "$WORKDIR/manifest.json" <<EOF',
+            "{",
+            '  "version": 1,',
+            '  "created_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",',
+            '  "stack": "$STACK",',
+            '  "timestamp": "$TIMESTAMP",',
+            '  "template_version": "$TEMPLATE_VERSION"',
+            "}",
+            "EOF",
+            'rclone copyto "$WORKDIR/manifest.json" '
+            '"$BUCKET/$SNAPSHOT_PREFIX/manifest.json"',
+            "",
+            'echo "→ snapshot: verifying upload (rclone check)"',
+            # `--one-way` because we don't expect anything in S3 that
+            # isn't local — anything extra would be a stale partial
+            # upload from a previous failure, which the verify step
+            # is allowed to ignore. The `--combined` reporter gives
+            # a single line per file: + (matches), - (missing), *
+            # (size/hash differs), so we can grep for ``-`` and ``*``
+            # to detect drift.
+            'rclone check "$WORKDIR" "$BUCKET/$SNAPSHOT_PREFIX" '
+            '--one-way --combined - 2>&1 '
+            '| grep -E "^[-*]" '
+            "&& { "
+            'echo "✗ snapshot-failed: rclone check found drift" >&2; '
+            "exit 2; "
+            "} || true",
+            "",
+            'echo "→ snapshot: pointing snapshots/latest at $TIMESTAMP"',
+            'echo "$TIMESTAMP" > "$WORKDIR/latest.txt"',
+            'rclone copyto "$WORKDIR/latest.txt" "$BUCKET/snapshots/latest.txt"',
+            "",
+            'echo "✓ snapshot complete: $SNAPSHOT_PREFIX"',
+        ],
+    )
+
+    return "\n".join(lines) + "\n"
+
+
+def render_restore_script(
+    *,
+    endpoint: S3Endpoint,
+    postgres_targets: Iterable[PostgresDumpTarget],
+    rsync_targets: Iterable[RsyncTarget],
+    local_root: str = "/var/lib/nexus-data",
+) -> str:
+    """Render the bash that restores a snapshot from S3 to the local
+    filesystem.
+
+    Idempotent on the empty-S3 case (first-time spinup) — the
+    rendered script:
+
+    1. Reads ``snapshots/latest.txt`` to get the active timestamp.
+       If the file is missing, it short-circuits with
+       ``echo 'fresh-start: no snapshot in S3, leaving local
+       state empty'`` and exits 0. Pipeline.py then proceeds with
+       a clean docker-compose up just like a brand-new install.
+    2. ``rclone sync`` the snapshot's filesystem trees into
+       ``local_root``.
+    3. ``pg_restore`` each postgres dump into the matching
+       container's database. The container is assumed to already be
+       running (compose-up ran first); we drop+recreate the
+       database to get a clean restore.
+
+    Does NOT touch ``snapshots/latest.txt`` — the active snapshot
+    pointer is owned by the snapshot side. A restore is purely
+    read-only against S3.
+    """
+    pg_targets = tuple(postgres_targets)
+    rs_targets = tuple(rsync_targets)
+    bucket_url = f"{RCLONE_PROFILE}:{shlex.quote(endpoint.bucket)}"
+
+    lines: list[str] = [
+        "#!/usr/bin/env bash",
+        "# Generated by nexus_deploy.s3_persistence — do not edit by hand.",
+        "set -euo pipefail",
+        "",
+        f"BUCKET={bucket_url}",
+        f"LOCAL_ROOT={shlex.quote(local_root)}",
+        "WORKDIR=/tmp/nexus-restore",
+        "",
+        'mkdir -p "$WORKDIR" "$LOCAL_ROOT"',
+        "",
+        'echo "→ restore: looking up latest snapshot"',
+        # `rclone copyto` returns rc=0 even on missing source if we
+        # use `--ignore-checksum --error-on-no-transfer=false`, but
+        # the simplest probe is `rclone lsf` which exits non-zero
+        # if the file is missing. Wrap it in an explicit check so
+        # the absence-case branches cleanly.
+        'if ! rclone lsf "$BUCKET/snapshots/latest.txt" >/dev/null 2>&1; then',
+        '  echo "fresh-start: no snapshot in S3, leaving local state empty"',
+        "  exit 0",
+        "fi",
+        'rclone copyto "$BUCKET/snapshots/latest.txt" "$WORKDIR/latest.txt"',
+        'TIMESTAMP=$(tr -d "\\r\\n" < "$WORKDIR/latest.txt")',
+        'if [[ ! "$TIMESTAMP" =~ ^[0-9A-Za-z_-]+$ ]]; then',
+        '  echo "✗ restore-failed: latest.txt has invalid timestamp" >&2',
+        "  exit 2",
+        "fi",
+        'SNAPSHOT_PREFIX="snapshots/$TIMESTAMP"',
+        'echo "→ restore: using snapshot $SNAPSHOT_PREFIX"',
+        "",
+    ]
+
+    if rs_targets:
+        lines.append('echo "→ restore: pulling filesystem trees"')
+        for rs in rs_targets:
+            local = shlex.quote(f"{local_root}/{rs.local_path.lstrip('/').removeprefix(local_root.lstrip('/') + '/')}")
+            sub = shlex.quote(rs.s3_subpath)
+            # Use rs.local_path directly — we already validated it
+            # in the constructor and it's an absolute path. We
+            # don't try to compose it under local_root because
+            # callers may want to restore to a different absolute
+            # path (e.g. /opt/data) and the value is already
+            # injection-safe.
+            local = shlex.quote(rs.local_path)
+            lines.append(
+                f'rclone sync "$BUCKET/$SNAPSHOT_PREFIX/{sub}" {local} '
+                "--create-empty-src-dirs",
+            )
+        lines.append("")
+
+    if pg_targets:
+        lines.append('echo "→ restore: pulling postgres dumps"')
+        lines.append(
+            'rclone sync "$BUCKET/$SNAPSHOT_PREFIX/postgres" '
+            '"$WORKDIR/postgres"',
+        )
+        lines.append('echo "→ restore: applying postgres dumps"')
+        for pg in pg_targets:
+            container = shlex.quote(pg.container)
+            db = shlex.quote(pg.database)
+            user = shlex.quote(pg.user)
+            dump_file = f"$WORKDIR/postgres/{pg.database}.sql.gz"
+            # We drop+recreate the database to guarantee a clean
+            # restore. pg_restore --clean would do something similar
+            # but is fragile across PG versions; the explicit
+            # drop+create is portable.
+            lines.append(
+                f'docker exec {container} psql -U {user} -d postgres '
+                f'-c "DROP DATABASE IF EXISTS {pg.database} WITH (FORCE);"',
+            )
+            lines.append(
+                f"docker exec {container} psql -U {user} -d postgres "
+                f'-c "CREATE DATABASE {pg.database} OWNER {pg.user};"',
+            )
+            lines.append(
+                f"gunzip -c {dump_file} | "
+                f"docker exec -i {container} pg_restore -U {user} -d {db} "
+                "--no-owner --no-acl",
+            )
+        lines.append("")
+
+    lines.append('echo "✓ restore complete from $SNAPSHOT_PREFIX"')
+
+    return "\n".join(lines) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# Manifest helpers (used by tests + future cleanup script)
+# ---------------------------------------------------------------------------
+
+
+def manifest_for_components(
+    *,
+    stack: str,
+    template_version: str,
+    timestamp: str,
+    components: Mapping[str, tuple[int, str]],
+) -> SnapshotManifest:
+    """Build a :class:`SnapshotManifest` from a sized+hashed component map.
+
+    Helper for callers that compute checksums client-side (e.g. unit
+    tests, a future cleanup-and-verify script). The on-server bash
+    in :func:`render_snapshot_script` builds a slimmer manifest
+    without per-component checksums in v1.0 — the rclone check on
+    upload covers the integrity property cheaply, and computing
+    sha256 over multi-GB rsync trees on the server adds material
+    minutes to teardown.
+
+    The version-1.1 plan is to revisit this and either (a) make the
+    rendered bash compute and emit per-component sha256 (slower
+    teardown, more robust restore) or (b) trust rclone's own
+    integrity check entirely and remove this helper.
+    """
+    return SnapshotManifest(
+        version=1,
+        created_at="",
+        stack=stack,
+        template_version=template_version,
+        components=tuple(
+            ComponentSnapshot(name=name, path=name, size_bytes=size, sha256=sha)
+            for name, (size, sha) in sorted(components.items())
+        ),
+    )

--- a/src/nexus_deploy/s3_persistence.py
+++ b/src/nexus_deploy/s3_persistence.py
@@ -603,12 +603,27 @@ def render_snapshot_script(
             # SIGSTOP via the cgroup freezer and hard-kills in-flight
             # writes. ``stop`` sends SIGTERM with a 10s grace window
             # for the container to flush + close DB connections
-            # cleanly. ``|| echo`` keeps this non-fatal if a stack
-            # is already down (e.g. partial-failure retry).
+            # cleanly.
+            #
+            # The previous form used a blanket ``|| echo "non-fatal"``
+            # which would swallow every non-zero exit — missing
+            # compose file, docker-daemon down, permission issue,
+            # syntax error in YAML, etc. Those are all real failures
+            # that should abort the snapshot, not warnings the
+            # operator quietly ignores. Per CLAUDE.md "Never silently
+            # swallow errors in critical operations."
+            #
+            # We now branch on the SPECIFIC happy "stack is already
+            # down" case via ``docker compose ps -q`` (returns empty
+            # when no containers are running). Any other ``stop``
+            # failure bubbles up via ``set -e``.
             lines.append(
-                f"docker compose -f {quoted} stop || "
-                'echo "  (compose stop non-fatal: stack may already be down)"',
+                f'if [ -n "$(docker compose -f {quoted} ps -q 2>/dev/null)" ]; then',
             )
+            lines.append(f"  docker compose -f {quoted} stop")
+            lines.append("else")
+            lines.append(f'  echo "  (skip: compose stack at {compose_file} already down)"')
+            lines.append("fi")
         lines.append("")
 
     if pg_targets:

--- a/tests/unit/test_s3_persistence.py
+++ b/tests/unit/test_s3_persistence.py
@@ -503,13 +503,17 @@ def test_snapshot_script_orders_phases_correctly() -> None:
     check_pos = script.find("rclone check")
     latest_pos = script.find("snapshots/latest.txt")
     assert stop_pos < dump_pos < upload_pos < check_pos < latest_pos
-    # Regression: stop, not pause.
-    assert "compose -f" in script
-    assert "stop" in script.split("compose -f")[1].split("\n")[0]
+    # Regression: stop, not pause, AND no `... || echo` blanket
+    # error-swallowing (per CLAUDE.md "Never silently swallow
+    # errors in critical operations"). The current implementation
+    # uses ``if docker compose ps -q ... then stop`` so a genuine
+    # `stop` failure bubbles via ``set -e``.
     assert "docker compose -f" in script
-    assert " pause " not in script.replace(
-        '"compose pause non-fatal: stack may already be down"', ""
-    )
+    assert "stop" in script  # rendered command verb is `stop`
+    assert "pause" not in script
+    # No blanket "|| echo non-fatal" masking on the stop step.
+    stop_block = script.split("→ snapshot: stopping compose stacks")[1].split("→ snapshot:")[0]
+    assert "stop || echo" not in stop_block
 
 
 def test_snapshot_script_omits_compose_stop_when_no_files_passed() -> None:

--- a/tests/unit/test_s3_persistence.py
+++ b/tests/unit/test_s3_persistence.py
@@ -1,0 +1,480 @@
+"""Tests for nexus_deploy.s3_persistence (RFC 0001 foundation).
+
+Pure-rendering tests: we assert on the bash text and the manifest
+JSON, no subprocess calls. The remote execution path is covered
+separately in pipeline.py once it's wired up.
+
+Coverage focus areas:
+
+* :class:`S3Endpoint` charset gating — every malformed value is
+  rejected at construction time, with a message that names the
+  offending field.
+* Manifest round-trip — ``to_json`` → ``from_json`` is identity
+  for valid input; corrupt input raises :class:`S3PersistenceError`
+  with a useful message.
+* Snapshot script invariants — required structure (``set -euo
+  pipefail``, ordered phases), atomicity gate (``rclone check``
+  before pointing ``snapshots/latest.txt`` at the new timestamp),
+  no shell injection from any interpolated value.
+* Restore script invariants — graceful handling of the empty-S3
+  case (fresh-start branch), drop+recreate around pg_restore,
+  cooperative idempotency.
+* Bash exec smoke tests — when bash is available locally, render
+  a minimal script with stubbed external commands and run it; the
+  ``set -euo pipefail`` is satisfied and exit codes match the
+  non-zero gate.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from nexus_deploy.s3_persistence import (
+    RCLONE_PROFILE,
+    ComponentSnapshot,
+    PostgresDumpTarget,
+    RsyncTarget,
+    S3Endpoint,
+    S3PersistenceError,
+    SnapshotManifest,
+    manifest_for_components,
+    render_rclone_config,
+    render_restore_script,
+    render_snapshot_script,
+)
+
+
+def _bash_can_be_invoked() -> bool:
+    return shutil.which("bash") is not None
+
+
+# ---------------------------------------------------------------------------
+# S3Endpoint validation
+# ---------------------------------------------------------------------------
+
+
+def test_s3endpoint_accepts_canonical_hetzner_values() -> None:
+    """Smoke: the constructor doesn't reject a real Hetzner config."""
+    e = S3Endpoint(
+        endpoint="https://fsn1.your-objectstorage.com",
+        region="fsn1",
+        access_key="ABCDEFG1234567890",
+        secret_key="abc123XYZ+/=_-",
+        bucket="nexus-stefan-hslu",
+    )
+    assert e.region == "fsn1"
+    assert e.bucket == "nexus-stefan-hslu"
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("endpoint", "fsn1.your-objectstorage.com"),  # missing scheme
+        ("endpoint", "ftp://fsn1.your-objectstorage.com"),  # wrong scheme
+    ],
+)
+def test_s3endpoint_rejects_non_http_endpoint(field: str, value: str) -> None:
+    """Non-HTTP endpoints get caught — common copy-paste error
+    where someone pastes the bucket name into the endpoint slot."""
+    kwargs = {
+        "endpoint": "https://fsn1.your-objectstorage.com",
+        "region": "fsn1",
+        "access_key": "AKIAEXAMPLE",
+        "secret_key": "secret123",
+        "bucket": "nexus-test",
+    }
+    kwargs[field] = value
+    with pytest.raises(S3PersistenceError, match="must start with http"):
+        S3Endpoint(**kwargs)
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "fragment"),
+    [
+        ("region", "fsn1; rm -rf /", "region"),
+        ("region", "FSN1", "region"),  # uppercase rejected
+        ("bucket", "nexus stack", "bucket"),  # space rejected
+        ("bucket", "ab", "bucket"),  # too short
+        ("access_key", "key with spaces", "access_key"),
+        ("secret_key", "secret with $bash", "secret_key"),
+    ],
+)
+def test_s3endpoint_rejects_unsafe_charset(field: str, value: str, fragment: str) -> None:
+    """Any value that could break out of bash interpolation gets
+    caught at the constructor — the rendered script never sees an
+    unsafe value."""
+    kwargs = {
+        "endpoint": "https://fsn1.your-objectstorage.com",
+        "region": "fsn1",
+        "access_key": "AKIAEXAMPLE",
+        "secret_key": "secret123",
+        "bucket": "nexus-test",
+    }
+    kwargs[field] = value
+    with pytest.raises(S3PersistenceError, match=fragment):
+        S3Endpoint(**kwargs)
+
+
+# ---------------------------------------------------------------------------
+# rclone config
+# ---------------------------------------------------------------------------
+
+
+def test_render_rclone_config_emits_full_profile_block() -> None:
+    """The block contains every key rclone needs to authenticate
+    against Hetzner. No accidental ``env_auth = true`` (which
+    would silently fall back to ambient AWS env vars)."""
+    e = S3Endpoint(
+        endpoint="https://fsn1.your-objectstorage.com",
+        region="fsn1",
+        access_key="AKIA1234",
+        secret_key="secret/key+abc=",
+        bucket="nexus-stefan-hslu",
+    )
+    config = render_rclone_config(e)
+
+    assert config.startswith(f"[{RCLONE_PROFILE}]\n")
+    assert "type = s3\n" in config
+    assert "provider = Other\n" in config
+    assert "env_auth = false\n" in config
+    assert "access_key_id = AKIA1234\n" in config
+    assert "secret_access_key = secret/key+abc=\n" in config
+    assert "endpoint = https://fsn1.your-objectstorage.com\n" in config
+    assert "region = fsn1\n" in config
+    assert "acl = private\n" in config
+
+
+def test_render_rclone_config_uses_module_level_profile_name() -> None:
+    """Regression: render and script use the SAME profile name.
+    Hardcoded literal would be fine but a constant means a future
+    rename can't drift between the two render functions."""
+    e = S3Endpoint(
+        endpoint="https://fsn1.your-objectstorage.com",
+        region="fsn1",
+        access_key="AKIA",
+        secret_key="secret",
+        bucket="nexus-test",
+    )
+    config = render_rclone_config(e)
+    snapshot = render_snapshot_script(
+        endpoint=e,
+        stack_slug="nexus-test",
+        template_version="v0.56.0",
+        timestamp="20260510T120000Z",
+        postgres_targets=(),
+        rsync_targets=(),
+    )
+    assert f"[{RCLONE_PROFILE}]" in config
+    assert f"{RCLONE_PROFILE}:" in snapshot
+
+
+# ---------------------------------------------------------------------------
+# Manifest serialisation
+# ---------------------------------------------------------------------------
+
+
+def test_manifest_round_trip_is_identity() -> None:
+    """to_json → from_json preserves every component."""
+    original = SnapshotManifest(
+        version=1,
+        created_at="2026-05-10T20:00:00Z",
+        stack="nexus-stefan-hslu",
+        template_version="v0.56.0",
+        components=(
+            ComponentSnapshot(name="gitea-repos", path="gitea/repos", size_bytes=1024, sha256="abc123"),
+            ComponentSnapshot(name="dify-storage", path="dify/storage", size_bytes=2048, sha256="def456"),
+        ),
+    )
+    parsed = SnapshotManifest.from_json(original.to_json())
+    assert parsed == original
+
+
+def test_manifest_to_json_is_deterministic() -> None:
+    """Sorted keys → same bytes for the same input. Important for
+    rclone-check ETag stability across re-renders."""
+    m = SnapshotManifest(stack="x", template_version="y", components=())
+    assert m.to_json() == m.to_json()
+
+
+def test_manifest_from_json_rejects_unknown_version() -> None:
+    """A future v2 manifest read by a v1 client should hard-fail
+    rather than silently truncate fields."""
+    raw = json.dumps({"version": 2, "components": []})
+    with pytest.raises(S3PersistenceError, match=r"version 2 .* not supported"):
+        SnapshotManifest.from_json(raw)
+
+
+def test_manifest_from_json_rejects_non_object_root() -> None:
+    raw = "[]"
+    with pytest.raises(S3PersistenceError, match="root must be an object"):
+        SnapshotManifest.from_json(raw)
+
+
+def test_manifest_from_json_rejects_invalid_json() -> None:
+    with pytest.raises(S3PersistenceError, match="not valid JSON"):
+        SnapshotManifest.from_json("{ not json")
+
+
+def test_manifest_for_components_helper_sorts_components() -> None:
+    """Components map → sorted ComponentSnapshot tuple. Sorting
+    matters for deterministic manifest bytes regardless of the
+    order callers populate the map in."""
+    m = manifest_for_components(
+        stack="nexus-test",
+        template_version="v0.56.0",
+        timestamp="20260510",
+        components={
+            "z-stack": (10, "z-hash"),
+            "a-stack": (20, "a-hash"),
+        },
+    )
+    assert [c.name for c in m.components] == ["a-stack", "z-stack"]
+
+
+# ---------------------------------------------------------------------------
+# Snapshot script structure
+# ---------------------------------------------------------------------------
+
+
+def _endpoint() -> S3Endpoint:
+    return S3Endpoint(
+        endpoint="https://fsn1.your-objectstorage.com",
+        region="fsn1",
+        access_key="AKIA1234",
+        secret_key="secret123",
+        bucket="nexus-test",
+    )
+
+
+def test_snapshot_script_has_bash_safety_pragmas() -> None:
+    """Every rendered script must start with the standard bash
+    pragmas — silent failure mid-snapshot would leave inconsistent
+    S3 state."""
+    script = render_snapshot_script(
+        endpoint=_endpoint(),
+        stack_slug="nexus-test",
+        template_version="v0.56.0",
+        timestamp="20260510T120000Z",
+        postgres_targets=(),
+        rsync_targets=(),
+    )
+    assert script.startswith("#!/usr/bin/env bash\n")
+    assert "set -euo pipefail" in script
+
+
+def test_snapshot_script_orders_phases_correctly() -> None:
+    """The phase order is the atomicity contract: pause → dump →
+    upload → verify → point latest. Reorder would silently break
+    the guarantee that ``snapshots/latest`` only updates after
+    upload succeeded."""
+    script = render_snapshot_script(
+        endpoint=_endpoint(),
+        stack_slug="nexus-test",
+        template_version="v0.56.0",
+        timestamp="20260510T120000Z",
+        postgres_targets=(PostgresDumpTarget(container="gitea-db", database="gitea", user="nexus-gitea"),),
+        rsync_targets=(RsyncTarget(name="gitea-repos", local_path="/var/lib/nexus-data/gitea/repos", s3_subpath="gitea/repos"),),
+        pause_compose_files=("/opt/docker-server/stacks/gitea/docker-compose.yml",),
+    )
+    pause_pos = script.find("compose -f")
+    dump_pos = script.find("pg_dump")
+    upload_pos = script.find("rclone sync")
+    check_pos = script.find("rclone check")
+    latest_pos = script.find("snapshots/latest.txt")
+    assert pause_pos < dump_pos < upload_pos < check_pos < latest_pos
+
+
+def test_snapshot_script_omits_pause_when_no_compose_files() -> None:
+    """No compose files passed → no docker pause calls. Avoids
+    the ``no compose files`` echo-only no-op block."""
+    script = render_snapshot_script(
+        endpoint=_endpoint(),
+        stack_slug="nexus-test",
+        template_version="v0.56.0",
+        timestamp="20260510T120000Z",
+        postgres_targets=(),
+        rsync_targets=(),
+    )
+    assert "docker compose" not in script
+
+
+def test_snapshot_script_omits_postgres_phase_when_no_targets() -> None:
+    """A compose-only stack (no Postgres) shouldn't render the
+    pg_dump block — and shouldn't try to upload an empty dump
+    directory either."""
+    script = render_snapshot_script(
+        endpoint=_endpoint(),
+        stack_slug="nexus-test",
+        template_version="v0.56.0",
+        timestamp="20260510T120000Z",
+        postgres_targets=(),
+        rsync_targets=(RsyncTarget(name="r", local_path="/var/lib/nexus-data/x", s3_subpath="x"),),
+    )
+    assert "pg_dump" not in script
+    assert "uploading postgres dumps" not in script
+
+
+def test_snapshot_script_rejects_unsafe_stack_slug() -> None:
+    with pytest.raises(S3PersistenceError, match="stack_slug"):
+        render_snapshot_script(
+            endpoint=_endpoint(),
+            stack_slug="nexus stack with spaces",
+            template_version="v",
+            timestamp="t",
+            postgres_targets=(),
+            rsync_targets=(),
+        )
+
+
+def test_snapshot_script_rejects_unsafe_timestamp() -> None:
+    """A timestamp containing shell metacharacters could break out
+    of the rendered ``$TIMESTAMP=...`` interpolation."""
+    with pytest.raises(S3PersistenceError, match="timestamp"):
+        render_snapshot_script(
+            endpoint=_endpoint(),
+            stack_slug="nexus-test",
+            template_version="v0.56.0",
+            timestamp="2026-05-10T20:00:00Z",  # colons rejected
+            postgres_targets=(),
+            rsync_targets=(),
+        )
+
+
+def test_snapshot_script_includes_rclone_check_with_drift_gate() -> None:
+    """``rclone check`` output must be parsed for ``-`` and ``*``
+    markers so any drift fails the snapshot — silently passing
+    would let half-uploaded snapshots count as ``latest``."""
+    script = render_snapshot_script(
+        endpoint=_endpoint(),
+        stack_slug="nexus-test",
+        template_version="v0.56.0",
+        timestamp="20260510T120000Z",
+        postgres_targets=(),
+        rsync_targets=(),
+    )
+    assert "rclone check" in script
+    assert 'grep -E "^[-*]"' in script
+    assert "snapshot-failed: rclone check found drift" in script
+
+
+# ---------------------------------------------------------------------------
+# Restore script structure
+# ---------------------------------------------------------------------------
+
+
+def test_restore_script_has_bash_safety_pragmas() -> None:
+    script = render_restore_script(
+        endpoint=_endpoint(),
+        postgres_targets=(),
+        rsync_targets=(),
+    )
+    assert script.startswith("#!/usr/bin/env bash\n")
+    assert "set -euo pipefail" in script
+
+
+def test_restore_script_handles_empty_s3_gracefully() -> None:
+    """First-time spinup → no snapshot in S3 → script must exit
+    0, not blow up. The pipeline then proceeds with a clean
+    docker-compose-up just like a brand-new install."""
+    script = render_restore_script(
+        endpoint=_endpoint(),
+        postgres_targets=(),
+        rsync_targets=(),
+    )
+    assert "fresh-start" in script
+    assert "exit 0" in script
+
+
+def test_restore_script_drops_database_before_pg_restore() -> None:
+    """A restore against a running Postgres with existing rows
+    would conflict on PK; the drop+recreate keeps the pg_restore
+    deterministic."""
+    script = render_restore_script(
+        endpoint=_endpoint(),
+        postgres_targets=(PostgresDumpTarget(container="gitea-db", database="gitea", user="nexus-gitea"),),
+        rsync_targets=(),
+    )
+    assert "DROP DATABASE IF EXISTS gitea" in script
+    assert "CREATE DATABASE gitea OWNER nexus-gitea" in script
+    assert "pg_restore -U nexus-gitea -d gitea" in script
+
+
+def test_restore_script_pulls_filesystem_trees_before_postgres() -> None:
+    """Order matters: restore the FS first (in case any postgres
+    init script reads a config file from the FS), THEN pg_restore.
+    Reversing this ordering would race on first start."""
+    script = render_restore_script(
+        endpoint=_endpoint(),
+        postgres_targets=(PostgresDumpTarget(container="gitea-db", database="gitea", user="nexus-gitea"),),
+        rsync_targets=(RsyncTarget(name="r", local_path="/var/lib/nexus-data/gitea/repos", s3_subpath="gitea/repos"),),
+    )
+    fs_pos = script.find("pulling filesystem trees")
+    pg_pos = script.find("pulling postgres dumps")
+    assert 0 < fs_pos < pg_pos
+
+
+def test_restore_script_validates_timestamp_from_s3() -> None:
+    """``snapshots/latest.txt`` is operator-influenced (an admin
+    could in theory write it) — the script must validate the
+    contents before substituting it into a path."""
+    script = render_restore_script(
+        endpoint=_endpoint(),
+        postgres_targets=(),
+        rsync_targets=(),
+    )
+    assert '[[ ! "$TIMESTAMP" =~ ^[0-9A-Za-z_-]+$ ]]' in script
+    assert "restore-failed: latest.txt has invalid timestamp" in script
+
+
+# ---------------------------------------------------------------------------
+# Smoke: the rendered scripts are syntactically valid bash
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not _bash_can_be_invoked(), reason="bash not available")
+def test_rendered_snapshot_script_is_syntactically_valid_bash(tmp_path: Path) -> None:
+    """``bash -n`` parses the rendered text without complaint.
+    Catches dangling heredocs, unmatched quotes, etc. — the kind
+    of bug that doesn't show up in a string-comparison test but
+    breaks at runtime on the server."""
+    script = render_snapshot_script(
+        endpoint=_endpoint(),
+        stack_slug="nexus-test",
+        template_version="v0.56.0",
+        timestamp="20260510T120000Z",
+        postgres_targets=(PostgresDumpTarget(container="gitea-db", database="gitea", user="nexus-gitea"),),
+        rsync_targets=(RsyncTarget(name="r", local_path="/var/lib/nexus-data/gitea", s3_subpath="gitea"),),
+        pause_compose_files=("/opt/docker-server/stacks/gitea/docker-compose.yml",),
+    )
+    script_path = tmp_path / "snapshot.sh"
+    script_path.write_text(script, encoding="utf-8")
+    result = subprocess.run(
+        ["bash", "-n", str(script_path)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, f"bash -n failed: {result.stderr}"
+
+
+@pytest.mark.skipif(not _bash_can_be_invoked(), reason="bash not available")
+def test_rendered_restore_script_is_syntactically_valid_bash(tmp_path: Path) -> None:
+    script = render_restore_script(
+        endpoint=_endpoint(),
+        postgres_targets=(PostgresDumpTarget(container="gitea-db", database="gitea", user="nexus-gitea"),),
+        rsync_targets=(RsyncTarget(name="r", local_path="/var/lib/nexus-data/gitea", s3_subpath="gitea"),),
+    )
+    script_path = tmp_path / "restore.sh"
+    script_path.write_text(script, encoding="utf-8")
+    result = subprocess.run(
+        ["bash", "-n", str(script_path)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, f"bash -n failed: {result.stderr}"

--- a/tests/unit/test_s3_persistence.py
+++ b/tests/unit/test_s3_persistence.py
@@ -9,20 +9,29 @@ Coverage focus areas:
 * :class:`S3Endpoint` charset gating — every malformed value is
   rejected at construction time, with a message that names the
   offending field.
+* :class:`PostgresDumpTarget` charset gating — container,
+  database and user identifiers all validated against shapes
+  that are safe to interpolate into the rendered bash + SQL.
 * Manifest round-trip — ``to_json`` → ``from_json`` is identity
-  for valid input; corrupt input raises :class:`S3PersistenceError`
-  with a useful message.
+  for valid input; corrupt input (bad JSON, wrong root type,
+  unknown version, malformed components) raises
+  :class:`S3PersistenceError` with a useful message rather than
+  a confusing ``KeyError`` from indexing into bad data.
 * Snapshot script invariants — required structure (``set -euo
   pipefail``, ordered phases), atomicity gate (``rclone check``
-  before pointing ``snapshots/latest.txt`` at the new timestamp),
-  no shell injection from any interpolated value.
+  exit code captured via ``PIPESTATUS`` so a check-itself failure
+  isn't masked by ``|| true``), no shell injection from any
+  interpolated value.
 * Restore script invariants — graceful handling of the empty-S3
   case (fresh-start branch), drop+recreate around pg_restore,
-  cooperative idempotency.
-* Bash exec smoke tests — when bash is available locally, render
-  a minimal script with stubbed external commands and run it; the
-  ``set -euo pipefail`` is satisfied and exit codes match the
-  non-zero gate.
+  filesystem-before-postgres ordering, ``snapshots/latest.txt``
+  shape validation.
+* ``bash -n`` syntax check — the rendered scripts parse cleanly
+  with bash's no-execute mode. Catches dangling heredocs,
+  unmatched quotes etc. — bugs that don't surface in
+  string-equality tests but break at runtime on the server. Full
+  exec-with-stubs smoke tests are deferred to the pipeline-
+  integration PR where the SSHClient runner is plumbed in.
 """
 
 from __future__ import annotations
@@ -186,8 +195,12 @@ def test_manifest_round_trip_is_identity() -> None:
         stack="nexus-stefan-hslu",
         template_version="v0.56.0",
         components=(
-            ComponentSnapshot(name="gitea-repos", path="gitea/repos", size_bytes=1024, sha256="abc123"),
-            ComponentSnapshot(name="dify-storage", path="dify/storage", size_bytes=2048, sha256="def456"),
+            ComponentSnapshot(
+                name="gitea-repos", path="gitea/repos", size_bytes=1024, sha256="abc123"
+            ),
+            ComponentSnapshot(
+                name="dify-storage", path="dify/storage", size_bytes=2048, sha256="def456"
+            ),
         ),
     )
     parsed = SnapshotManifest.from_json(original.to_json())
@@ -218,6 +231,92 @@ def test_manifest_from_json_rejects_non_object_root() -> None:
 def test_manifest_from_json_rejects_invalid_json() -> None:
     with pytest.raises(S3PersistenceError, match="not valid JSON"):
         SnapshotManifest.from_json("{ not json")
+
+
+def test_manifest_from_json_rejects_non_dict_component() -> None:
+    """A component that's not a dict (e.g. a stray string) must
+    surface as :class:`S3PersistenceError` with an actionable
+    message, not a confusing TypeError. Promised in the
+    docstring; the previous implementation indexed straight in
+    and raised ``TypeError: string indices must be integers``."""
+    raw = json.dumps({"version": 1, "components": ["not-a-dict"]})
+    with pytest.raises(S3PersistenceError, match=r"components\[0\] must be an object"):
+        SnapshotManifest.from_json(raw)
+
+
+def test_manifest_from_json_rejects_component_missing_keys() -> None:
+    """A component dict missing one of the four required keys is
+    a manifest corruption — caller needs an actionable error,
+    not a KeyError stack trace."""
+    raw = json.dumps(
+        {
+            "version": 1,
+            "components": [{"name": "x", "path": "x"}],  # no size_bytes/sha256
+        }
+    )
+    with pytest.raises(S3PersistenceError, match=r"missing required key"):
+        SnapshotManifest.from_json(raw)
+
+
+def test_manifest_from_json_rejects_component_with_bad_size() -> None:
+    """``size_bytes`` must be coerce-able to int. A string like
+    'banana' would have raised ValueError mid-parse with the old
+    code; we now wrap it to S3PersistenceError."""
+    raw = json.dumps(
+        {
+            "version": 1,
+            "components": [
+                {
+                    "name": "x",
+                    "path": "x",
+                    "size_bytes": "banana",  # invalid
+                    "sha256": "abc",
+                }
+            ],
+        }
+    )
+    with pytest.raises(S3PersistenceError, match="bad value"):
+        SnapshotManifest.from_json(raw)
+
+
+# ---------------------------------------------------------------------------
+# PostgresDumpTarget charset gating (added in PR review round 2)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "fragment"),
+    [
+        # container — docker-service-name shape (Hetzner-region regex)
+        ("container", "Gitea_DB", "container"),  # underscore + uppercase
+        ("container", "gitea db", "container"),  # space
+        ("container", "gitea;rm", "container"),  # injection attempt
+        # database / user — strict PG identifier
+        ("database", "drop table users", "database"),
+        ("database", "1abc", "database"),  # leading digit
+        ("database", 'gitea"', "database"),  # quote injection
+        ("user", "user;DROP", "user"),
+        ("user", "user with space", "user"),
+    ],
+)
+def test_postgres_dump_target_rejects_unsafe_identifiers(
+    field: str, value: str, fragment: str
+) -> None:
+    """Every value that could break out of bash interpolation OR
+    SQL identifier interpolation must be rejected at construction
+    time. The rendered bash + SQL never sees an unsafe value."""
+    kwargs = {"container": "gitea-db", "database": "gitea", "user": "nexus-gitea"}
+    kwargs[field] = value
+    with pytest.raises(S3PersistenceError, match=fragment):
+        PostgresDumpTarget(**kwargs)
+
+
+def test_postgres_dump_target_accepts_canonical_values() -> None:
+    """Smoke: real-world configs (``gitea-db`` / ``gitea`` /
+    ``nexus-gitea``) pass the gate."""
+    PostgresDumpTarget(container="gitea-db", database="gitea", user="nexus-gitea")
+    PostgresDumpTarget(container="dify-db", database="dify", user="nexus_dify")
+    PostgresDumpTarget(container="x-db-2", database="db_v2", user="role_admin")
 
 
 def test_manifest_for_components_helper_sorts_components() -> None:
@@ -277,8 +376,16 @@ def test_snapshot_script_orders_phases_correctly() -> None:
         stack_slug="nexus-test",
         template_version="v0.56.0",
         timestamp="20260510T120000Z",
-        postgres_targets=(PostgresDumpTarget(container="gitea-db", database="gitea", user="nexus-gitea"),),
-        rsync_targets=(RsyncTarget(name="gitea-repos", local_path="/var/lib/nexus-data/gitea/repos", s3_subpath="gitea/repos"),),
+        postgres_targets=(
+            PostgresDumpTarget(container="gitea-db", database="gitea", user="nexus-gitea"),
+        ),
+        rsync_targets=(
+            RsyncTarget(
+                name="gitea-repos",
+                local_path="/var/lib/nexus-data/gitea/repos",
+                s3_subpath="gitea/repos",
+            ),
+        ),
         pause_compose_files=("/opt/docker-server/stacks/gitea/docker-compose.yml",),
     )
     pause_pos = script.find("compose -f")
@@ -345,10 +452,18 @@ def test_snapshot_script_rejects_unsafe_timestamp() -> None:
         )
 
 
-def test_snapshot_script_includes_rclone_check_with_drift_gate() -> None:
-    """``rclone check`` output must be parsed for ``-`` and ``*``
-    markers so any drift fails the snapshot — silently passing
-    would let half-uploaded snapshots count as ``latest``."""
+def test_snapshot_script_atomicity_gate_distinguishes_two_failure_modes() -> None:
+    """The atomicity gate must distinguish (a) rclone-check itself
+    erroring (auth/network/quota — ``rclone_rc != 0``) from
+    (b) rclone-check succeeding but reporting drift (``drift_rc ==
+    0`` because ``grep`` found a ``-`` or ``*`` marker line).
+
+    The previous ``... | grep ... && {...} || true`` form
+    silently merged both cases and let ``set -e`` mask the
+    rclone-check-itself failure. We assert the rendered bash
+    captures both rcs via ``PIPESTATUS`` and aborts with a
+    distinct message for each.
+    """
     script = render_snapshot_script(
         endpoint=_endpoint(),
         stack_slug="nexus-test",
@@ -358,8 +473,18 @@ def test_snapshot_script_includes_rclone_check_with_drift_gate() -> None:
         rsync_targets=(),
     )
     assert "rclone check" in script
-    assert 'grep -E "^[-*]"' in script
+    # Both PIPESTATUS captures must be present.
+    assert "rclone_rc=${PIPESTATUS[0]}" in script
+    assert "drift_rc=${PIPESTATUS[1]}" in script
+    # And both abort messages must distinguish the two modes.
+    assert "snapshot-failed: rclone check itself errored" in script
     assert "snapshot-failed: rclone check found drift" in script
+    # The rclone-check command itself must not be wrapped in `... ||
+    # true` (which would swallow non-zero exit). The diagnostic
+    # ``cat err || true`` (a best-effort log dump if the err file
+    # didn't get written) is allowed.
+    rclone_check_block = script.split("rclone check ")[1].split("\n", 1)[0]
+    assert "|| true" not in rclone_check_block
 
 
 # ---------------------------------------------------------------------------
@@ -396,7 +521,9 @@ def test_restore_script_drops_database_before_pg_restore() -> None:
     deterministic."""
     script = render_restore_script(
         endpoint=_endpoint(),
-        postgres_targets=(PostgresDumpTarget(container="gitea-db", database="gitea", user="nexus-gitea"),),
+        postgres_targets=(
+            PostgresDumpTarget(container="gitea-db", database="gitea", user="nexus-gitea"),
+        ),
         rsync_targets=(),
     )
     assert "DROP DATABASE IF EXISTS gitea" in script
@@ -410,8 +537,14 @@ def test_restore_script_pulls_filesystem_trees_before_postgres() -> None:
     Reversing this ordering would race on first start."""
     script = render_restore_script(
         endpoint=_endpoint(),
-        postgres_targets=(PostgresDumpTarget(container="gitea-db", database="gitea", user="nexus-gitea"),),
-        rsync_targets=(RsyncTarget(name="r", local_path="/var/lib/nexus-data/gitea/repos", s3_subpath="gitea/repos"),),
+        postgres_targets=(
+            PostgresDumpTarget(container="gitea-db", database="gitea", user="nexus-gitea"),
+        ),
+        rsync_targets=(
+            RsyncTarget(
+                name="r", local_path="/var/lib/nexus-data/gitea/repos", s3_subpath="gitea/repos"
+            ),
+        ),
     )
     fs_pos = script.find("pulling filesystem trees")
     pg_pos = script.find("pulling postgres dumps")
@@ -447,8 +580,12 @@ def test_rendered_snapshot_script_is_syntactically_valid_bash(tmp_path: Path) ->
         stack_slug="nexus-test",
         template_version="v0.56.0",
         timestamp="20260510T120000Z",
-        postgres_targets=(PostgresDumpTarget(container="gitea-db", database="gitea", user="nexus-gitea"),),
-        rsync_targets=(RsyncTarget(name="r", local_path="/var/lib/nexus-data/gitea", s3_subpath="gitea"),),
+        postgres_targets=(
+            PostgresDumpTarget(container="gitea-db", database="gitea", user="nexus-gitea"),
+        ),
+        rsync_targets=(
+            RsyncTarget(name="r", local_path="/var/lib/nexus-data/gitea", s3_subpath="gitea"),
+        ),
         pause_compose_files=("/opt/docker-server/stacks/gitea/docker-compose.yml",),
     )
     script_path = tmp_path / "snapshot.sh"
@@ -466,8 +603,12 @@ def test_rendered_snapshot_script_is_syntactically_valid_bash(tmp_path: Path) ->
 def test_rendered_restore_script_is_syntactically_valid_bash(tmp_path: Path) -> None:
     script = render_restore_script(
         endpoint=_endpoint(),
-        postgres_targets=(PostgresDumpTarget(container="gitea-db", database="gitea", user="nexus-gitea"),),
-        rsync_targets=(RsyncTarget(name="r", local_path="/var/lib/nexus-data/gitea", s3_subpath="gitea"),),
+        postgres_targets=(
+            PostgresDumpTarget(container="gitea-db", database="gitea", user="nexus-gitea"),
+        ),
+        rsync_targets=(
+            RsyncTarget(name="r", local_path="/var/lib/nexus-data/gitea", s3_subpath="gitea"),
+        ),
     )
     script_path = tmp_path / "restore.sh"
     script_path.write_text(script, encoding="utf-8")

--- a/tests/unit/test_s3_persistence.py
+++ b/tests/unit/test_s3_persistence.py
@@ -514,6 +514,16 @@ def test_snapshot_script_orders_phases_correctly() -> None:
     # No blanket "|| echo non-fatal" masking on the stop step.
     stop_block = script.split("→ snapshot: stopping compose stacks")[1].split("→ snapshot:")[0]
     assert "stop || echo" not in stop_block
+    # Regression for Copilot round-6 #3216702497: the
+    # ``ps -q`` probe must capture both the exit code AND the
+    # stdout separately, so an empty-stdout-from-ps-FAILING
+    # case (missing compose file, daemon down, YAML syntax)
+    # doesn't masquerade as the empty-stdout-from-no-containers
+    # case. The earlier ``[ -n "$(ps -q 2>/dev/null)" ]`` form
+    # silently mapped failure to "skip stop" and continued the
+    # snapshot while services kept running.
+    assert "PS_RC=$?" in stop_block
+    assert '[ "$PS_RC" -eq 0 ] && [ -z "$PS_OUT" ]' in stop_block
 
 
 def test_snapshot_script_omits_compose_stop_when_no_files_passed() -> None:

--- a/tests/unit/test_s3_persistence.py
+++ b/tests/unit/test_s3_persistence.py
@@ -319,6 +319,79 @@ def test_postgres_dump_target_accepts_canonical_values() -> None:
     PostgresDumpTarget(container="x-db-2", database="db_v2", user="role_admin")
 
 
+# ---------------------------------------------------------------------------
+# RsyncTarget charset gating (Copilot round-3 #3216323836 / #3216323852)
+# ---------------------------------------------------------------------------
+
+
+def test_rsync_target_accepts_canonical_values() -> None:
+    """Smoke: the typical nexus-data layout passes the gate."""
+    RsyncTarget(
+        name="gitea-repos", local_path="/var/lib/nexus-data/gitea/repos", s3_subpath="gitea/repos"
+    )
+    RsyncTarget(
+        name="dify-storage",
+        local_path="/var/lib/nexus-data/dify/storage",
+        s3_subpath="dify/storage",
+    )
+
+
+@pytest.mark.parametrize(
+    "subpath",
+    [
+        "gitea/$(rm -rf /)",  # command substitution
+        "gitea/`whoami`",  # backticks
+        "gitea/repos with space",
+        "/gitea/repos",  # leading slash
+        "gitea/repos/",  # trailing slash
+        "../gitea",  # parent ref
+        "gitea/../etc",  # parent ref middle
+        'gitea/"injection',  # quote
+    ],
+)
+def test_rsync_target_rejects_unsafe_s3_subpath(subpath: str) -> None:
+    """``s3_subpath`` is interpolated into double-quoted bash strings
+    where ``shlex.quote`` doesn't help. Constructor must catch every
+    shape that would corrupt the rendered bash or escape the bucket
+    path."""
+    with pytest.raises(S3PersistenceError, match="s3_subpath"):
+        RsyncTarget(name="x", local_path="/var/lib/nexus-data/x", s3_subpath=subpath)
+
+
+def test_rsync_target_rejects_relative_local_path() -> None:
+    with pytest.raises(S3PersistenceError, match="local_path must be absolute"):
+        RsyncTarget(name="x", local_path="relative/path", s3_subpath="x")
+
+
+# ---------------------------------------------------------------------------
+# S3Endpoint endpoint-URL charset gating (Copilot round-3 #3216323864)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "endpoint",
+    [
+        "https://fsn1.your-objectstorage.com\nextra_key = injection",
+        "https://fsn1 .your-objectstorage.com",  # space
+        "https://fsn1.your-objectstorage.com\r\n",
+        "https://fsn1.your-objectstorage.com\t",
+    ],
+)
+def test_s3endpoint_rejects_endpoint_with_whitespace_or_newlines(endpoint: str) -> None:
+    """Whitespace/newlines in the endpoint URL would corrupt the
+    rendered rclone config (split the value across multiple keys,
+    inject extra config lines). Regression for Copilot round-3
+    #3216323864."""
+    with pytest.raises(S3PersistenceError, match="corrupt the rendered rclone config"):
+        S3Endpoint(
+            endpoint=endpoint,
+            region="fsn1",
+            access_key="AKIA",
+            secret_key="secret",
+            bucket="nexus-test",
+        )
+
+
 def test_manifest_for_components_helper_sorts_components() -> None:
     """Components map → sorted ComponentSnapshot tuple. Sorting
     matters for deterministic manifest bytes regardless of the
@@ -326,13 +399,26 @@ def test_manifest_for_components_helper_sorts_components() -> None:
     m = manifest_for_components(
         stack="nexus-test",
         template_version="v0.56.0",
-        timestamp="20260510",
+        created_at="2026-05-11T04:00:00Z",
         components={
             "z-stack": (10, "z-hash"),
             "a-stack": (20, "a-hash"),
         },
     )
     assert [c.name for c in m.components] == ["a-stack", "z-stack"]
+
+
+def test_manifest_for_components_propagates_created_at() -> None:
+    """Regression: ``created_at`` is now an actual parameter (was
+    previously a no-op ``timestamp`` arg that the helper ignored).
+    The value must land on the manifest's ``created_at`` field."""
+    m = manifest_for_components(
+        stack="nexus-test",
+        template_version="v0.56.0",
+        created_at="2026-05-11T04:00:00Z",
+        components={},
+    )
+    assert m.created_at == "2026-05-11T04:00:00Z"
 
 
 # ---------------------------------------------------------------------------
@@ -454,16 +540,10 @@ def test_snapshot_script_rejects_unsafe_timestamp() -> None:
 
 def test_snapshot_script_atomicity_gate_distinguishes_two_failure_modes() -> None:
     """The atomicity gate must distinguish (a) rclone-check itself
-    erroring (auth/network/quota — ``rclone_rc != 0``) from
-    (b) rclone-check succeeding but reporting drift (``drift_rc ==
-    0`` because ``grep`` found a ``-`` or ``*`` marker line).
-
-    The previous ``... | grep ... && {...} || true`` form
-    silently merged both cases and let ``set -e`` mask the
-    rclone-check-itself failure. We assert the rendered bash
-    captures both rcs via ``PIPESTATUS`` and aborts with a
-    distinct message for each.
-    """
+    erroring (auth/network/quota) from (b) drift found via the
+    pipe-grep on rclone-check's --combined output. Both rcs are
+    captured via ``PIPESTATUS`` so neither can be silently masked
+    by ``|| true``."""
     script = render_snapshot_script(
         endpoint=_endpoint(),
         stack_slug="nexus-test",
@@ -473,18 +553,49 @@ def test_snapshot_script_atomicity_gate_distinguishes_two_failure_modes() -> Non
         rsync_targets=(),
     )
     assert "rclone check" in script
-    # Both PIPESTATUS captures must be present.
+    # Both PIPESTATUS captures must be present in the verify_one helper.
     assert "rclone_rc=${PIPESTATUS[0]}" in script
     assert "drift_rc=${PIPESTATUS[1]}" in script
     # And both abort messages must distinguish the two modes.
-    assert "snapshot-failed: rclone check itself errored" in script
-    assert "snapshot-failed: rclone check found drift" in script
-    # The rclone-check command itself must not be wrapped in `... ||
-    # true` (which would swallow non-zero exit). The diagnostic
-    # ``cat err || true`` (a best-effort log dump if the err file
-    # didn't get written) is allowed.
-    rclone_check_block = script.split("rclone check ")[1].split("\n", 1)[0]
-    assert "|| true" not in rclone_check_block
+    assert "snapshot-failed: rclone check ${label} errored" in script
+    assert "snapshot-failed: rclone check ${label} found drift" in script
+
+
+def test_snapshot_script_verifies_every_rsync_target() -> None:
+    """The verify gate must run an rclone check for ``$WORKDIR``
+    (manifest + postgres dumps) AND one per ``RsyncTarget`` — the
+    filesystem trees uploaded via ``rclone sync {local} {dst}``
+    are NOT in $WORKDIR, so a $WORKDIR-only check would have left
+    the bulk of the persisted state unverified.
+
+    Regression for Copilot round-3 #3216323822."""
+    script = render_snapshot_script(
+        endpoint=_endpoint(),
+        stack_slug="nexus-test",
+        template_version="v0.56.0",
+        timestamp="20260510T120000Z",
+        postgres_targets=(),
+        rsync_targets=(
+            RsyncTarget(
+                name="gitea-repos",
+                local_path="/var/lib/nexus-data/gitea/repos",
+                s3_subpath="gitea/repos",
+            ),
+            RsyncTarget(
+                name="dify-storage",
+                local_path="/var/lib/nexus-data/dify/storage",
+                s3_subpath="dify/storage",
+            ),
+        ),
+    )
+    # Workdir verify (manifest + postgres dumps)
+    assert 'verify_one "$WORKDIR" "$BUCKET/$SNAPSHOT_PREFIX" "workdir(manifest+postgres)"' in script
+    # Plus per-rsync-target verify
+    assert "verify_one /var/lib/nexus-data/gitea/repos" in script
+    assert "verify_one /var/lib/nexus-data/dify/storage" in script
+    # Final gate before pointing snapshots/latest
+    assert 'if [ "$verify_failed" -ne 0 ]; then' in script
+    assert "not pointing snapshots/latest at $TIMESTAMP" in script
 
 
 # ---------------------------------------------------------------------------
@@ -518,7 +629,13 @@ def test_restore_script_handles_empty_s3_gracefully() -> None:
 def test_restore_script_drops_database_before_pg_restore() -> None:
     """A restore against a running Postgres with existing rows
     would conflict on PK; the drop+recreate keeps the pg_restore
-    deterministic."""
+    deterministic.
+
+    SQL identifiers are now ALWAYS double-quoted because real role
+    names use hyphens (``nexus-gitea``) which would be invalid as
+    unquoted SQL — the previous unquoted form would have produced
+    ``OWNER nexus-gitea`` which Postgres rejects as a syntax error.
+    """
     script = render_restore_script(
         endpoint=_endpoint(),
         postgres_targets=(
@@ -526,8 +643,10 @@ def test_restore_script_drops_database_before_pg_restore() -> None:
         ),
         rsync_targets=(),
     )
-    assert "DROP DATABASE IF EXISTS gitea" in script
-    assert "CREATE DATABASE gitea OWNER nexus-gitea" in script
+    assert 'DROP DATABASE IF EXISTS "gitea"' in script
+    assert 'CREATE DATABASE "gitea" OWNER "nexus-gitea"' in script
+    # CLI args don't need SQL quoting — pg_restore's -U/-d take plain
+    # values via argv, not embedded SQL.
     assert "pg_restore -U nexus-gitea -d gitea" in script
 
 

--- a/tests/unit/test_s3_persistence.py
+++ b/tests/unit/test_s3_persistence.py
@@ -470,10 +470,15 @@ def test_snapshot_script_has_bash_safety_pragmas() -> None:
 
 
 def test_snapshot_script_orders_phases_correctly() -> None:
-    """The phase order is the atomicity contract: pause → dump →
+    """The phase order is the atomicity contract: stop → dump →
     upload → verify → point latest. Reorder would silently break
-    the guarantee that ``snapshots/latest`` only updates after
-    upload succeeded."""
+    the guarantee that ``snapshots/latest.txt`` only updates after
+    upload succeeded.
+
+    We use ``docker compose stop`` (graceful 10s drain), not
+    ``pause`` (SIGSTOP via cgroup freezer, hard-kills in-flight
+    writes mid-transaction).
+    """
     script = render_snapshot_script(
         endpoint=_endpoint(),
         stack_slug="nexus-test",
@@ -489,19 +494,27 @@ def test_snapshot_script_orders_phases_correctly() -> None:
                 s3_subpath="gitea/repos",
             ),
         ),
-        pause_compose_files=("/opt/docker-server/stacks/gitea/docker-compose.yml",),
+        stop_compose_files=("/opt/docker-server/stacks/gitea/docker-compose.yml",),
     )
-    pause_pos = script.find("compose -f")
+    # Locate each phase via a stable substring + assert ordering.
+    stop_pos = script.find("compose -f")
     dump_pos = script.find("pg_dump")
     upload_pos = script.find("rclone sync")
     check_pos = script.find("rclone check")
     latest_pos = script.find("snapshots/latest.txt")
-    assert pause_pos < dump_pos < upload_pos < check_pos < latest_pos
+    assert stop_pos < dump_pos < upload_pos < check_pos < latest_pos
+    # Regression: stop, not pause.
+    assert "compose -f" in script
+    assert "stop" in script.split("compose -f")[1].split("\n")[0]
+    assert "docker compose -f" in script
+    assert " pause " not in script.replace(
+        '"compose pause non-fatal: stack may already be down"', ""
+    )
 
 
-def test_snapshot_script_omits_pause_when_no_compose_files() -> None:
-    """No compose files passed → no docker pause calls. Avoids
-    the ``no compose files`` echo-only no-op block."""
+def test_snapshot_script_omits_compose_stop_when_no_files_passed() -> None:
+    """No compose files passed → no docker compose calls at all.
+    Avoids the ``no compose files`` echo-only no-op block."""
     script = render_snapshot_script(
         endpoint=_endpoint(),
         stack_slug="nexus-test",
@@ -722,7 +735,7 @@ def test_rendered_snapshot_script_is_syntactically_valid_bash(tmp_path: Path) ->
         rsync_targets=(
             RsyncTarget(name="r", local_path="/var/lib/nexus-data/gitea", s3_subpath="gitea"),
         ),
-        pause_compose_files=("/opt/docker-server/stacks/gitea/docker-compose.yml",),
+        stop_compose_files=("/opt/docker-server/stacks/gitea/docker-compose.yml",),
     )
     script_path = tmp_path / "snapshot.sh"
     script_path.write_text(script, encoding="utf-8")

--- a/tests/unit/test_s3_persistence.py
+++ b/tests/unit/test_s3_persistence.py
@@ -584,8 +584,14 @@ def test_snapshot_script_atomicity_gate_distinguishes_two_failure_modes() -> Non
     )
     assert "rclone check" in script
     # Both PIPESTATUS captures must be present in the verify_one helper.
+    # Pipeline is `rclone | tee | grep`, so PIPESTATUS indexes are:
+    #   [0] = rclone (the integrity check), [1] = tee (always 0),
+    #   [2] = grep (0 = drift markers found, 1 = clean).
+    # An earlier revision had drift_rc=[1] (tee) which made the gate
+    # report "drift" on every snapshot — locking in [2] (grep) here
+    # is the regression test.
     assert "rclone_rc=${PIPESTATUS[0]}" in script
-    assert "drift_rc=${PIPESTATUS[1]}" in script
+    assert "drift_rc=${PIPESTATUS[2]}" in script
     # And both abort messages must distinguish the two modes.
     assert "snapshot-failed: rclone check ${label} errored" in script
     assert "snapshot-failed: rclone check ${label} found drift" in script

--- a/tests/unit/test_s3_persistence.py
+++ b/tests/unit/test_s3_persistence.py
@@ -67,8 +67,23 @@ def _bash_can_be_invoked() -> bool:
 # ---------------------------------------------------------------------------
 
 
+def test_s3endpoint_accepts_canonical_r2_values() -> None:
+    """Smoke: the constructor doesn't reject a real R2 config."""
+    e = S3Endpoint(
+        endpoint="https://abc123.r2.cloudflarestorage.com",
+        region="auto",
+        access_key="ABCDEFG1234567890",
+        secret_key="abc123XYZ+/=_-",
+        bucket="nexus-stefan-hslu",
+    )
+    assert e.region == "auto"
+    assert e.bucket == "nexus-stefan-hslu"
+
+
 def test_s3endpoint_accepts_canonical_hetzner_values() -> None:
-    """Smoke: the constructor doesn't reject a real Hetzner config."""
+    """Smoke: the module is endpoint-agnostic; a Hetzner Object
+    Storage config also passes the gate (used by future migration
+    tooling, not the v1.0 steady state)."""
     e = S3Endpoint(
         endpoint="https://fsn1.your-objectstorage.com",
         region="fsn1",
@@ -83,15 +98,15 @@ def test_s3endpoint_accepts_canonical_hetzner_values() -> None:
 @pytest.mark.parametrize(
     ("field", "value"),
     [
-        ("endpoint", "fsn1.your-objectstorage.com"),  # missing scheme
-        ("endpoint", "ftp://fsn1.your-objectstorage.com"),  # wrong scheme
+        ("endpoint", "abc123.r2.cloudflarestorage.com"),  # missing scheme
+        ("endpoint", "ftp://abc123.r2.cloudflarestorage.com"),  # wrong scheme
     ],
 )
 def test_s3endpoint_rejects_non_http_endpoint(field: str, value: str) -> None:
     """Non-HTTP endpoints get caught — common copy-paste error
     where someone pastes the bucket name into the endpoint slot."""
     kwargs = {
-        "endpoint": "https://fsn1.your-objectstorage.com",
+        "endpoint": "https://abc123.r2.cloudflarestorage.com",
         "region": "fsn1",
         "access_key": "AKIAEXAMPLE",
         "secret_key": "secret123",
@@ -118,7 +133,7 @@ def test_s3endpoint_rejects_unsafe_charset(field: str, value: str, fragment: str
     caught at the constructor — the rendered script never sees an
     unsafe value."""
     kwargs = {
-        "endpoint": "https://fsn1.your-objectstorage.com",
+        "endpoint": "https://abc123.r2.cloudflarestorage.com",
         "region": "fsn1",
         "access_key": "AKIAEXAMPLE",
         "secret_key": "secret123",
@@ -136,11 +151,13 @@ def test_s3endpoint_rejects_unsafe_charset(field: str, value: str, fragment: str
 
 def test_render_rclone_config_emits_full_profile_block() -> None:
     """The block contains every key rclone needs to authenticate
-    against Hetzner. No accidental ``env_auth = true`` (which
-    would silently fall back to ambient AWS env vars)."""
+    against R2. No accidental ``env_auth = true`` (which would
+    silently fall back to ambient AWS env vars). The
+    ``provider = Cloudflare`` switch is what tells rclone to
+    apply R2-specific quirks."""
     e = S3Endpoint(
-        endpoint="https://fsn1.your-objectstorage.com",
-        region="fsn1",
+        endpoint="https://abc123.r2.cloudflarestorage.com",
+        region="auto",
         access_key="AKIA1234",
         secret_key="secret/key+abc=",
         bucket="nexus-stefan-hslu",
@@ -149,12 +166,12 @@ def test_render_rclone_config_emits_full_profile_block() -> None:
 
     assert config.startswith(f"[{RCLONE_PROFILE}]\n")
     assert "type = s3\n" in config
-    assert "provider = Other\n" in config
+    assert "provider = Cloudflare\n" in config
     assert "env_auth = false\n" in config
     assert "access_key_id = AKIA1234\n" in config
     assert "secret_access_key = secret/key+abc=\n" in config
-    assert "endpoint = https://fsn1.your-objectstorage.com\n" in config
-    assert "region = fsn1\n" in config
+    assert "endpoint = https://abc123.r2.cloudflarestorage.com\n" in config
+    assert "region = auto\n" in config
     assert "acl = private\n" in config
 
 
@@ -163,8 +180,8 @@ def test_render_rclone_config_uses_module_level_profile_name() -> None:
     Hardcoded literal would be fine but a constant means a future
     rename can't drift between the two render functions."""
     e = S3Endpoint(
-        endpoint="https://fsn1.your-objectstorage.com",
-        region="fsn1",
+        endpoint="https://abc123.r2.cloudflarestorage.com",
+        region="auto",
         access_key="AKIA",
         secret_key="secret",
         bucket="nexus-test",
@@ -385,7 +402,7 @@ def test_s3endpoint_rejects_endpoint_with_whitespace_or_newlines(endpoint: str) 
     with pytest.raises(S3PersistenceError, match="corrupt the rendered rclone config"):
         S3Endpoint(
             endpoint=endpoint,
-            region="fsn1",
+            region="auto",
             access_key="AKIA",
             secret_key="secret",
             bucket="nexus-test",
@@ -428,8 +445,8 @@ def test_manifest_for_components_propagates_created_at() -> None:
 
 def _endpoint() -> S3Endpoint:
     return S3Endpoint(
-        endpoint="https://fsn1.your-objectstorage.com",
-        region="fsn1",
+        endpoint="https://abc123.r2.cloudflarestorage.com",
+        region="auto",
         access_key="AKIA1234",
         secret_key="secret123",
         bucket="nexus-test",


### PR DESCRIPTION
## Summary

Foundation PR (1 of ~7) for the S3-backed persistence refactor — see [RFC 0001](https://github.com/stefanko-ch/Nexus-Stack/pull/550).

This PR ships the **building blocks**: the Python module, the rendering helpers, the bucket-lifecycle shell scripts, and a comprehensive test suite. Nothing is wired into the pipeline yet — that's the follow-up PRs in this series. Reviewing/merging this in isolation is safe: no behaviour change, just new files.

## What's in this PR

### `src/nexus_deploy/s3_persistence.py` (new module)

| Surface | What it does |
|---|---|
| `S3Endpoint` | Frozen dataclass with charset gating on every field. Construction-time validation surfaces config errors at the right place. |
| `SnapshotManifest` + `ComponentSnapshot` | JSON round-trip with version gating (v1 only; future v2 explicitly rejected). |
| `render_rclone_config()` | Emits the `[hetzner-s3]` rclone profile block. Module-level `RCLONE_PROFILE` constant so config and scripts can't drift. |
| `render_snapshot_script()` | Bash for atomic teardown-time snapshot: pause → pg_dump → rclone sync → manifest → **`rclone check` gate** → point `snapshots/latest.txt`. Caller treats rc≠0 as "abort teardown". |
| `render_restore_script()` | Bash for spinup-time restore. Graceful exit on empty S3 (first-time spinup). FS sync happens before pg_restore. Drop+recreate around restore for determinism. |

### `scripts/init-s3-bucket.sh` (new)

- Idempotent bucket bootstrap on Hetzner Object Storage
- Enables versioning + applies 30-day lifecycle on noncurrent versions (covers 7-daily + 4-weekly retention window per RFC decision #5)
- Optional Infisical credential push when env vars are set
- Charset gating on `STACK_SLUG` and `HETZNER_S3_LOCATION` allowlist
- stdout emits parseable `KEY=VALUE` block for downstream automation

### `scripts/cleanup-s3-bucket.sh` (new)

- **Opt-in destructive**: no-op unless `CONFIRM_DELETE_DATA=DESTROY` (per RFC decision #6, same pattern as `destroy-all.yml`'s `confirm=DESTROY`)
- Paginates `list-object-versions` and batch-deletes every object version + delete-marker (a plain `aws s3 rb --force` would 409 on the bucket-delete because noncurrent versions persist)

### `tests/unit/test_s3_persistence.py`

31 tests, all passing. Covers:
- `S3Endpoint` charset gating (constructor rejects unsafe chars in every field)
- Manifest round-trip + version gating + corrupt-input handling
- Snapshot script structure (bash safety pragmas, ordered phases, atomicity gate, omits empty phases cleanly, rejects unsafe `stack_slug` / `timestamp`)
- Restore script structure (empty-S3 graceful exit, drop+recreate, FS-before-postgres ordering, `latest.txt` validation)
- `bash -n` syntax check on both rendered scripts (catches dangling heredocs, unmatched quotes)

## Trade-offs

- **No client-side rclone bindings.** The module renders bash; SSHClient runs it. Avoids shipping rclone in the dev environment + cross-platform binary headaches. Same pattern as `setup.py:_render_volume_mount_script`.
- **v1.0 manifests are slim** (no per-component sha256 in the rendered bash). Computing sha256 over multi-GB rsync trees adds material minutes to teardown. The `rclone check` gate covers integrity cheaply via ETags. v1.1 may revisit.
- **Lifecycle policy is "30-day expiry on noncurrent versions"** rather than exact "7 daily + 4 weekly". The 30-day cap is the safety net; a follow-up cron-script can do precise N-daily-M-weekly retention if needed.

## Test plan

- [x] `uv run pytest tests/unit/test_s3_persistence.py -q` — 31 passed
- [x] `uv run pytest tests/unit/` — full suite, 1363 passed (no regression)
- [x] `uv run ruff check` on new files — clean
- [x] `uv run mypy --strict` on new module — clean
- [x] `shellcheck --severity=warning` on both scripts — clean
- [ ] **Manual** (post-merge): run `init-s3-bucket.sh` against a real Hetzner project to confirm the lifecycle policy applies. Out of scope for the foundation PR; covered by the integration PR that wires the module into pipeline.py.

## Next PRs in the series

| # | Scope |
|---|---|
| 2 | Wire the module into `nexus_deploy.pipeline` — spinup-restore phase + atomic-teardown phase |
| 3 | Remove `hcloud_volume "persistent"` from `tofu/control-plane/` |
| 4 | Update `stacks/gitea/`, `stacks/dify/` mount paths from `/mnt/nexus-data` to `/var/lib/nexus-data` (or symlink) |
| 5 | `.github/workflows/` — atomic-teardown logic, opt-in `destroy-all --delete-data` |
| 6 | One-shot `evacuate-volume-to-s3.yaml` migration workflow for the existing 26 stacks |
| 7 | Education-side cleanup — drop `persistent_volume_size` from schema, replace volume-creation with bucket-creation in `setup.ts` |

Refs RFC 0001 (`docs/proposals/0001-s3-persistence.md`).
