### PR TITLE
feat(kestra): Bi-directional flow sync — push UI edits back to Gitea fork

### DIFF
--- a/docs/admin-guides/setup-guide.md
+++ b/docs/admin-guides/setup-guide.md
@@ -94,7 +94,7 @@ This guide walks you through the complete setup of Nexus Stack.
    | Zone | DNS | Edit |
    | Zone | Zone | Read |
 
-   > **Note:** 
+   > **Note:**
    > - "Workers R2 Storage" is required for the remote state backend
    > - "Workers KV Storage" is required for the Workers KV namespace
    > - "D1" is required for the database used by the Control Plane
@@ -479,6 +479,98 @@ Docker Hub limits anonymous image pulls to **100 pulls per 6 hours per IP**. Add
 Documentation in `docs/` can be synced to [nexus-stack.ch](https://nexus-stack.ch) when changes are pushed to `main`. This is handled by the `sync-docs-site.yml` workflow and only runs on the original repository (not on forks).
 
 See [Website Sync Guide](docs-website-sync.md) for setup instructions. Sync requires a Cloudflare Deploy Hook URL stored as `WEBSITE_DEPLOY_HOOK` secret and the `WEBSITE_SYNC_ENABLED` repository variable set to `true`.
+
+## Kestra ↔ Gitea bi-directional flow sync
+
+When the `kestra` service is enabled the orchestrator registers three system-namespace flows that sync flow definitions between Kestra and the user's Gitea workspace fork.
+
+### Two-namespace model
+
+Flows live in two distinct Kestra namespaces, each tied to a separate path in the Gitea fork:
+
+| Kestra namespace | Gitea path in fork | Meaning |
+|---|---|---|
+| `nexus-tutorials.*` | `nexus_seeds/kestra/flows/` | **Seeded reference flows** shipped by Nexus-Stack. Read-mostly from the student's perspective. NEVER pushed back from the UI (would corrupt the upstream tutorial baseline). |
+| `my-flows.*` | `kestra/flows/` | **Student's own work** — clones of seeded flows, new flows. UI-edits in this namespace auto-push to Git every 10 min. |
+
+The `nexus_seeds/` prefix is reserved for Nexus-Stack-shipped content; user-authored flows live at the repo root under `kestra/flows/` to make the ownership distinction visible at a glance in the Gitea fork tree.
+
+### The three system flows
+
+| Flow | Direction | Trigger | Purpose |
+|---|---|---|---|
+| `system.git-sync` | Gitea → Kestra | once at spin-up | Pulls namespace files (SQL, scripts, queries) from `nexus_seeds/kestra/workflows/` into Kestra's namespace storage |
+| `system.flow-sync` | Gitea → Kestra | once at spin-up | Two tasks in one flow: `sync-seeds` pulls `nexus_seeds/kestra/flows/` → `nexus-tutorials.*`; `sync-user` pulls `kestra/flows/` → `my-flows.*`. Both `delete: true`, separate namespaces ensure no interference. |
+| `system.flow-export` | Kestra → Gitea | every 10 minutes | Pushes `my-flows.*` only to `kestra/flows/`. Excludes `nexus-tutorials.*` (protects seeds) and `system.*` (echo-prevention). |
+
+### Design rationale
+
+**Pull direction (`git-sync` + `flow-sync`) runs only at spin-up, not on a schedule.** The previous form (`cron: */15`) caused two distinct problems:
+
+1. **Silent overwrite of UI edits.** `SyncFlows` with `delete: true` reconciles Kestra's target namespaces to whatever is in Git every tick. A student editing a flow in the Kestra UI had a 15-minute window before their changes vanished — invisible data loss, no error log.
+2. **Ping-pong with the export direction.** A pull running on a 15-min schedule combined with a push running on any schedule would chase each other's commits.
+
+**Steady-state source of truth:**
+- For *in-session edits in `my-flows.*`* → the Kestra UI (auto-pushed to Gitea via `flow-export`).
+- For *cross-stack restore* → Gitea (the persistence-bucket snapshot covers Kestra's Postgres DB; `flow-sync` re-hydrates Kestra at the next spin-up from Gitea as canonical source).
+- For *seeded tutorial flows in `nexus-tutorials.*`* → Git is canonical (the upstream Nexus-Stack repo seeded them). UI-edits there are preserved via DB-snapshot but **not** via Git, and `flow-sync` at the next spin-up will reconcile them away. The copy-before-edit workflow exists to avoid this.
+
+### Loop diagram
+
+```
+                  ┌─────────────────────────────────────────┐
+                  │  Nexus-Stack repo (upstream)            │
+                  │  examples/workspace-seeds/kestra/flows/ │
+                  └────────────────┬────────────────────────┘
+                                   │
+                                   ▼  (POSTed by _phase_seed at first deploy)
+                  ┌─────────────────────────────────────────┐
+                  │  Gitea fork                             │
+                  │  ├── nexus_seeds/kestra/flows/  (seeds) │◀──┐
+                  │  └── kestra/flows/             (user)   │   │
+                  └────────────────┬───────────────┬────────┘   │
+                                   │               ▲           │
+                  [Spin-up: flow-sync, 2 tasks]   │           │
+                                   │               │           │
+                                   ▼               │           │
+                  ┌─────────────────────────────────────────┐  │
+                  │  Kestra                                 │  │
+                  │  ├── nexus-tutorials.*  (read-mostly)   │  │
+                  │  └── my-flows.*         (UI-editable)  ─┼──┘
+                  │                          every 10 min,  │
+                  │                          via flow-export │
+                  └─────────────────────────────────────────┘
+```
+
+### `flow-export` specifics
+
+- **Cadence:** `cron: "*/10 * * * *"` (every 10 minutes). A stack crash loses at most ~10 minutes of student work in `my-flows.*`. Faster (every 5 min) would multiply commits + R2 egress for marginal recovery; slower (hourly) would lose unacceptable amounts.
+- **Source namespace:** `my-flows` only. The PushFlows plugin has no exclude-list, so positive-only namespace scoping is the only way to (a) prevent the exporter from pushing itself (`system.*` echo-loop) AND (b) protect `nexus-tutorials.*` seeds from getting overwritten with student edits.
+- **`delete: false`:** a UI-side delete does *not* propagate to Git. To permanently delete a `my-flows.*` flow, the operator commits the removal directly in the Gitea fork; the next `flow-sync` (at next spin-up) drops it from Kestra.
+- **Commit identity:** `Kestra Auto-Export <kestra@nexus-stack.local>` (synthetic, never a real user). The Gitea push log still attributes the push to whoever owns the admin token, but Git blame stays clean.
+- **Conflict behaviour:** `REJECTED_NONFASTFORWARD` is fail-loud — visible as an execution failure in the Kestra UI, manually resolvable by an operator. Happens when someone commits directly to the fork between two export ticks.
+
+### What students see in the Gitea fork
+
+Two directories under the fork:
+
+```
+<fork-root>/
+├── nexus_seeds/
+│   └── kestra/
+│       ├── flows/                         ← seeded tutorial flows
+│       │   └── nexus-tutorials/
+│       │       └── r2-taxi-pipeline.yml
+│       └── workflows/                     ← namespace files (SQL/scripts)
+└── kestra/
+    └── flows/                             ← student's own auto-exported flows
+        └── my-flows/
+            └── r2-taxi-experiment.yml     ← auto-commit every ~10 min
+```
+
+The `system/` directory is **never** in either tree — those flows are infrastructure (regenerated per deploy).
+
+See [user-guides/kestra-flow-editing.md](../user-guides/kestra-flow-editing.md) for the recommended student-side workflow (copy a seeded flow into `my-flows` before editing).
 
 ## 📚 Next Steps
 

--- a/docs/user-guides/kestra-flow-editing.md
+++ b/docs/user-guides/kestra-flow-editing.md
@@ -1,0 +1,91 @@
+# Editing Kestra flows
+
+Nexus-Stack syncs your Kestra flows bi-directionally with your Gitea workspace fork. Two distinct namespaces live in Kestra, each tied to a separate directory in your fork:
+
+| Kestra namespace | Gitea path in your fork | Meaning |
+|---|---|---|
+| `nexus-tutorials.*` | `nexus_seeds/kestra/flows/` | **Seeded tutorial flows.** Shipped by Nexus-Stack as reference material. Read-mostly — your UI edits here are **not** auto-saved to Git. |
+| `my-flows.*` | `kestra/flows/` | **Your own work.** Edits in this namespace auto-export to your Gitea fork every 10 minutes. |
+
+## The golden rule: copy seeded flows into `my-flows` before editing
+
+The seeded `nexus-tutorials.*` flows are the same for every student who deploys Nexus-Stack. They are not your personal workspace — they are the upstream-distributed tutorial baseline. If you edit one in-place in the Kestra UI:
+
+- Your edit **does** survive across spin-ups via Kestra's DB snapshot mechanism.
+- Your edit is **not** in Git, so it's not backed up via the R2 snapshot of your fork.
+- The next time `system.flow-sync` runs (at spin-up), Kestra reconciles `nexus-tutorials.*` back to whatever is in `nexus_seeds/kestra/flows/` — i.e. the original seeded version. **Your edit is reverted.**
+
+To make your edits persistent and Git-tracked: **copy the seeded flow into the `my-flows` namespace first.**
+
+### How to copy a seeded flow
+
+1. Open the seeded flow in the Kestra UI, e.g. `nexus-tutorials.r2-taxi-pipeline`.
+2. Open the YAML view → copy the entire source.
+3. Create a new flow with:
+   - `id:` something fresh, e.g. `r2-taxi-experiment-v1`
+   - `namespace: my-flows` (the only auto-exported namespace)
+4. Paste the body, save.
+
+Your flow is now `my-flows.r2-taxi-experiment-v1`. The next `system.flow-export` run (within 10 min) commits it to `kestra/flows/my-flows/r2-taxi-experiment-v1.yml` in your Gitea fork.
+
+### Why "copy" instead of just "edit in place"?
+
+| Benefit | What it means |
+|---|---|
+| Original tutorial stays intact | Reference material always available. After three weeks of editing, you can still see the unmodified starting point. |
+| Reset is one delete away | Don't like your changes? Delete your copy → original (in `nexus-tutorials.*`) is untouched. |
+| Multiple iterations | `r2-taxi-experiment-v1`, `r2-taxi-experiment-v2`, ... typical "draft → improve → final" workflow without losing earlier versions. |
+| Clean Git history | Your fork's commit log shows what's yours (`my-flows/...`) vs the seeded baseline (`nexus_seeds/...`). |
+| Predictable spin-up behavior | Your flow is in Git after the next export tick; the next spin-up's `flow-sync` re-hydrates it. |
+
+## Round-trip across spin-ups
+
+```
+[10:03] Edit my-flows.r2-taxi-experiment-v1 in Kestra UI
+            │
+            ▼ (next */10 tick: 10:10)
+[10:10] flow-export pushes kestra/flows/my-flows/r2-taxi-experiment-v1.yml to Gitea
+            │
+            ▼  (at some point: stack teardown)
+[Teardown] R2 snapshot captures the fork incl. your flow file
+            │
+            ▼  (next spin-up — could be 5 min or 5 weeks later)
+[Spin-up] flow-sync's sync-user task pulls kestra/flows/ → my-flows.* namespace
+            │
+            ▼
+[Kestra UI shows my-flows.r2-taxi-experiment-v1, exactly as you left it]
+```
+
+## Deleting a flow
+
+The `flow-export` task uses `delete: false`, meaning a UI-side delete does **not** rewrite Git history. The flow file stays in your fork. The next `flow-sync` at spin-up will pull it back.
+
+To permanently delete a `my-flows.*` flow:
+
+1. Delete it in the Kestra UI (immediate effect, but only until next spin-up).
+2. Open your Gitea fork, navigate to `kestra/flows/my-flows/<flow-id>.yml`, click **Delete file**, commit the deletion.
+3. At the next spin-up, `flow-sync`'s `sync-user` task with `delete: true` will reconcile the deletion: Kestra removes the flow.
+
+To "reset to upstream" a seeded flow you accidentally edited in `nexus-tutorials.*`: just trigger `system.flow-sync` manually from the UI. The seeded original wins (Git is canonical for that namespace).
+
+## What about the `system.*` flows?
+
+Three flows live in the `system` namespace:
+
+- `system.git-sync` (pulls namespace files at spin-up)
+- `system.flow-sync` (pulls both seed + user flows at spin-up — two tasks in one flow)
+- `system.flow-export` (pushes `my-flows.*` to Git every 10 min)
+
+These are **infrastructure** — regenerated per deploy by Nexus-Stack itself. They are **never** pushed to your Gitea fork (echo-prevention). Don't edit them in the UI — your edits would be silently overwritten on the next spin-up. They're not part of your workspace.
+
+## When your `my-flows.*` edits aren't appearing in the Gitea fork
+
+If you don't see a recent UI edit in the fork:
+
+1. **Check the cadence.** `flow-export` runs every 10 min on the `:00`, `:10`, `:20`... ticks. If you edited at `:08`, wait until `:10`, or trigger `system.flow-export` from the Kestra UI manually for an immediate push.
+2. **Check the namespace.** Only flows in `my-flows.*` get exported. A flow in `nexus-tutorials.*` (the seeded namespace) or any other custom namespace won't be pushed. Move the flow to `my-flows.*` to make it persistent.
+3. **Check the execution log.** Open `system.flow-export` in the Kestra UI → Executions tab. A `FAILED` execution with `REJECTED_NONFASTFORWARD` means someone (or you, via the Gitea web UI) committed to the fork between two export ticks and the export couldn't fast-forward. Resolve by pulling the conflicting commit into your local edit and re-running the export.
+
+## See also
+
+- [admin-guides/setup-guide.md](../admin-guides/setup-guide.md#kestra--gitea-bi-directional-flow-sync) — the bi-directional sync design + cadence rationale + loop diagram

--- a/docs/user-guides/kestra-flow-editing.md
+++ b/docs/user-guides/kestra-flow-editing.md
@@ -1,3 +1,9 @@
+---
+title: "Editing Kestra flows"
+description: "How to make edits to Kestra flows that survive a stack restart — the copy-before-edit rule"
+order: 9
+---
+
 # Editing Kestra flows
 
 Nexus-Stack syncs your Kestra flows bi-directionally with your Gitea workspace fork. Two distinct namespaces live in Kestra, each tied to a separate directory in your fork:
@@ -11,11 +17,11 @@ Nexus-Stack syncs your Kestra flows bi-directionally with your Gitea workspace f
 
 The seeded `nexus-tutorials.*` flows are the same for every student who deploys Nexus-Stack. They are not your personal workspace — they are the upstream-distributed tutorial baseline. If you edit one in-place in the Kestra UI:
 
-- Your edit **does** survive across spin-ups via Kestra's DB snapshot mechanism.
-- Your edit is **not** in Git, so it's not backed up via the R2 snapshot of your fork.
-- The next time `system.flow-sync` runs (at spin-up), Kestra reconciles `nexus-tutorials.*` back to whatever is in `nexus_seeds/kestra/flows/` — i.e. the original seeded version. **Your edit is reverted.**
+- **During the current session** (until the next spin-up): your edit is live in Kestra's DB and you can run it.
+- **At the next spin-up**: `system.flow-sync` reconciles the `nexus-tutorials.*` namespace back to whatever is in `nexus_seeds/kestra/flows/` (i.e. the upstream-distributed version). Your in-place edit is **reverted**.
+- Your edit is **not** captured in Git either — `flow-export` deliberately excludes `nexus-tutorials.*` so it cannot corrupt the upstream tutorial baseline.
 
-To make your edits persistent and Git-tracked: **copy the seeded flow into the `my-flows` namespace first.**
+**Net outcome:** in-place edits to `nexus-tutorials.*` flows do NOT survive a spin-up cycle. To make your changes permanent, **copy the seeded flow into the `my-flows` namespace first.**
 
 ### How to copy a seeded flow
 

--- a/src/nexus_deploy/kestra.py
+++ b/src/nexus_deploy/kestra.py
@@ -36,6 +36,7 @@ no service-side credentials in argv).
 
 from __future__ import annotations
 
+import contextlib
 import time
 from dataclasses import dataclass
 from typing import Literal
@@ -436,9 +437,32 @@ class KestraClient:
 # targetNamespace / namespace fields on v1.0).
 # ---------------------------------------------------------------------------
 
+# Pull-direction flows (Gitea → Kestra) deliberately have NO
+# schedule trigger. They run ONCE at spin-up via the onboarding
+# kick-offs in ``run_register_system_flows`` and can additionally
+# be triggered manually from the Kestra UI. The previous form
+# (cron */15) caused two problems:
+#
+# 1. **Silent overwrite of UI edits.** Every 15 min the SyncFlows
+#    task with ``delete: true`` would reconcile Kestra's
+#    ``nexus-tutorials`` namespace to whatever's in the Gitea
+#    fork. A student editing a flow in the Kestra UI had a
+#    15-min window before their changes vanished — invisible
+#    data loss with no error log.
+#
+# 2. **Ping-pong with flow-export below.** Push-direction
+#    (Kestra → Gitea, ``system.flow-export``) and pull-direction
+#    running on similar cadences caused commit churn: every push
+#    triggered a pull which re-pushed identical content.
+#
+# Steady-state source of truth: Kestra UI for student edits,
+# Gitea for upstream/seeded flows. ``flow-export`` (push) keeps
+# Gitea in sync with UI; ``flow-sync`` (pull) re-hydrates Kestra
+# from Gitea ONLY at spin-up so cross-stack restoration works.
 GIT_SYNC_FLOW_TEMPLATE = """\
 id: git-sync
 namespace: system
+description: Pull namespace files (SQL/scripts/queries) from internal Gitea on spin-up. No schedule — UI edits would otherwise be silently reconciled away.
 tasks:
   - id: sync
     type: io.kestra.plugin.git.SyncNamespaceFiles
@@ -448,18 +472,14 @@ tasks:
     password: "{{{{ secret('GITEA_TOKEN') }}}}"
     namespace: "{{{{ flow.namespace }}}}"
     gitDirectory: nexus_seeds/kestra/workflows
-triggers:
-  - id: schedule
-    type: io.kestra.core.models.triggers.types.Schedule
-    cron: "*/15 * * * *"
 """
 
 FLOW_SYNC_FLOW_TEMPLATE = """\
 id: flow-sync
 namespace: system
-description: Pull flow definitions from internal Gitea, register them in Kestra. Git is source of truth.
+description: Pull flow definitions from internal Gitea on spin-up. Two-task design separates seeded reference flows from the student's own work — seeds at nexus_seeds/kestra/flows/ → nexus-tutorials.*, student work at kestra/flows/ → my-flows.*. Both load with delete:true so Git is canonical at restore-time; namespaces don't collide so the two reconciles don't interfere.
 tasks:
-  - id: sync
+  - id: sync-seeds
     type: io.kestra.plugin.git.SyncFlows
     url: http://gitea:3000/{repo_owner}/{repo_name}.git
     branch: {branch}
@@ -469,10 +489,83 @@ tasks:
     targetNamespace: nexus-tutorials
     includeChildNamespaces: true
     delete: true
+  - id: sync-user
+    type: io.kestra.plugin.git.SyncFlows
+    url: http://gitea:3000/{repo_owner}/{repo_name}.git
+    branch: {branch}
+    username: {admin_username}
+    password: "{{{{ secret('GITEA_TOKEN') }}}}"
+    gitDirectory: kestra/flows
+    targetNamespace: my-flows
+    includeChildNamespaces: true
+    delete: true
+"""
+
+# Push direction: Kestra UI → Gitea fork. Runs every 10 minutes
+# so a stack crash loses at most ~10 minutes of student work.
+#
+# **Scope: ``my-flows.*`` only.** Two namespaces with two
+# different meanings under Option C of the bi-directional sync
+# design:
+#   - ``nexus-tutorials.*``  — seeded reference material. Lives
+#     at ``nexus_seeds/kestra/flows/`` in Git. Read-mostly from
+#     the student's perspective. NEVER pushed back from Kestra
+#     UI (would corrupt the upstream-distributed examples).
+#   - ``my-flows.*``         — the student's own work. Lives at
+#     ``kestra/flows/`` in Git (no ``nexus_seeds/`` prefix
+#     because it's NOT Nexus-Stack-shipped content). Pushed
+#     here by this flow every 10 min.
+#
+# Recommended student workflow: clone-then-edit. Open the seeded
+# tutorial flow, save-as with a fresh id under the ``my-flows``
+# namespace. The clone gets auto-exported here; the original
+# stays untouched in Git as reference material.
+#
+# Echo-prevention: ``sourceNamespace: my-flows`` excludes both
+# ``system.*`` (infrastructure flows including this exporter)
+# AND ``nexus-tutorials.*`` (seeded reference material). The
+# PushFlows plugin has no exclude-list, so positive-only
+# scoping is the ONLY way to prevent the exporter from
+# pushing itself or corrupting upstream seeds.
+#
+# ``delete: false`` because a UI delete shouldn't auto-rewrite
+# Git history. To permanently delete a my-flows.* flow,
+# the operator commits the deletion directly in the Gitea fork.
+#
+# Synthetic commit identity (``Kestra Auto-Export`` /
+# ``kestra@nexus-stack.local``) so commits aren't attributed to
+# a real user. The Gitea push log still shows the admin token
+# holder as the pusher — acceptable trade-off.
+#
+# Conflict behaviour: PushFlows fails loud on
+# ``REJECTED_NONFASTFORWARD`` (no force-push, no rebase). A
+# parallel direct-to-Gitea commit from the operator would
+# cause this — visible in the Kestra execution log, manually
+# resolvable.
+FLOW_EXPORT_FLOW_TEMPLATE = """\
+id: flow-export
+namespace: system
+description: Push UI-edited flows from the my-flows.* namespace back to the internal Gitea fork every 10 min. Source-of-truth direction for student work; loses at most ~10 min on stack crash. Seeded tutorial flows in nexus-tutorials.* are NOT pushed (would corrupt upstream reference material) — copy into my-flows.* first to make edits persistent.
+tasks:
+  - id: export
+    type: io.kestra.plugin.git.PushFlows
+    url: http://gitea:3000/{repo_owner}/{repo_name}.git
+    branch: {branch}
+    username: {admin_username}
+    password: "{{{{ secret('GITEA_TOKEN') }}}}"
+    sourceNamespace: my-flows
+    includeChildNamespaces: true
+    flows: "**"
+    gitDirectory: kestra/flows
+    delete: false
+    dryRun: false
+    commitMessage: "Auto-export from Kestra UI"
+    authorName: "Kestra Auto-Export"
+    authorEmail: "kestra@nexus-stack.local"
 triggers:
   - id: schedule
     type: io.kestra.core.models.triggers.types.Schedule
-    cron: "*/15 * * * *"
+    cron: "*/10 * * * *"
 """
 
 
@@ -506,7 +599,13 @@ def render_system_flows(
     branch: str,
     admin_username: str,
 ) -> dict[str, str]:
-    """Return ``{full_name: yaml_body}`` for both system flows."""
+    """Return ``{full_name: yaml_body}`` for all three system flows.
+
+    Three flows in the bi-directional sync system:
+      - ``system.git-sync`` (pull, namespace files; spin-up only)
+      - ``system.flow-sync`` (pull, flows; spin-up only)
+      - ``system.flow-export`` (push, flows; every 10 min)
+    """
     common = {
         "repo_owner": repo_owner,
         "repo_name": repo_name,
@@ -516,6 +615,7 @@ def render_system_flows(
     return {
         "system.git-sync": render_system_flow_yaml(GIT_SYNC_FLOW_TEMPLATE, **common),
         "system.flow-sync": render_system_flow_yaml(FLOW_SYNC_FLOW_TEMPLATE, **common),
+        "system.flow-export": render_system_flow_yaml(FLOW_EXPORT_FLOW_TEMPLATE, **common),
     }
 
 
@@ -531,6 +631,28 @@ def register_all_system_flows(
     return tuple(results)
 
 
+def trigger_git_sync_onboarding(
+    client: KestraClient,
+    *,
+    timeout_s: float = 60.0,
+) -> ExecutionState:
+    """One-shot execute ``system.git-sync`` (namespace files) at spin-up.
+
+    Symmetric to :func:`trigger_flow_sync_onboarding`. Since the
+    pull-direction flows lost their schedule trigger, this is the
+    ONLY automated path for namespace files (SQL/scripts/queries)
+    to reach Kestra from the Gitea fork. Without it, seeded
+    namespace files would only appear if an operator manually
+    triggered the flow from the UI.
+
+    Run BEFORE :func:`trigger_flow_sync_onboarding` so any flow
+    that references a namespace file finds its dependency in
+    place on first execution.
+    """
+    exec_id = client.execute_flow("system", "git-sync")
+    return client.wait_for_execution(exec_id, timeout_s=timeout_s)
+
+
 def trigger_flow_sync_onboarding(
     client: KestraClient,
     *,
@@ -539,12 +661,13 @@ def trigger_flow_sync_onboarding(
     """One-shot execute ``system.flow-sync`` and wait for terminal state.
 
     Without this, user-seeded flows in ``nexus_seeds/kestra/flows/`` only
-    appear after the next 15-min cron tick — the deploy would print
+    appear after a manual UI trigger (since the schedule was removed
+    to prevent silent overwrite of UI edits) — the deploy would print
     "Deployment Complete" with no user flows visible in the Kestra UI,
     causing reasonable "where are my flows?" confusion. The trigger here
-    is best-effort: if the execute call or polling fails, the cron will
-    still tick eventually, so we surface the failure as a warning, not
-    a deploy abort.
+    is best-effort: if the execute call or polling fails, the operator
+    can still trigger manually from the UI, so we surface the failure
+    as a warning, not a deploy abort.
 
     Raises :class:`KestraError` only on the initial execute_flow call;
     polling failures coalesce to ``"UNKNOWN"`` then ``"RUNNING"`` at
@@ -584,13 +707,16 @@ def run_register_system_flows(
         password=config.kestra_admin_password or "",
     )
     if not client.wait_ready(timeout_s=ready_timeout_s):
-        # Kestra never reached basic-auth-accepted state. Both flows
-        # would 401; surface a clean partial result so the caller
-        # sees rc=1 (yellow warning, continue).
+        # Kestra never reached basic-auth-accepted state. All three
+        # flows would 401; surface a clean partial result so the
+        # caller sees rc=1 (yellow warning, continue).
         return SystemFlowsResult(
             flows=(
                 RegisterResult(name="system.git-sync", status="failed", detail="kestra not ready"),
                 RegisterResult(name="system.flow-sync", status="failed", detail="kestra not ready"),
+                RegisterResult(
+                    name="system.flow-export", status="failed", detail="kestra not ready"
+                ),
             ),
         )
 
@@ -605,11 +731,23 @@ def run_register_system_flows(
     if not trigger_onboarding:
         return SystemFlowsResult(flows=register_results)
 
-    # Only trigger the onboarding execute when both register calls
-    # succeeded — otherwise we'd execute a flow-sync against a stale
+    # Only trigger the onboarding executes when all register calls
+    # succeeded — otherwise we'd execute syncs against a stale
     # flow definition.
     if any(r.status == "failed" for r in register_results):
         return SystemFlowsResult(flows=register_results)
+
+    # Trigger git-sync FIRST so namespace files (SQL/scripts) are
+    # in place before any flow that might reference them runs.
+    # Best-effort: a failure here does NOT block flow-sync below.
+    # Namespace files are auxiliary; flows can still register and
+    # execute, just might fail at runtime if they reference a
+    # not-yet-synced file. Operator sees that via the per-flow
+    # Kestra execution log, not here. (contextlib.suppress is the
+    # canonical Python form for "intentionally ignore this
+    # exception class".)
+    with contextlib.suppress(KestraError):
+        trigger_git_sync_onboarding(client, timeout_s=onboarding_timeout_s)
 
     try:
         exec_state: ExecutionState = trigger_flow_sync_onboarding(

--- a/tests/unit/test_kestra.py
+++ b/tests/unit/test_kestra.py
@@ -17,6 +17,7 @@ import responses
 
 from nexus_deploy.config import NexusConfig
 from nexus_deploy.kestra import (
+    FLOW_EXPORT_FLOW_TEMPLATE,
     FLOW_SYNC_FLOW_TEMPLATE,
     GIT_SYNC_FLOW_TEMPLATE,
     KestraClient,
@@ -445,10 +446,17 @@ def test_render_git_sync_substitutes_placeholders() -> None:
 
 
 def test_render_flow_sync_pins_target_namespace() -> None:
-    """v1.0 plugin requires targetNamespace; our template MUST set it
-    to nexus-tutorials. A regression here would bring back the
-    'tasks[0].targetNamespace: must not be null' deploy failure
-    that PR (cited in the caller comments) chased down."""
+    """v1.0 plugin requires targetNamespace on every SyncFlows
+    task. Both tasks (sync-seeds and sync-user) must specify it,
+    and they MUST map to DIFFERENT namespaces so the two
+    delete:true reconciles don't fight each other:
+
+      - sync-seeds: nexus_seeds/kestra/flows → nexus-tutorials.*
+      - sync-user:  kestra/flows             → my-flows.*
+
+    A future regression that collapses both into the same
+    namespace would have each reconcile wiping the other's
+    flows; both being non-null is the v1.0 plugin requirement."""
     yaml_body = render_system_flow_yaml(
         FLOW_SYNC_FLOW_TEMPLATE,
         repo_owner="bob",
@@ -456,19 +464,182 @@ def test_render_flow_sync_pins_target_namespace() -> None:
         branch="dev",
         admin_username="admin",
     )
+    # Both targetNamespace mappings present.
     assert "targetNamespace: nexus-tutorials" in yaml_body
-    assert "includeChildNamespaces: true" in yaml_body
-    assert "delete: true" in yaml_body
+    assert "targetNamespace: my-flows" in yaml_body
+    # Both source paths.
     assert "gitDirectory: nexus_seeds/kestra/flows" in yaml_body
+    assert "gitDirectory: kestra/flows" in yaml_body
+    # Two task IDs distinguish seeds from user.
+    assert "id: sync-seeds" in yaml_body
+    assert "id: sync-user" in yaml_body
+    # Both reconcile with delete:true (Git canonical at restore time),
+    # safe because they target separate namespaces.
+    assert yaml_body.count("delete: true") == 2
+    assert yaml_body.count("includeChildNamespaces: true") == 2
 
 
-def test_render_system_flows_returns_both() -> None:
+def test_render_flow_sync_seeds_and_user_paths_in_correct_tasks() -> None:
+    """Pin the path-to-namespace pairing so a future copy-paste
+    can't accidentally swap them (e.g. user-path → tutorials
+    namespace, which would let UI-edited flows leak into the
+    seeded reference namespace and clobber upstream examples)."""
+    yaml_body = render_system_flow_yaml(
+        FLOW_SYNC_FLOW_TEMPLATE,
+        repo_owner="o",
+        repo_name="r",
+        branch="b",
+        admin_username="a",
+    )
+    # Find each task block by id and assert its gitDirectory +
+    # targetNamespace are paired correctly.
+    seeds_block = yaml_body.split("id: sync-seeds")[1].split("id: sync-user")[0]
+    user_block = yaml_body.split("id: sync-user")[1]
+    assert "gitDirectory: nexus_seeds/kestra/flows" in seeds_block
+    assert "targetNamespace: nexus-tutorials" in seeds_block
+    assert "gitDirectory: kestra/flows" in user_block
+    assert "targetNamespace: my-flows" in user_block
+
+
+def test_render_system_flows_returns_all_three() -> None:
+    """The bi-directional sync system has three flows: two pull-direction
+    (git-sync for namespace files, flow-sync for flows) and one push-
+    direction (flow-export). All three must be rendered together so
+    the registration loop in run_register_system_flows registers
+    all of them in one batch."""
     flows = render_system_flows(
         repo_owner="alice", repo_name="r", branch="main", admin_username="admin"
     )
-    assert set(flows.keys()) == {"system.git-sync", "system.flow-sync"}
+    assert set(flows.keys()) == {
+        "system.git-sync",
+        "system.flow-sync",
+        "system.flow-export",
+    }
     assert "git-sync" in flows["system.git-sync"]
     assert "flow-sync" in flows["system.flow-sync"]
+    assert "flow-export" in flows["system.flow-export"]
+    # Each carries the correct task type — guards against accidental
+    # template copy-paste swaps.
+    assert "SyncNamespaceFiles" in flows["system.git-sync"]
+    assert "SyncFlows" in flows["system.flow-sync"]
+    assert "PushFlows" in flows["system.flow-export"]
+
+
+def test_pull_direction_flows_have_no_schedule_trigger() -> None:
+    """Pull-direction flows (git-sync + flow-sync) MUST NOT have a
+    schedule trigger. The previous form (cron */15) caused two bugs:
+
+    1. Silent overwrite of UI edits: SyncFlows with delete=true would
+       reconcile away student edits in nexus-tutorials.* every 15 min,
+       invisibly.
+    2. Ping-pong with flow-export (the push direction): pull+push on
+       similar cadences caused commit churn loops.
+
+    These flows now run ONLY at spin-up via the onboarding kick-offs.
+    A future maintainer adding a schedule back would regress both
+    bugs — this test is the regression gate."""
+    flows = render_system_flows(repo_owner="o", repo_name="r", branch="b", admin_username="a")
+    assert "triggers:" not in flows["system.git-sync"], (
+        "git-sync must have no schedule — pull-direction at spin-up only"
+    )
+    assert "triggers:" not in flows["system.flow-sync"], (
+        "flow-sync must have no schedule — pull-direction at spin-up only"
+    )
+    # And no cron string smuggled into the tasks section either.
+    assert "cron:" not in flows["system.git-sync"]
+    assert "cron:" not in flows["system.flow-sync"]
+
+
+def test_render_flow_export_pins_source_namespace_for_echo_break() -> None:
+    """flow-export's ``sourceNamespace`` is the echo-prevention
+    invariant under the two-namespace design (Option C):
+
+      - ``system.*`` excluded → exporter doesn't push itself
+      - ``nexus-tutorials.*`` excluded → seeded reference flows
+        stay untouched in Git (corrupting upstream reference
+        material via UI-edits would lose the tutorial baseline)
+      - ``my-flows.*`` is the ONLY pushed namespace → student's
+        own work, copy-before-edit pattern
+
+    The PushFlows plugin has no exclude-list, so positive-only
+    scoping is the only way to enforce all three constraints."""
+    yaml_body = render_system_flow_yaml(
+        FLOW_EXPORT_FLOW_TEMPLATE,
+        repo_owner="carol",
+        repo_name="ws",
+        branch="main",
+        admin_username="admin",
+    )
+    assert "type: io.kestra.plugin.git.PushFlows" in yaml_body
+    assert "sourceNamespace: my-flows" in yaml_body
+    # Anti-regression: under no circumstances should the seeded-
+    # reference namespace appear as the source namespace — that
+    # would corrupt the tutorial baseline by pushing student
+    # edits over upstream files.
+    assert "sourceNamespace: nexus-tutorials" not in yaml_body
+    assert "includeChildNamespaces: true" in yaml_body
+    # Target path is the USER path, not the seeds path.
+    assert "gitDirectory: kestra/flows" in yaml_body
+    assert "gitDirectory: nexus_seeds/kestra/flows" not in yaml_body
+    assert "url: http://gitea:3000/carol/ws.git" in yaml_body
+    assert "branch: main" in yaml_body
+    assert "username: admin" in yaml_body
+    # Pebble secret reference passes through unchanged.
+    assert "{{ secret('GITEA_TOKEN') }}" in yaml_body
+
+
+def test_render_flow_export_is_additive_not_destructive() -> None:
+    """``delete: false`` because a UI deletion shouldn't auto-rewrite
+    Git history. To permanently delete a flow, the operator commits
+    the deletion directly in the Gitea fork. Pinning this prevents
+    a future copy-paste from flow-sync (which uses ``delete: true``
+    for the reverse direction) from accidentally enabling destructive
+    Git rewrites here."""
+    yaml_body = render_system_flow_yaml(
+        FLOW_EXPORT_FLOW_TEMPLATE,
+        repo_owner="o",
+        repo_name="r",
+        branch="b",
+        admin_username="a",
+    )
+    assert "delete: false" in yaml_body
+    assert "delete: true" not in yaml_body
+    assert "dryRun: false" in yaml_body
+
+
+def test_render_flow_export_uses_synthetic_commit_identity() -> None:
+    """Commits land with a synthetic author ('Kestra Auto-Export') so
+    Git blame doesn't attribute student work to whoever owns the
+    push-token (admin). Real students see 'Kestra Auto-Export' as
+    the commit author, distinguishing UI-pushed commits from
+    operator-direct commits in the fork."""
+    yaml_body = render_system_flow_yaml(
+        FLOW_EXPORT_FLOW_TEMPLATE,
+        repo_owner="o",
+        repo_name="r",
+        branch="b",
+        admin_username="a",
+    )
+    assert 'authorName: "Kestra Auto-Export"' in yaml_body
+    assert 'authorEmail: "kestra@nexus-stack.local"' in yaml_body
+    assert 'commitMessage: "Auto-export from Kestra UI"' in yaml_body
+
+
+def test_render_flow_export_has_10min_schedule() -> None:
+    """flow-export runs every 10 min so a stack crash loses at most
+    ~10 minutes of student work. Faster (e.g. */5) would multiply
+    commits / R2 egress for marginal recovery; slower (e.g. hourly)
+    would lose unacceptable amounts of student work. The 10-min
+    cadence is the sweet spot — pinning this guards against a
+    future 'optimize cron' that breaks the recovery contract."""
+    yaml_body = render_system_flow_yaml(
+        FLOW_EXPORT_FLOW_TEMPLATE,
+        repo_owner="o",
+        repo_name="r",
+        branch="b",
+        admin_username="a",
+    )
+    assert 'cron: "*/10 * * * *"' in yaml_body
 
 
 def test_render_system_flows_does_not_double_substitute_secret_pebble() -> None:
@@ -496,10 +667,15 @@ def test_render_system_flows_does_not_double_substitute_secret_pebble() -> None:
 def test_register_all_system_flows_returns_one_result_per_flow() -> None:
     responses.add(responses.POST, f"{BASE_URL}/api/v1/flows", status=201)
     responses.add(responses.POST, f"{BASE_URL}/api/v1/flows", status=201)
+    responses.add(responses.POST, f"{BASE_URL}/api/v1/flows", status=201)
     flows = render_system_flows(repo_owner="o", repo_name="r", branch="b", admin_username="a")
     results = register_all_system_flows(_client(), flows)
-    assert len(results) == 2
-    assert {r.name for r in results} == {"system.git-sync", "system.flow-sync"}
+    assert len(results) == 3
+    assert {r.name for r in results} == {
+        "system.git-sync",
+        "system.flow-sync",
+        "system.flow-export",
+    }
     assert all(r.status == "created" for r in results)
 
 
@@ -527,10 +703,28 @@ def test_trigger_flow_sync_onboarding_returns_terminal_state() -> None:
 
 @responses.activate
 def test_run_register_system_flows_happy_path_with_onboarding() -> None:
-    """Wait → register both → execute flow-sync → poll SUCCESS → seed-flow visible."""
+    """Wait → register all three → execute git-sync (namespace files) →
+    execute flow-sync → poll SUCCESS → seed-flow visible."""
     responses.add(responses.GET, f"{BASE_URL}/api/v1/flows", status=200)
+    # Three register POSTs (git-sync, flow-sync, flow-export).
     responses.add(responses.POST, f"{BASE_URL}/api/v1/flows", status=201)
     responses.add(responses.POST, f"{BASE_URL}/api/v1/flows", status=201)
+    responses.add(responses.POST, f"{BASE_URL}/api/v1/flows", status=201)
+    # git-sync onboarding (fires BEFORE flow-sync so namespace files
+    # are in place when flows that reference them run).
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/executions/system/git-sync",
+        status=201,
+        json={"id": "exec-git"},
+    )
+    responses.add(
+        responses.GET,
+        f"{BASE_URL}/api/v1/executions/exec-git",
+        status=200,
+        json={"state": {"current": "SUCCESS"}},
+    )
+    # flow-sync onboarding.
     responses.add(
         responses.POST,
         f"{BASE_URL}/api/v1/executions/system/flow-sync",
@@ -543,7 +737,7 @@ def test_run_register_system_flows_happy_path_with_onboarding() -> None:
         status=200,
         json={"state": {"current": "SUCCESS"}},
     )
-    # Post-execute verification: seed flow IS visible
+    # Post-execute verification: seed flow IS visible.
     responses.add(
         responses.GET,
         f"{BASE_URL}/api/v1/flows/nexus-tutorials/r2-taxi-pipeline",
@@ -585,6 +779,129 @@ def test_run_register_system_flows_kestra_not_ready_returns_failed_results() -> 
     assert all(f.status == "failed" for f in result.flows)
     assert all("not ready" in f.detail for f in result.flows)
     assert result.execution_state is None  # no execute attempt
+
+
+@responses.activate
+def test_run_register_system_flows_triggers_git_sync_before_flow_sync() -> None:
+    """The git-sync onboarding (namespace files) must fire BEFORE
+    the flow-sync onboarding (flows). A flow that references a
+    namespace file would otherwise fail on its first execution
+    because the file isn't in Kestra's storage yet. Pin the
+    ordering via call-history inspection on responses.calls."""
+    responses.add(responses.GET, f"{BASE_URL}/api/v1/flows", status=200)
+    responses.add(responses.POST, f"{BASE_URL}/api/v1/flows", status=201)
+    responses.add(responses.POST, f"{BASE_URL}/api/v1/flows", status=201)
+    responses.add(responses.POST, f"{BASE_URL}/api/v1/flows", status=201)
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/executions/system/git-sync",
+        status=201,
+        json={"id": "g"},
+    )
+    responses.add(
+        responses.GET,
+        f"{BASE_URL}/api/v1/executions/g",
+        status=200,
+        json={"state": {"current": "SUCCESS"}},
+    )
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/executions/system/flow-sync",
+        status=201,
+        json={"id": "f"},
+    )
+    responses.add(
+        responses.GET,
+        f"{BASE_URL}/api/v1/executions/f",
+        status=200,
+        json={"state": {"current": "SUCCESS"}},
+    )
+    responses.add(
+        responses.GET,
+        f"{BASE_URL}/api/v1/flows/nexus-tutorials/r2-taxi-pipeline",
+        status=200,
+        json={"id": "r2-taxi-pipeline"},
+    )
+
+    run_register_system_flows(
+        _make_config(),
+        base_url=BASE_URL,
+        repo_owner="o",
+        repo_name="r",
+        branch="main",
+        admin_email="admin@example.com",
+        ready_timeout_s=0.05,
+        onboarding_timeout_s=2.0,
+    )
+
+    # Find the execute-POSTs in call order and assert git-sync came
+    # before flow-sync. ``PreparedRequest.url`` is typed ``str | None``;
+    # coalesce to "" so the substring + endswith checks are
+    # unambiguously string ops.
+    execute_urls: list[str] = []
+    for c in responses.calls:
+        url = c.request.url or ""
+        if "/api/v1/executions/system/" in url and c.request.method == "POST":
+            execute_urls.append(url)
+    assert execute_urls[0].endswith("/executions/system/git-sync"), (
+        f"git-sync must execute first; got {execute_urls}"
+    )
+    assert execute_urls[1].endswith("/executions/system/flow-sync"), (
+        f"flow-sync must execute second; got {execute_urls}"
+    )
+
+
+@responses.activate
+def test_run_register_system_flows_git_sync_onboarding_failure_is_non_blocking() -> None:
+    """git-sync onboarding is BEST-EFFORT. If the namespace-files sync
+    fails, flow-sync (the primary onboarding) MUST still run — the
+    operator can manually retrigger git-sync from the UI later.
+    Without this guarantee a transient git-sync hiccup would block
+    the entire deploy from reaching success."""
+    responses.add(responses.GET, f"{BASE_URL}/api/v1/flows", status=200)
+    responses.add(responses.POST, f"{BASE_URL}/api/v1/flows", status=201)
+    responses.add(responses.POST, f"{BASE_URL}/api/v1/flows", status=201)
+    responses.add(responses.POST, f"{BASE_URL}/api/v1/flows", status=201)
+    # git-sync execute fails with 5xx (transport error → KestraError).
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/executions/system/git-sync",
+        status=503,
+    )
+    # flow-sync execute succeeds — this is what we want to prove.
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/executions/system/flow-sync",
+        status=201,
+        json={"id": "f"},
+    )
+    responses.add(
+        responses.GET,
+        f"{BASE_URL}/api/v1/executions/f",
+        status=200,
+        json={"state": {"current": "SUCCESS"}},
+    )
+    responses.add(
+        responses.GET,
+        f"{BASE_URL}/api/v1/flows/nexus-tutorials/r2-taxi-pipeline",
+        status=200,
+        json={"id": "r2-taxi-pipeline"},
+    )
+
+    result = run_register_system_flows(
+        _make_config(),
+        base_url=BASE_URL,
+        repo_owner="o",
+        repo_name="r",
+        branch="main",
+        admin_email="admin@example.com",
+        ready_timeout_s=0.05,
+        onboarding_timeout_s=2.0,
+    )
+    # Deploy still succeeds — flow-sync state is the canonical
+    # success signal, not git-sync.
+    assert result.is_success
+    assert result.execution_state == "SUCCESS"
 
 
 @responses.activate


### PR DESCRIPTION
## Summary

Adds bi-directional sync between Kestra and the user's Gitea workspace fork. Student edits in the Kestra UI auto-commit back to the fork every 10 minutes; previously the sync was pull-only and UI edits were silently overwritten every 15 minutes.

Implements the **two-namespace** ("Option C") design so seeded tutorial flows stay distinct from student-authored work.

## The two-namespace model

| Kestra namespace | Gitea path in fork | Meaning |
|---|---|---|
| `nexus-tutorials.*` | `nexus_seeds/kestra/flows/` | **Seeded reference flows** shipped by Nexus-Stack. Read-mostly. Never pushed back from UI (would corrupt upstream tutorial baseline). |
| `my-flows.*` | `kestra/flows/` | **Student's own work** — clones, new flows. Auto-exported every 10 min. |

The `nexus_seeds/` prefix in Git stays reserved for Nexus-Stack-shipped content; user flows live at the repo root under `kestra/flows/` so ownership is visible at a glance.

## The three system flows

| Flow | Direction | Trigger | Path → Namespace |
|---|---|---|---|
| `system.git-sync` | Gitea → Kestra | once at spin-up | `nexus_seeds/kestra/workflows/` → namespace storage |
| `system.flow-sync` | Gitea → Kestra | once at spin-up | Two tasks: `sync-seeds` (`nexus_seeds/.../flows` → `nexus-tutorials.*`) + `sync-user` (`kestra/flows` → `my-flows.*`) |
| `system.flow-export` | Kestra → Gitea | every 10 minutes | `my-flows.*` → `kestra/flows/` |

## Why these specific design choices

### Pull direction (`git-sync` + `flow-sync`) runs only at spin-up

Removed the `cron: */15` from both pull-direction flows. Previously:

1. **Silent overwrite of UI edits.** `SyncFlows` with `delete: true` reconciled `nexus-tutorials.*` to whatever was in Git every 15 min. A student editing a flow had a 15-min window before their changes vanished — invisible data loss.
2. **Ping-pong with the new export direction.** Pull + push on similar cadences chase each other's commits.

Now: pull-direction runs ONLY at spin-up (via existing onboarding kick-offs in `run_register_system_flows`). New `trigger_git_sync_onboarding()` helper added for the namespace-files sync, called BEFORE `trigger_flow_sync_onboarding()` so flows that reference namespace files find their dependencies in place.

### Push direction (`flow-export`) runs `cron: */10`

Sweet spot:
- Faster (`*/5`) = unnecessary commit spam + R2 egress for marginal recovery
- Slower (hourly or more) = unacceptable data-loss window for students
- `*/10` = at most ~10 min of UI work lost on stack crash

### Echo-prevention via `sourceNamespace: my-flows`

PushFlows has no exclude-list, so positive-only namespace scoping is the only enforcement. Setting `sourceNamespace: my-flows` excludes BOTH `system.*` (the exporter itself + its sibling system flows — would create push-pull echo loop) AND `nexus-tutorials.*` (would corrupt the upstream tutorial baseline with student-specific edits).

### `delete: false` on flow-export

A UI-side delete should not auto-rewrite Git history. To permanently delete a `my-flows.*` flow, the operator commits the deletion in the Gitea fork; next `flow-sync` then drops it from Kestra.

### Synthetic commit identity

`Kestra Auto-Export <kestra@nexus-stack.local>` — never claims to be a real user. The Gitea push log still shows the admin token holder as the pusher, but Git blame stays clean.

## Code changes

`src/nexus_deploy/kestra.py`:
- Remove `triggers:` block from `GIT_SYNC_FLOW_TEMPLATE` + `FLOW_SYNC_FLOW_TEMPLATE`
- `FLOW_SYNC_FLOW_TEMPLATE`: rewrite as two-task flow (`sync-seeds` + `sync-user`) with distinct `gitDirectory` + `targetNamespace` per task. Both `delete: true` (Git canonical at restore-time); separate target namespaces ensure the two reconciles don't fight.
- New `FLOW_EXPORT_FLOW_TEMPLATE` with cron `*/10`, sourceNamespace `my-flows`, gitDirectory `kestra/flows`.
- `render_system_flows()` returns all three templates.
- `run_register_system_flows()`: register all three flows, then trigger git-sync onboarding before flow-sync (best-effort: git-sync failure does NOT block flow-sync; uses `contextlib.suppress`).
- New `trigger_git_sync_onboarding()` helper, parallel to existing `trigger_flow_sync_onboarding()`.

## Tests

10 new + 4 updated (`tests/unit/test_kestra.py`), 80/80 pass:
- `test_render_system_flows_returns_all_three` — three keys with correct task types
- `test_pull_direction_flows_have_no_schedule_trigger` — regression gate for cron removal
- `test_render_flow_sync_pins_target_namespace` — updated to assert BOTH `nexus-tutorials` AND `my-flows` task target-namespaces present, both `delete: true`, both `includeChildNamespaces`
- `test_render_flow_sync_seeds_and_user_paths_in_correct_tasks` — pins path↔namespace pairing (anti-swap regression)
- `test_render_flow_export_pins_source_namespace_for_echo_break` — `sourceNamespace: my-flows` (not nexus-tutorials), `gitDirectory: kestra/flows` (not nexus_seeds/...)
- `test_render_flow_export_is_additive_not_destructive` — `delete: false`
- `test_render_flow_export_uses_synthetic_commit_identity` — synthetic author/email/message
- `test_render_flow_export_has_10min_schedule` — cron `*/10`
- `test_register_all_system_flows_returns_one_result_per_flow` — updated for 3 flows
- `test_run_register_system_flows_happy_path_with_onboarding` — updated to mock git-sync + flow-sync execution endpoints
- `test_run_register_system_flows_triggers_git_sync_before_flow_sync` — order pin
- `test_run_register_system_flows_git_sync_onboarding_failure_is_non_blocking` — flow-sync still runs

## Docs

- `docs/admin-guides/setup-guide.md`: new "Kestra ↔ Gitea bi-directional flow sync" section with two-namespace model, three flows table, design rationale, ASCII loop diagram, `flow-export` specifics, what students see in the fork tree
- `docs/user-guides/kestra-flow-editing.md` (new): student-facing guide with **the golden rule** (copy seeded flows into `my-flows` before editing), round-trip across spin-ups, delete semantics, `system.*` namespace caveat, troubleshooting (cadence, namespace mismatch, conflict resolution)

## Test plan after merge

1. `gh workflow run spin-up.yml` — verify:
   - Kestra UI → Flows → `system` namespace shows three flows: `git-sync`, `flow-sync`, `flow-export`
   - `system.flow-sync` has TWO execution tasks visible in the topology view
   - `system.flow-export` has a `cron: */10 * * * *` trigger visible
2. In Kestra UI, clone `nexus-tutorials.r2-taxi-pipeline` to `my-flows.r2-taxi-experiment` (change namespace + id, save).
3. Wait up to 10 min OR manually execute `system.flow-export` once.
4. Open Gitea fork → navigate to `kestra/flows/my-flows/r2-taxi-experiment.yml` — file exists, content matches UI, author = "Kestra Auto-Export".
5. Confirm `kestra/flows/nexus-tutorials/` does NOT exist in the fork (would be a regression — nexus-tutorials is read-only from the UI side).
6. Edit `my-flows.r2-taxi-experiment` in the UI, wait for next export tick, confirm Gitea fork's file has the new content.
7. Run `destroy-all` + `initial-setup`, then `spin-up`. Confirm the `my-flows.r2-taxi-experiment` flow re-appears in Kestra UI (via `flow-sync`'s `sync-user` task) with your edits preserved.
