### PR TITLE
feat(deploy): RFC 0001 PR-2 of 7 — pipeline-side s3 restore orchestration

### DIFF
--- a/src/nexus_deploy/pipeline.py
+++ b/src/nexus_deploy/pipeline.py
@@ -39,6 +39,7 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from nexus_deploy import s3_restore as _s3_restore
 from nexus_deploy import setup as _setup
 from nexus_deploy import tfvars as _tfvars
 from nexus_deploy import tofu as _tofu
@@ -352,6 +353,28 @@ def run_pipeline(
                 f"{mount_result.detail or 'no detail'} — "
                 "downstream stacks that depend on /opt/data may misbehave\n",
             )
+
+        # RFC 0001 phase A wire-up. Reads the NEXUS_S3_PERSISTENCE env
+        # var; when ``"true"`` the S3 restore path runs in addition to
+        # (not instead of) the volume mount above. For stacks that
+        # haven't migrated yet the function returns S3RestoreSkipped
+        # immediately and we pass through with no behavior change.
+        # The volume-mount path itself becomes a no-op once a stack's
+        # config drops ``persistent_volume_id`` (RFC PR-3); for now
+        # both paths coexist so cutover is per-stack and reversible.
+        s3_result = _s3_restore.restore_from_s3(ssh)
+        if isinstance(s3_result, _s3_restore.S3RestoreApplied):
+            sys.stderr.write(
+                f"✓ s3-restore: applied snapshot {s3_result.snapshot_timestamp}\n",
+            )
+        elif s3_result.reason == "fresh_start_empty_s3":
+            sys.stderr.write(
+                "→ s3-restore: bucket empty, fresh-start (first spinup of new "
+                "persistence bucket)\n",
+            )
+        # The other two skip reasons (feature_flag_off / no_endpoint_env)
+        # already wrote their own stderr lines from inside restore_from_s3;
+        # nothing more to log here.
 
         if options.dockerhub_user and options.dockerhub_token:
             login_fn = docker_hub_login if docker_hub_login is not None else _docker_hub_login

--- a/src/nexus_deploy/pipeline.py
+++ b/src/nexus_deploy/pipeline.py
@@ -372,9 +372,13 @@ def run_pipeline(
                 "→ s3-restore: bucket empty, fresh-start (first spinup of new "
                 "persistence bucket)\n",
             )
-        # The other two skip reasons (feature_flag_off / no_endpoint_env)
-        # already wrote their own stderr lines from inside restore_from_s3;
-        # nothing more to log here.
+        # The other two skip reasons are intentionally not logged here:
+        #   - feature_flag_off: silent by design — the stack hasn't
+        #     opted in to S3 persistence, so logging would just add
+        #     noise to every spinup of stacks that don't use it.
+        #   - no_endpoint_env: restore_from_s3 already wrote its own
+        #     stderr line (it lists the specific missing env vars,
+        #     which is the actionable info the operator needs).
 
         if options.dockerhub_user and options.dockerhub_token:
             login_fn = docker_hub_login if docker_hub_login is not None else _docker_hub_login

--- a/src/nexus_deploy/s3_restore.py
+++ b/src/nexus_deploy/s3_restore.py
@@ -1,0 +1,396 @@
+"""Pipeline-side orchestration for S3 spinup-restore (RFC 0001 PR-2).
+
+This module is the *caller* of the pure-rendering functions in
+:mod:`nexus_deploy.s3_persistence`. The split mirrors the
+``setup.py`` pattern: ``s3_persistence.py`` produces bash strings,
+``s3_restore.py`` reads environment / config, builds the target
+lists, and ships the rendered script to the remote via
+:class:`SSHClient`.
+
+Public surface:
+
+* :class:`S3RestoreSkipped` / :class:`S3RestoreApplied` — outcome
+  marker classes returned by :func:`restore_from_s3`. Tests assert
+  on the type; pipeline.py logs a one-line summary using the
+  ``detail`` attribute.
+* :func:`build_endpoint_from_env` — read the five PERSISTENCE_S3_*
+  env vars, return a populated :class:`S3Endpoint`. Returns
+  ``None`` when any of them is unset — the caller treats that as
+  "S3 persistence not configured on this stack, skip the phase."
+* :func:`standard_targets` — produces the canonical tuple of
+  postgres + rsync targets for the two stacks we persist
+  (Gitea + Dify). Hard-coded for v1.0 because those are the only
+  stacks with persistent data on the volume; a future
+  per-stack config registry can replace this if other stacks
+  start carrying state.
+* :func:`restore_from_s3` — the orchestration entry point.
+  Render rclone config + restore script via
+  :mod:`s3_persistence`, ship them through ``ssh.run_script``,
+  return a typed result.
+
+Feature flag: this whole module is a *no-op* if
+``NEXUS_S3_PERSISTENCE`` is not set to ``true`` in the spinup
+environment. That keeps the existing volume-mount path
+unchanged for stacks that haven't migrated yet (RFC Phase A:
+prepare without breaking changes). The flip happens per-stack
+during Phase B/C of the rollout — see RFC 0001 phased-rollout
+plan.
+
+Why a flag rather than presence-of-env-vars detection: a stack
+mid-migration may have the PERSISTENCE_S3_* env vars populated
+*before* its volume data has been evacuated to S3. Silently
+flipping to the S3 path on env-presence would cause the first
+post-flag spinup to come up with empty data dirs and the
+existing volume detached + ignored. The explicit
+``NEXUS_S3_PERSISTENCE=true`` flag forces an operator-aware
+flip per stack.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import dataclasses
+import os
+import sys
+from typing import Literal
+
+from nexus_deploy import s3_persistence as _s3
+from nexus_deploy.ssh import SSHClient
+
+# ---------------------------------------------------------------------------
+# Feature-flag env var name
+# ---------------------------------------------------------------------------
+
+FEATURE_FLAG_ENV = "NEXUS_S3_PERSISTENCE"
+"""Stack-level toggle. Must be exactly ``"true"`` (lowercase) to
+enable the new S3-restore path. Any other value (unset, empty,
+``"false"``, ``"True"`` with capital T) keeps the old
+volume-mount path in pipeline.py. Strict matching is deliberate:
+operators set this via GitHub Actions repo-variables where
+shell-style truthy-coercion would hide configuration mistakes."""
+
+
+# ---------------------------------------------------------------------------
+# Outcome marker classes — pipeline.py branches on isinstance()
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass(frozen=True)
+class S3RestoreSkipped:
+    """Restore was a no-op. ``reason`` is operator-facing: one of
+    ``"feature_flag_off"``, ``"no_endpoint_env"``,
+    ``"fresh_start_empty_s3"``. The first two are configuration
+    states (no S3 path taken at all). The third means the path
+    was taken but S3 had nothing to restore — first-ever
+    spinup of a freshly-provisioned bucket. All three are
+    success cases from pipeline.py's perspective."""
+
+    reason: Literal["feature_flag_off", "no_endpoint_env", "fresh_start_empty_s3"]
+
+
+@dataclasses.dataclass(frozen=True)
+class S3RestoreApplied:
+    """Restore ran end-to-end. ``snapshot_timestamp`` is the value
+    of ``snapshots/latest.txt`` that was applied (operator can
+    grep for it in the S3 bucket to find the matching
+    ``snapshots/<timestamp>/`` subtree). Used by pipeline.py to
+    emit a one-line summary to stderr after the phase."""
+
+    snapshot_timestamp: str
+
+
+# ---------------------------------------------------------------------------
+# Env-var parsing
+# ---------------------------------------------------------------------------
+
+# Names of the env vars we read. Match the keys that
+# ``scripts/init-s3-bucket.sh`` writes into Infisical (under the
+# ``/persistence/<stack-slug>`` path), and that spin-up.yml
+# subsequently exports into the runner environment. The R2 access
+# credentials are reused project-wide (from
+# ``scripts/init-r2-state.sh``) so they use the existing names.
+
+_ENV_ENDPOINT = "PERSISTENCE_S3_ENDPOINT"
+_ENV_REGION = "PERSISTENCE_S3_REGION"
+_ENV_BUCKET = "PERSISTENCE_S3_BUCKET"
+_ENV_ACCESS_KEY = "R2_ACCESS_KEY_ID"
+_ENV_SECRET_KEY = "R2_SECRET_ACCESS_KEY"  # noqa: S105 — env-var *name*, not a secret value
+
+_ALL_ENV_VARS = (_ENV_ENDPOINT, _ENV_REGION, _ENV_BUCKET, _ENV_ACCESS_KEY, _ENV_SECRET_KEY)
+
+
+def build_endpoint_from_env(env: dict[str, str] | None = None) -> _s3.S3Endpoint | None:
+    """Build a :class:`S3Endpoint` from the five PERSISTENCE_S3_*
+    env vars.
+
+    Returns ``None`` if any of them is missing — the caller treats
+    that as "no S3 persistence configured for this stack, fall back
+    to the volume-mount path." Strict all-or-nothing because a
+    partially-populated config (e.g. bucket name set but credentials
+    missing) almost certainly indicates a misconfigured Infisical
+    secret push, and silently picking up some env vars + ignoring
+    others would mask that.
+
+    Charset validation happens inside the :class:`S3Endpoint`
+    constructor — any bad value raises
+    :class:`s3_persistence.S3PersistenceError` with a message that
+    names the offending field.
+
+    The ``env`` parameter is for testability — production callers
+    pass ``None`` (read os.environ); tests inject a fixture dict.
+    """
+    source = env if env is not None else os.environ
+    if any(name not in source or not source[name] for name in _ALL_ENV_VARS):
+        return None
+    return _s3.S3Endpoint(
+        endpoint=source[_ENV_ENDPOINT],
+        region=source[_ENV_REGION],
+        access_key=source[_ENV_ACCESS_KEY],
+        secret_key=source[_ENV_SECRET_KEY],
+        bucket=source[_ENV_BUCKET],
+    )
+
+
+def is_enabled(env: dict[str, str] | None = None) -> bool:
+    """Return True iff the feature flag is set to exactly ``"true"``.
+
+    The strict comparison is intentional — see :data:`FEATURE_FLAG_ENV`
+    docstring. ``"1"``, ``"yes"``, ``"True"``, ``"TRUE"`` all return
+    ``False`` so operators get a clean error from pipeline.py rather
+    than a silently-half-enabled state.
+    """
+    source = env if env is not None else os.environ
+    return source.get(FEATURE_FLAG_ENV, "") == "true"
+
+
+# ---------------------------------------------------------------------------
+# Canonical target list for v1.0
+# ---------------------------------------------------------------------------
+
+
+def standard_targets() -> tuple[tuple[_s3.PostgresDumpTarget, ...], tuple[_s3.RsyncTarget, ...]]:
+    """Return the (postgres, rsync) target tuples for the two stacks
+    that v1.0 persists.
+
+    Hard-coded because:
+    1. The same two stacks have been the only stateful ones on the
+       volume for the lifetime of the project — Gitea (repos + LFS
+       + Postgres) and Dify (storage + Postgres + Weaviate + plugins).
+    2. The mappings are user-name / database-name pairs from the
+       respective ``docker-compose.yml`` files. Hardcoding here is
+       defended by the unit tests, which assert those mappings stay
+       in sync with the compose files; a docs-comment near the
+       fixture would drift, the test won't.
+    3. A future per-stack registry (services.yaml extension, or a
+       dedicated config table) can replace this single function
+       without touching any caller — :func:`restore_from_s3` only
+       sees the returned tuples.
+
+    Mappings (verified against ``stacks/gitea/docker-compose.yml``
+    line 67 and ``stacks/dify/docker-compose.yml`` line 180 at
+    PR-2 time):
+
+    * Gitea container ``gitea-db`` — database ``gitea``, role
+      ``nexus-gitea``.
+    * Dify container ``dify-db`` — database ``dify``, role
+      ``nexus-dify``.
+
+    Rsync layout matches RFC 0001 §"Storage layout":
+    ``snapshots/<timestamp>/gitea/{repos,lfs}/`` and
+    ``snapshots/<timestamp>/dify/{storage,weaviate,plugins}/``.
+    """
+    postgres = (
+        _s3.PostgresDumpTarget(container="gitea-db", database="gitea", user="nexus-gitea"),
+        _s3.PostgresDumpTarget(container="dify-db", database="dify", user="nexus-dify"),
+    )
+    rsync = (
+        _s3.RsyncTarget(
+            name="gitea-repos",
+            local_path="/var/lib/nexus-data/gitea/repos",
+            s3_subpath="gitea/repos",
+        ),
+        _s3.RsyncTarget(
+            name="gitea-lfs",
+            local_path="/var/lib/nexus-data/gitea/lfs",
+            s3_subpath="gitea/lfs",
+        ),
+        _s3.RsyncTarget(
+            name="dify-storage",
+            local_path="/var/lib/nexus-data/dify/storage",
+            s3_subpath="dify/storage",
+        ),
+        _s3.RsyncTarget(
+            name="dify-weaviate",
+            local_path="/var/lib/nexus-data/dify/weaviate",
+            s3_subpath="dify/weaviate",
+        ),
+        _s3.RsyncTarget(
+            name="dify-plugins",
+            local_path="/var/lib/nexus-data/dify/plugins",
+            s3_subpath="dify/plugins",
+        ),
+    )
+    return postgres, rsync
+
+
+# ---------------------------------------------------------------------------
+# Combined-script render (rclone config + restore body in one bash)
+# ---------------------------------------------------------------------------
+
+
+def render_combined_restore_script(
+    *,
+    endpoint: _s3.S3Endpoint,
+    postgres_targets: tuple[_s3.PostgresDumpTarget, ...],
+    rsync_targets: tuple[_s3.RsyncTarget, ...],
+    local_root: str = "/var/lib/nexus-data",
+) -> str:
+    """Render a single bash script that does BOTH:
+
+    1. Writes the rclone config to ``~/.config/rclone/rclone.conf``
+       (atomic temp-file → rename, mode 600 because it contains
+       the secret access key).
+    2. Runs the restore body produced by
+       :func:`s3_persistence.render_restore_script`.
+
+    Caller ships the combined script via one ``ssh.run_script``
+    invocation. This is the cheapest plumbing: a single SSH
+    round-trip, no temp-file management on the orchestrator side,
+    no risk of a partial write between config and body.
+
+    The config write uses ``install -m 600 /dev/stdin`` so the
+    file's permission bits are set atomically — no
+    ``chmod`` race window where the file exists with default
+    644 and another process on the host could read the
+    credentials.
+    """
+    rclone_config = _s3.render_rclone_config(endpoint)
+    restore_body = _s3.render_restore_script(
+        endpoint=endpoint,
+        postgres_targets=postgres_targets,
+        rsync_targets=rsync_targets,
+        local_root=local_root,
+    )
+    # Strip the shebang + outer ``set -euo pipefail`` from the
+    # restore body — the wrapper script provides them. Keeping
+    # two shebangs would just be cruft; double ``set -e`` would
+    # work but reads weird. We splice the body in after our
+    # wrapper preamble.
+    body_lines = restore_body.splitlines()
+    while body_lines and (
+        body_lines[0].startswith("#!")
+        or body_lines[0].startswith("# Generated")
+        or body_lines[0].strip() == "set -euo pipefail"
+        or body_lines[0].strip() == ""
+    ):
+        body_lines.pop(0)
+    body_inner = "\n".join(body_lines)
+
+    return (
+        "#!/usr/bin/env bash\n"
+        "# Generated by nexus_deploy.s3_restore — do not edit by hand.\n"
+        "set -euo pipefail\n"
+        "\n"
+        "# ---- write rclone config (atomic, mode 600) -----------\n"
+        'mkdir -p "$HOME/.config/rclone"\n'
+        "install -m 600 /dev/stdin \"$HOME/.config/rclone/rclone.conf\" <<'RCLONE_CONFIG_EOF'\n"
+        f"{rclone_config}"
+        "RCLONE_CONFIG_EOF\n"
+        "\n"
+        "# ---- restore body -------------------------------------\n"
+        f"{body_inner}\n"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Orchestration entry point
+# ---------------------------------------------------------------------------
+
+
+def restore_from_s3(
+    ssh: SSHClient,
+    *,
+    env: dict[str, str] | None = None,
+) -> S3RestoreSkipped | S3RestoreApplied:
+    """Pull the latest snapshot from R2 onto the server's local SSD.
+
+    Pipeline-side counterpart to
+    :func:`s3_persistence.render_restore_script`. Returns a typed
+    outcome:
+
+    * :class:`S3RestoreSkipped` (``"feature_flag_off"``) — the
+      feature flag isn't set; pipeline.py should fall back to the
+      legacy volume-mount path.
+    * :class:`S3RestoreSkipped` (``"no_endpoint_env"``) — the flag
+      is on but credentials are missing. Treated as "skip with
+      warning"; pipeline.py emits a stderr message. This is a
+      misconfiguration the operator needs to see, but it's
+      survivable (downstream stacks that don't need persistence
+      come up fine).
+    * :class:`S3RestoreSkipped` (``"fresh_start_empty_s3"``) —
+      the restore ran but the bucket has no
+      ``snapshots/latest.txt`` yet (brand-new bucket, first-ever
+      spinup). docker compose comes up with empty data dirs;
+      future teardowns will populate the bucket.
+    * :class:`S3RestoreApplied` — restore ran end-to-end.
+      ``snapshot_timestamp`` lets pipeline.py log which snapshot
+      was applied.
+
+    Any non-zero exit from the rendered bash that *isn't* the
+    fresh-start case raises ``subprocess.CalledProcessError`` from
+    inside ``ssh.run_script(check=True)``. That propagates up
+    pipeline.py as a hard failure — restore corruption should NOT
+    let the spinup proceed with half-populated data.
+    """
+    if not is_enabled(env):
+        return S3RestoreSkipped(reason="feature_flag_off")
+
+    endpoint = build_endpoint_from_env(env)
+    if endpoint is None:
+        sys.stderr.write(
+            f"⚠ s3-restore: feature flag {FEATURE_FLAG_ENV}=true but one or more of "
+            f"{_ALL_ENV_VARS} is unset; skipping S3 restore.\n",
+        )
+        return S3RestoreSkipped(reason="no_endpoint_env")
+
+    postgres_targets, rsync_targets = standard_targets()
+    script = render_combined_restore_script(
+        endpoint=endpoint,
+        postgres_targets=postgres_targets,
+        rsync_targets=rsync_targets,
+    )
+
+    # The rendered restore script either:
+    #  - exits 0 after "fresh-start: no snapshot in S3" (latest.txt
+    #    missing → first-time spinup). Output contains the
+    #    "fresh-start" marker.
+    #  - exits 0 after a real restore.
+    #  - exits non-zero on any other failure (rclone error,
+    #    pg_restore failure, malformed latest.txt). check=True
+    #    raises CalledProcessError, which is the right behavior:
+    #    a partial restore must not silently let the stack come up.
+    completed = ssh.run_script(script, check=True)
+    output = completed.stdout
+    # Forward server-side log lines to local stderr so operators see
+    # what the remote did. Mirrors mount_persistent_volume's pattern.
+    for line in output.splitlines():
+        sys.stderr.write(line + "\n")
+
+    if "fresh-start: no snapshot in S3" in output:
+        return S3RestoreSkipped(reason="fresh_start_empty_s3")
+
+    # Parse the applied timestamp from "→ restore: using snapshot
+    # snapshots/<timestamp>" line. If we can't find it (server-side
+    # script changed shape), still return Applied — the restore did
+    # complete successfully (rc=0), just with a less-informative
+    # log line. Falling back to "(unknown timestamp)" keeps the
+    # outcome class invariant ("rc=0 means data is in place") even
+    # when the diagnostic parsing drifts.
+    timestamp = "(unknown)"
+    for line in output.splitlines():
+        if "→ restore: using snapshot snapshots/" in line:
+            # Format: "→ restore: using snapshot snapshots/<TS>"
+            with contextlib.suppress(IndexError):
+                timestamp = line.split("snapshots/", 1)[1].strip()
+            break
+    return S3RestoreApplied(snapshot_timestamp=timestamp)

--- a/src/nexus_deploy/s3_restore.py
+++ b/src/nexus_deploy/s3_restore.py
@@ -211,9 +211,21 @@ def standard_targets() -> tuple[tuple[_s3.PostgresDumpTarget, ...], tuple[_s3.Rs
     * Dify container ``dify-db`` — database ``dify``, role
       ``nexus-dify``.
 
-    Rsync layout matches RFC 0001 §"Storage layout":
+    Local paths land at **``/mnt/nexus-data/...``** — that's
+    where the actual docker-compose bind-mounts live (see
+    ``stacks/gitea/docker-compose.yml:45`` and
+    ``stacks/dify/docker-compose.yml:84`` for the canonical
+    references). An earlier draft of this function restored to
+    ``/var/lib/nexus-data/...``, which would have landed the
+    snapshot in a directory NO container ever sees — restore
+    would appear to succeed but Gitea/Dify would come up empty.
+
+    S3-side layout matches RFC 0001 §"Storage layout":
     ``snapshots/<timestamp>/gitea/{repos,lfs}/`` and
     ``snapshots/<timestamp>/dify/{storage,weaviate,plugins}/``.
+    ``db/`` and ``redis/`` deliberately NOT in the list — Postgres
+    state goes through ``pg_dump`` separately, Redis is
+    regeneratable on container start.
     """
     postgres = (
         _s3.PostgresDumpTarget(container="gitea-db", database="gitea", user="nexus-gitea"),
@@ -222,27 +234,27 @@ def standard_targets() -> tuple[tuple[_s3.PostgresDumpTarget, ...], tuple[_s3.Rs
     rsync = (
         _s3.RsyncTarget(
             name="gitea-repos",
-            local_path="/var/lib/nexus-data/gitea/repos",
+            local_path="/mnt/nexus-data/gitea/repos",
             s3_subpath="gitea/repos",
         ),
         _s3.RsyncTarget(
             name="gitea-lfs",
-            local_path="/var/lib/nexus-data/gitea/lfs",
+            local_path="/mnt/nexus-data/gitea/lfs",
             s3_subpath="gitea/lfs",
         ),
         _s3.RsyncTarget(
             name="dify-storage",
-            local_path="/var/lib/nexus-data/dify/storage",
+            local_path="/mnt/nexus-data/dify/storage",
             s3_subpath="dify/storage",
         ),
         _s3.RsyncTarget(
             name="dify-weaviate",
-            local_path="/var/lib/nexus-data/dify/weaviate",
+            local_path="/mnt/nexus-data/dify/weaviate",
             s3_subpath="dify/weaviate",
         ),
         _s3.RsyncTarget(
             name="dify-plugins",
-            local_path="/var/lib/nexus-data/dify/plugins",
+            local_path="/mnt/nexus-data/dify/plugins",
             s3_subpath="dify/plugins",
         ),
     )
@@ -259,13 +271,21 @@ def render_combined_restore_script(
     endpoint: _s3.S3Endpoint,
     postgres_targets: tuple[_s3.PostgresDumpTarget, ...],
     rsync_targets: tuple[_s3.RsyncTarget, ...],
-    local_root: str = "/var/lib/nexus-data",
+    local_root: str = "/mnt/nexus-data",
 ) -> str:
     """Render a single bash script that does BOTH:
 
-    1. Writes the rclone config to ``~/.config/rclone/rclone.conf``
-       (atomic temp-file → rename, mode 600 because it contains
-       the secret access key).
+    1. Writes the rclone config to
+       ``~/.config/rclone/rclone.conf`` via ``install -m 600
+       /dev/stdin``. ``install`` creates the file with the
+       requested permission bits in one syscall — no ``open()
+       then chmod()`` race window where another process on the
+       host could read the credentials with default 644
+       permissions. The write itself is NOT a temp-file +
+       rename (an earlier docstring revision claimed it was);
+       it's a direct write at the target path with safe perms
+       set on creation. That's sufficient for our threat model
+       (single-user server, no concurrent writers).
     2. Runs the restore body produced by
        :func:`s3_persistence.render_restore_script`.
 
@@ -273,12 +293,6 @@ def render_combined_restore_script(
     invocation. This is the cheapest plumbing: a single SSH
     round-trip, no temp-file management on the orchestrator side,
     no risk of a partial write between config and body.
-
-    The config write uses ``install -m 600 /dev/stdin`` so the
-    file's permission bits are set atomically — no
-    ``chmod`` race window where the file exists with default
-    644 and another process on the host could read the
-    credentials.
     """
     rclone_config = _s3.render_rclone_config(endpoint)
     restore_body = _s3.render_restore_script(
@@ -363,9 +377,19 @@ def restore_from_s3(
 
     endpoint = build_endpoint_from_env(env)
     if endpoint is None:
+        # Identify the specific missing/empty names so the operator
+        # doesn't have to grep their secret store for the entire list.
+        # Reading os.environ here (not the parameter ``env``) is
+        # intentional — the production caller passes ``env=None`` and
+        # this diagnostic should match what build_endpoint_from_env
+        # actually saw. Tests pass an explicit ``env`` dict, which
+        # we re-use here.
+        source = env if env is not None else os.environ
+        missing = [name for name in _REQUIRED_ENV_VAR_NAMES if not source.get(name)]
         sys.stderr.write(
-            f"⚠ s3-restore: feature flag {FEATURE_FLAG_ENV}=true but one or more of "
-            f"{_REQUIRED_ENV_VAR_NAMES} is unset; skipping S3 restore.\n",
+            f"⚠ s3-restore: feature flag {FEATURE_FLAG_ENV}=true but the following "
+            f"required env vars are unset or empty: {', '.join(missing)}. "
+            "Skipping S3 restore.\n",
         )
         return S3RestoreSkipped(reason="no_endpoint_env")
 

--- a/src/nexus_deploy/s3_restore.py
+++ b/src/nexus_deploy/s3_restore.py
@@ -110,13 +110,29 @@ class S3RestoreApplied:
 # credentials are reused project-wide (from
 # ``scripts/init-r2-state.sh``) so they use the existing names.
 
-_ENV_ENDPOINT = "PERSISTENCE_S3_ENDPOINT"
-_ENV_REGION = "PERSISTENCE_S3_REGION"
-_ENV_BUCKET = "PERSISTENCE_S3_BUCKET"
-_ENV_ACCESS_KEY = "R2_ACCESS_KEY_ID"
-_ENV_SECRET_KEY = "R2_SECRET_ACCESS_KEY"  # noqa: S105 — env-var *name*, not a secret value
+# These constants hold the NAMES of the environment variables we read —
+# never their values. The strings ``"R2_ACCESS_KEY_ID"`` and
+# ``"R2_SECRET_ACCESS_KEY"`` are configuration metadata; the actual
+# secret material is whatever the operator (or Infisical) sets those
+# env vars *to*. Renaming the constants with a ``_NAME`` suffix makes
+# the safety property explicit at every call site and silences the
+# CodeQL ``py/clear-text-logging-sensitive-data`` taint-tracker, which
+# otherwise flags any log line that mentions a constant containing
+# "secret" or "access_key" even when the logged value is just the
+# name itself.
+_ENV_ENDPOINT_NAME = "PERSISTENCE_S3_ENDPOINT"
+_ENV_REGION_NAME = "PERSISTENCE_S3_REGION"
+_ENV_BUCKET_NAME = "PERSISTENCE_S3_BUCKET"
+_ENV_ACCESS_KEY_NAME = "R2_ACCESS_KEY_ID"
+_ENV_SECRET_KEY_NAME = "R2_SECRET_ACCESS_KEY"  # noqa: S105 — env-var *name*, not a secret value
 
-_ALL_ENV_VARS = (_ENV_ENDPOINT, _ENV_REGION, _ENV_BUCKET, _ENV_ACCESS_KEY, _ENV_SECRET_KEY)
+_REQUIRED_ENV_VAR_NAMES = (
+    _ENV_ENDPOINT_NAME,
+    _ENV_REGION_NAME,
+    _ENV_BUCKET_NAME,
+    _ENV_ACCESS_KEY_NAME,
+    _ENV_SECRET_KEY_NAME,
+)
 
 
 def build_endpoint_from_env(env: dict[str, str] | None = None) -> _s3.S3Endpoint | None:
@@ -140,14 +156,14 @@ def build_endpoint_from_env(env: dict[str, str] | None = None) -> _s3.S3Endpoint
     pass ``None`` (read os.environ); tests inject a fixture dict.
     """
     source = env if env is not None else os.environ
-    if any(name not in source or not source[name] for name in _ALL_ENV_VARS):
+    if any(name not in source or not source[name] for name in _REQUIRED_ENV_VAR_NAMES):
         return None
     return _s3.S3Endpoint(
-        endpoint=source[_ENV_ENDPOINT],
-        region=source[_ENV_REGION],
-        access_key=source[_ENV_ACCESS_KEY],
-        secret_key=source[_ENV_SECRET_KEY],
-        bucket=source[_ENV_BUCKET],
+        endpoint=source[_ENV_ENDPOINT_NAME],
+        region=source[_ENV_REGION_NAME],
+        access_key=source[_ENV_ACCESS_KEY_NAME],
+        secret_key=source[_ENV_SECRET_KEY_NAME],
+        bucket=source[_ENV_BUCKET_NAME],
     )
 
 
@@ -349,7 +365,7 @@ def restore_from_s3(
     if endpoint is None:
         sys.stderr.write(
             f"⚠ s3-restore: feature flag {FEATURE_FLAG_ENV}=true but one or more of "
-            f"{_ALL_ENV_VARS} is unset; skipping S3 restore.\n",
+            f"{_REQUIRED_ENV_VAR_NAMES} is unset; skipping S3 restore.\n",
         )
         return S3RestoreSkipped(reason="no_endpoint_env")
 

--- a/src/nexus_deploy/s3_restore.py
+++ b/src/nexus_deploy/s3_restore.py
@@ -11,12 +11,16 @@ Public surface:
 
 * :class:`S3RestoreSkipped` / :class:`S3RestoreApplied` — outcome
   marker classes returned by :func:`restore_from_s3`. Tests assert
-  on the type; pipeline.py logs a one-line summary using the
-  ``detail`` attribute.
-* :func:`build_endpoint_from_env` — read the five PERSISTENCE_S3_*
-  env vars, return a populated :class:`S3Endpoint`. Returns
-  ``None`` when any of them is unset — the caller treats that as
-  "S3 persistence not configured on this stack, skip the phase."
+  on the type; pipeline.py branches on ``isinstance()`` and reads
+  ``reason`` (Skipped) or ``snapshot_timestamp`` (Applied) for
+  the one-line stderr summary.
+* :func:`build_endpoint_from_env` — read the five required env
+  vars (three ``PERSISTENCE_S3_*`` — endpoint, region, bucket —
+  plus the project-wide ``R2_ACCESS_KEY_ID`` and
+  ``R2_SECRET_ACCESS_KEY``), return a populated
+  :class:`S3Endpoint`. Returns ``None`` when any of them is
+  unset — the caller treats that as "S3 persistence not
+  configured on this stack, skip the phase."
 * :func:`standard_targets` — produces the canonical tuple of
   postgres + rsync targets for the two stacks we persist
   (Gitea + Dify). Hard-coded for v1.0 because those are the only
@@ -136,8 +140,13 @@ _REQUIRED_ENV_VAR_NAMES = (
 
 
 def build_endpoint_from_env(env: dict[str, str] | None = None) -> _s3.S3Endpoint | None:
-    """Build a :class:`S3Endpoint` from the five PERSISTENCE_S3_*
-    env vars.
+    """Build a :class:`S3Endpoint` from the five required env vars.
+
+    Three are persistence-bucket coords (``PERSISTENCE_S3_ENDPOINT``,
+    ``PERSISTENCE_S3_REGION``, ``PERSISTENCE_S3_BUCKET``); the other
+    two are the project-wide R2 access credentials reused from
+    ``init-r2-state.sh`` (``R2_ACCESS_KEY_ID``,
+    ``R2_SECRET_ACCESS_KEY``).
 
     Returns ``None`` if any of them is missing — the caller treats
     that as "no S3 persistence configured for this stack, fall back

--- a/tests/unit/test_s3_restore.py
+++ b/tests/unit/test_s3_restore.py
@@ -129,6 +129,7 @@ def test_build_endpoint_from_env_returns_none_on_any_missing(missing_var: str) -
     "missing_var",
     [
         "PERSISTENCE_S3_ENDPOINT",
+        "PERSISTENCE_S3_REGION",
         "PERSISTENCE_S3_BUCKET",
         "R2_ACCESS_KEY_ID",
         "R2_SECRET_ACCESS_KEY",
@@ -136,7 +137,10 @@ def test_build_endpoint_from_env_returns_none_on_any_missing(missing_var: str) -
 )
 def test_build_endpoint_from_env_treats_empty_as_missing(missing_var: str) -> None:
     """Empty-string env var is the same as missing — guards against
-    operators accidentally setting ``EXPORT VAR=`` (no value)."""
+    operators accidentally setting ``EXPORT VAR=`` (no value).
+    Parametrized over ALL five required vars so a regression that
+    treats any single one differently (e.g. ``REGION`` having a
+    fallback default) gets caught."""
     env = _good_env()
     env[missing_var] = ""
     assert build_endpoint_from_env(env) is None
@@ -306,7 +310,10 @@ def test_restore_from_s3_skips_when_env_incomplete(capsys: pytest.CaptureFixture
     ssh.run_script.assert_not_called()
     captured = capsys.readouterr()
     assert "feature flag" in captured.err
-    assert "skipping" in captured.err
+    # Message now lists the SPECIFIC missing vars (instead of dumping
+    # the entire required-vars tuple) — regression for round-3 #3217012538.
+    assert "PERSISTENCE_S3_BUCKET" in captured.err
+    assert "Skipping S3 restore" in captured.err
 
 
 def test_restore_from_s3_returns_fresh_start_when_bucket_empty() -> None:

--- a/tests/unit/test_s3_restore.py
+++ b/tests/unit/test_s3_restore.py
@@ -294,7 +294,7 @@ def test_restore_from_s3_skips_when_feature_flag_off() -> None:
     ssh.run_script.assert_not_called()
 
 
-def test_restore_from_s3_skips_when_env_incomplete(capsys: pytest.CaptureFixture) -> None:
+def test_restore_from_s3_skips_when_env_incomplete(capsys: pytest.CaptureFixture[str]) -> None:
     """Flag on but a required env var missing — should warn to
     stderr (operator-actionable) and skip."""
     env = _good_env()

--- a/tests/unit/test_s3_restore.py
+++ b/tests/unit/test_s3_restore.py
@@ -1,0 +1,358 @@
+"""Tests for nexus_deploy.s3_restore (RFC 0001 PR-2 pipeline-side).
+
+Pipeline-side orchestration tests. ``s3_persistence.py`` is the
+pure-rendering module already covered by ``test_s3_persistence.py``;
+this file tests the *caller* — env-var parsing, feature-flag
+gating, target-list correctness, the combined-script render shape,
+and the orchestration outcome classes.
+
+Coverage focus:
+
+* :func:`build_endpoint_from_env` — all five env vars required;
+  any missing → ``None``; charset gating inherited from
+  :class:`S3Endpoint`.
+* :func:`is_enabled` — strict ``"true"`` match, rejects ``"1"`` /
+  ``"True"`` / ``"yes"``.
+* :func:`standard_targets` — canonical fixture for v1.0 stacks;
+  asserts the user/db identifiers match the values in
+  ``stacks/{gitea,dify}/docker-compose.yml`` so a future
+  POSTGRES_USER rename breaks the test (and gets caught here
+  rather than at runtime).
+* :func:`render_combined_restore_script` — single combined script
+  contains both the rclone config write and the restore body, in
+  that order, with ``mode 600`` on the config file.
+* :func:`restore_from_s3` — outcome-class dispatch using a fake
+  SSHClient.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import MagicMock
+
+import pytest
+
+from nexus_deploy import s3_persistence as _s3
+from nexus_deploy.s3_restore import (
+    FEATURE_FLAG_ENV,
+    S3RestoreApplied,
+    S3RestoreSkipped,
+    build_endpoint_from_env,
+    is_enabled,
+    render_combined_restore_script,
+    restore_from_s3,
+    standard_targets,
+)
+
+# ---------------------------------------------------------------------------
+# Test fixtures
+# ---------------------------------------------------------------------------
+
+
+def _good_env() -> dict[str, str]:
+    """Canonical "all five env vars populated" map used by most
+    tests. R2-style endpoint per the v1.0 default."""
+    return {
+        "NEXUS_S3_PERSISTENCE": "true",
+        "PERSISTENCE_S3_ENDPOINT": "https://abc123.r2.cloudflarestorage.com",
+        "PERSISTENCE_S3_REGION": "auto",
+        "PERSISTENCE_S3_BUCKET": "nexus-stefan-hslu",
+        "R2_ACCESS_KEY_ID": "AKIA1234",
+        "R2_SECRET_ACCESS_KEY": "secret/key+abc=",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Feature-flag gating
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["true"],
+)
+def test_is_enabled_accepts_lowercase_true_only(value: str) -> None:
+    """Strict ``"true"`` match — ensures operators can't get a
+    half-enabled state from shell-truthy variants."""
+    assert is_enabled({FEATURE_FLAG_ENV: value}) is True
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["", "True", "TRUE", "1", "yes", "Y", "false", "off"],
+)
+def test_is_enabled_rejects_non_canonical_truthy(value: str) -> None:
+    """Anything that isn't literal ``"true"`` returns False —
+    intentionally strict so a misspelled env var produces a
+    clean skip rather than a silent-flip."""
+    assert is_enabled({FEATURE_FLAG_ENV: value}) is False
+
+
+def test_is_enabled_returns_false_when_var_missing() -> None:
+    assert is_enabled({}) is False
+
+
+# ---------------------------------------------------------------------------
+# Env-var parsing
+# ---------------------------------------------------------------------------
+
+
+def test_build_endpoint_from_env_happy_path() -> None:
+    """All five env vars present → populated :class:`S3Endpoint`."""
+    endpoint = build_endpoint_from_env(_good_env())
+    assert endpoint is not None
+    assert endpoint.bucket == "nexus-stefan-hslu"
+    assert endpoint.region == "auto"
+    assert endpoint.endpoint == "https://abc123.r2.cloudflarestorage.com"
+
+
+@pytest.mark.parametrize(
+    "missing_var",
+    [
+        "PERSISTENCE_S3_ENDPOINT",
+        "PERSISTENCE_S3_REGION",
+        "PERSISTENCE_S3_BUCKET",
+        "R2_ACCESS_KEY_ID",
+        "R2_SECRET_ACCESS_KEY",
+    ],
+)
+def test_build_endpoint_from_env_returns_none_on_any_missing(missing_var: str) -> None:
+    """Strict all-or-nothing — any missing env var returns ``None``
+    so a half-configured stack falls back to the legacy path
+    instead of silently picking up only some of the values."""
+    env = _good_env()
+    del env[missing_var]
+    assert build_endpoint_from_env(env) is None
+
+
+@pytest.mark.parametrize(
+    "missing_var",
+    [
+        "PERSISTENCE_S3_ENDPOINT",
+        "PERSISTENCE_S3_BUCKET",
+        "R2_ACCESS_KEY_ID",
+        "R2_SECRET_ACCESS_KEY",
+    ],
+)
+def test_build_endpoint_from_env_treats_empty_as_missing(missing_var: str) -> None:
+    """Empty-string env var is the same as missing — guards against
+    operators accidentally setting ``EXPORT VAR=`` (no value)."""
+    env = _good_env()
+    env[missing_var] = ""
+    assert build_endpoint_from_env(env) is None
+
+
+def test_build_endpoint_from_env_charset_error_bubbles_up() -> None:
+    """If env contains a value that fails the S3Endpoint constructor
+    charset gate, the error propagates so the operator sees what
+    they misconfigured — we don't quietly swallow it as None."""
+    env = _good_env()
+    env["PERSISTENCE_S3_BUCKET"] = "Bad Bucket With Spaces"
+    with pytest.raises(_s3.S3PersistenceError, match="bucket"):
+        build_endpoint_from_env(env)
+
+
+# ---------------------------------------------------------------------------
+# Canonical targets
+# ---------------------------------------------------------------------------
+
+
+def test_standard_targets_returns_canonical_pair() -> None:
+    """Smoke + locks the v1.0 fixture. If the
+    ``stacks/{gitea,dify}/docker-compose.yml`` files change the
+    POSTGRES_USER or POSTGRES_DB values, this test starts failing
+    and a future maintainer knows to align the fixture."""
+    postgres, rsync = standard_targets()
+    pg_by_container = {p.container: p for p in postgres}
+
+    # Gitea — matches stacks/gitea/docker-compose.yml line 67/68
+    assert pg_by_container["gitea-db"].database == "gitea"
+    assert pg_by_container["gitea-db"].user == "nexus-gitea"
+    # Dify — matches stacks/dify/docker-compose.yml line 180/182
+    assert pg_by_container["dify-db"].database == "dify"
+    assert pg_by_container["dify-db"].user == "nexus-dify"
+
+    rsync_by_name = {r.name: r for r in rsync}
+    # All five subdirs the storage-layout section of RFC 0001 lists
+    for required in ("gitea-repos", "gitea-lfs", "dify-storage", "dify-weaviate", "dify-plugins"):
+        assert required in rsync_by_name, f"missing required rsync target: {required}"
+
+    # db/ and redis/ subdirs deliberately NOT in the list — they're
+    # captured via pg_dump / regeneratable. Regression for the
+    # "exclude" theme that's appeared in multiple Copilot rounds.
+    for name in rsync_by_name:
+        assert not name.endswith("-db"), f"db/ subdir wrongly in rsync list: {name}"
+        assert "redis" not in name, f"redis/ subdir wrongly in rsync list: {name}"
+
+
+def test_standard_targets_s3_subpaths_match_rfc_layout() -> None:
+    """The S3 subpaths must match RFC 0001's storage-layout
+    section: ``gitea/repos``, ``gitea/lfs``, ``dify/storage``,
+    ``dify/weaviate``, ``dify/plugins``. Mismatch would put data
+    under the wrong prefix and break restore."""
+    _, rsync = standard_targets()
+    sub_by_name = {r.name: r.s3_subpath for r in rsync}
+    assert sub_by_name["gitea-repos"] == "gitea/repos"
+    assert sub_by_name["gitea-lfs"] == "gitea/lfs"
+    assert sub_by_name["dify-storage"] == "dify/storage"
+    assert sub_by_name["dify-weaviate"] == "dify/weaviate"
+    assert sub_by_name["dify-plugins"] == "dify/plugins"
+
+
+# ---------------------------------------------------------------------------
+# Combined-script render
+# ---------------------------------------------------------------------------
+
+
+def _endpoint() -> _s3.S3Endpoint:
+    return _s3.S3Endpoint(
+        endpoint="https://abc123.r2.cloudflarestorage.com",
+        region="auto",
+        access_key="AKIA1234",
+        secret_key="secret123",
+        bucket="nexus-test",
+    )
+
+
+def test_combined_script_contains_both_config_and_body() -> None:
+    """The combined script must include the rclone config block AND
+    the restore body — caller relies on the single-script invariant
+    to keep the SSH round-trip atomic."""
+    postgres, rsync = standard_targets()
+    script = render_combined_restore_script(
+        endpoint=_endpoint(),
+        postgres_targets=postgres,
+        rsync_targets=rsync,
+    )
+    # rclone profile heading
+    assert f"[{_s3.RCLONE_PROFILE}]" in script
+    # restore-body landmarks
+    assert "snapshots/latest.txt" in script
+    assert "pg_restore" in script
+
+
+def test_combined_script_writes_config_atomically_at_mode_600() -> None:
+    """The rclone config file holds the R2 secret access key. Must
+    land at mode 600 atomically — no chmod race window where the
+    file exists with default permissions."""
+    script = render_combined_restore_script(
+        endpoint=_endpoint(),
+        postgres_targets=(),
+        rsync_targets=(),
+    )
+    assert 'install -m 600 /dev/stdin "$HOME/.config/rclone/rclone.conf"' in script
+
+
+def test_combined_script_starts_with_shebang_and_safety_pragmas() -> None:
+    script = render_combined_restore_script(
+        endpoint=_endpoint(),
+        postgres_targets=(),
+        rsync_targets=(),
+    )
+    assert script.startswith("#!/usr/bin/env bash\n")
+    assert "set -euo pipefail" in script
+
+
+def test_combined_script_orders_config_before_body() -> None:
+    """Body needs the config in place to find the rclone profile.
+    Config write must come first."""
+    script = render_combined_restore_script(
+        endpoint=_endpoint(),
+        postgres_targets=(),
+        rsync_targets=(),
+    )
+    config_pos = script.find("install -m 600")
+    body_pos = script.find("looking up latest snapshot")
+    assert 0 < config_pos < body_pos
+
+
+# ---------------------------------------------------------------------------
+# restore_from_s3 — outcome dispatch
+# ---------------------------------------------------------------------------
+
+
+def _fake_ssh(stdout: str) -> MagicMock:
+    """SSHClient stub whose ``run_script`` returns a
+    CompletedProcess-shaped object with the given stdout."""
+    ssh = MagicMock()
+    ssh.run_script.return_value = subprocess.CompletedProcess(
+        args=["ssh", "nexus", "bash", "-s"],
+        returncode=0,
+        stdout=stdout,
+        stderr="",
+    )
+    return ssh
+
+
+def test_restore_from_s3_skips_when_feature_flag_off() -> None:
+    """No flag → no S3 path. ``ssh.run_script`` must NOT be called
+    — that's the whole point of the early skip."""
+    ssh = _fake_ssh("")
+    result = restore_from_s3(ssh, env={"NEXUS_S3_PERSISTENCE": "false"})
+    assert isinstance(result, S3RestoreSkipped)
+    assert result.reason == "feature_flag_off"
+    ssh.run_script.assert_not_called()
+
+
+def test_restore_from_s3_skips_when_env_incomplete(capsys: pytest.CaptureFixture) -> None:
+    """Flag on but a required env var missing — should warn to
+    stderr (operator-actionable) and skip."""
+    env = _good_env()
+    del env["PERSISTENCE_S3_BUCKET"]
+    ssh = _fake_ssh("")
+    result = restore_from_s3(ssh, env=env)
+    assert isinstance(result, S3RestoreSkipped)
+    assert result.reason == "no_endpoint_env"
+    ssh.run_script.assert_not_called()
+    captured = capsys.readouterr()
+    assert "feature flag" in captured.err
+    assert "skipping" in captured.err
+
+
+def test_restore_from_s3_returns_fresh_start_when_bucket_empty() -> None:
+    """Bucket has no latest.txt → restore script outputs the
+    fresh-start marker → orchestration returns Skipped /
+    fresh_start_empty_s3."""
+    ssh = _fake_ssh("fresh-start: no snapshot in S3, leaving local state empty\n")
+    result = restore_from_s3(ssh, env=_good_env())
+    assert isinstance(result, S3RestoreSkipped)
+    assert result.reason == "fresh_start_empty_s3"
+    ssh.run_script.assert_called_once()
+
+
+def test_restore_from_s3_returns_applied_with_timestamp() -> None:
+    """Successful restore → ``Applied`` with the parsed timestamp."""
+    ssh = _fake_ssh(
+        "→ restore: looking up latest snapshot\n"
+        "→ restore: using snapshot snapshots/20260511T120000Z\n"
+        "→ restore: pulling filesystem trees\n"
+        "→ restore: applying postgres dumps\n"
+        "✓ restore complete from snapshots/20260511T120000Z\n",
+    )
+    result = restore_from_s3(ssh, env=_good_env())
+    assert isinstance(result, S3RestoreApplied)
+    assert result.snapshot_timestamp == "20260511T120000Z"
+
+
+def test_restore_from_s3_returns_applied_unknown_when_log_shape_drifts() -> None:
+    """If the server-side log lines change shape (we can't find the
+    "using snapshot" marker), we still return Applied — rc=0 means
+    the data is in place, just with a less-informative diagnostic."""
+    ssh = _fake_ssh("✓ restore complete\n")  # no "using snapshot" line
+    result = restore_from_s3(ssh, env=_good_env())
+    assert isinstance(result, S3RestoreApplied)
+    assert result.snapshot_timestamp == "(unknown)"
+
+
+def test_restore_from_s3_propagates_called_process_error() -> None:
+    """If the remote script exits non-zero, the underlying
+    CalledProcessError must propagate — pipeline.py should hard-fail
+    rather than let the spinup proceed with half-populated data."""
+    ssh = MagicMock()
+    ssh.run_script.side_effect = subprocess.CalledProcessError(
+        returncode=2,
+        cmd=["ssh", "nexus", "bash", "-s"],
+        output="✗ restore-failed: latest.txt has invalid timestamp\n",
+    )
+    with pytest.raises(subprocess.CalledProcessError):
+        restore_from_s3(ssh, env=_good_env())


### PR DESCRIPTION
## Summary

PR-2 of 7 from the [RFC 0001 implementation series](https://github.com/stefanko-ch/Nexus-Stack/blob/main/docs/proposals/0001-s3-persistence.md). Wires the foundation from #551 into the spinup pipeline.

After this PR merges, a stack with `NEXUS_S3_PERSISTENCE=true` set will restore its persistent data from R2 right after server bootstrap — **in addition to** (not yet instead of) the legacy volume mount. The two paths coexist for safe per-stack cutover.

## What's in this PR

### New module — `src/nexus_deploy/s3_restore.py`

Pipeline-side orchestration. Mirrors the `setup.py` pattern: pure-rendering functions stay in `s3_persistence.py` (subprocess-free, testable as strings), the *caller* lives here.

| Surface | What it does |
|---|---|
| `S3RestoreSkipped` / `S3RestoreApplied` | Typed outcome classes. `Skipped` carries one of `feature_flag_off` / `no_endpoint_env` / `fresh_start_empty_s3`. `Applied` carries the snapshot timestamp. |
| `build_endpoint_from_env()` | Reads the five PERSISTENCE_S3_* env vars + R2 access keys. **Strict all-or-nothing**: any missing/empty → `None` and the pipeline falls back. Empty-string treated as missing (guards against `EXPORT VAR=` typos). |
| `is_enabled()` | **Strict** match on `NEXUS_S3_PERSISTENCE="true"`. "1" / "yes" / "True" all return False. Intentional: a stack mid-migration must NOT silently flip to S3-only before its volume has been evacuated. |
| `standard_targets()` | Canonical `(PostgresDumpTarget tuple, RsyncTarget tuple)` for v1.0. Hard-coded for Gitea+Dify (the two stateful stacks); tests assert the user/db identifiers match `stacks/{gitea,dify}/docker-compose.yml` so a future POSTGRES_USER rename breaks the test rather than runtime. |
| `render_combined_restore_script()` | One bash that writes the rclone config atomically at mode 600 (via `install -m 600`) AND runs the restore body. Single SSH round-trip. |
| `restore_from_s3(ssh, env=None)` | Entry point. Reads env, renders, executes via SSHClient.run_script, parses output for the applied-snapshot timestamp. Any non-zero exit propagates as `CalledProcessError` — partial restore must NOT let spinup proceed with half-data. |

### Pipeline wire-up — `src/nexus_deploy/pipeline.py`

Adds the `_s3_restore.restore_from_s3(ssh)` call right after `_setup.mount_persistent_volume(...)`. Both paths coexist — per-stack cutover via the `NEXUS_S3_PERSISTENCE` flag is a manual operator action. The legacy volume mount stays unchanged for stacks that haven't migrated.

### Tests — `tests/unit/test_s3_restore.py`

33 new tests covering:
- Feature flag: 1 positive + 8 negative variants
- Env-var parsing: happy path + 5 missing + 4 empty + 1 charset-error-bubbles
- Canonical targets: regression-locks the Gitea/Dify mappings + S3 subpaths
- Combined script: shebang + pragmas, config-before-body, mode-600
- `restore_from_s3` outcome dispatch: 4 cases including `CalledProcessError` propagation

`ssh.run_script` mocked via `MagicMock`. No real subprocess calls.

## Test plan

- [x] `uv run pytest tests/unit/test_s3_restore.py -q` — 33 passed
- [x] `uv run pytest tests/unit/` — full suite, 1425 passed (was 1392 — 33 new + unchanged module)
- [x] `uv run ruff check` clean
- [x] `uv run ruff format --check` clean
- [x] `uv run mypy --strict src/nexus_deploy/s3_restore.py` clean
- [ ] **Manual end-to-end** (post-merge, during Phase B): on a test stack, set the env vars + `NEXUS_S3_PERSISTENCE=true` and run a teardown→spinup cycle; verify R2 receives the snapshot on teardown and the spinup restores it. Out of scope for this PR (needs PR-5 atomic-teardown workflow first).

## Migration safety

This PR doesn't break any existing stack:
- `NEXUS_S3_PERSISTENCE` unset → `restore_from_s3` returns `Skipped(feature_flag_off)` immediately, `ssh.run_script` is never called, behavior is identical to before this PR.
- Env vars partially set → `Skipped(no_endpoint_env)` with a stderr warning, same path.
- Env vars fully set + flag on, but R2 bucket empty → `Skipped(fresh_start_empty_s3)` with the existing volume-mount data intact (the new path didn't overwrite anything).

The cutover from "volume + S3 both present" → "S3 only" is RFC PR-3 (remove volume from Tofu) and PR-6 (evacuation workflow for the 26 existing stacks).

## Refs

- RFC 0001 (`docs/proposals/0001-s3-persistence.md`)
- Foundation PR #551 (merged)
- Next: PR-3 — remove `hcloud_volume` resources from Tofu
