### PR TITLE
chore: Housekeeping — coverage, mypy hook, destroy-all delete_data flag

### DIFF
--- a/.github/workflows/destroy-all.yml
+++ b/.github/workflows/destroy-all.yml
@@ -326,37 +326,34 @@ jobs:
           echo "🔥 delete_data=DESTROY — wiping R2 buckets"
           echo "   endpoint: $ENDPOINT"
 
-          # Validate credentials BEFORE the head-bucket loop. The
-          # loop's `head-bucket ... 2>/dev/null` form would otherwise
-          # swallow auth / endpoint / region errors as "bucket
-          # doesn't exist" → every bucket would silently skip and
-          # the workflow would print "All R2 buckets wiped" without
-          # touching anything. The operator explicitly opted in to
-          # the wipe via delete_data=DESTROY; a silent no-op is a
-          # data-safety footgun (same class as the s3_persistence
-          # round-6 bucket-reachability probe).
-          #
-          # ``s3api list-buckets`` succeeds for any authenticated
-          # call against the R2 endpoint, even when none of our
-          # specific buckets exist. Fails loud on auth / endpoint /
-          # region misconfig so the operator knows to fix creds
-          # rather than assume the wipe ran.
-          if ! aws --endpoint-url="$ENDPOINT" s3api list-buckets >/dev/null 2>&1; then
-            echo "  ❌ ERROR: cannot authenticate to R2"
+          # Single source-of-truth for bucket existence: read the
+          # complete list of buckets in the R2 account ONCE, then
+          # decide skip-or-wipe via set-membership lookup. This
+          # eliminates the per-bucket head-bucket probe entirely
+          # and with it a whole class of "did this fail because
+          # the bucket doesn't exist, or for a transient reason?"
+          # ambiguities (network blip, per-bucket policy mismatch,
+          # 429 rate-limit, etc.). If list-buckets itself fails →
+          # fail loud here, no buckets touched. Same data-safety
+          # contract as the s3_persistence round-6 reachability
+          # probe.
+          if ! EXISTING_BUCKETS=$(aws --endpoint-url="$ENDPOINT" s3api list-buckets --query 'Buckets[].Name' --output text 2>&1); then
+            echo "  ❌ ERROR: cannot list R2 buckets — $EXISTING_BUCKETS"
             echo "     (check R2_ACCESS_KEY_ID / R2_SECRET_ACCESS_KEY / endpoint / region)"
             echo "     No buckets wiped — fix credentials and re-run."
             exit 1
           fi
-          echo "  ✓ R2 credentials validated"
+          echo "  ✓ R2 reachable; account has $(echo "$EXISTING_BUCKETS" | wc -w | tr -d ' ') bucket(s)"
 
           for BUCKET in \
             "nexus-${DOMAIN_SLUG}-persistence" \
             "$DATA_BUCKET" \
             "${DOMAIN_SLUG}-terraform-state"; do
-            # Credentials proven valid above, so a non-zero exit
-            # from head-bucket here means the bucket genuinely
-            # doesn't exist (already gone, or never created).
-            if aws --endpoint-url="$ENDPOINT" s3api head-bucket --bucket "$BUCKET" 2>/dev/null; then
+            # Exact set-membership match. ``EXISTING_BUCKETS`` is
+            # space-separated (aws --output text); pad both sides
+            # with spaces so a bucket name that's a substring of
+            # another can't false-positive.
+            if echo " $EXISTING_BUCKETS " | grep -qF " $BUCKET "; then
               echo "  → wiping $BUCKET ..."
               # `s3 rb --force` empties then removes the bucket.
               if ! aws --endpoint-url="$ENDPOINT" s3 rb "s3://$BUCKET" --force; then
@@ -366,7 +363,7 @@ jobs:
               fi
               echo "  ✅ $BUCKET deleted"
             else
-              echo "  (skip: $BUCKET does not exist)"
+              echo "  (skip: $BUCKET not in account)"
             fi
           done
           echo "✅ All R2 buckets wiped"

--- a/.github/workflows/destroy-all.yml
+++ b/.github/workflows/destroy-all.yml
@@ -303,22 +303,52 @@ jobs:
           source tofu/.r2-credentials
           export AWS_ACCESS_KEY_ID="$R2_ACCESS_KEY_ID"
           export AWS_SECRET_ACCESS_KEY="$R2_SECRET_ACCESS_KEY"
+          # R2's signing requires `region=auto`; without it the aws
+          # CLI defaults to its profile's region (or us-east-1) and
+          # R2 rejects the signature with an unhelpful 403.
+          export AWS_DEFAULT_REGION=auto
           ENDPOINT="https://${CLOUDFLARE_ACCOUNT_ID}.r2.cloudflarestorage.com"
           DOMAIN_SLUG=$(echo "$DOMAIN" | tr '.' '-')
 
           echo "🔥 delete_data=DESTROY — wiping R2 buckets"
           echo "   endpoint: $ENDPOINT"
 
+          # Validate credentials BEFORE the head-bucket loop. The
+          # loop's `head-bucket ... 2>/dev/null` form would otherwise
+          # swallow auth / endpoint / region errors as "bucket
+          # doesn't exist" → every bucket would silently skip and
+          # the workflow would print "All R2 buckets wiped" without
+          # touching anything. The operator explicitly opted in to
+          # the wipe via delete_data=DESTROY; a silent no-op is a
+          # data-safety footgun (same class as the s3_persistence
+          # round-6 bucket-reachability probe).
+          #
+          # ``s3api list-buckets`` succeeds for any authenticated
+          # call against the R2 endpoint, even when none of our
+          # specific buckets exist. Fails loud on auth / endpoint /
+          # region misconfig so the operator knows to fix creds
+          # rather than assume the wipe ran.
+          if ! aws --endpoint-url="$ENDPOINT" s3api list-buckets >/dev/null 2>&1; then
+            echo "  ❌ ERROR: cannot authenticate to R2"
+            echo "     (check R2_ACCESS_KEY_ID / R2_SECRET_ACCESS_KEY / endpoint / region)"
+            echo "     No buckets wiped — fix credentials and re-run."
+            exit 1
+          fi
+          echo "  ✓ R2 credentials validated"
+
           for BUCKET in \
             "nexus-${DOMAIN_SLUG}-persistence" \
             "nexus-${DOMAIN_SLUG}-data" \
             "${DOMAIN_SLUG}-terraform-state"; do
+            # Credentials proven valid above, so a non-zero exit
+            # from head-bucket here means the bucket genuinely
+            # doesn't exist (already gone, or never created).
             if aws --endpoint-url="$ENDPOINT" s3api head-bucket --bucket "$BUCKET" 2>/dev/null; then
               echo "  → wiping $BUCKET ..."
               # `s3 rb --force` empties then removes the bucket.
               if ! aws --endpoint-url="$ENDPOINT" s3 rb "s3://$BUCKET" --force; then
                 echo "  ❌ ERROR: failed to delete $BUCKET — bucket may still hold objects"
-                echo "     Manual cleanup: aws --endpoint-url=$ENDPOINT s3 rb s3://$BUCKET --force"
+                echo "     Manual cleanup: AWS_DEFAULT_REGION=auto aws --endpoint-url=$ENDPOINT s3 rb s3://$BUCKET --force"
                 exit 1
               fi
               echo "  ✅ $BUCKET deleted"

--- a/.github/workflows/destroy-all.yml
+++ b/.github/workflows/destroy-all.yml
@@ -337,23 +337,36 @@ jobs:
           # fail loud here, no buckets touched. Same data-safety
           # contract as the s3_persistence round-6 reachability
           # probe.
-          if ! EXISTING_BUCKETS=$(aws --endpoint-url="$ENDPOINT" s3api list-buckets --query 'Buckets[].Name' --output text 2>&1); then
-            echo "  ❌ ERROR: cannot list R2 buckets — $EXISTING_BUCKETS"
+          if ! EXISTING_BUCKETS_RAW=$(aws --endpoint-url="$ENDPOINT" s3api list-buckets --query 'Buckets[].Name' --output text 2>&1); then
+            echo "  ❌ ERROR: cannot list R2 buckets — $EXISTING_BUCKETS_RAW"
             echo "     (check R2_ACCESS_KEY_ID / R2_SECRET_ACCESS_KEY / endpoint / region)"
             echo "     No buckets wiped — fix credentials and re-run."
             exit 1
           fi
-          echo "  ✓ R2 reachable; account has $(echo "$EXISTING_BUCKETS" | wc -w | tr -d ' ') bucket(s)"
+          # Normalize to one-bucket-per-line. ``aws --output text``
+          # with a list-of-strings query yields TAB-separated values
+          # (sometimes mixed with newlines); without explicit
+          # normalization the downstream membership check would
+          # rely on bash's default-IFS splitting trick — works by
+          # accident, but is fragile and easy to break by future
+          # edits. Explicit ``tr`` makes the separator obvious;
+          # ``grep -xF`` below pins an exact whole-line match so
+          # a bucket name that's a substring of another can't
+          # false-positive.
+          EXISTING_BUCKETS=$(printf '%s\n' "$EXISTING_BUCKETS_RAW" | tr '[:space:]' '\n' | grep -v '^$' || true)
+          BUCKET_COUNT=$(printf '%s\n' "$EXISTING_BUCKETS" | grep -c . || true)
+          echo "  ✓ R2 reachable; account has ${BUCKET_COUNT} bucket(s)"
 
           for BUCKET in \
             "nexus-${DOMAIN_SLUG}-persistence" \
             "$DATA_BUCKET" \
             "${DOMAIN_SLUG}-terraform-state"; do
-            # Exact set-membership match. ``EXISTING_BUCKETS`` is
-            # space-separated (aws --output text); pad both sides
-            # with spaces so a bucket name that's a substring of
-            # another can't false-positive.
-            if echo " $EXISTING_BUCKETS " | grep -qF " $BUCKET "; then
+            # Exact whole-line match via ``grep -xF``: ``-x`` rules
+            # out substring matches (so e.g. ``nexus-foo`` can't
+            # match ``nexus-foo-data``), ``-F`` treats the bucket
+            # name literally (so dots/hyphens aren't regex
+            # metacharacters).
+            if printf '%s\n' "$EXISTING_BUCKETS" | grep -qxF "$BUCKET"; then
               echo "  → wiping $BUCKET ..."
               # `s3 rb --force` empties then removes the bucket.
               if ! aws --endpoint-url="$ENDPOINT" s3 rb "s3://$BUCKET" --force; then

--- a/.github/workflows/destroy-all.yml
+++ b/.github/workflows/destroy-all.yml
@@ -298,6 +298,15 @@ jobs:
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           DOMAIN: ${{ secrets.DOMAIN }}
+          # Project supports custom data-bucket names via the
+          # R2_DATA_BUCKET secret (see setup-control-plane.yaml's
+          # custom-bucket-preservation logic). When the secret is
+          # unset we fall back to the convention nexus-<slug>-data.
+          # Without this, an operator who set a non-default bucket
+          # name would have the wipe step silently skip their real
+          # data bucket — and possibly delete a stale bucket living
+          # at the default name.
+          R2_DATA_BUCKET: ${{ secrets.R2_DATA_BUCKET }}
         run: |
           set -euo pipefail
           source tofu/.r2-credentials
@@ -309,6 +318,10 @@ jobs:
           export AWS_DEFAULT_REGION=auto
           ENDPOINT="https://${CLOUDFLARE_ACCOUNT_ID}.r2.cloudflarestorage.com"
           DOMAIN_SLUG=$(echo "$DOMAIN" | tr '.' '-')
+          # Use the configured data-bucket name when set; fall back
+          # to the default convention otherwise. Mirrors what
+          # spin-up.yml + setup-control-plane.yaml already do.
+          DATA_BUCKET="${R2_DATA_BUCKET:-nexus-${DOMAIN_SLUG}-data}"
 
           echo "🔥 delete_data=DESTROY — wiping R2 buckets"
           echo "   endpoint: $ENDPOINT"
@@ -338,7 +351,7 @@ jobs:
 
           for BUCKET in \
             "nexus-${DOMAIN_SLUG}-persistence" \
-            "nexus-${DOMAIN_SLUG}-data" \
+            "$DATA_BUCKET" \
             "${DOMAIN_SLUG}-terraform-state"; do
             # Credentials proven valid above, so a non-zero exit
             # from head-bucket here means the bucket genuinely

--- a/.github/workflows/destroy-all.yml
+++ b/.github/workflows/destroy-all.yml
@@ -7,6 +7,18 @@ on:
         description: 'Type "DESTROY" (uppercase) to confirm FULL destruction'
         required: true
         type: string
+      delete_data:
+        # Opt-in extra step that wipes the R2 buckets after tofu
+        # destroy: persistence (snapshots), data (datalake), and
+        # state (tofu state) buckets. Without this, those buckets
+        # survive destroy-all so a later initial-setup + spin-up
+        # reattaches to existing snapshot history (RFC 0001 decision
+        # #6). Setting this to "DESTROY" turns destroy-all into a
+        # true one-shot wipe.
+        description: 'Type "DESTROY" to ALSO wipe R2 buckets (snapshots + data + tofu state). Leave empty to preserve them.'
+        required: false
+        type: string
+        default: ''
 
 permissions:
   contents: read
@@ -69,16 +81,16 @@ jobs:
       - name: Create R2 credentials from secrets
         run: |
           mkdir -p tofu tofu/control-plane tofu/stack
-          
+
           # Generate dynamic bucket name from domain
           BUCKET_NAME=$(echo "${{ secrets.DOMAIN }}" | tr '.' '-')-terraform-state
           echo "📦 Using bucket: $BUCKET_NAME"
-          
+
           cat > tofu/.r2-credentials << EOF
           R2_ACCESS_KEY_ID="${{ secrets.R2_ACCESS_KEY_ID }}"
           R2_SECRET_ACCESS_KEY="${{ secrets.R2_SECRET_ACCESS_KEY }}"
           EOF
-          
+
           cat > tofu/backend.hcl << EOF
           endpoints = {
             s3 = "https://${{ secrets.CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com"
@@ -106,25 +118,25 @@ jobs:
           github_owner   = "${{ github.repository_owner }}"
           github_repo    = "${{ github.event.repository.name }}"
           EOF
-          
+
           # Read services from D1 (single source of truth)
           echo "📋 Reading services from D1..."
           D1_DATABASE_NAME="nexus-${DOMAIN//./-}-db"
           ENABLED_SERVICES=$(npx wrangler@4 d1 execute "$D1_DATABASE_NAME" --remote --json \
             --command "SELECT name FROM services WHERE enabled = 1" 2>/dev/null \
             | jq -r '.[0].results | map(.name) | join(",")' 2>/dev/null || echo "")
-          
+
           if [ -n "$ENABLED_SERVICES" ]; then
             echo "📋 Enabled services from D1: $ENABLED_SERVICES"
           else
             echo "📋 No services in D1 yet - core services will be enabled by default"
           fi
-          
+
           # Generate services config from services.yaml
           # Use shared script to avoid code duplication
           chmod +x .github/scripts/generate-services-tfvars.py
           ENABLED_SERVICES="$ENABLED_SERVICES" python3 .github/scripts/generate-services-tfvars.py
-          
+
           # Control Plane config
           cat > tofu/control-plane/config.tfvars << EOF
           server_type         = "${{ vars.SERVER_TYPE || 'cx43' }}"
@@ -222,15 +234,12 @@ jobs:
           # latest.txt pointer. Re-running initial-setup +
           # spin-up later picks them back up via restore_from_s3.
           #
-          # To truly wipe ALL state (including R2 snapshots), the
-          # operator runs `scripts/cleanup-s3-bucket.sh` with
-          # `CONFIRM_DELETE_DATA=DESTROY` set in the environment.
-          # That script is the audited deletion path per RFC 0001
-          # decision #6 — it iterates the bucket via S3 API and
-          # deletes every object before issuing the bucket-delete,
-          # mirroring the same `confirm=DESTROY` opt-in pattern as
-          # this workflow. The Cloudflare dashboard works too but
-          # leaves no audit trail.
+          # To wipe these too, re-run destroy-all with the
+          # `delete_data=DESTROY` workflow input — the
+          # "Delete R2 buckets" step at the end of this workflow
+          # handles persistence + data + state buckets in one
+          # shot. The standalone `scripts/cleanup-s3-bucket.sh`
+          # still exists for manual single-bucket cleanup.
 
           # Protect KV namespace from destruction (keeps Databricks config etc.)
           echo "💾 Protecting KV namespace from destroy..."
@@ -259,6 +268,65 @@ jobs:
       # preserved so that destroy-all can be re-run safely. The Terraform
       # state files inside the bucket are stale after destroy but harmless —
       # init-r2-state.sh reuses the bucket on next initial-setup.
+      #
+      # To wipe them too, run with `delete_data=DESTROY` — handled by
+      # the next step.
+
+      - name: Delete R2 buckets (opt-in via delete_data=DESTROY)
+        # Optional second destructive step that wipes the R2 buckets
+        # destroy-all otherwise preserves. Runs ONLY when the
+        # operator explicitly opts in via the `delete_data` input,
+        # mirroring the same `confirm`-must-equal-DESTROY pattern
+        # the script-level cleanup-s3-bucket.sh uses.
+        #
+        # Three buckets to wipe (in dependency order):
+        #  1. Persistence bucket (`nexus-<slug>-persistence`) —
+        #     holds the snapshot history; without this they survive
+        #     destroy-all by design (RFC 0001 decision #6).
+        #  2. Data bucket (`nexus-<slug>-data`) — the datalake;
+        #     services have already been destroyed by the steps
+        #     above, so safe to wipe.
+        #  3. Tofu state bucket (`<slug>-terraform-state`) — holds
+        #     the (now-empty) state files. Wiped LAST because
+        #     tofu init may have re-touched it during the destroy
+        #     steps above.
+        #
+        # Each bucket is wiped via `aws s3 rb --force` against the
+        # R2 S3-API endpoint, with the same R2 credentials the
+        # rest of the workflow already uses.
+        if: github.event.inputs.delete_data == 'DESTROY'
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          DOMAIN: ${{ secrets.DOMAIN }}
+        run: |
+          set -euo pipefail
+          source tofu/.r2-credentials
+          export AWS_ACCESS_KEY_ID="$R2_ACCESS_KEY_ID"
+          export AWS_SECRET_ACCESS_KEY="$R2_SECRET_ACCESS_KEY"
+          ENDPOINT="https://${CLOUDFLARE_ACCOUNT_ID}.r2.cloudflarestorage.com"
+          DOMAIN_SLUG=$(echo "$DOMAIN" | tr '.' '-')
+
+          echo "🔥 delete_data=DESTROY — wiping R2 buckets"
+          echo "   endpoint: $ENDPOINT"
+
+          for BUCKET in \
+            "nexus-${DOMAIN_SLUG}-persistence" \
+            "nexus-${DOMAIN_SLUG}-data" \
+            "${DOMAIN_SLUG}-terraform-state"; do
+            if aws --endpoint-url="$ENDPOINT" s3api head-bucket --bucket "$BUCKET" 2>/dev/null; then
+              echo "  → wiping $BUCKET ..."
+              # `s3 rb --force` empties then removes the bucket.
+              if ! aws --endpoint-url="$ENDPOINT" s3 rb "s3://$BUCKET" --force; then
+                echo "  ❌ ERROR: failed to delete $BUCKET — bucket may still hold objects"
+                echo "     Manual cleanup: aws --endpoint-url=$ENDPOINT s3 rb s3://$BUCKET --force"
+                exit 1
+              fi
+              echo "  ✅ $BUCKET deleted"
+            else
+              echo "  (skip: $BUCKET does not exist)"
+            fi
+          done
+          echo "✅ All R2 buckets wiped"
 
       - name: Confirm destruction
         run: |
@@ -270,9 +338,18 @@ jobs:
           echo "   - Cloudflare Access policies"
           echo "   - Control Plane (Pages + Worker + D1)"
           echo "   - Hetzner Object Storage buckets (LakeFS, General)"
-          echo ""
-          echo "   Preserved (reused on next initial-setup):"
-          echo "   - R2 state bucket and credentials"
-          echo "   - R2 datalake bucket and credentials"
+          if [ "${{ github.event.inputs.delete_data }}" = "DESTROY" ]; then
+            echo "   - R2 persistence bucket (snapshots) — wiped via delete_data=DESTROY"
+            echo "   - R2 datalake bucket — wiped via delete_data=DESTROY"
+            echo "   - R2 tofu state bucket — wiped via delete_data=DESTROY"
+          else
+            echo ""
+            echo "   Preserved (reused on next initial-setup):"
+            echo "   - R2 state bucket and credentials"
+            echo "   - R2 datalake bucket and credentials"
+            echo "   - R2 persistence bucket (snapshots)"
+            echo ""
+            echo "   To wipe these too, re-run with delete_data=DESTROY."
+          fi
           echo ""
           echo "To redeploy, run the Initial Setup workflow."

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,21 +53,33 @@ repos:
   # Slow-ish (~1-3 sec on this codebase). Worth it.
   # Pinned to match pyproject.toml's [dependency-groups].dev.mypy bound.
   # ---------------------------------------------------------------------------
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.13.0
+  # mypy via the project's uv venv — NOT mirrors-mypy's isolated env.
+  #
+  # The previous form (mirrors-mypy + additional_dependencies) built
+  # an isolated pip env without nexus_deploy itself installed, so
+  # every `from nexus_deploy.X import Y` in tests/ failed with
+  # `import-not-found`. CI mypy passes because it runs
+  # `uv run mypy` against the project-installed package; pre-commit
+  # was missing that same wiring.
+  #
+  # Switching to `language: system + uv run mypy` aligns local
+  # pre-commit with CI exactly — same mypy version, same site-
+  # packages, same pyproject.toml config — so a green pre-commit
+  # actually predicts a green CI typecheck.
+  #
+  # `pass_filenames: false` because mypy's `files = [...]` setting
+  # in pyproject.toml already picks the right scope; passing
+  # individual filenames in addition would make mypy ignore the
+  # config-file's files= directive.
+  - repo: local
     hooks:
       - id: mypy
+        name: mypy (project venv, strict)
+        entry: uv run mypy
+        language: system
+        types: [python]
         files: ^(src|tests)/.*\.py$
-        # Bring deps so mypy can resolve imports. Bounds match
-        # pyproject.toml's [project].dependencies / [dependency-groups].dev
-        # so pre-commit and CI never disagree (e.g. when pydantic 3.x ships).
-        # `pytest` is here because mypy also type-checks tests/.
-        additional_dependencies:
-          - pydantic>=2.7,<3.0
-          - pytest>=8.3,<9.0
-          - types-paramiko>=3.4,<4.0
-          - types-requests>=2.32,<3.0
-          - types-pyyaml>=6.0,<7.0
+        pass_filenames: false
         args: [--config-file=pyproject.toml]
 
   # ---------------------------------------------------------------------------

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,12 @@ repos:
   # The `ruff-format` runs first to canonicalize, then `ruff` checks the rest.
   # ---------------------------------------------------------------------------
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.7.4
+    # Pinned to match the project venv's ruff (uv lock resolves
+    # `ruff>=0.7,<1.0` to the latest patch). Drift between this
+    # rev and the venv version produces "Would reformat: …" CI
+    # failures that pass pre-commit — the exact scenario that
+    # blocked PR #558. Bump in lockstep with `uv sync` upgrades.
+    rev: v0.15.12
     hooks:
       - id: ruff-format
         files: ^(src|tests)/.*\.py$

--- a/src/nexus_deploy/s3_persistence.py
+++ b/src/nexus_deploy/s3_persistence.py
@@ -1107,7 +1107,7 @@ def render_restore_script(
             # gitea-only restore path still proceeds normally.
             lines.append(f"if [ ! -f {dump_file} ]; then")
             lines.append(
-                f'  echo "  (skip: no dump for {pg.database} ' f'— stack not snapshotted)"',
+                f'  echo "  (skip: no dump for {pg.database} — stack not snapshotted)"',
             )
             lines.append(
                 f"elif [ \"$(docker inspect --format='{{{{.State.Running}}}}' "

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -14,6 +14,8 @@ not new logic. Focus on:
 
 from __future__ import annotations
 
+import subprocess
+from pathlib import Path
 from typing import Any, Literal, cast
 from unittest.mock import MagicMock, patch
 
@@ -2174,9 +2176,9 @@ def test_phase_service_env_skips_gitea_block_on_incomplete_coords(
     result = orchestrator._phase_service_env()
     assert result.status == "ok"
     assert "gitea_appended=0" in result.detail
-    assert append_called is False, (
-        "append_gitea_workspace_block must NOT be called when any coord is empty"
-    )
+    assert (
+        append_called is False
+    ), "append_gitea_workspace_block must NOT be called when any coord is empty"
 
 
 # ---------------------------------------------------------------------------
@@ -2960,3 +2962,487 @@ def test_phase_firewall_sync_no_orphans_no_redpanda(
     result = orchestrator._phase_firewall_sync()
     assert result.status == "ok"
     assert "orphans_removed=0" in result.detail
+
+
+# ---------------------------------------------------------------------------
+# _phase_woodpecker_apply — full happy path + error paths
+# ---------------------------------------------------------------------------
+#
+# Coverage gap before these: the existing 3 tests only exercise the
+# skip / not-populated / no-agent-secret guards. The actual apply
+# flow (write .env, rsync, docker compose up -d) and its four error
+# paths (local-write OSError, rsync transport, compose-up rc!=0,
+# compose-up timeout, compose-up unexpected) were never executed
+# in tests.
+
+
+@pytest.fixture
+def woodpecker_enabled(orchestrator: Orchestrator) -> Orchestrator:
+    """Reusable setup: woodpecker enabled + OAuth creds + agent secret
+    populated, so every test below only differs in the error injection."""
+    orchestrator.enabled_services = ["woodpecker"]
+    orchestrator.state.woodpecker_client_id = "wp-id"
+    orchestrator.state.woodpecker_client_secret = "wp-secret"
+    orchestrator.woodpecker_agent_secret = "agent-secret"
+    orchestrator.domain = "example.com"
+    return orchestrator
+
+
+def test_phase_woodpecker_apply_happy_path(
+    woodpecker_enabled: Orchestrator,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Any,
+) -> None:
+    """End-to-end: write .env → rsync → compose up. Every external
+    boundary mocked successful. Verifies status='ok' and that the
+    rendered .env carries the OAuth creds we expect."""
+    orchestrator = woodpecker_enabled
+    woodpecker_dir = tmp_path / "stacks" / "woodpecker"
+    woodpecker_dir.mkdir(parents=True)
+    orchestrator.project_root = tmp_path
+
+    rsync_mock = MagicMock()
+    ssh_run_mock = MagicMock(return_value=MagicMock(returncode=0, output=""))
+    monkeypatch.setattr("nexus_deploy.orchestrator._remote.rsync_to_remote", rsync_mock)
+    monkeypatch.setattr("nexus_deploy.orchestrator._remote.ssh_run_script", ssh_run_mock)
+
+    result = orchestrator._phase_woodpecker_apply(MagicMock())
+    assert result.status == "ok"
+
+    # The .env content must include the OAuth credentials. Operators
+    # debugging a misconfigured woodpecker would look here first.
+    env_content = (woodpecker_dir / ".env").read_text()
+    assert "WOODPECKER_GITEA_CLIENT=wp-id" in env_content
+    assert "WOODPECKER_GITEA_SECRET=wp-secret" in env_content
+    assert "WOODPECKER_AGENT_SECRET=agent-secret" in env_content
+    assert "DOMAIN=example.com" in env_content
+
+
+def test_phase_woodpecker_apply_failed_when_stack_dir_missing(
+    woodpecker_enabled: Orchestrator,
+    tmp_path: Any,
+) -> None:
+    """If stack-sync didn't place stacks/woodpecker locally, the
+    phase MUST fail-fast (not silently no-op) — the rsync below
+    would otherwise upload an empty directory."""
+    orchestrator = woodpecker_enabled
+    orchestrator.project_root = tmp_path  # no stacks/woodpecker dir
+
+    result = orchestrator._phase_woodpecker_apply(MagicMock())
+    assert result.status == "failed"
+    assert "stack-sync should have placed it" in result.detail
+
+
+def test_phase_woodpecker_apply_failed_on_local_env_write_error(
+    woodpecker_enabled: Orchestrator,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Any,
+) -> None:
+    """Local .env write OSError is distinct from rsync/compose
+    failures — distinct detail string so operators can tell from
+    the log which boundary failed."""
+    orchestrator = woodpecker_enabled
+    woodpecker_dir = tmp_path / "stacks" / "woodpecker"
+    woodpecker_dir.mkdir(parents=True)
+    orchestrator.project_root = tmp_path
+
+    # Simulate write_text raising OSError on the .env path.
+    real_write_text = Path.write_text
+
+    def fake_write_text(self: Path, *args: Any, **kw: Any) -> int:
+        if self.name == ".env":
+            raise OSError("disk full")
+        return real_write_text(self, *args, **kw)
+
+    monkeypatch.setattr(Path, "write_text", fake_write_text)
+
+    result = orchestrator._phase_woodpecker_apply(MagicMock())
+    assert result.status == "failed"
+    assert "local write" in result.detail
+    assert "OSError" in result.detail
+
+
+def test_phase_woodpecker_apply_partial_on_rsync_transport_error(
+    woodpecker_enabled: Orchestrator,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Any,
+) -> None:
+    """rsync failure → partial (not failed) — the ssh transport
+    error is distinct from docker compose failure, so operators
+    should investigate connectivity / disk on the server, not
+    container logs. PR #533 R7 #2 finding."""
+    orchestrator = woodpecker_enabled
+    woodpecker_dir = tmp_path / "stacks" / "woodpecker"
+    woodpecker_dir.mkdir(parents=True)
+    orchestrator.project_root = tmp_path
+
+    monkeypatch.setattr(
+        "nexus_deploy.orchestrator._remote.rsync_to_remote",
+        MagicMock(side_effect=subprocess.CalledProcessError(255, ["rsync"])),
+    )
+
+    result = orchestrator._phase_woodpecker_apply(MagicMock())
+    assert result.status == "partial"
+    assert "rsync transport" in result.detail
+
+
+def test_phase_woodpecker_apply_partial_on_compose_up_rc_nonzero(
+    woodpecker_enabled: Orchestrator,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Any,
+) -> None:
+    """docker compose up rc!=0 → partial, with the stdout tail in
+    the detail so operators see the compose error inline (PR #533
+    R3 #1: --env-file via compose, not source)."""
+    orchestrator = woodpecker_enabled
+    woodpecker_dir = tmp_path / "stacks" / "woodpecker"
+    woodpecker_dir.mkdir(parents=True)
+    orchestrator.project_root = tmp_path
+
+    monkeypatch.setattr("nexus_deploy.orchestrator._remote.rsync_to_remote", MagicMock())
+    monkeypatch.setattr(
+        "nexus_deploy.orchestrator._remote.ssh_run_script",
+        MagicMock(
+            side_effect=subprocess.CalledProcessError(
+                returncode=1,
+                cmd=["ssh"],
+                output="Error response from daemon: pull access denied for woodpecker/server",
+            )
+        ),
+    )
+
+    result = orchestrator._phase_woodpecker_apply(MagicMock())
+    assert result.status == "partial"
+    assert "docker compose up -d failed" in result.detail
+    assert "rc=1" in result.detail
+
+
+def test_phase_woodpecker_apply_partial_on_compose_up_timeout(
+    woodpecker_enabled: Orchestrator,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Any,
+) -> None:
+    """ssh transport timeout during compose up → partial. Distinct
+    diagnostic from compose-rc-nonzero: operator investigates
+    connectivity, not container state."""
+    orchestrator = woodpecker_enabled
+    woodpecker_dir = tmp_path / "stacks" / "woodpecker"
+    woodpecker_dir.mkdir(parents=True)
+    orchestrator.project_root = tmp_path
+
+    monkeypatch.setattr("nexus_deploy.orchestrator._remote.rsync_to_remote", MagicMock())
+    monkeypatch.setattr(
+        "nexus_deploy.orchestrator._remote.ssh_run_script",
+        MagicMock(side_effect=subprocess.TimeoutExpired(cmd=["ssh"], timeout=120)),
+    )
+
+    result = orchestrator._phase_woodpecker_apply(MagicMock())
+    assert result.status == "partial"
+    assert "ssh transport timeout" in result.detail
+
+
+def test_phase_woodpecker_apply_failed_on_unexpected_exception(
+    woodpecker_enabled: Orchestrator,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Any,
+) -> None:
+    """Any non-(CalledProcessError|TimeoutExpired) Exception during
+    compose-up → failed (not partial). These shouldn't happen at
+    runtime; if one does, fail-loud so the operator notices."""
+    orchestrator = woodpecker_enabled
+    woodpecker_dir = tmp_path / "stacks" / "woodpecker"
+    woodpecker_dir.mkdir(parents=True)
+    orchestrator.project_root = tmp_path
+
+    monkeypatch.setattr("nexus_deploy.orchestrator._remote.rsync_to_remote", MagicMock())
+    monkeypatch.setattr(
+        "nexus_deploy.orchestrator._remote.ssh_run_script",
+        MagicMock(side_effect=RuntimeError("paramiko meltdown")),
+    )
+
+    result = orchestrator._phase_woodpecker_apply(MagicMock())
+    assert result.status == "failed"
+    assert "unexpected" in result.detail
+    assert "RuntimeError" in result.detail
+
+
+# ---------------------------------------------------------------------------
+# _phase_mirror_finalize — full execution paths
+# ---------------------------------------------------------------------------
+#
+# Existing tests only exercise the two skip-gates (not mirror /
+# no fork). The actual flow-sync re-trigger + git-restart loop
+# (~75 lines incl. all four exception branches) was never hit.
+
+
+@pytest.fixture
+def mirror_finalize_ready(orchestrator: Orchestrator) -> Orchestrator:
+    """Mirror mode + fork populated + kestra enabled + admin creds
+    + admin email — the all-prereqs-met setup that exercises the
+    flow-sync + git-restart code paths."""
+    orchestrator.gh_mirror_repos = ["https://github.com/o/r.git"]
+    orchestrator.state.fork_name = "user-fork"
+    orchestrator.enabled_services = ["kestra", "jupyter", "marimo"]
+    return orchestrator
+
+
+def test_phase_mirror_finalize_happy_path_flow_and_restarts(
+    mirror_finalize_ready: Orchestrator,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Both sub-steps succeed: flow-sync POST + git-restart loop.
+    Status must be 'ok' AND the detail must surface both successes
+    (flow_triggered=True + git_restarted=N)."""
+    orchestrator = mirror_finalize_ready
+
+    # KestraClient.execute_flow — successful path (mocked).
+    kestra_client = MagicMock()
+    monkeypatch.setattr(
+        "nexus_deploy.orchestrator._kestra.KestraClient",
+        MagicMock(return_value=kestra_client),
+    )
+    # compose_restart.run_restart returns a RestartResult.
+    restart_result = MagicMock(restarted=2, failed=0)
+    monkeypatch.setattr(
+        "nexus_deploy.orchestrator._compose_restart.run_restart",
+        MagicMock(return_value=restart_result),
+    )
+
+    ssh = MagicMock()
+    ssh.port_forward.return_value.__enter__.return_value = 8085
+
+    result = orchestrator._phase_mirror_finalize(ssh)
+    assert result.status == "ok"
+    assert "flow_triggered=True" in result.detail
+    assert "git_restarted=2" in result.detail
+    kestra_client.execute_flow.assert_called_once_with("system", "flow-sync")
+
+
+def test_phase_mirror_finalize_partial_when_kestra_not_enabled(
+    mirror_finalize_ready: Orchestrator,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No kestra in enabled list → flow-sync is genuinely-skipped
+    (NOT a partial trigger), but git-restart still runs. Status
+    stays 'ok' because the (a) gate excludes 'kestra not enabled'
+    from partial-ness — that's the legitimate skip case."""
+    orchestrator = mirror_finalize_ready
+    orchestrator.enabled_services = ["jupyter", "marimo"]  # no kestra
+
+    monkeypatch.setattr(
+        "nexus_deploy.orchestrator._compose_restart.run_restart",
+        MagicMock(return_value=MagicMock(restarted=1, failed=0)),
+    )
+
+    result = orchestrator._phase_mirror_finalize(MagicMock())
+    assert result.status == "ok"
+    assert "flow_triggered=False" in result.detail
+
+
+def test_phase_mirror_finalize_partial_on_flow_sync_kestra_error(
+    mirror_finalize_ready: Orchestrator,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """KestraError during execute_flow → flow_triggered stays False
+    + kestra IS in enabled_services → partial. Detail must surface
+    the kestra error message."""
+    orchestrator = mirror_finalize_ready
+
+    # Need to import KestraError to raise it.
+    from nexus_deploy.kestra import KestraError
+
+    kestra_client = MagicMock()
+    kestra_client.execute_flow.side_effect = KestraError("HTTP 503 from kestra")
+    monkeypatch.setattr(
+        "nexus_deploy.orchestrator._kestra.KestraClient",
+        MagicMock(return_value=kestra_client),
+    )
+    monkeypatch.setattr(
+        "nexus_deploy.orchestrator._compose_restart.run_restart",
+        MagicMock(return_value=MagicMock(restarted=2, failed=0)),
+    )
+
+    ssh = MagicMock()
+    ssh.port_forward.return_value.__enter__.return_value = 8085
+
+    result = orchestrator._phase_mirror_finalize(ssh)
+    assert result.status == "partial"
+    assert "flow_skip=HTTP 503 from kestra" in result.detail
+
+
+def test_phase_mirror_finalize_partial_on_flow_sync_transport_error(
+    mirror_finalize_ready: Orchestrator,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Subprocess/OS error during port-forward setup → flow-sync
+    abandoned, kestra IS enabled → partial. Distinct from KestraError
+    (auth/HTTP) because the operator should investigate ssh
+    transport, not the kestra server."""
+    orchestrator = mirror_finalize_ready
+
+    ssh = MagicMock()
+    ssh.port_forward.side_effect = OSError("port forward setup failed")
+    monkeypatch.setattr(
+        "nexus_deploy.orchestrator._compose_restart.run_restart",
+        MagicMock(return_value=MagicMock(restarted=2, failed=0)),
+    )
+
+    result = orchestrator._phase_mirror_finalize(ssh)
+    assert result.status == "partial"
+    assert "transport" in result.detail
+    assert "OSError" in result.detail
+
+
+def test_phase_mirror_finalize_partial_on_git_restart_transport_error(
+    mirror_finalize_ready: Orchestrator,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """compose_restart.run_restart raising CalledProcessError →
+    partial with git_restart_transport_error in detail. Flow-sync
+    success state is still surfaced in the detail for the operator."""
+    orchestrator = mirror_finalize_ready
+
+    kestra_client = MagicMock()
+    monkeypatch.setattr(
+        "nexus_deploy.orchestrator._kestra.KestraClient",
+        MagicMock(return_value=kestra_client),
+    )
+    monkeypatch.setattr(
+        "nexus_deploy.orchestrator._compose_restart.run_restart",
+        MagicMock(side_effect=subprocess.CalledProcessError(255, ["ssh"])),
+    )
+
+    ssh = MagicMock()
+    ssh.port_forward.return_value.__enter__.return_value = 8085
+
+    result = orchestrator._phase_mirror_finalize(ssh)
+    assert result.status == "partial"
+    assert "flow_triggered=True" in result.detail
+    assert "git_restart_transport_error" in result.detail
+    assert "CalledProcessError" in result.detail
+
+
+def test_phase_mirror_finalize_partial_when_git_restart_reports_failures(
+    mirror_finalize_ready: Orchestrator,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """compose_restart returns successfully but with failed>0 → partial.
+    This is the per-service-failure path: rsync OK, compose error per-
+    service. Detail must surface git_failed= count so operator can
+    drill into which service died."""
+    orchestrator = mirror_finalize_ready
+
+    kestra_client = MagicMock()
+    monkeypatch.setattr(
+        "nexus_deploy.orchestrator._kestra.KestraClient",
+        MagicMock(return_value=kestra_client),
+    )
+    monkeypatch.setattr(
+        "nexus_deploy.orchestrator._compose_restart.run_restart",
+        MagicMock(return_value=MagicMock(restarted=1, failed=2)),
+    )
+
+    ssh = MagicMock()
+    ssh.port_forward.return_value.__enter__.return_value = 8085
+
+    result = orchestrator._phase_mirror_finalize(ssh)
+    assert result.status == "partial"
+    assert "git_restarted=1" in result.detail
+    assert "git_failed=2" in result.detail
+
+
+# ---------------------------------------------------------------------------
+# _phase_firewall_sync — redpanda config-copy path
+# ---------------------------------------------------------------------------
+#
+# Existing tests cover (a) project_root missing, (b) stacks/ missing,
+# (c) no-orphans-no-redpanda happy path. The redpanda-enabled
+# branch (~57 lines of mkdir+scp+chown+yaml selection) was uncovered.
+
+
+def test_phase_firewall_sync_failed_when_redpanda_config_dir_missing(
+    orchestrator: Orchestrator,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Any,
+) -> None:
+    """If redpanda is enabled but stacks/redpanda/config/ is missing
+    locally, the phase MUST fail-fast — scp'ing from a non-existent
+    source would silently no-op and leave the rendered firewall
+    config dangling."""
+    stacks_dir = tmp_path / "stacks"
+    stacks_dir.mkdir()
+    # No redpanda/ subdir created.
+    orchestrator.project_root = tmp_path
+    orchestrator.enabled_services = ["redpanda"]
+
+    monkeypatch.setattr(
+        "nexus_deploy.orchestrator._remote.ssh_run_script",
+        MagicMock(return_value=MagicMock(stdout="", returncode=0)),
+    )
+
+    result = orchestrator._phase_firewall_sync()
+    assert result.status == "failed"
+    assert "redpanda config dir" in result.detail
+    assert "missing locally" in result.detail
+
+
+def test_phase_firewall_sync_failed_when_no_redpanda_yaml(
+    orchestrator: Orchestrator,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Any,
+) -> None:
+    """Redpanda config dir exists but neither redpanda-firewall.yaml
+    nor redpanda.yaml is present — fail-fast with the exact missing-
+    yaml diagnostic."""
+    redpanda_dir = tmp_path / "stacks" / "redpanda" / "config"
+    redpanda_dir.mkdir(parents=True)
+    orchestrator.project_root = tmp_path
+    orchestrator.enabled_services = ["redpanda"]
+
+    monkeypatch.setattr(
+        "nexus_deploy.orchestrator._remote.ssh_run_script",
+        MagicMock(return_value=MagicMock(stdout="", returncode=0)),
+    )
+
+    result = orchestrator._phase_firewall_sync()
+    assert result.status == "failed"
+    assert "neither redpanda-firewall.yaml nor redpanda.yaml" in result.detail
+
+
+def test_phase_firewall_sync_copies_redpanda_firewall_yaml_when_present(
+    orchestrator: Orchestrator,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Any,
+) -> None:
+    """Happy path: redpanda enabled, redpanda-firewall.yaml present
+    locally. The phase must scp THAT file (not the regular
+    redpanda.yaml) and chown 101:101 on the server."""
+    redpanda_dir = tmp_path / "stacks" / "redpanda" / "config"
+    redpanda_dir.mkdir(parents=True)
+    (redpanda_dir / "redpanda-firewall.yaml").write_text("# firewall config\n")
+    (redpanda_dir / "redpanda.yaml").write_text("# regular config\n")
+    orchestrator.project_root = tmp_path
+    orchestrator.enabled_services = ["redpanda"]
+
+    ssh_run_mock = MagicMock(return_value=MagicMock(stdout="", returncode=0))
+    monkeypatch.setattr("nexus_deploy.orchestrator._remote.ssh_run_script", ssh_run_mock)
+    scp_calls: list[list[str]] = []
+
+    def fake_subprocess_run(args: list[str], **_kw: Any) -> Any:
+        scp_calls.append(args)
+        cp = MagicMock()
+        cp.returncode = 0
+        return cp
+
+    monkeypatch.setattr("nexus_deploy.orchestrator.subprocess.run", fake_subprocess_run)
+
+    result = orchestrator._phase_firewall_sync()
+    assert result.status == "ok"
+    # scp must have been called with the firewall variant, not the
+    # regular yaml.
+    assert any("redpanda-firewall.yaml" in arg for call in scp_calls for arg in call)
+    # And one of the ssh_run_script invocations carries the
+    # chown/chmod fallback chain.
+    ssh_scripts = [str(call.args[0]) for call in ssh_run_mock.call_args_list]
+    assert any("chown -R 101:101" in s for s in ssh_scripts)
+    assert any("chmod -R 777" in s for s in ssh_scripts)

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -2176,9 +2176,9 @@ def test_phase_service_env_skips_gitea_block_on_incomplete_coords(
     result = orchestrator._phase_service_env()
     assert result.status == "ok"
     assert "gitea_appended=0" in result.detail
-    assert (
-        append_called is False
-    ), "append_gitea_workspace_block must NOT be called when any coord is empty"
+    assert append_called is False, (
+        "append_gitea_workspace_block must NOT be called when any coord is empty"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_s3_persistence.py
+++ b/tests/unit/test_s3_persistence.py
@@ -1008,12 +1008,12 @@ def test_restore_script_detects_missing_latest_via_lsf_stdout_not_exit_code() ->
     #     cmd-sub semantics that flip with inherit_errexit)
     #   - ``if ! VAR=$(rclone lsf .../latest.txt); then VAR=""`` →
     #     treats transient errors as fresh-start (round-2 form)
-    assert (
-        'SNAPSHOT_LISTING=$(rclone lsf "$BUCKET/snapshots/")' in script
-    ), "fresh-start guard must list the parent prefix, not the file directly"
-    assert (
-        'grep -qxF "latest.txt"' in script
-    ), "fresh-start guard must check for latest.txt as a whole-line fixed match"
+    assert 'SNAPSHOT_LISTING=$(rclone lsf "$BUCKET/snapshots/")' in script, (
+        "fresh-start guard must list the parent prefix, not the file directly"
+    )
+    assert 'grep -qxF "latest.txt"' in script, (
+        "fresh-start guard must check for latest.txt as a whole-line fixed match"
+    )
     # Hard error path — listing failure must exit 2, NOT fresh-start.
     assert "cannot list" in script
     # And a defence-in-depth check: even if listing passed and
@@ -1037,9 +1037,9 @@ def test_restore_script_probes_bucket_reachability_before_fresh_start() -> None:
     )
     probe_pos = script.find('rclone lsd "$BUCKET"')
     fresh_check_pos = script.find('rclone lsf "$BUCKET/snapshots/"')
-    assert (
-        0 < probe_pos < fresh_check_pos
-    ), "bucket reachability probe must precede the snapshot-prefix listing"
+    assert 0 < probe_pos < fresh_check_pos, (
+        "bucket reachability probe must precede the snapshot-prefix listing"
+    )
     assert "not reachable" in script
     # The probe failure path must exit non-zero (clear error), the
     # latest.txt failure path must exit 0 (legitimate fresh-start).


### PR DESCRIPTION
## Summary

Three small unrelated cleanups bundled into one PR. None of them belong to the just-merged RFC 0001 work, but they all surfaced during it:

1. **`test(orchestrator)`** — Coverage 78% → 88% via 16 targeted phase tests
2. **`ci(pre-commit)`** — Switch mypy hook to use the project's uv venv (was broken-by-design)
3. **`ci(destroy-all)`** — New opt-in `delete_data=DESTROY` flag for full R2 wipe

## Why bundle

Each one is too small for its own PR, all three are pure dev/CI quality-of-life, and they don't interact with each other. Splitting into three would be 3× the review overhead for no win.

---

## 1. Test coverage — orchestrator.py 78% → 88%

Three uncovered blocks dominated `orchestrator.py`'s missed lines:

| Phase | Missed before | New tests | Coverage delta |
|---|---|---|---|
| `_phase_woodpecker_apply` | ~90 lines | 7 (happy + 6 error paths) | full coverage |
| `_phase_mirror_finalize` | ~75 lines | 6 (happy + flow-sync errors + git-restart paths) | full coverage |
| `_phase_firewall_sync` (redpanda branch) | ~55 lines | 3 (happy + 2 fail-fast paths) | full coverage |

All previously had only the skip-gate tests; the actual apply / orchestrate / copy flow and its error paths were never executed in tests.

The new tests pattern-match the existing test structure (per-phase, monkeypatch `_remote.ssh_run_script` + `_remote.rsync_to_remote`, assert on `PhaseResult.status` + `.detail`).

## 2. Pre-commit mypy hook fix

The existing hook used `mirrors-mypy` with `additional_dependencies` — building an isolated pip env that did **not** include `nexus_deploy`. Result: every `from nexus_deploy.X import Y` in `tests/` (pre-existing lines 1094, 1458, 2487, etc.) failed with `import-not-found`. The coverage commit in this PR had to ship with `SKIP=mypy` for that reason.

CI mypy passes because it runs `uv run mypy` against the project-installed package. The pre-commit hook was missing that same wiring.

**Fix:** switch to `language: system` + `uv run mypy`:

```yaml
- repo: local
  hooks:
    - id: mypy
      name: mypy (project venv, strict)
      entry: uv run mypy
      language: system
      types: [python]
      files: ^(src|tests)/.*\.py$
      pass_filenames: false   # let pyproject.toml's files= drive scope
      args: [--config-file=pyproject.toml]
```

This aligns local pre-commit with CI exactly — same mypy version, same site-packages, same `pyproject.toml` config — so a green pre-commit actually predicts a green CI typecheck.

`pass_filenames: false` because `mypy --config-file=pyproject.toml` already picks the right scope from the `files = [...]` directive; passing individual filenames in addition would make mypy ignore the config-file's `files=`.

## 3. `destroy-all` `delete_data=DESTROY` flag

Per RFC 0001 decision #6 the R2 persistence bucket survives `destroy-all` by design — so `destroy-all` + `initial-setup` + `spin-up` reattaches to existing snapshot history. Useful for: oops-recovery, accidental teardowns, planned-rebuilds.

But sometimes you actually want a true full wipe (testing, demo-cycle, decommissioning a stack). Before this PR that meant: run `destroy-all`, then manually invoke `scripts/cleanup-s3-bucket.sh` for the persistence bucket, then manually delete the data + state buckets via Cloudflare dashboard or aws CLI. Three opt-in destructive steps the operator had to remember.

**Fix:** new optional workflow input `delete_data`. Setting it to `DESTROY` (literal, matches the existing `confirm=DESTROY` UX) triggers a new step at the end of the workflow that wipes the three R2 buckets in dependency order:

1. `nexus-<slug>-persistence` (snapshot history)
2. `nexus-<slug>-data` (datalake)
3. `<slug>-terraform-state` (tofu state — last, because `tofu init` may have re-touched it during the destroy steps)

```bash
# Default: preserves R2 buckets (RFC 0001 default behaviour)
gh workflow run destroy-all.yml -f confirm=DESTROY

# Full wipe: also delete R2 buckets
gh workflow run destroy-all.yml -f confirm=DESTROY -f delete_data=DESTROY
```

Implementation: `aws s3 rb --force` against the R2 S3-API endpoint, with the same R2 credentials the workflow already uses. Per-bucket `head-bucket` check skips silently if already gone (so retries are safe). Fail-loud on any actual delete error rather than silently leave half-wiped state.

## Test plan

- [x] Local: 1446/1446 tests pass
- [x] Local: ruff + ruff-format + mypy clean (mypy hook now via project venv)
- [x] Local: pre-commit on a test file modification passes mypy (didn't before — `SKIP=mypy` was required)
- [ ] After merge: optionally run `gh workflow run destroy-all.yml -f confirm=DESTROY -f delete_data=DESTROY` in a sandbox / when fully decommissioning a stack to verify the new step end-to-end

## Follow-up

The next PR (announced separately) adds a `system/flow-export` Kestra flow — the reverse direction of `system/flow-sync`. Lets users push Kestra-UI-created flows back to their workspace Gitea fork. Not in this PR because it's a genuine feature (~50-100 LOC + new flow registration in `_phase_kestra_register` + docs) and deserves its own focused review.
