### PR TITLE
fix(deploy): Install rclone before restore — fixes silent fresh-start bug

### DIFF
--- a/src/nexus_deploy/pipeline.py
+++ b/src/nexus_deploy/pipeline.py
@@ -11,7 +11,10 @@ sits above and around them:
    firewall_rules, ssh_service_token, server_ip)
 5. SSH known_hosts cleanup (``ssh-keygen -R``)
 6. ``setup.configure_ssh`` → ``setup.wait_for_ssh`` →
-   ``setup.ensure_jq``
+   ``setup.ensure_jq`` → ``setup.ensure_rclone`` (rclone MUST exist
+   before step 7 — otherwise the restore script's command-not-found
+   exits silently fresh-start, leading to silent data loss on the
+   next teardown)
 7. ``s3_restore.restore_from_s3(phase="filesystem")`` — rclone-syncs
    the FS bind-mount trees onto local SSD; fresh-start exits 0
 8. ``setup.ensure_data_dirs`` — chowns the rsync'd trees to
@@ -348,6 +351,16 @@ def run_pipeline(
 
         ssh = stack.enter_context(SSHClient("nexus"))
         _setup.ensure_jq(ssh)
+        # rclone MUST be installed before restore_from_s3 runs. Without
+        # this, the rendered restore script's `rclone lsd / rclone lsf`
+        # calls return rc=127 (command not found), which the Round-6
+        # reachability probe correctly flags as "bucket not reachable"
+        # and aborts the spinup with rc=2. The PRE-Round-6 behavior was
+        # even worse: a missing rclone silently fresh-started the spinup
+        # and the next teardown overwrote real R2 data with empty
+        # snapshots. See ensure_rclone's docstring for the full
+        # rationale.
+        _setup.ensure_rclone(ssh)
 
         # RFC 0001 cutover wire-up — split into two halves because
         # pg_restore needs the gitea-db / dify-db containers running

--- a/src/nexus_deploy/pipeline.py
+++ b/src/nexus_deploy/pipeline.py
@@ -11,10 +11,13 @@ sits above and around them:
    firewall_rules, ssh_service_token, server_ip)
 5. SSH known_hosts cleanup (``ssh-keygen -R``)
 6. ``setup.configure_ssh`` → ``setup.wait_for_ssh`` →
-   ``setup.ensure_jq`` → ``setup.ensure_rclone`` (rclone MUST exist
-   before step 7 — otherwise the restore script's command-not-found
-   exits silently fresh-start, leading to silent data loss on the
-   next teardown)
+   ``setup.ensure_jq`` → ``setup.ensure_rclone``. rclone MUST be
+   installed before step 7 — otherwise the Round-6 bucket-
+   reachability probe sees rc=127 (command not found) and aborts
+   the spinup with rc=2. (Historical: pre-Round-6 the same
+   missing-rclone case silently fresh-started instead, leading
+   to data loss on the next teardown — see ensure_rclone's
+   docstring.)
 7. ``s3_restore.restore_from_s3(phase="filesystem")`` — rclone-syncs
    the FS bind-mount trees onto local SSD; fresh-start exits 0
 8. ``setup.ensure_data_dirs`` — chowns the rsync'd trees to

--- a/src/nexus_deploy/setup.py
+++ b/src/nexus_deploy/setup.py
@@ -480,7 +480,7 @@ def ensure_rclone(ssh: SSHClient) -> bool:
     if check.returncode == 0:
         return False
     install = ssh.run(
-        "sudo apt-get update -qq >/dev/null && " "sudo apt-get install -y -qq rclone >/dev/null",
+        "sudo apt-get update -qq >/dev/null && sudo apt-get install -y -qq rclone >/dev/null",
         check=True,
     )
     _ = install

--- a/src/nexus_deploy/setup.py
+++ b/src/nexus_deploy/setup.py
@@ -22,6 +22,12 @@ Public surface:
   remote. Bootstrap for VMs that pre-date the cloud-init jq install
   (newer VMs have it baked in via ``tofu/stack/main.tf``); near-no-op
   on healthy VMs.
+* **``ensure_rclone``** — idempotent ``apt-get install -y rclone``
+  on the remote. MUST run before ``s3_restore.restore_from_s3``;
+  without rclone the restore script's bucket-reachability probe
+  fails (rc=127 → 2), and the legacy pre-Round-6 code path would
+  have silently fresh-started → data loss on next teardown.
+  See the function's own docstring for the historical incident.
 * **``ensure_data_dirs``** — idempotent ``mkdir -p`` + ``chown`` on
   the Gitea + Dify bind-mount sources under ``/mnt/nexus-data/``.
   Gitea: ``gitea/{repos,lfs}`` (uid 1000) + ``gitea/db`` (uid 70).
@@ -437,6 +443,44 @@ def ensure_jq(ssh: SSHClient) -> bool:
         return False
     install = ssh.run(
         "sudo apt-get update -qq >/dev/null && sudo apt-get install -y -qq jq >/dev/null",
+        check=True,
+    )
+    _ = install
+    return True
+
+
+def ensure_rclone(ssh: SSHClient) -> bool:
+    """Install ``rclone`` on the remote if not already present.
+
+    Returns ``True`` if ``apt-get install`` actually ran (fresh VM
+    or rebuild), ``False`` if the binary was already there.
+
+    Why this matters — and why it MUST run before
+    :func:`s3_restore.restore_from_s3` in the pipeline:
+
+    Pre-RFC-0001 the rendered restore script did ``if ! rclone lsf
+    .../latest.txt``. If rclone wasn't installed, that branch
+    evaluated as ``!127 == true`` and the script silently exited 0
+    with a "fresh-start: no snapshot in S3" message. Operationally:
+    every spinup that touched a brand-new VM would *appear* to
+    fresh-start (because rclone was missing), and the next teardown
+    would happily snapshot the empty local state OVER any real R2
+    data — silent data loss.
+
+    Round 6 of PR #555 added a bucket-reachability probe that turns
+    this into a loud rc=2, so the loop now FAILS instead of corrupting.
+    But the right fix is to ensure rclone is actually installed
+    BEFORE the probe runs, which is what this helper does.
+
+    Raises :class:`subprocess.CalledProcessError` on install failure.
+    The Ubuntu 24.04 main repo carries rclone 1.65, which is recent
+    enough for the S3/R2 operations we use.
+    """
+    check = ssh.run("command -v rclone", check=False)
+    if check.returncode == 0:
+        return False
+    install = ssh.run(
+        "sudo apt-get update -qq >/dev/null && " "sudo apt-get install -y -qq rclone >/dev/null",
         check=True,
     )
     _ = install

--- a/tests/unit/test_pipeline.py
+++ b/tests/unit/test_pipeline.py
@@ -123,6 +123,10 @@ def setup_mocks(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
         "configure_ssh": MagicMock(return_value=None),
         "wait_for_ssh": MagicMock(return_value=SSHReadinessResult(succeeded=True, attempts=1)),
         "ensure_jq": MagicMock(return_value=False),
+        # rclone must be installed BEFORE restore_from_s3 — pipeline
+        # calls ensure_rclone right after ensure_jq. Pre-Round-6
+        # missing-rclone caused silent fresh-starts → data loss.
+        "ensure_rclone": MagicMock(return_value=False),
         # RFC 0001 cutover: mount_persistent_volume replaced by
         # ensure_data_dirs (chown-only; the Hetzner volume is gone).
         "ensure_data_dirs": MagicMock(return_value=None),
@@ -133,6 +137,10 @@ def setup_mocks(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
     monkeypatch.setattr("nexus_deploy.pipeline._setup.configure_ssh", mocks["configure_ssh"])
     monkeypatch.setattr("nexus_deploy.pipeline._setup.wait_for_ssh", mocks["wait_for_ssh"])
     monkeypatch.setattr("nexus_deploy.pipeline._setup.ensure_jq", mocks["ensure_jq"])
+    monkeypatch.setattr(
+        "nexus_deploy.pipeline._setup.ensure_rclone",
+        mocks["ensure_rclone"],
+    )
     monkeypatch.setattr(
         "nexus_deploy.pipeline._setup.ensure_data_dirs",
         mocks["ensure_data_dirs"],
@@ -492,6 +500,7 @@ def test_pipeline_runs_restore_then_ensure_data_dirs_then_pg_restore(
     out-of-order regressions like calling pg-restore BEFORE
     pre_bootstrap (which was the round-4 bug Copilot caught)."""
     parent = MagicMock()
+    parent.attach_mock(setup_mocks["ensure_rclone"], "ensure_rclone")
     parent.attach_mock(setup_mocks["ensure_data_dirs"], "ensure_data_dirs")
 
     restore_calls: list[str] = []
@@ -532,6 +541,7 @@ def test_pipeline_runs_restore_then_ensure_data_dirs_then_pg_restore(
         for c in parent.mock_calls
         if c[0]
         in {
+            "ensure_rclone",
             "restore_from_s3",
             "ensure_data_dirs",
             "run_pre_bootstrap",
@@ -539,6 +549,7 @@ def test_pipeline_runs_restore_then_ensure_data_dirs_then_pg_restore(
         }
     ]
     assert relevant == [
+        "ensure_rclone",  # MUST come before restore_from_s3
         "restore_from_s3",  # phase="filesystem"
         "ensure_data_dirs",
         "run_pre_bootstrap",  # compose-up happens here

--- a/tests/unit/test_setup.py
+++ b/tests/unit/test_setup.py
@@ -26,6 +26,7 @@ from nexus_deploy.setup import (
     configure_ssh,
     ensure_data_dirs,
     ensure_jq,
+    ensure_rclone,
     render_ssh_config_block,
     strip_existing_block,
     wait_for_service_token,
@@ -431,6 +432,40 @@ def test_ensure_jq_installs_when_missing() -> None:
     result = ensure_jq(ssh)
     assert result is True
     assert ssh.run.call_count == 2
+
+
+def test_ensure_rclone_returns_false_when_already_present() -> None:
+    """If rclone is already installed (rc=0 from `command -v rclone`),
+    skip the apt-get install."""
+    ssh = MagicMock()
+    ssh.run.return_value = subprocess.CompletedProcess(
+        args=["ssh"], returncode=0, stdout="/usr/bin/rclone\n", stderr=""
+    )
+    result = ensure_rclone(ssh)
+    assert result is False
+    ssh.run.assert_called_once()
+
+
+def test_ensure_rclone_installs_when_missing() -> None:
+    """Pre-Round-6, a missing rclone caused the restore script to
+    silently fresh-start (data loss on next teardown). The current
+    Round-6 probe turns it into a loud rc=2, but the real fix is to
+    install rclone BEFORE the probe runs. This test pins that the
+    install actually happens when the binary is missing."""
+    ssh = MagicMock()
+    ssh.run.side_effect = [
+        # `command -v rclone` → rc=1 (missing)
+        subprocess.CompletedProcess(args=["ssh"], returncode=1, stdout="", stderr=""),
+        # apt-get install → rc=0
+        subprocess.CompletedProcess(args=["ssh"], returncode=0, stdout="", stderr=""),
+    ]
+    result = ensure_rclone(ssh)
+    assert result is True
+    assert ssh.run.call_count == 2
+    # The install command must reference rclone explicitly so a
+    # future refactor doesn't silently swap the package name.
+    install_call = ssh.run.call_args_list[1]
+    assert "rclone" in install_call.args[0]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes a silent-data-loss bug uncovered by PR #555 round 6's bucket-reachability probe. The R2-persistence code path has **never actually worked end-to-end** — every spin-up against a fresh VM silently fresh-started because `rclone` was never installed on the server, and the pre-Round-6 `if ! rclone lsf ...` form treated `command-not-found` (rc=127) as "no snapshot exists" and exited 0.

The first real teardown would have written empty snapshots over the (non-existent) snapshot history, but since teardown.yml on main wasn't wired up before #555 either, the bug stayed latent.

Round 6 turned the silent fresh-start into a loud rc=2 with an error message. This PR fixes the actual root cause: install rclone before `restore_from_s3` runs.

## Changes

- **`src/nexus_deploy/setup.py`** — new `ensure_rclone(ssh)` helper, idempotent `apt-get install -y rclone`. Mirrors the existing `ensure_jq` pattern. Ubuntu 24.04's main repo carries rclone 1.65 which covers every S3/R2 op we use.
- **`src/nexus_deploy/pipeline.py`** — call `ensure_rclone(ssh)` right after `ensure_jq(ssh)`, before `restore_from_s3(phase="filesystem")`. Updated module docstring step list (was 14 steps, still 14 — refined step 6).
- **`tests/unit/test_setup.py`** — 2 new tests:
  - `test_ensure_rclone_returns_false_when_already_present` (idempotent skip on rc=0)
  - `test_ensure_rclone_installs_when_missing` (install runs + asserts the install command actually mentions rclone)
- **`tests/unit/test_pipeline.py`** — updated `setup_mocks` fixture with `ensure_rclone` mock, and extended `test_pipeline_runs_restore_then_ensure_data_dirs_then_pg_restore` to pin `ensure_rclone → restore_from_s3` ordering.

## Historical context

| Code state | Behaviour when rclone missing |
|---|---|
| Pre-Round-6 (`if ! rclone lsf .../latest.txt`) | `!127 == true` → enters fresh-start branch → exits 0 with "fresh-start: no snapshot in S3" message → **silent data loss on next teardown** |
| Round 6 (added `rclone lsd "$BUCKET"` probe) | Probe exits rc=127 → flagged as "bucket not reachable" → script aborts rc=2 → loud failure |
| This PR (`ensure_rclone` before probe) | rclone installed → probe + restore work as intended |

Round 6 turned a silent corruption bug into a loud failure; this PR addresses the root cause so the loud failure doesn't trigger.

## Test plan

- [x] Local: 1430/1430 tests pass
- [x] Local: ruff format + ruff check + mypy all clean (verified via pre-commit hook)
- [ ] Merge this PR
- [ ] `gh workflow run destroy-all.yml -f confirm=DESTROY` (clean the stuck stack from the failed run)
- [ ] `gh workflow run initial-setup.yaml` — should:
  - [ ] See `ensure_rclone: installed` (or similar) in the spin-up logs
  - [ ] `→ restore: looking up latest snapshot` followed by `fresh-start: no snapshot in S3, leaving local state empty` (genuinely empty bucket, not the rclone-missing fake fresh-start)
  - [ ] No `✗ restore-failed: bucket ... is not reachable`
- [ ] Manual data creation in Gitea
- [ ] `gh workflow run teardown.yml -f confirm=TEARDOWN` — verify `✓ s3-snapshot: applied snapshot <TS>` and R2 `latest.txt` updates
- [ ] `gh workflow run spin-up.yml` — verify `✓ s3-restore (filesystem): applied snapshot <TS>` and the previously-created data is restored

Closes the latent silent-fresh-start bug surfaced by PR #555 round 6.
