### PR TITLE
fix(scripts): Define CYAN to unblock init-r2-state.sh on fresh forks

### DIFF
--- a/scripts/init-r2-state.sh
+++ b/scripts/init-r2-state.sh
@@ -23,6 +23,7 @@ RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
+CYAN='\033[0;36m'
 NC='\033[0m' # No Color
 
 # Generate bucket name from domain: nexus-stack.ch -> nexus-stack-ch-terraform-state
@@ -205,11 +206,11 @@ if [ -f "$R2_CREDENTIALS_FILE" ]; then
     source "$R2_CREDENTIALS_FILE"
     if [ -n "$R2_ACCESS_KEY_ID" ] && [ -n "$R2_SECRET_ACCESS_KEY" ]; then
         echo -e "  ${GREEN}✓${NC} R2 credentials already configured"
-        
+
         # Export for current session
         export AWS_ACCESS_KEY_ID="$R2_ACCESS_KEY_ID"
         export AWS_SECRET_ACCESS_KEY="$R2_SECRET_ACCESS_KEY"
-        
+
         # Generate backend.hcl with dynamic bucket name
         echo ""
         echo -e "${BLUE}Step 3/4: Generating backend configuration...${NC}"
@@ -222,7 +223,7 @@ endpoints = {
 bucket = "${BUCKET_NAME}"
 EOF
         echo -e "  ${GREEN}✓${NC} Generated tofu/backend.hcl (bucket: ${BUCKET_NAME})"
-        
+
         echo ""
         echo -e "${GREEN}✅ R2 bootstrap complete!${NC}"
         echo ""
@@ -327,15 +328,15 @@ while [ $RETRY -lt $MAX_RETRIES ]; do
                 }
             ]
         }")
-    
+
     if echo "$TOKEN_RESPONSE" | grep -q '"success":true'; then
         break
     fi
-    
+
     # Extract error message and code
     ERROR_MSG=$(extract_error "$TOKEN_RESPONSE")
     ERROR_CODE=$(echo "$TOKEN_RESPONSE" | grep -o '"code":[0-9]*' | head -1 | cut -d: -f2)
-    
+
     # Token already exists — delete it and retry (credentials can't be retrieved after creation)
     if echo "$TOKEN_RESPONSE" | grep -q "already exists"; then
         RETRY=$((RETRY + 1))
@@ -374,7 +375,7 @@ while [ $RETRY -lt $MAX_RETRIES ]; do
             exit 1
         fi
     fi
-    
+
     # Retry on 500 errors or rate limits (retryable)
     if [ "$ERROR_CODE" = "500" ] || [ "$ERROR_CODE" = "429" ] || [ -z "$ERROR_CODE" ]; then
         RETRY=$((RETRY + 1))
@@ -386,7 +387,7 @@ while [ $RETRY -lt $MAX_RETRIES ]; do
             continue
         fi
     fi
-    
+
     # Non-retryable error or max retries reached
     ERROR_MSG=$(extract_error "$TOKEN_RESPONSE")
     echo -e "  ${RED}❌ Failed to create token: ${ERROR_MSG:-Unknown error}${NC}"


### PR DESCRIPTION
## Summary

Fixes the `unbound variable: CYAN` crash in `scripts/init-r2-state.sh` that blocks every fresh `initial-setup.yaml` run on v0.58.0 and `main`.

## Root cause

`scripts/init-r2-state.sh` runs under `set -euo pipefail` (line 19). The colour palette declared at the top defines `RED`, `GREEN`, `YELLOW`, `BLUE`, and `NC` (lines 22-26) — but **not** `CYAN`. Line 269 then reads `${CYAN}` for the pre-cleanup banner:

```bash
echo -e "  ${CYAN}→${NC} Pre-cleanup: looking for stale '${TOKEN_NAME}' tokens..."
```

With `set -u` the unbound read aborts the script before any cleanup or token-create work happens:

```
./scripts/init-r2-state.sh: line 269: CYAN: unbound variable
❌ init-r2-state.sh script failed
```

## Why this didn't surface in the upstream repo

The script has an **early-exit at line 232** that short-circuits when R2 credentials already exist locally:

```bash
if [ -f "$R2_CREDENTIALS_FILE" ]; then
    source "$R2_CREDENTIALS_FILE"
    if [ -n "$R2_ACCESS_KEY_ID" ] && [ -n "$R2_SECRET_ACCESS_KEY" ]; then
        ...generate backend.hcl...
        exit 0   # ← Line 232: shortcuts before line 269
    fi
fi
```

In a repo that's already bootstrapped once (R2 creds saved as GitHub Secrets via `GH_SECRETS_TOKEN` auto-save), `setup-control-plane.yaml` writes those secrets to `tofu/.r2-credentials` before invoking `init-r2-state.sh`. The early-exit fires and line 269 is never reached. Fresh forks have neither the secrets nor the file, so the script proceeds to the token-create path and crashes.

Introduced in commit `a708adb` (PR round-2 for the orphan-token fix). The PR author tested with existing credentials, so the new pre-cleanup banner's CYAN reference was never executed.

## Fix

Add the missing palette entry next to the existing colours. `grep -n CYAN scripts/init-r2-state.sh` confirms line 269 is the only reference, so this one definition closes the bug.

```diff
 BLUE='\033[0;34m'
+CYAN='\033[0;36m'
 NC='\033[0m' # No Color
```

Alternative would have been to rewrite line 269 to use the already-defined `${BLUE}` (similar hue), but that loses the visual distinction the author intended.

## Test plan

- [x] `grep -n CYAN scripts/init-r2-state.sh` → only the one reference at line 269, no other surprises
- [x] `shellcheck scripts/init-r2-state.sh` clean (CI's shellcheck hook passes locally)
- [ ] After merge: re-run `initial-setup.yaml` on a fresh fork; the "Initialize R2 State Bucket" workflow step should now reach step 2/4 successfully instead of crashing at the CYAN read

Closes #561.
