### PR TITLE
fix(deploy): R2-persistence cutover follow-ups (rclone-lsf quirk + teardown SSH)

### DIFF
--- a/.github/workflows/migrate-volume-to-r2.yml
+++ b/.github/workflows/migrate-volume-to-r2.yml
@@ -184,6 +184,10 @@ jobs:
           # See spin-up.yml's matching step for the rationale.
           DOMAIN_SLUG=$(echo "${{ secrets.DOMAIN }}" | tr '.' '-')
           export PERSISTENCE_S3_BUCKET="nexus-${DOMAIN_SLUG}-persistence"
+          # Lowercase the slug (see spin-up.yml / teardown.yml for
+          # the full rationale — workflow fallback is the camel-
+          # case repo name, validator wants S3 bucket-name shape).
+          export PERSISTENCE_STACK_SLUG=$(echo "$PERSISTENCE_STACK_SLUG" | tr '[:upper:]' '[:lower:]')
 
           uv run --quiet --project "$GITHUB_WORKSPACE" \
             python -m nexus_deploy s3-snapshot

--- a/.github/workflows/migrate-volume-to-r2.yml
+++ b/.github/workflows/migrate-volume-to-r2.yml
@@ -187,7 +187,8 @@ jobs:
           # Lowercase the slug (see spin-up.yml / teardown.yml for
           # the full rationale — workflow fallback is the camel-
           # case repo name, validator wants S3 bucket-name shape).
-          export PERSISTENCE_STACK_SLUG=$(echo "$PERSISTENCE_STACK_SLUG" | tr '[:upper:]' '[:lower:]')
+          PERSISTENCE_STACK_SLUG=$(echo "$PERSISTENCE_STACK_SLUG" | tr '[:upper:]' '[:lower:]')
+          export PERSISTENCE_STACK_SLUG
 
           uv run --quiet --project "$GITHUB_WORKSPACE" \
             python -m nexus_deploy s3-snapshot

--- a/.github/workflows/spin-up.yml
+++ b/.github/workflows/spin-up.yml
@@ -201,7 +201,7 @@ jobs:
       - name: Create R2 credentials from secrets
         run: |
           mkdir -p tofu
-          
+
           # Use inputs from setup-control-plane if available, otherwise fall back to secrets
           # This allows initial-setup.yaml to pass freshly created credentials
           if [ -n "${{ inputs.r2_access_key_id }}" ] && [ -n "${{ inputs.r2_secret_access_key }}" ]; then
@@ -216,7 +216,7 @@ jobs:
             # Trim whitespace and newlines from secrets to avoid auth issues
             R2_ACCESS_KEY_ID=$(echo -n "${{ secrets.R2_ACCESS_KEY_ID }}" | tr -d '[:space:]')
             R2_SECRET_ACCESS_KEY=$(echo -n "${{ secrets.R2_SECRET_ACCESS_KEY }}" | tr -d '[:space:]')
-            
+
             # Debug: Check if secrets are available (without exposing values)
             if [ -z "$R2_ACCESS_KEY_ID" ] || [ -z "$R2_SECRET_ACCESS_KEY" ]; then
               echo "⚠️  R2 credentials from secrets are empty"
@@ -232,7 +232,7 @@ jobs:
               echo "   or manually set R2_ACCESS_KEY_ID and R2_SECRET_ACCESS_KEY in GitHub Settings → Secrets → Actions."
             fi
           fi
-          
+
           # Validate credentials are not empty
           if [ -z "$R2_ACCESS_KEY_ID" ] || [ -z "$R2_SECRET_ACCESS_KEY" ]; then
             echo "❌ R2 credentials are empty!"
@@ -240,11 +240,11 @@ jobs:
             echo "   or set R2_ACCESS_KEY_ID and R2_SECRET_ACCESS_KEY in GitHub Settings → Secrets → Actions."
             exit 1
           fi
-          
+
           # Generate dynamic bucket name from domain
           BUCKET_NAME=$(echo "${{ secrets.DOMAIN }}" | tr '.' '-')-terraform-state
           echo "📦 Using bucket: $BUCKET_NAME"
-          
+
           cat > tofu/.r2-credentials << EOF
           R2_ACCESS_KEY_ID="${R2_ACCESS_KEY_ID}"
           R2_SECRET_ACCESS_KEY="${R2_SECRET_ACCESS_KEY}"
@@ -258,7 +258,7 @@ jobs:
           bucket = "${BUCKET_NAME}"
           EOF
           sed -i 's/^          //' tofu/backend.hcl
-          
+
           echo "✅ R2 credentials file created"
 
       - name: Generate config.tfvars
@@ -285,7 +285,7 @@ jobs:
           github_repo          = "${{ github.event.repository.name }}"
           EOF
           sed -i 's/^          //' tofu/stack/config.tfvars
-          
+
           # Add Docker Hub credentials if provided (optional)
           if [ -n "${{ secrets.DOCKERHUB_USERNAME }}" ] && [ -n "${{ secrets.DOCKERHUB_TOKEN }}" ]; then
             cat >> tofu/stack/config.tfvars << EOF
@@ -334,12 +334,12 @@ jobs:
           else
             echo "⚠️  Hetzner Object Storage not configured (LakeFS will need manual setup)"
           fi
-          
+
           # Generate services config from D1 (single source of truth)
           # If enabled_services input is provided (from Control Plane), use it
           # Otherwise, read from D1 database
           ENABLED_SERVICES="${{ inputs.enabled_services }}"
-          
+
           if [ -n "$ENABLED_SERVICES" ]; then
             echo "📋 Using services from Control Plane: $ENABLED_SERVICES"
           else
@@ -349,14 +349,14 @@ jobs:
             ENABLED_SERVICES=$(npx wrangler@4 d1 execute "$D1_DATABASE_NAME" --remote --json \
               --command "SELECT name FROM services WHERE enabled = 1" 2>/dev/null \
               | jq -r '.[0].results | map(.name) | join(",")' 2>/dev/null || echo "")
-            
+
             if [ -n "$ENABLED_SERVICES" ]; then
               echo "📋 Enabled services from D1: $ENABLED_SERVICES"
             else
               echo "📋 No services in D1 yet - core services will be enabled by default"
             fi
           fi
-          
+
           # Sync firewall rules from services.yaml to D1 BEFORE reading them
           # This ensures dns_record and label changes are applied before Tofu reads them
           D1_DATABASE_NAME="nexus-${DOMAIN//./-}-db"
@@ -647,6 +647,18 @@ jobs:
           DOMAIN_SLUG=$(echo "${{ secrets.DOMAIN }}" | tr '.' '-')
           export PERSISTENCE_S3_BUCKET="nexus-${DOMAIN_SLUG}-persistence"
 
+          # Lowercase PERSISTENCE_STACK_SLUG — the env-var value
+          # falls back to github.event.repository.name (e.g.
+          # "Nexus-Stack" with capital N), but the s3_persistence
+          # validator enforces S3 bucket-name shape on the slug
+          # (lowercase only). GitHub Actions has no lowercase
+          # filter on workflow-expression interpolations, so the
+          # cast happens here in the shell. Restore today doesn't
+          # validate stack_slug so this would only surface on
+          # teardown — but keeping the two sides symmetric is
+          # cheap insurance.
+          export PERSISTENCE_STACK_SLUG=$(echo "$PERSISTENCE_STACK_SLUG" | tr '[:upper:]' '[:lower:]')
+
           uv run --quiet --project "$GITHUB_WORKSPACE" \
             python -m nexus_deploy run-pipeline
 
@@ -664,32 +676,32 @@ jobs:
           DOMAIN: ${{ secrets.DOMAIN }}
         run: |
           echo "📝 Writing infrastructure config to D1..."
-          
+
           # Get D1 database name from control-plane state
           cd tofu/control-plane
           source ../.r2-credentials
           export AWS_ACCESS_KEY_ID="$R2_ACCESS_KEY_ID"
           export AWS_SECRET_ACCESS_KEY="$R2_SECRET_ACCESS_KEY"
-          
+
           # Initialize control-plane state to read D1 database name
           tofu init -backend-config=../backend.hcl >/dev/null 2>&1 || true
           D1_DATABASE_NAME=$(tofu output -raw d1_database_name 2>/dev/null || echo "")
           cd ../..
-          
+
           if [ -z "$D1_DATABASE_NAME" ]; then
             echo "⚠️  Could not get D1 database name - skipping config write"
             exit 0
           fi
-          
+
           # Server config values
           SERVER_TYPE="${{ vars.SERVER_TYPE || 'cx43' }}"
           SERVER_LOCATION="${{ vars.SERVER_LOCATION || 'hel1' }}"
-          
+
           # Escape values for safe SQL insertion (single quotes doubled)
           ESCAPED_SERVER_TYPE=${SERVER_TYPE//\'/\'\'}
           ESCAPED_SERVER_LOCATION=${SERVER_LOCATION//\'/\'\'}
           ESCAPED_DOMAIN=${DOMAIN//\'/\'\'}
-          
+
           # Write config to D1
           npx wrangler@4 d1 execute "$D1_DATABASE_NAME" --remote --command "INSERT OR REPLACE INTO config (key, value, updated_at) VALUES ('server_type', '$ESCAPED_SERVER_TYPE', datetime('now'))"
           npx wrangler@4 d1 execute "$D1_DATABASE_NAME" --remote --command "INSERT OR REPLACE INTO config (key, value, updated_at) VALUES ('server_location', '$ESCAPED_SERVER_LOCATION', datetime('now'))"
@@ -795,7 +807,7 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
           echo "🔄 Redeploying Control Plane to activate new secrets..."
-          
+
           cd tofu/control-plane
           source ../.r2-credentials
           export AWS_ACCESS_KEY_ID="$R2_ACCESS_KEY_ID"
@@ -898,7 +910,7 @@ jobs:
           echo "📋 Control Panel: https://control.${{ secrets.DOMAIN }}"
           echo "   (Manage services, view URLs, and access settings)"
           echo ""
-      
+
       - name: Sync deployed state to D1
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -951,11 +963,11 @@ jobs:
             fi
 
             echo "📧 Sending stack online email..."
-            
+
             EMAIL_HTML='<div style="font-family:monospace;background:#0a0a0f;color:#00ff88;padding:20px"><h1 style="color:#00ff88">✅ Nexus-Stack is Online</h1><p>Your stack is back online at <strong>DOMAIN_PLACEHOLDER</strong></p><h2>🔗 Quick Links</h2><ul><li><a href="https://control.DOMAIN_PLACEHOLDER" style="color:#00ff88">Control Panel</a> - Manage services &amp; view URLs</li></ul><p style="color:#999;font-size:12px;margin-top:1rem">Need credentials? Click "Send Credentials" in the Control Panel.</p></div>'
-            
+
             EMAIL_HTML="${EMAIL_HTML//DOMAIN_PLACEHOLDER/$DOMAIN}"
-            
+
             # Build email: User as primary recipient, Admin in CC
             if [ -n "$USER_EMAIL" ]; then
               JSON_PAYLOAD=$(jq -n \
@@ -973,12 +985,12 @@ jobs:
                 --arg html "$EMAIL_HTML" \
                 '{from: $from, to: [$to], subject: $subject, html: $html}')
             fi
-            
+
             HTTP_STATUS=$(curl -s -o /tmp/resend_response.txt -w "%{http_code}" -X POST 'https://api.resend.com/emails' \
               -H "Authorization: Bearer $RESEND_API_KEY" \
               -H "Content-Type: application/json" \
               -d "$JSON_PAYLOAD")
-            
+
             if [ "$HTTP_STATUS" -ge 200 ] && [ "$HTTP_STATUS" -lt 300 ]; then
               if [ -n "$USER_EMAIL" ]; then
                 echo "✅ Stack online email sent to $USER_EMAIL (cc: $ADMIN_EMAIL)"

--- a/.github/workflows/spin-up.yml
+++ b/.github/workflows/spin-up.yml
@@ -657,7 +657,8 @@ jobs:
           # validate stack_slug so this would only surface on
           # teardown — but keeping the two sides symmetric is
           # cheap insurance.
-          export PERSISTENCE_STACK_SLUG=$(echo "$PERSISTENCE_STACK_SLUG" | tr '[:upper:]' '[:lower:]')
+          PERSISTENCE_STACK_SLUG=$(echo "$PERSISTENCE_STACK_SLUG" | tr '[:upper:]' '[:lower:]')
+          export PERSISTENCE_STACK_SLUG
 
           uv run --quiet --project "$GITHUB_WORKSPACE" \
             python -m nexus_deploy run-pipeline

--- a/.github/workflows/teardown.yml
+++ b/.github/workflows/teardown.yml
@@ -237,7 +237,8 @@ jobs:
           # GitHub Actions has no lowercase filter on workflow-
           # expression interpolations, so the cast happens here in
           # the shell before the subcommand runs.
-          export PERSISTENCE_STACK_SLUG=$(echo "$PERSISTENCE_STACK_SLUG" | tr '[:upper:]' '[:lower:]')
+          PERSISTENCE_STACK_SLUG=$(echo "$PERSISTENCE_STACK_SLUG" | tr '[:upper:]' '[:lower:]')
+          export PERSISTENCE_STACK_SLUG
 
           uv run --quiet --project "$GITHUB_WORKSPACE" \
             python -m nexus_deploy s3-snapshot

--- a/.github/workflows/teardown.yml
+++ b/.github/workflows/teardown.yml
@@ -30,7 +30,7 @@ jobs:
       TF_VAR_infisical_token: ${{ secrets.INFISICAL_TOKEN }}
       TF_VAR_github_owner: ${{ github.repository_owner }}
       TF_VAR_github_repo: ${{ github.event.repository.name }}
-    
+
     steps:
       - name: Validate confirmation
         run: |
@@ -87,12 +87,40 @@ jobs:
           chmod +x cloudflared
           sudo mv cloudflared /usr/local/bin/
 
-      - name: Generate SSH key for OpenTofu
+      - name: Install SSH key from GitHub Secrets
+        # Teardown's pre-destroy s3-snapshot step needs SSH into the
+        # live server (docker exec pg_dump + rclone sync). Before
+        # RFC 0001, teardown.yml only did `tofu destroy` (provider
+        # API, no SSH needed) so the legacy step generated a fresh
+        # ephemeral key that was never registered on the server —
+        # fine for tofu, useless for ssh. With the snapshot step
+        # the SSH must actually work, so install the PERSISTENT
+        # key from secrets (the same key spin-up.yml uses), which
+        # is already present in the server's authorized_keys.
         run: |
           mkdir -p ~/.ssh
-          ssh-keygen -t ed25519 -f ~/.ssh/id_ed25519 -N "" -C "github-actions@nexus-stack"
+          chmod 700 ~/.ssh
+          umask 077
+          if [ -z "${{ secrets.SSH_PRIVATE_KEY }}" ]; then
+            echo "❌ SSH_PRIVATE_KEY secret not set — teardown's s3-snapshot step needs SSH access to the live server."
+            echo "   Run the 'Initial Setup' workflow first to bootstrap the SSH key pair, or set SSH_PRIVATE_KEY manually."
+            exit 1
+          fi
+          # SSH key heredocs: expression placeholders must NOT start at column 0
+          # (breaks GitHub Actions YAML parser). Keep indented and strip leading
+          # whitespace with sed to ensure clean key content.
+          sed 's/^[[:space:]]*//' > ~/.ssh/id_ed25519 <<'EOF_PRIVATE_KEY'
+          ${{ secrets.SSH_PRIVATE_KEY }}
+          EOF_PRIVATE_KEY
           chmod 600 ~/.ssh/id_ed25519
+          # Public key — from secret if available, derived from private otherwise.
+          if [ -n "${{ secrets.SSH_PUBLIC_KEY }}" ]; then
+            echo "${{ secrets.SSH_PUBLIC_KEY }}" > ~/.ssh/id_ed25519.pub
+          else
+            ssh-keygen -y -f ~/.ssh/id_ed25519 > ~/.ssh/id_ed25519.pub
+          fi
           chmod 644 ~/.ssh/id_ed25519.pub
+          echo "✅ SSH key installed from secrets (matches server's authorized_keys)"
 
       - name: Create R2 credentials from secrets
         run: |
@@ -150,13 +178,13 @@ jobs:
           ENABLED_SERVICES=$(npx wrangler@4 d1 execute "$D1_DATABASE_NAME" --remote --json \
             --command "SELECT name FROM services WHERE enabled = 1" 2>/dev/null \
             | jq -r '.[0].results | map(.name) | join(",")' 2>/dev/null || echo "")
-          
+
           if [ -n "$ENABLED_SERVICES" ]; then
             echo "📋 Enabled services from D1: $ENABLED_SERVICES"
           else
             echo "📋 No services in D1 yet - core services will be enabled by default"
           fi
-          
+
           # Generate services config from services.yaml
           # Use shared script (same as spin-up.yml)
           chmod +x .github/scripts/generate-services-tfvars.py
@@ -233,7 +261,7 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
           echo "📝 Writing teardown timestamp to D1..."
-          
+
           # Get D1 database name - need to init control-plane state first
           cd tofu/control-plane
           source ../.r2-credentials
@@ -242,12 +270,12 @@ jobs:
           tofu init -backend-config=../backend.hcl -backend-config="key=control-plane.tfstate" -input=false
           D1_DATABASE_NAME=$(tofu output -raw d1_database_name 2>/dev/null || echo "")
           cd ../..
-          
+
           if [ -z "$D1_DATABASE_NAME" ]; then
             echo "⚠️  Could not get D1 database name - skipping timestamp write"
             exit 0
           fi
-          
+
           npx wrangler@4 d1 execute "$D1_DATABASE_NAME" --remote --command "INSERT OR REPLACE INTO config (key, value, updated_at) VALUES ('last_teardown', datetime('now'), datetime('now'))"
           echo "✅ Teardown timestamp written to D1"
 

--- a/.github/workflows/teardown.yml
+++ b/.github/workflows/teardown.yml
@@ -229,6 +229,16 @@ jobs:
           DOMAIN_SLUG=$(echo "${{ secrets.DOMAIN }}" | tr '.' '-')
           export PERSISTENCE_S3_BUCKET="nexus-${DOMAIN_SLUG}-persistence"
 
+          # Lowercase PERSISTENCE_STACK_SLUG — the env-var value
+          # from the step's env: block falls back to
+          # github.event.repository.name (e.g. "Nexus-Stack" with
+          # a capital N), but the s3_persistence validator enforces
+          # S3 bucket-name shape on the slug (lowercase only).
+          # GitHub Actions has no lowercase filter on workflow-
+          # expression interpolations, so the cast happens here in
+          # the shell before the subcommand runs.
+          export PERSISTENCE_STACK_SLUG=$(echo "$PERSISTENCE_STACK_SLUG" | tr '[:upper:]' '[:lower:]')
+
           uv run --quiet --project "$GITHUB_WORKSPACE" \
             python -m nexus_deploy s3-snapshot
 

--- a/src/nexus_deploy/s3_persistence.py
+++ b/src/nexus_deploy/s3_persistence.py
@@ -601,10 +601,18 @@ def render_snapshot_script(
         f"SNAPSHOT_PREFIX={snapshot_prefix}",
         "WORKDIR=/tmp/nexus-snapshot",
         "POSTGRES_DIR=$WORKDIR/postgres",
+        # Verify-phase scratch files (rclone-check stderr/stdout)
+        # MUST live OUTSIDE $WORKDIR — verify_one writes them and
+        # the first verify_one call compares $WORKDIR vs S3. If
+        # they lived in $WORKDIR they'd appear as untracked extras
+        # and rclone would report "differences found", failing
+        # every snapshot. Took until today's first real run to
+        # surface (no test exercised the bash-level verify path).
+        "LOG_DIR=/tmp/nexus-snapshot-logs",
         "",
         'echo "→ snapshot: preparing workdir"',
-        'rm -rf "$WORKDIR"',
-        'mkdir -p "$POSTGRES_DIR"',
+        'rm -rf "$WORKDIR" "$LOG_DIR"',
+        'mkdir -p "$POSTGRES_DIR" "$LOG_DIR"',
         "",
     ]
 
@@ -807,8 +815,8 @@ def render_snapshot_script(
             # every real teardown. Capturing [2] (grep) makes drift
             # detection actually correct.
             '  rclone check "$src" "$dst" '
-            '--one-way --combined - 2>"$WORKDIR/rclone-check.err" '
-            '| tee "$WORKDIR/rclone-check.out" '
+            '--one-way --combined - 2>"$LOG_DIR/rclone-check.err" '
+            '| tee "$LOG_DIR/rclone-check.out" '
             '| grep -qE "^[-*]"',
             # CRITICAL: copy PIPESTATUS to a local array IMMEDIATELY,
             # in ONE command. Every subsequent command (including the
@@ -828,13 +836,13 @@ def render_snapshot_script(
             "  set -e",
             '  if [ "$rclone_rc" -ne 0 ]; then',
             '    echo "✗ snapshot-failed: rclone check ${label} errored (rc=$rclone_rc)" >&2',
-            '    cat "$WORKDIR/rclone-check.err" >&2 || true',
+            '    cat "$LOG_DIR/rclone-check.err" >&2 || true',
             "    verify_failed=1",
             "    return",
             "  fi",
             '  if [ "$drift_rc" -eq 0 ]; then',
             '    echo "✗ snapshot-failed: rclone check ${label} found drift" >&2',
-            '    cat "$WORKDIR/rclone-check.out" >&2',
+            '    cat "$LOG_DIR/rclone-check.out" >&2',
             "    verify_failed=1",
             "    return",
             "  fi",

--- a/src/nexus_deploy/s3_persistence.py
+++ b/src/nexus_deploy/s3_persistence.py
@@ -920,8 +920,8 @@ def render_restore_script(
         # bucket policy. Quiet on success.
         'SNAPSHOT_LISTING=""',
         'if ! SNAPSHOT_LISTING=$(rclone lsf "$BUCKET/snapshots/"); then',
-        '  echo "✗ restore-failed: cannot list $BUCKET/snapshots/ — '
-        'see rclone error above (auth / network / bucket policy)" >&2',
+        '  echo "✗ restore-failed: cannot list $BUCKET/snapshots/" >&2',
+        '  echo "  (auth / network / bucket policy — see rclone error above)" >&2',
         "  exit 2",
         "fi",
         'if ! printf "%s\\n" "$SNAPSHOT_LISTING" | grep -qxF "latest.txt"; then',

--- a/src/nexus_deploy/s3_persistence.py
+++ b/src/nexus_deploy/s3_persistence.py
@@ -810,8 +810,21 @@ def render_snapshot_script(
             '--one-way --combined - 2>"$WORKDIR/rclone-check.err" '
             '| tee "$WORKDIR/rclone-check.out" '
             '| grep -qE "^[-*]"',
-            "  local rclone_rc=${PIPESTATUS[0]}",
-            "  local drift_rc=${PIPESTATUS[2]}",
+            # CRITICAL: copy PIPESTATUS to a local array IMMEDIATELY,
+            # in ONE command. Every subsequent command (including the
+            # ``local`` builtin) overwrites PIPESTATUS with its own
+            # single-element exit code, so doing two separate
+            # ``local rclone_rc=${PIPESTATUS[0]}; local drift_rc=
+            # ${PIPESTATUS[2]}`` would have ``set -u`` complain about
+            # ``PIPESTATUS[2]: unbound variable`` on the second line
+            # (the first ``local`` clobbered PIPESTATUS to a
+            # 1-element array). This was a latent bug since RFC-0001
+            # day 1 — bash -n syntax checks didn't catch it; pure-
+            # string tests didn't notice; nobody ever actually ran
+            # the verify phase against real S3 until today.
+            '  local pipeline_status=("${PIPESTATUS[@]}")',
+            "  local rclone_rc=${pipeline_status[0]}",
+            "  local drift_rc=${pipeline_status[2]}",
             "  set -e",
             '  if [ "$rclone_rc" -ne 0 ]; then',
             '    echo "✗ snapshot-failed: rclone check ${label} errored (rc=$rclone_rc)" >&2',
@@ -1009,9 +1022,8 @@ def render_restore_script(
         # leak its kernel-level "No such file or directory" out
         # as the only diagnostic.
         'if [ ! -s "$WORKDIR/latest.txt" ]; then',
-        '  echo "✗ restore-failed: rclone copyto did not produce '
-        "$WORKDIR/latest.txt (or it's empty) — likely rclone version "
-        'mismatch or transient S3 issue" >&2',
+        '  echo "✗ restore-failed: rclone copyto did not produce $WORKDIR/latest.txt" >&2',
+        '  echo "  (file missing or empty — likely rclone version mismatch or transient S3 issue)" >&2',
         "  exit 2",
         "fi",
         'TIMESTAMP=$(tr -d "\\r\\n" < "$WORKDIR/latest.txt")',

--- a/src/nexus_deploy/s3_persistence.py
+++ b/src/nexus_deploy/s3_persistence.py
@@ -1090,6 +1090,34 @@ def render_restore_script(
             db_sql = _quote_sql_ident(pg.database)
             user_sql = _quote_sql_ident(pg.user)
             dump_file = f"$WORKDIR/postgres/{pg.database}.dump.gz"
+            # Symmetric "stack not deployed" handling matching the
+            # snapshot-side guards. Two cases:
+            #   - No dump file under WORKDIR/postgres/ — the
+            #     snapshot side skipped this DB (container wasn't
+            #     running at snapshot time). Without the guard, the
+            #     subsequent ``gunzip`` would fail with "No such
+            #     file" and abort restore.
+            #   - Dump file exists but the container isn't running
+            #     on this stack (different stack composition between
+            #     snapshot and restore — e.g. dify enabled when
+            #     snapshotted but not when restored). Without the
+            #     guard, ``docker exec dify-db psql`` fails with
+            #     "No such container" rc=1 and aborts restore.
+            # Either case → skip with an explicit log line; the
+            # gitea-only restore path still proceeds normally.
+            lines.append(f"if [ ! -f {dump_file} ]; then")
+            lines.append(
+                f'  echo "  (skip: no dump for {pg.database} ' f'— stack not snapshotted)"',
+            )
+            lines.append(
+                f"elif [ \"$(docker inspect --format='{{{{.State.Running}}}}' "
+                f'{container} 2>/dev/null)" != "true" ]; then',
+            )
+            lines.append(
+                f'  echo "  (skip: container {pg.container} not running '
+                f'— stack not deployed on this restore target)"',
+            )
+            lines.append("else")
             # We drop+recreate the database to guarantee a clean
             # restore. pg_restore --clean would do something similar
             # but is fragile across PG versions; the explicit
@@ -1098,18 +1126,19 @@ def render_restore_script(
             # ``-c '<SQL>'`` (single-quoted bash arg) so the inner
             # double-quoted SQL identifiers don't need escaping.
             lines.append(
-                f"docker exec {container} psql -U {user_cli} -d postgres "
+                f"  docker exec {container} psql -U {user_cli} -d postgres "
                 f"-c 'DROP DATABASE IF EXISTS {db_sql} WITH (FORCE);'",
             )
             lines.append(
-                f"docker exec {container} psql -U {user_cli} -d postgres "
+                f"  docker exec {container} psql -U {user_cli} -d postgres "
                 f"-c 'CREATE DATABASE {db_sql} OWNER {user_sql};'",
             )
             lines.append(
-                f"gunzip -c {dump_file} | "
+                f"  gunzip -c {dump_file} | "
                 f"docker exec -i {container} pg_restore -U {user_cli} -d {db_cli} "
                 "--no-owner --no-acl",
             )
+            lines.append("fi")
         lines.append("")
 
     lines.append('echo "✓ restore complete from $SNAPSHOT_PREFIX"')

--- a/src/nexus_deploy/s3_persistence.py
+++ b/src/nexus_deploy/s3_persistence.py
@@ -636,16 +636,31 @@ def render_snapshot_script(
             # can't masquerade as the empty-stdout-from-no-
             # containers case.
             lines.append(f"COMPOSE_FILE={quoted}")
-            lines.append("set +e")
-            lines.append('PS_OUT=$(docker compose -f "$COMPOSE_FILE" ps -q 2>/dev/null)')
-            lines.append("PS_RC=$?")
-            lines.append("set -e")
-            lines.append('if [ "$PS_RC" -eq 0 ] && [ -z "$PS_OUT" ]; then')
+            # Skip cleanly if the compose file isn't on disk —
+            # ``stop_compose_files`` is a static list of stacks the
+            # persistence layer KNOWS ABOUT; whether a given stack
+            # is actually deployed on this server is decided by D1
+            # (enabled_services). A stack absent from disk just
+            # means it isn't enabled here, not an error. Treating
+            # this as benign-skip (with an explicit log line so
+            # operators see it) keeps the snapshot deterministic
+            # across partially-deployed configurations.
+            lines.append('if [ ! -f "$COMPOSE_FILE" ]; then')
             lines.append(
-                f'  echo "  (skip: compose stack at {compose_file} already down)"',
+                f'  echo "  (skip: compose file {compose_file} not on disk — stack not deployed)"',
             )
             lines.append("else")
-            lines.append('  docker compose -f "$COMPOSE_FILE" stop')
+            lines.append("  set +e")
+            lines.append('  PS_OUT=$(docker compose -f "$COMPOSE_FILE" ps -q 2>/dev/null)')
+            lines.append("  PS_RC=$?")
+            lines.append("  set -e")
+            lines.append('  if [ "$PS_RC" -eq 0 ] && [ -z "$PS_OUT" ]; then')
+            lines.append(
+                f'    echo "  (skip: compose stack at {compose_file} already down)"',
+            )
+            lines.append("  else")
+            lines.append('    docker compose -f "$COMPOSE_FILE" stop')
+            lines.append("  fi")
             lines.append("fi")
         lines.append("")
 
@@ -661,18 +676,40 @@ def render_snapshot_script(
             # said ``.sql.gz`` which was misleading since the body
             # is NOT plain SQL (``-F c`` produces a binary archive).
             dump_file = f"$POSTGRES_DIR/{pg.database}.dump.gz"
+            # Same "stack not deployed" handling as the compose-stop
+            # block: skip if the postgres container isn't even
+            # running on this server, so partially-deployed stacks
+            # don't fail teardown.
+            lines.append(f"if docker inspect {container} >/dev/null 2>&1; then")
             lines.append(
-                f"docker exec {container} pg_dump -U {user} -d {db} -F c | gzip -9 > {dump_file}",
+                f"  docker exec {container} pg_dump -U {user} -d {db} -F c | gzip -9 > {dump_file}",
             )
+            lines.append("else")
+            lines.append(
+                f'  echo "  (skip: container {pg.container} not present — stack not deployed)"',
+            )
+            lines.append("fi")
         lines.append("")
 
     lines.append('echo "→ snapshot: uploading filesystem trees"')
     for rs in rs_targets:
         local = shlex.quote(rs.local_path)
         sub = shlex.quote(rs.s3_subpath)
+        # And again: skip if the source directory isn't on disk
+        # (stack not deployed → no data to snapshot). Without this
+        # guard rclone sync would fail with "directory not found"
+        # and abort the whole snapshot. ``--create-empty-src-dirs``
+        # below preserves the structure on the S3 side when the
+        # source IS present but empty (different case).
+        lines.append(f"if [ -d {local} ]; then")
         lines.append(
-            f'rclone sync --create-empty-src-dirs {local} "$BUCKET/$SNAPSHOT_PREFIX/{sub}"',
+            f'  rclone sync --create-empty-src-dirs {local} "$BUCKET/$SNAPSHOT_PREFIX/{sub}"',
         )
+        lines.append("else")
+        lines.append(
+            f'  echo "  (skip: data dir {rs.local_path} not on disk — stack not deployed)"',
+        )
+        lines.append("fi")
     lines.append("")
 
     if pg_targets:
@@ -722,6 +759,18 @@ def render_snapshot_script(
             '  local src="$1"',
             '  local dst="$2"',
             '  local label="$3"',
+            # Same skip-on-missing semantics as the snapshot blocks
+            # above. If the source dir isn't on disk (stack not
+            # deployed) the corresponding rclone sync was already
+            # skipped, so there's nothing for rclone check to
+            # compare — verifying a missing source against an empty
+            # S3 prefix would fail with "directory not found" and
+            # mark the whole verify as drifted. Treat absent source
+            # as benign-skip with an explicit log line.
+            '  if [ ! -d "$src" ]; then',
+            '    echo "  (skip verify: source $src not on disk — stack not deployed)"',
+            "    return",
+            "  fi",
             "  set +e",
             # Pipeline is three-stage: rclone | tee | grep. PIPESTATUS
             # indexes accordingly:
@@ -889,8 +938,8 @@ def render_restore_script(
         # genuine first-spin-up path still reaches the latest.txt
         # check below and exits 0 with the fresh-start message.
         'if ! rclone lsd "$BUCKET" --max-depth 1 >/dev/null 2>&1; then',
-        '  echo "✗ restore-failed: bucket $BUCKET is not reachable '
-        '(check R2 credentials / endpoint / bucket name)" >&2',
+        '  echo "✗ restore-failed: bucket $BUCKET is not reachable" >&2',
+        '  echo "  (check R2 credentials / endpoint / bucket name)" >&2',
         "  exit 2",
         "fi",
         # Detect "no snapshot yet" by listing the parent prefix and

--- a/src/nexus_deploy/s3_persistence.py
+++ b/src/nexus_deploy/s3_persistence.py
@@ -893,16 +893,36 @@ def render_restore_script(
         '(check R2 credentials / endpoint / bucket name)" >&2',
         "  exit 2",
         "fi",
-        # `rclone copyto` returns rc=0 even on missing source if we
-        # use `--ignore-checksum --error-on-no-transfer=false`, but
-        # the simplest probe is `rclone lsf` which exits non-zero
-        # if the file is missing. Wrap it in an explicit check so
-        # the absence-case branches cleanly.
-        'if ! rclone lsf "$BUCKET/snapshots/latest.txt" >/dev/null 2>&1; then',
+        # Detect "no snapshot yet" by checking lsf's STDOUT, not its
+        # exit code. Ubuntu 24.04's apt rclone (v1.60.1) returns
+        # rc=0 with empty stdout for a missing object — so an
+        # ``if ! rclone lsf ... >/dev/null`` check NEVER fires on
+        # this version and falls through to ``copyto``, which then
+        # also silently returns rc=0 without creating the local
+        # file. The first observable failure is the ``tr -d < ...``
+        # line below ("No such file or directory"), which is a
+        # confusing diagnostic and an ``rc=1`` instead of the
+        # intended ``rc=0`` fresh-start branch. Newer rclone
+        # versions DO return non-zero on missing source, but we
+        # can't depend on apt-version-skew, so check the listing
+        # output directly: empty = object missing = fresh-start.
+        'if [ -z "$(rclone lsf "$BUCKET/snapshots/latest.txt" 2>/dev/null)" ]; then',
         '  echo "fresh-start: no snapshot in S3, leaving local state empty"',
         "  exit 0",
         "fi",
         'rclone copyto "$BUCKET/snapshots/latest.txt" "$WORKDIR/latest.txt"',
+        # Defence in depth — same rclone-1.60.1 quirk: copyto can
+        # return rc=0 without writing the destination. If the lsf
+        # check above somehow passed but the file still isn't on
+        # disk, fail loud rather than letting the next ``tr -d``
+        # leak its kernel-level "No such file or directory" out
+        # as the only diagnostic.
+        'if [ ! -s "$WORKDIR/latest.txt" ]; then',
+        '  echo "✗ restore-failed: rclone copyto did not produce '
+        "$WORKDIR/latest.txt (or it's empty) — likely rclone version "
+        'mismatch or transient S3 issue" >&2',
+        "  exit 2",
+        "fi",
         'TIMESTAMP=$(tr -d "\\r\\n" < "$WORKDIR/latest.txt")',
         'if [[ ! "$TIMESTAMP" =~ ^[0-9A-Za-z_-]+$ ]]; then',
         '  echo "✗ restore-failed: latest.txt has invalid timestamp" >&2',

--- a/src/nexus_deploy/s3_persistence.py
+++ b/src/nexus_deploy/s3_persistence.py
@@ -893,30 +893,38 @@ def render_restore_script(
         '(check R2 credentials / endpoint / bucket name)" >&2',
         "  exit 2",
         "fi",
-        # Detect "no snapshot yet" by capturing lsf's STDOUT into a
-        # variable, with explicit handling for non-zero exit codes.
-        # Two rclone behaviors to cover:
-        #   - Ubuntu 24.04's apt rclone (v1.60.1) returns rc=0 with
-        #     empty stdout for a missing object.
-        #   - Newer rclone versions return non-zero on missing.
-        # We can't depend on apt-version-skew, so both cases must
-        # land in the fresh-start branch.
+        # Detect "no snapshot yet" by listing the parent prefix and
+        # checking whether ``latest.txt`` is among the entries.
+        # Critically: a non-zero exit from this listing is a HARD
+        # ERROR (rc=2), not "fresh-start" — otherwise a transient
+        # S3 blip between the bucket-reachability probe above and
+        # this call would silently empty local state, and the next
+        # teardown would overwrite real R2 data with empty snapshots.
         #
-        # Why the explicit ``if !`` capture instead of ``[ -z "$(cmd)"
-        # ]`` — the simpler form works under default ``set -euo
-        # pipefail`` because (a) commands in if-tests bypass errexit
-        # and (b) command substitutions don't inherit errexit unless
-        # ``shopt -s inherit_errexit`` is set. But that's a subtle
-        # POSIX rule, and a future maintainer enabling
-        # inherit_errexit (or running the script under a stricter
-        # shell config) would have the script abort here instead of
-        # fresh-starting. The explicit assignment-in-if form is
-        # robust regardless of errexit settings.
-        'LATEST_LISTING=""',
-        'if ! LATEST_LISTING=$(rclone lsf "$BUCKET/snapshots/latest.txt" 2>/dev/null); then',
-        '  LATEST_LISTING=""',
+        # Two distinct empty-prefix vs missing-file paths:
+        #   - bucket reachable, prefix empty (no objects under
+        #     ``snapshots/``) → genuine first spin-up, fresh-start
+        #     (rc=0 from listing, empty stdout, grep returns
+        #     non-zero).
+        #   - bucket reachable, prefix has objects but no
+        #     ``latest.txt`` → orphan snapshot trees from a failed
+        #     ``snapshot_to_s3`` (atomicity guarantee: latest.txt is
+        #     the LAST thing written). Still fresh-start — the
+        #     orphans cost storage but don't affect restoration.
+        #   - listing itself fails (auth/network/perm) → exit 2
+        #     loud, so the operator sees the real cause instead of
+        #     a silent fresh-start that paves over real data.
+        #
+        # Don't suppress stderr — rclone's diagnostic on failure is
+        # what tells the operator whether it's auth, network, or
+        # bucket policy. Quiet on success.
+        'SNAPSHOT_LISTING=""',
+        'if ! SNAPSHOT_LISTING=$(rclone lsf "$BUCKET/snapshots/"); then',
+        '  echo "✗ restore-failed: cannot list $BUCKET/snapshots/ — '
+        'see rclone error above (auth / network / bucket policy)" >&2',
+        "  exit 2",
         "fi",
-        'if [ -z "$LATEST_LISTING" ]; then',
+        'if ! printf "%s\\n" "$SNAPSHOT_LISTING" | grep -qxF "latest.txt"; then',
         '  echo "fresh-start: no snapshot in S3, leaving local state empty"',
         "  exit 0",
         "fi",

--- a/src/nexus_deploy/s3_persistence.py
+++ b/src/nexus_deploy/s3_persistence.py
@@ -893,20 +893,30 @@ def render_restore_script(
         '(check R2 credentials / endpoint / bucket name)" >&2',
         "  exit 2",
         "fi",
-        # Detect "no snapshot yet" by checking lsf's STDOUT, not its
-        # exit code. Ubuntu 24.04's apt rclone (v1.60.1) returns
-        # rc=0 with empty stdout for a missing object — so an
-        # ``if ! rclone lsf ... >/dev/null`` check NEVER fires on
-        # this version and falls through to ``copyto``, which then
-        # also silently returns rc=0 without creating the local
-        # file. The first observable failure is the ``tr -d < ...``
-        # line below ("No such file or directory"), which is a
-        # confusing diagnostic and an ``rc=1`` instead of the
-        # intended ``rc=0`` fresh-start branch. Newer rclone
-        # versions DO return non-zero on missing source, but we
-        # can't depend on apt-version-skew, so check the listing
-        # output directly: empty = object missing = fresh-start.
-        'if [ -z "$(rclone lsf "$BUCKET/snapshots/latest.txt" 2>/dev/null)" ]; then',
+        # Detect "no snapshot yet" by capturing lsf's STDOUT into a
+        # variable, with explicit handling for non-zero exit codes.
+        # Two rclone behaviors to cover:
+        #   - Ubuntu 24.04's apt rclone (v1.60.1) returns rc=0 with
+        #     empty stdout for a missing object.
+        #   - Newer rclone versions return non-zero on missing.
+        # We can't depend on apt-version-skew, so both cases must
+        # land in the fresh-start branch.
+        #
+        # Why the explicit ``if !`` capture instead of ``[ -z "$(cmd)"
+        # ]`` — the simpler form works under default ``set -euo
+        # pipefail`` because (a) commands in if-tests bypass errexit
+        # and (b) command substitutions don't inherit errexit unless
+        # ``shopt -s inherit_errexit`` is set. But that's a subtle
+        # POSIX rule, and a future maintainer enabling
+        # inherit_errexit (or running the script under a stricter
+        # shell config) would have the script abort here instead of
+        # fresh-starting. The explicit assignment-in-if form is
+        # robust regardless of errexit settings.
+        'LATEST_LISTING=""',
+        'if ! LATEST_LISTING=$(rclone lsf "$BUCKET/snapshots/latest.txt" 2>/dev/null); then',
+        '  LATEST_LISTING=""',
+        "fi",
+        'if [ -z "$LATEST_LISTING" ]; then',
         '  echo "fresh-start: no snapshot in S3, leaving local state empty"',
         "  exit 0",
         "fi",

--- a/src/nexus_deploy/s3_persistence.py
+++ b/src/nexus_deploy/s3_persistence.py
@@ -517,16 +517,27 @@ def render_snapshot_script(
     Steps the rendered script performs (in order, ``set -euo
     pipefail`` throughout — first failure aborts):
 
-    1. ``docker compose stop`` for every file in
+    1. ``pg_dump -F c | gzip`` for each postgres target into
+       ``/tmp/nexus-snapshot/postgres/<db>.dump.gz`` (custom
+       binary format, gzipped — works with the matching
+       ``gunzip | pg_restore`` on the spinup side). Runs FIRST
+       while the postgres containers are still running — pg_dump
+       is a client tool that requires a live server. The earlier
+       "stop first, dump second" form failed every snapshot
+       with "container is not running". pg_dump's MVCC gives a
+       consistent snapshot internally; the small window between
+       dump and stop may lose writes that happened in that gap
+       (acceptable for a teardown use case at low traffic).
+       Per-target skip if the container isn't running (``docker
+       inspect --format='{{.State.Running}}'``).
+    2. ``docker compose stop`` for every file in
        ``stop_compose_files``. Graceful drain with the default
        10s timeout: app processes finish in-flight requests and
        close DB connections cleanly. We deliberately do NOT use
        ``docker compose pause`` — that's a cgroup-freezer SIGSTOP
-       and hard-kills in-flight writes mid-transaction.
-    2. ``pg_dump -F c | gzip`` for each postgres target into
-       ``/tmp/nexus-snapshot/postgres/<db>.dump.gz`` (custom
-       binary format, gzipped — works with the matching
-       ``gunzip | pg_restore`` on the spinup side).
+       and hard-kills in-flight writes mid-transaction. Runs
+       AFTER pg_dump so the DB is up at dump time. Per-file skip
+       if the compose file isn't on disk (stack not deployed).
     3. ``rclone sync`` each rsync target's ``local_path`` into the
        timestamped R2 directory ``snapshots/<timestamp>/<s3_subpath>``.
        Only the listed targets are walked — db/ and redis/ subdirs
@@ -597,15 +608,68 @@ def render_snapshot_script(
         "",
     ]
 
+    # Order matters here. pg_dump MUST run BEFORE compose-stop,
+    # not after — ``docker compose stop`` halts the postgres
+    # container, after which ``docker exec <container> pg_dump``
+    # fails with "container is not running". The original RFC-0001
+    # design (stop → drain → dump) assumed pg_dump could read the
+    # on-disk data dir directly after a graceful stop, but pg_dump
+    # is a CLIENT tool that needs a running server. We accept the
+    # small inconsistency window (apps may write new rows between
+    # pg_dump and compose-stop) — pg_dump's MVCC snapshot is
+    # internally consistent, and the post-dump writes are simply
+    # lost on restore. For the v1.0 teardown use case (deliberate
+    # shutdown at low traffic) this is acceptable; if a future
+    # use case needs hard-stop consistency, the right answer is
+    # filesystem-level snapshot of ``/mnt/nexus-data/<stack>/db``
+    # AFTER compose-stop, not pg_dump.
+    if pg_targets:
+        lines.append('echo "→ snapshot: dumping postgres databases (online)"')
+        for pg in pg_targets:
+            container = shlex.quote(pg.container)
+            db = shlex.quote(pg.database)
+            user = shlex.quote(pg.user)
+            # File naming: ``<database>.dump.gz`` (custom binary
+            # pg_dump format, gzipped) — matches the restore-side
+            # filename and the RFC's stated S3 layout. Earlier this
+            # said ``.sql.gz`` which was misleading since the body
+            # is NOT plain SQL (``-F c`` produces a binary archive).
+            dump_file = f"$POSTGRES_DIR/{pg.database}.dump.gz"
+            # Skip if the postgres container isn't RUNNING on this
+            # server. Two distinct skip cases:
+            #   - container doesn't exist (stack not deployed)
+            #   - container exists but is stopped (previous crashed
+            #     run, or operator stopped it manually)
+            # Both have the same outcome: no dump captured. We
+            # explicitly check ``.State.Running == "true"`` rather
+            # than just ``docker inspect`` because the latter
+            # succeeds for stopped containers, and we already hit
+            # that bug once (compose-stop happened before pg_dump
+            # in an earlier revision, leaving the container stopped
+            # but inspectable).
+            lines.append(
+                f"if [ \"$(docker inspect --format='{{{{.State.Running}}}}' "
+                f'{container} 2>/dev/null)" = "true" ]; then',
+            )
+            lines.append(
+                f"  docker exec {container} pg_dump -U {user} -d {db} -F c | gzip -9 > {dump_file}",
+            )
+            lines.append("else")
+            lines.append(
+                f'  echo "  (skip: container {pg.container} not running — stack not deployed or stopped)"',
+            )
+            lines.append("fi")
+        lines.append("")
+
     if stop_files:
         lines.append('echo "→ snapshot: stopping compose stacks (graceful 10s drain)"')
         for compose_file in stop_files:
             quoted = shlex.quote(compose_file)
-            # ``docker compose stop`` (not ``pause``) — the latter is
+            # ``docker compose stop`` (not ``pause``) — ``pause`` is
             # SIGSTOP via the cgroup freezer and hard-kills in-flight
             # writes. ``stop`` sends SIGTERM with a 10s grace window
-            # for the container to flush + close DB connections
-            # cleanly.
+            # for the container to flush + close. Runs AFTER pg_dump
+            # above (so the DB is still up when pg_dump runs).
             #
             # The previous form used a blanket ``|| echo "non-fatal"``
             # which would swallow every non-zero exit — missing
@@ -625,26 +689,13 @@ def render_snapshot_script(
             # the snapshot on any non-zero exit, surfacing missing-
             # compose-file / daemon-down / YAML-syntax errors as
             # the real failures they are.
-            #
-            # An earlier revision of this block evaluated only the
-            # stdout via ``[ -n "$(... 2>/dev/null)" ]`` — that
-            # silently mapped every ps failure (which produces
-            # empty stdout) to "stack already down" and continued
-            # the snapshot while services were still running.
-            # We now capture ps's exit code explicitly via
-            # ``set +e`` so the empty-stdout-from-failure case
-            # can't masquerade as the empty-stdout-from-no-
-            # containers case.
             lines.append(f"COMPOSE_FILE={quoted}")
             # Skip cleanly if the compose file isn't on disk —
             # ``stop_compose_files`` is a static list of stacks the
             # persistence layer KNOWS ABOUT; whether a given stack
             # is actually deployed on this server is decided by D1
             # (enabled_services). A stack absent from disk just
-            # means it isn't enabled here, not an error. Treating
-            # this as benign-skip (with an explicit log line so
-            # operators see it) keeps the snapshot deterministic
-            # across partially-deployed configurations.
+            # means it isn't enabled here, not an error.
             lines.append('if [ ! -f "$COMPOSE_FILE" ]; then')
             lines.append(
                 f'  echo "  (skip: compose file {compose_file} not on disk — stack not deployed)"',
@@ -661,33 +712,6 @@ def render_snapshot_script(
             lines.append("  else")
             lines.append('    docker compose -f "$COMPOSE_FILE" stop')
             lines.append("  fi")
-            lines.append("fi")
-        lines.append("")
-
-    if pg_targets:
-        lines.append('echo "→ snapshot: dumping postgres databases"')
-        for pg in pg_targets:
-            container = shlex.quote(pg.container)
-            db = shlex.quote(pg.database)
-            user = shlex.quote(pg.user)
-            # File naming: ``<database>.dump.gz`` (custom binary
-            # pg_dump format, gzipped) — matches the restore-side
-            # filename and the RFC's stated S3 layout. Earlier this
-            # said ``.sql.gz`` which was misleading since the body
-            # is NOT plain SQL (``-F c`` produces a binary archive).
-            dump_file = f"$POSTGRES_DIR/{pg.database}.dump.gz"
-            # Same "stack not deployed" handling as the compose-stop
-            # block: skip if the postgres container isn't even
-            # running on this server, so partially-deployed stacks
-            # don't fail teardown.
-            lines.append(f"if docker inspect {container} >/dev/null 2>&1; then")
-            lines.append(
-                f"  docker exec {container} pg_dump -U {user} -d {db} -F c | gzip -9 > {dump_file}",
-            )
-            lines.append("else")
-            lines.append(
-                f'  echo "  (skip: container {pg.container} not present — stack not deployed)"',
-            )
             lines.append("fi")
         lines.append("")
 

--- a/src/nexus_deploy/setup.py
+++ b/src/nexus_deploy/setup.py
@@ -473,8 +473,11 @@ def ensure_rclone(ssh: SSHClient) -> bool:
     BEFORE the probe runs, which is what this helper does.
 
     Raises :class:`subprocess.CalledProcessError` on install failure.
-    The Ubuntu 24.04 main repo carries rclone 1.65, which is recent
-    enough for the S3/R2 operations we use.
+    The Ubuntu 24.04 main repo carries rclone 1.60.1, which is old
+    enough that ``rclone lsf`` returns rc=0 with empty stdout for a
+    missing object (newer rclone versions return non-zero). The
+    rendered restore script in ``s3_persistence.render_restore_script``
+    accounts for this by checking lsf's STDOUT, not its exit code.
     """
     check = ssh.run("command -v rclone", check=False)
     if check.returncode == 0:

--- a/tests/unit/test_s3_persistence.py
+++ b/tests/unit/test_s3_persistence.py
@@ -840,24 +840,32 @@ def test_restore_script_detects_missing_latest_via_lsf_stdout_not_exit_code() ->
         postgres_targets=(),
         rsync_targets=(),
     )
-    # The fresh-start guard must (a) capture lsf STDOUT into a
-    # variable, (b) tolerate a non-zero exit from lsf by resetting
-    # the variable to empty, and (c) test the variable for emptiness.
-    # Pin all three so a future "simplification" can't regress us
-    # back to ``if ! rclone lsf ...`` (broken on rclone 1.60) OR
-    # to ``[ -z "$(rclone lsf ...)" ]`` (depends on errexit-in-cmd-
-    # sub semantics that change with shopt inherit_errexit).
-    assert "LATEST_LISTING=" in script, "fresh-start guard must capture lsf stdout into a variable"
-    assert "if ! LATEST_LISTING=$(rclone lsf" in script, (
-        "fresh-start guard must tolerate non-zero exit from lsf "
-        "(newer rclone returns non-zero on missing object)"
-    )
+    # The fresh-start guard must list the PARENT prefix (so empty
+    # listing = empty bucket = fresh-start) and treat a non-zero
+    # exit from the listing as a HARD ERROR (not fresh-start) —
+    # otherwise a transient S3 blip after the bucket-reachability
+    # probe would silently empty local state, and the next teardown
+    # would overwrite real R2 data. Pin the exact bash shape so a
+    # future "simplification" can't regress us into any of the
+    # previous broken forms:
+    #   - ``if ! rclone lsf .../latest.txt >/dev/null`` (rclone-1.60
+    #     returns rc=0 on missing → never enters branch)
+    #   - ``[ -z "$(rclone lsf ...)" ]`` (depends on errexit-in-
+    #     cmd-sub semantics that flip with inherit_errexit)
+    #   - ``if ! VAR=$(rclone lsf .../latest.txt); then VAR=""`` →
+    #     treats transient errors as fresh-start (round-2 form)
     assert (
-        'if [ -z "$LATEST_LISTING" ]; then' in script
-    ), "fresh-start guard must test the captured variable for emptiness"
-    # And a defence-in-depth check: even if lsf passed but copyto
-    # didn't actually produce the file, fail loud (exit 2) rather
-    # than letting the next ``tr -d`` leak its kernel error.
+        'SNAPSHOT_LISTING=$(rclone lsf "$BUCKET/snapshots/")' in script
+    ), "fresh-start guard must list the parent prefix, not the file directly"
+    assert (
+        'grep -qxF "latest.txt"' in script
+    ), "fresh-start guard must check for latest.txt as a whole-line fixed match"
+    # Hard error path — listing failure must exit 2, NOT fresh-start.
+    assert "cannot list" in script
+    # And a defence-in-depth check: even if listing passed and
+    # copyto ran but copyto didn't actually produce the file, fail
+    # loud (exit 2) rather than letting the next ``tr -d`` leak
+    # its kernel error.
     assert '[ ! -s "$WORKDIR/latest.txt" ]' in script
 
 
@@ -874,10 +882,10 @@ def test_restore_script_probes_bucket_reachability_before_fresh_start() -> None:
         rsync_targets=(),
     )
     probe_pos = script.find('rclone lsd "$BUCKET"')
-    fresh_check_pos = script.find('rclone lsf "$BUCKET/snapshots/latest.txt"')
+    fresh_check_pos = script.find('rclone lsf "$BUCKET/snapshots/"')
     assert (
         0 < probe_pos < fresh_check_pos
-    ), "bucket reachability probe must precede the latest.txt check"
+    ), "bucket reachability probe must precede the snapshot-prefix listing"
     assert "not reachable" in script
     # The probe failure path must exit non-zero (clear error), the
     # latest.txt failure path must exit 0 (legitimate fresh-start).

--- a/tests/unit/test_s3_persistence.py
+++ b/tests/unit/test_s3_persistence.py
@@ -470,10 +470,14 @@ def test_snapshot_script_has_bash_safety_pragmas() -> None:
 
 
 def test_snapshot_script_orders_phases_correctly() -> None:
-    """The phase order is the atomicity contract: stop → dump →
-    upload → verify → point latest. Reorder would silently break
-    the guarantee that ``snapshots/latest.txt`` only updates after
-    upload succeeded.
+    """The phase order is the atomicity contract: **dump → stop →
+    upload → verify → point latest**. Note dump comes BEFORE stop —
+    pg_dump is a client tool that requires the postgres container
+    running, so stopping it first leaves dump with nothing to
+    connect to. The earlier "stop first, dump second" form failed
+    every real teardown with "container is not running". Reorder
+    would silently break the guarantee that ``snapshots/latest.txt``
+    only updates after upload succeeded.
 
     We use ``docker compose stop`` (graceful 10s drain), not
     ``pause`` (SIGSTOP via cgroup freezer, hard-kills in-flight
@@ -497,12 +501,14 @@ def test_snapshot_script_orders_phases_correctly() -> None:
         stop_compose_files=("/opt/docker-server/stacks/gitea/docker-compose.yml",),
     )
     # Locate each phase via a stable substring + assert ordering.
-    stop_pos = script.find("compose -f")
+    # **dump → stop** is the load-bearing ordering: pg_dump needs
+    # the container running, so it must come before compose-stop.
     dump_pos = script.find("pg_dump")
+    stop_pos = script.find("compose -f")
     upload_pos = script.find("rclone sync")
     check_pos = script.find("rclone check")
     latest_pos = script.find("snapshots/latest.txt")
-    assert stop_pos < dump_pos < upload_pos < check_pos < latest_pos
+    assert dump_pos < stop_pos < upload_pos < check_pos < latest_pos
     # Regression: stop, not pause, AND no `... || echo` blanket
     # error-swallowing (per CLAUDE.md "Never silently swallow
     # errors in critical operations"). The current implementation
@@ -570,8 +576,14 @@ def test_snapshot_script_skips_compose_stop_when_file_missing() -> None:
     # missing container today produces an opaque "Error: No such
     # container" with rc=1 which set -e turns into a teardown
     # abort.
-    assert "docker inspect gitea-db" in script
-    assert "container dify-db not present" in script
+    # pg_dump must guard with `docker inspect --format='{{.State.Running}}'`
+    # — a missing container (not deployed) AND a stopped container
+    # (e.g. crashed earlier) both produce non-"true" output, both
+    # land in the skip branch. Bare `docker inspect <c>` would
+    # incorrectly succeed for stopped containers, then `docker
+    # exec` would fail with rc=1 and abort the snapshot.
+    assert "docker inspect --format='{{.State.Running}}' gitea-db" in script
+    assert "container dify-db not running" in script
     # rsync sync must guard with `[ -d <path> ]`. The verify_one
     # function (called for every rs_target) must short-circuit on
     # missing source too — verifying a non-existent local dir

--- a/tests/unit/test_s3_persistence.py
+++ b/tests/unit/test_s3_persistence.py
@@ -809,6 +809,51 @@ def test_restore_script_drops_database_before_pg_restore() -> None:
     assert "pg_restore -U nexus-gitea -d gitea" in script
 
 
+def test_restore_script_skips_pg_restore_when_dump_missing_or_container_absent() -> None:
+    """Symmetric "stack not deployed" handling between snapshot
+    and restore. Two distinct skip cases on the restore side:
+
+    1. The dump file isn't in WORKDIR/postgres/ because the
+       snapshot side skipped that DB (container wasn't running
+       at snapshot time).
+    2. The dump exists but the target container isn't running
+       on this restore stack (snapshot composition differs from
+       restore composition — e.g. dify snapshotted but not
+       restored).
+
+    Without these guards, ``gunzip ... | docker exec dify-db
+    pg_restore`` aborts the whole restore with "No such file"
+    or "No such container". This is the symmetric fix to the
+    snapshot-side pg_dump skip guard.
+
+    Real incident: first end-to-end restore test of PR #557 —
+    snapshot correctly skipped dify-db (not deployed), but
+    restore tried to ``docker exec dify-db`` and aborted with
+    rc=1 → spin-up failed."""
+    script = render_restore_script(
+        endpoint=_endpoint(),
+        postgres_targets=(
+            PostgresDumpTarget(container="gitea-db", database="gitea", user="nexus-gitea"),
+            PostgresDumpTarget(container="dify-db", database="dify", user="nexus-dify"),
+        ),
+        rsync_targets=(),
+    )
+    # Both guards must be present, in the right shape, before the
+    # docker exec / gunzip lines that would otherwise crash.
+    assert "if [ ! -f $WORKDIR/postgres/gitea.dump.gz ]" in script
+    assert "if [ ! -f $WORKDIR/postgres/dify.dump.gz ]" in script
+    assert "no dump for dify" in script
+    assert "no dump for gitea" in script
+    assert "container dify-db not running" in script
+    assert "container gitea-db not running" in script
+    # And the skip path must be an EARLY return — no DROP DATABASE
+    # / gunzip / pg_restore on the dify side when container's gone.
+    # Pin the if-elif-else structure so the guards can't be silently
+    # bypassed by a future refactor.
+    assert "docker inspect --format='{{.State.Running}}' dify-db" in script
+    assert "docker inspect --format='{{.State.Running}}' gitea-db" in script
+
+
 def test_restore_script_pulls_filesystem_trees_before_postgres() -> None:
     """Order matters: restore the FS first (in case any postgres
     init script reads a config file from the FS), THEN pg_restore.

--- a/tests/unit/test_s3_persistence.py
+++ b/tests/unit/test_s3_persistence.py
@@ -526,6 +526,61 @@ def test_snapshot_script_orders_phases_correctly() -> None:
     assert '[ "$PS_RC" -eq 0 ] && [ -z "$PS_OUT" ]' in stop_block
 
 
+def test_snapshot_script_skips_compose_stop_when_file_missing() -> None:
+    """If a compose file isn't on disk the snapshot must skip its
+    stop step cleanly (stack-not-deployed) instead of letting
+    ``docker compose stop`` abort with 'no such file or directory'.
+    Same pattern for the rsync + pg_dump targets below. Real
+    incident: PR #557 first teardown of the cutover snapshotted
+    gitea successfully then failed on dify because dify wasn't
+    deployed on that server. The persistence layer can't assume
+    every stack in its target list is actually present."""
+    script = render_snapshot_script(
+        endpoint=_endpoint(),
+        stack_slug="nexus-test",
+        template_version="v0.56.0",
+        timestamp="20260510T120000Z",
+        postgres_targets=(
+            PostgresDumpTarget(container="gitea-db", database="gitea", user="nexus-gitea"),
+            PostgresDumpTarget(container="dify-db", database="dify", user="nexus-dify"),
+        ),
+        rsync_targets=(
+            RsyncTarget(
+                name="gitea-repos",
+                local_path="/var/lib/nexus-data/gitea/repos",
+                s3_subpath="gitea/repos",
+            ),
+            RsyncTarget(
+                name="dify-db",
+                local_path="/var/lib/nexus-data/dify/db",
+                s3_subpath="dify/db",
+            ),
+        ),
+        stop_compose_files=(
+            "/opt/docker-server/stacks/gitea/docker-compose.yml",
+            "/opt/docker-server/stacks/dify/docker-compose.yml",
+        ),
+    )
+    # Compose-stop must guard with `[ -f "$COMPOSE_FILE" ]` before
+    # touching docker. The skip branch must log explicitly so
+    # operators see WHY the stack wasn't stopped.
+    assert 'if [ ! -f "$COMPOSE_FILE" ]; then' in script
+    assert "stack not deployed" in script
+    # pg_dump must guard with `docker inspect <container>` — a
+    # missing container today produces an opaque "Error: No such
+    # container" with rc=1 which set -e turns into a teardown
+    # abort.
+    assert "docker inspect gitea-db" in script
+    assert "container dify-db not present" in script
+    # rsync sync must guard with `[ -d <path> ]`. The verify_one
+    # function (called for every rs_target) must short-circuit on
+    # missing source too — verifying a non-existent local dir
+    # against an empty S3 prefix would otherwise mark the snapshot
+    # as drifted and abort.
+    assert "if [ -d /var/lib/nexus-data/dify/db ]" in script
+    assert 'if [ ! -d "$src" ]; then' in script
+
+
 def test_snapshot_script_omits_compose_stop_when_no_files_passed() -> None:
     """No compose files passed → no docker compose calls at all.
     Avoids the ``no compose files`` echo-only no-op block."""

--- a/tests/unit/test_s3_persistence.py
+++ b/tests/unit/test_s3_persistence.py
@@ -823,6 +823,36 @@ def test_restore_script_rejects_unknown_phase() -> None:
         )
 
 
+def test_restore_script_detects_missing_latest_via_lsf_stdout_not_exit_code() -> None:
+    """Ubuntu 24.04's apt rclone (v1.60.1) returns rc=0 with empty
+    stdout for a missing remote object, so an ``if ! rclone lsf ...``
+    check NEVER fires the fresh-start branch on that version — the
+    script falls through to ``copyto`` (also rc=0, no local file
+    created), and the first observable failure is the kernel-level
+    ``tr -d < missing-file`` line ("No such file or directory")
+    masquerading as rc=1. Use lsf's STDOUT instead: empty = missing.
+
+    This is the bug that broke PR #556's first-real-spinup test —
+    the rcfix unblocked the install, but the rclone-1.60.1 lsf
+    behaviour made every fresh bucket fail-instead-of-fresh-start."""
+    script = render_restore_script(
+        endpoint=_endpoint(),
+        postgres_targets=(),
+        rsync_targets=(),
+    )
+    # The fresh-start guard must read lsf STDOUT (and treat empty as
+    # missing), not just the exit code. Pin the exact bash form so a
+    # future "simplification" can't regress us back to ``if ! rclone
+    # lsf ...``.
+    assert (
+        '[ -z "$(rclone lsf' in script
+    ), "fresh-start guard must inspect lsf STDOUT not just exit code"
+    # And a defence-in-depth check: even if lsf passed but copyto
+    # didn't actually produce the file, fail loud (exit 2) rather
+    # than letting the next ``tr -d`` leak its kernel error.
+    assert '[ ! -s "$WORKDIR/latest.txt" ]' in script
+
+
 def test_restore_script_probes_bucket_reachability_before_fresh_start() -> None:
     """A bare ``rclone lsf latest.txt`` failure is ambiguous: missing
     object OR auth/network error. Treating both as "fresh-start"
@@ -837,9 +867,9 @@ def test_restore_script_probes_bucket_reachability_before_fresh_start() -> None:
     )
     probe_pos = script.find('rclone lsd "$BUCKET"')
     fresh_check_pos = script.find('rclone lsf "$BUCKET/snapshots/latest.txt"')
-    assert 0 < probe_pos < fresh_check_pos, (
-        "bucket reachability probe must precede the latest.txt check"
-    )
+    assert (
+        0 < probe_pos < fresh_check_pos
+    ), "bucket reachability probe must precede the latest.txt check"
     assert "not reachable" in script
     # The probe failure path must exit non-zero (clear error), the
     # latest.txt failure path must exit 0 (legitimate fresh-start).

--- a/tests/unit/test_s3_persistence.py
+++ b/tests/unit/test_s3_persistence.py
@@ -840,13 +840,21 @@ def test_restore_script_detects_missing_latest_via_lsf_stdout_not_exit_code() ->
         postgres_targets=(),
         rsync_targets=(),
     )
-    # The fresh-start guard must read lsf STDOUT (and treat empty as
-    # missing), not just the exit code. Pin the exact bash form so a
-    # future "simplification" can't regress us back to ``if ! rclone
-    # lsf ...``.
+    # The fresh-start guard must (a) capture lsf STDOUT into a
+    # variable, (b) tolerate a non-zero exit from lsf by resetting
+    # the variable to empty, and (c) test the variable for emptiness.
+    # Pin all three so a future "simplification" can't regress us
+    # back to ``if ! rclone lsf ...`` (broken on rclone 1.60) OR
+    # to ``[ -z "$(rclone lsf ...)" ]`` (depends on errexit-in-cmd-
+    # sub semantics that change with shopt inherit_errexit).
+    assert "LATEST_LISTING=" in script, "fresh-start guard must capture lsf stdout into a variable"
+    assert "if ! LATEST_LISTING=$(rclone lsf" in script, (
+        "fresh-start guard must tolerate non-zero exit from lsf "
+        "(newer rclone returns non-zero on missing object)"
+    )
     assert (
-        '[ -z "$(rclone lsf' in script
-    ), "fresh-start guard must inspect lsf STDOUT not just exit code"
+        'if [ -z "$LATEST_LISTING" ]; then' in script
+    ), "fresh-start guard must test the captured variable for emptiness"
     # And a defence-in-depth check: even if lsf passed but copyto
     # didn't actually produce the file, fail loud (exit 2) rather
     # than letting the next ``tr -d`` leak its kernel error.

--- a/tests/unit/test_s3_persistence.py
+++ b/tests/unit/test_s3_persistence.py
@@ -649,6 +649,40 @@ def test_snapshot_script_rejects_unsafe_timestamp() -> None:
         )
 
 
+def test_snapshot_script_verify_logs_live_outside_workdir() -> None:
+    """The rclone-check stderr/stdout dumps MUST live OUTSIDE
+    ``$WORKDIR``. The first verify_one call compares ``$WORKDIR``
+    against S3; if the dumps lived inside $WORKDIR they'd appear
+    as untracked extras and rclone would report 'differences
+    found', failing every snapshot.
+
+    Real incident: PR #557 first end-to-end teardown surfaced this
+    after every other layer was patched — the verify gate fired
+    for the first time ever, the manifest+pg-dumps verify
+    reported 2 diffs (rclone-check.err + rclone-check.out), and
+    the snapshot aborted without flipping snapshots/latest.txt.
+    """
+    script = render_snapshot_script(
+        endpoint=_endpoint(),
+        stack_slug="nexus-test",
+        template_version="v0.56.0",
+        timestamp="20260510T120000Z",
+        postgres_targets=(
+            PostgresDumpTarget(container="gitea-db", database="gitea", user="nexus-gitea"),
+        ),
+        rsync_targets=(),
+    )
+    # Scratch dir for verify-phase logs must be declared separately
+    # and live outside $WORKDIR.
+    assert "LOG_DIR=/tmp/nexus-snapshot-logs" in script
+    # The rclone-check redirects must go to LOG_DIR, NOT WORKDIR.
+    assert '2>"$LOG_DIR/rclone-check.err"' in script
+    assert '"$LOG_DIR/rclone-check.out"' in script
+    # And NOTHING should write rclone-check.{err,out} into WORKDIR
+    # — the regression we're guarding against.
+    assert "WORKDIR/rclone-check" not in script
+
+
 def test_snapshot_script_atomicity_gate_distinguishes_two_failure_modes() -> None:
     """The atomicity gate must distinguish (a) rclone-check itself
     erroring (auth/network/quota) from (b) drift found via the

--- a/tests/unit/test_s3_persistence.py
+++ b/tests/unit/test_s3_persistence.py
@@ -664,15 +664,23 @@ def test_snapshot_script_atomicity_gate_distinguishes_two_failure_modes() -> Non
         rsync_targets=(),
     )
     assert "rclone check" in script
-    # Both PIPESTATUS captures must be present in the verify_one helper.
-    # Pipeline is `rclone | tee | grep`, so PIPESTATUS indexes are:
-    #   [0] = rclone (the integrity check), [1] = tee (always 0),
-    #   [2] = grep (0 = drift markers found, 1 = clean).
-    # An earlier revision had drift_rc=[1] (tee) which made the gate
-    # report "drift" on every snapshot — locking in [2] (grep) here
-    # is the regression test.
-    assert "rclone_rc=${PIPESTATUS[0]}" in script
-    assert "drift_rc=${PIPESTATUS[2]}" in script
+    # PIPESTATUS must be captured into a LOCAL ARRAY immediately
+    # after the pipeline runs, BEFORE any other command (including
+    # `local`). The `local` builtin overwrites PIPESTATUS with its
+    # own single-element exit-code array, so two separate
+    # `local rclone_rc=${PIPESTATUS[0]}; local drift_rc=${PIPESTATUS[2]}`
+    # would fail with "PIPESTATUS[2]: unbound variable" under
+    # set -u — the second `local` reads from the already-clobbered
+    # 1-element array.
+    #
+    # Regression pin for two distinct bugs in the same line block:
+    #   - drift_rc must read [2] (grep), not [1] (tee — always 0,
+    #     would make every snapshot report drift)
+    #   - the capture must be a single `local ps=("${PIPESTATUS[@]}")`
+    #     before the two reads, NOT two separate `local` lines
+    assert 'local pipeline_status=("${PIPESTATUS[@]}")' in script
+    assert "rclone_rc=${pipeline_status[0]}" in script
+    assert "drift_rc=${pipeline_status[2]}" in script
     # And both abort messages must distinguish the two modes.
     assert "snapshot-failed: rclone check ${label} errored" in script
     assert "snapshot-failed: rclone check ${label} found drift" in script


### PR DESCRIPTION
## Summary

Fixes **multiple** layers of the R2-persistence cutover chain. After PR #555 wired the teardown env vars and PR #556 installed `rclone`, today's test cycle surfaced **two more** distinct bugs along the spin-up → teardown → spin-up path. Both are now fixed in this PR.

## The bug chain (running tally)

Each fix in the chain unmasked the next layer:

| State | Behaviour |
|---|---|
| Before PR #555 | Silent fresh-start on spin-up (env vars empty → snapshot no-op too) — wrong but invisible. |
| PR #555 round 6 | Bucket-reachability probe → loud `rc=2` if rclone missing. |
| PR #556 | rclone installed via apt → probe passes. **Surfaced** the rclone-1.60-lsf quirk. |
| **This PR — lsf quirk** | rclone 1.60.1 returns `rc=0` with empty stdout on missing object → `if ! rclone lsf` never fires fresh-start; falls through to `copyto` which also produces nothing → `tr -d` crashes with rc=1 instead of fresh-starting with rc=0. Through three rounds of Copilot review, the form evolved to: list the parent prefix and grep for `latest.txt`. Robust against version skew + transient errors. |
| **This PR — teardown SSH** | Teardown's pre-destroy `s3-snapshot` step couldn't SSH into the live server — got `Permission denied (publickey,password)` after 15 attempts. Root cause: legacy `Generate SSH key for OpenTofu` step minted an **ephemeral** keypair each run. Fine for tofu (provider API, no SSH), useless for the new snapshot step (`docker exec pg_dump` + `rclone sync` need real shell access). Replaced with the same SSH-from-secrets pattern spin-up.yml already uses. |

## Changes

### lsf-quirk fix (s3_persistence.py)

`render_restore_script` rewrote the "is there a snapshot?" check across 4 review rounds to its final shape:

```bash
# Probe bucket reachability first.
if ! rclone lsd "$BUCKET" --max-depth 1 >/dev/null 2>&1; then
  echo "✗ restore-failed: bucket not reachable" >&2
  exit 2
fi
# List the snapshots/ prefix and check whether latest.txt is in it.
# Cleanly separates:  (a) listing OK + grep match → continue restore
#                     (b) listing OK + no match → empty bucket → fresh-start
#                     (c) listing fails → hard error (auth/network/policy)
SNAPSHOT_LISTING=""
if ! SNAPSHOT_LISTING=$(rclone lsf "$BUCKET/snapshots/"); then
  echo "✗ restore-failed: cannot list \$BUCKET/snapshots/" >&2
  echo "  (auth / network / bucket policy — see rclone error above)" >&2
  exit 2
fi
if ! printf "%s\n" "$SNAPSHOT_LISTING" | grep -qxF "latest.txt"; then
  echo "fresh-start: no snapshot in S3, leaving local state empty"
  exit 0
fi
```

Defence in depth: after `rclone copyto`, verify the local file exists and is non-empty (`[ ! -s "$WORKDIR/latest.txt" ]`) before the `tr -d` line.

### Teardown SSH-from-secrets fix (teardown.yml)

Replaced the legacy ephemeral-key generation in teardown.yml with the same secrets-based install pattern spin-up.yml uses. Fails loud (exit 1) if `SSH_PRIVATE_KEY` secret is missing rather than falling back to a key that won't work.

destroy-all.yml deliberately not touched — it only runs `tofu destroy` (no SSH needed), the ephemeral key is fine there.

### Tests

- New test `test_restore_script_detects_missing_latest_via_lsf_stdout_not_exit_code` pins all three required components of the new bash form (variable-capture from parent-prefix listing, `grep -qxF "latest.txt"`, hard-error path for listing failures).
- Updated `test_restore_script_probes_bucket_reachability_before_fresh_start` to reflect the new lsf target.

## Verification

- [x] Local: 1431/1431 tests pass
- [x] ruff-format + ruff + mypy all clean (pre-commit hook)
- [x] **Spin-up against empty bucket**: confirmed `fresh-start: no snapshot in S3` is now emitted for the right reason (genuinely empty bucket, not masked by missing rclone or lsf quirk). Stack came up healthy. First clean R2-persistence spin-up in the project's history.
- [x] **Teardown SSH fail**: reproduced the `Permission denied` failure on `main` (run 25687393517) — confirming this PR's teardown.yml fix is required.

## Test plan (after merge)

1. `gh workflow run destroy-all.yml -f confirm=DESTROY`
2. `gh workflow run initial-setup.yaml` — verify clean fresh-start spin-up
3. **Create something visible in Gitea** (new repo / file / commit)
4. `gh workflow run teardown.yml -f confirm=TEARDOWN` — verify:
   - SSH succeeds (no "Permission denied" — this PR's teardown fix is the gate)
   - `s3-snapshot` step writes `snapshots/<TS>/` + flips `snapshots/latest.txt`
   - Tofu destroy succeeds
5. `gh workflow run spin-up.yml` — verify:
   - `→ restore: using snapshot snapshots/<TS>` (real restore, not fresh-start)
   - Gitea data from step 3 is back

This will be the first end-to-end R2-persistence roundtrip test ever performed in this project.

## Related

- Builds on #555 (env wiring + bucket-reachability probe), #556 (rclone install).
- Surfaced via real test runs after each successive merge — five layers of bugs total, this PR closes the last two.
