### PR TITLE
fix(teardown): Skip s3-snapshot when stack has no Tofu state

### DIFF
--- a/src/nexus_deploy/__main__.py
+++ b/src/nexus_deploy/__main__.py
@@ -3010,6 +3010,15 @@ def _s3_snapshot(args: list[str]) -> int:
     # here (filtered above) but kept for symmetry.
     if outcome.reason == "feature_flag_off":
         return 0
+    if outcome.reason == "no_state_to_snapshot":
+        # Issue #564: partially-deployed fork (setup-control-plane
+        # succeeded, spin-up aborted before any tofu apply). Nothing
+        # on the server to snapshot; teardown should proceed.
+        sys.stderr.write(
+            "s3-snapshot: stack has no Tofu state - nothing to snapshot "
+            "(partial deploy?). Teardown will proceed.\n",
+        )
+        return 0
     # no_endpoint_env — snapshot_to_s3 already wrote its own
     # diagnostic listing the missing env vars. Map to rc=2.
     return 2

--- a/src/nexus_deploy/__main__.py
+++ b/src/nexus_deploy/__main__.py
@@ -2915,8 +2915,13 @@ def _s3_snapshot(args: list[str]) -> int:
     - ``PROJECT_ROOT`` — defaults to ``$PWD``; the repo checkout root
 
     Exit codes:
-    - 0: snapshot applied OR feature flag off (nothing to snapshot;
-         teardown can proceed)
+    - 0: snapshot applied OR a legitimate no-op (teardown proceeds):
+         * feature flag off (nothing to snapshot; stack hasn't opted
+           in to S3 persistence)
+         * no Tofu state to snapshot (issue #564: partial deploy —
+           setup-control-plane succeeded but spin-up aborted before
+           any ``tofu apply`` ran, so there's nothing on the server
+           to back up; subsequent ``tofu destroy`` is also a no-op)
     - 2: hard failure — pipeline pre-flight, SSH wait timeout,
          CalledProcessError from the rendered bash, or feature flag
          on with credentials missing. Teardown MUST abort.

--- a/src/nexus_deploy/pipeline.py
+++ b/src/nexus_deploy/pipeline.py
@@ -532,6 +532,12 @@ def run_snapshot(
     - Snapshot returns ``S3SnapshotSkipped(reason='no_endpoint_env')``
       → rc=2, flag is on but credentials missing; teardown MUST
       abort to avoid data loss.
+    - Snapshot returns ``S3SnapshotSkipped(reason='no_state_to_snapshot')``
+      → rc=0, partially-deployed fork (no ``tofu apply`` ever
+      ran against ``tofu/stack``, e.g. spin-up aborted at the
+      Hetzner capacity step). Nothing on the server to snapshot;
+      teardown proceeds and ``tofu destroy`` is also a no-op
+      against the empty state. See issue #564.
     - Snapshot returns ``S3SnapshotApplied`` → rc=0, safe to
       proceed with ``tofu destroy``.
 

--- a/src/nexus_deploy/pipeline.py
+++ b/src/nexus_deploy/pipeline.py
@@ -566,12 +566,31 @@ def run_snapshot(
         os.environ["AWS_ACCESS_KEY_ID"] = creds.access_key_id
         os.environ["AWS_SECRET_ACCESS_KEY"] = creds.secret_access_key
 
-    # 2. tofu state pre-flight (identical to run_pipeline step 2).
+    # 2. tofu state pre-flight (identical to run_pipeline step 2,
+    #    plus an issue-#564 carve-out for the "stack was never
+    #    spun up" case).
     tofu_dir = project_root / "tofu" / "stack"
     runner = tofu_runner if tofu_runner is not None else _tofu.TofuRunner(tofu_dir=tofu_dir)
     if not runner.state_list_ok():
         reason_obj = runner.diagnose_state() if hasattr(runner, "diagnose_state") else None
         reason: str | None = reason_obj if isinstance(reason_obj, str) else None
+        # Issue #564: distinguish "no state to snapshot" (partial
+        # deploy: setup-control-plane succeeded, spin-up aborted
+        # before tofu apply — e.g. Hetzner capacity exhausted)
+        # from a real state-list failure (binary missing, R2
+        # auth/timeout, etc.). The former is a legitimate no-op:
+        # the subsequent tofu destroy will also be a no-op, and
+        # teardown should be allowed to complete green so the
+        # operator can recover without falling back to
+        # destroy-all. We narrowly match on the "No state file
+        # was found" substring that diagnose_state() surfaces
+        # verbatim from tofu's stderr.
+        if reason and "No state file was found" in reason:
+            return SnapshotResult(
+                outcome=_s3_restore.S3SnapshotSkipped(
+                    reason="no_state_to_snapshot",
+                ),
+            )
         if reason:
             raise PipelineError(
                 f"OpenTofu state at {tofu_dir} not usable: {reason} — "

--- a/src/nexus_deploy/s3_restore.py
+++ b/src/nexus_deploy/s3_restore.py
@@ -138,8 +138,8 @@ class S3SnapshotSkipped:
       is the partially-deployed-fork case from issue #564: the
       Spin-Up workflow failed BEFORE any stack resources were
       provisioned (e.g. Hetzner capacity selection aborted), so
-      there is literally nothing on the server to snapshot. The
-      legitimate no-op — teardown proceeds (the subsequent ``tofu
+      there is literally nothing on the server to snapshot. A
+      legitimate no-op; teardown proceeds (the subsequent ``tofu
       destroy`` will also be a no-op against the empty state) and
       operators can recover without needing ``destroy-all`` to
       wipe the whole fork. CLI rc=0. NOTE: This is *narrowly*

--- a/src/nexus_deploy/s3_restore.py
+++ b/src/nexus_deploy/s3_restore.py
@@ -131,9 +131,28 @@ class S3SnapshotSkipped:
       state. CLI rc=2 enforces this. The :func:`snapshot_to_s3`
       caller has already written an operator-actionable
       ``Refusing to teardown`` line to stderr listing the
-      missing env vars."""
+      missing env vars.
+    * ``"no_state_to_snapshot"`` — opted in, credentials present,
+      but ``tofu state list`` reports ``No state file was found!``
+      (i.e. ``tofu apply`` never ran against ``tofu/stack``). This
+      is the partially-deployed-fork case from issue #564: the
+      Spin-Up workflow failed BEFORE any stack resources were
+      provisioned (e.g. Hetzner capacity selection aborted), so
+      there is literally nothing on the server to snapshot. The
+      legitimate no-op — teardown proceeds (the subsequent ``tofu
+      destroy`` will also be a no-op against the empty state) and
+      operators can recover without needing ``destroy-all`` to
+      wipe the whole fork. CLI rc=0. NOTE: This is *narrowly*
+      matched on the ``"No state file was found"`` substring from
+      ``diagnose_state()`` — any other state-list failure (binary
+      missing, R2 backend timeout, auth error) still raises
+      ``PipelineError`` and aborts the teardown."""
 
-    reason: Literal["feature_flag_off", "no_endpoint_env"]
+    reason: Literal[
+        "feature_flag_off",
+        "no_endpoint_env",
+        "no_state_to_snapshot",
+    ]
 
 
 @dataclasses.dataclass(frozen=True)

--- a/tests/unit/test_pipeline.py
+++ b/tests/unit/test_pipeline.py
@@ -997,6 +997,72 @@ def test_run_snapshot_aborts_when_tofu_state_uninitialized(
         )
 
 
+def test_run_snapshot_skips_when_state_file_missing(
+    project_root: Path,
+    fake_tofu_runner: MagicMock,
+    setup_mocks: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Issue #564: partially-deployed forks (setup-control-plane
+    succeeded, spin-up aborted before any ``tofu apply``) have a
+    state-list failure with the specific stderr "No state file was
+    found!". This is materially different from a real state-list
+    failure (binary missing, R2 auth/timeout) — there is genuinely
+    nothing on the server to snapshot, so teardown should proceed.
+
+    The narrow ``"No state file was found"`` substring match is
+    what distinguishes this skip from a hard PipelineError. Once
+    this branch fires we must NOT reach output_json (no outputs
+    to read) and we must NOT touch SSH (no server to snapshot
+    from)."""
+    monkeypatch.setenv("NEXUS_S3_PERSISTENCE", "true")
+    fake_tofu_runner.state_list_ok.return_value = False
+    fake_tofu_runner.diagnose_state.return_value = (
+        "state list failed (rc=1): No state file was found!"
+    )
+    result = run_snapshot(
+        project_root=project_root,
+        stack_slug="nexus-test",
+        template_version="v1.0.0",
+        tofu_runner=fake_tofu_runner,
+    )
+    assert isinstance(result.outcome, S3SnapshotSkipped)
+    assert result.outcome.reason == "no_state_to_snapshot"
+    # Skip path must short-circuit before reading outputs or
+    # touching SSH — otherwise we'd ironically fail the very
+    # teardown we're trying to unblock.
+    fake_tofu_runner.output_json.assert_not_called()
+    setup_mocks["configure_ssh"].assert_not_called()
+    setup_mocks["wait_for_ssh"].assert_not_called()
+    setup_mocks["SSHClient"].assert_not_called()
+
+
+def test_run_snapshot_aborts_on_other_state_failures(
+    project_root: Path,
+    fake_tofu_runner: MagicMock,
+    setup_mocks: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Issue #564 counterpart: every state-list failure that does
+    NOT contain ``"No state file was found"`` must still raise
+    PipelineError → CLI rc=2 → teardown aborts. The carve-out is
+    *narrow*: a missing tofu binary, an R2 backend timeout, an
+    auth failure — these are all unsafe to ignore because we
+    can't know whether state actually exists or just isn't
+    reachable, and a tofu destroy against unverifiable state
+    could lose data."""
+    monkeypatch.setenv("NEXUS_S3_PERSISTENCE", "true")
+    fake_tofu_runner.state_list_ok.return_value = False
+    fake_tofu_runner.diagnose_state.return_value = "tofu binary not found on PATH"
+    with pytest.raises(PipelineError, match=r"tofu binary not found on PATH"):
+        run_snapshot(
+            project_root=project_root,
+            stack_slug="nexus-test",
+            template_version="v1.0.0",
+            tofu_runner=fake_tofu_runner,
+        )
+
+
 def test_run_snapshot_aborts_on_empty_domain(
     project_root: Path,
     fake_tofu_runner: MagicMock,


### PR DESCRIPTION
## Summary

Fixes #564 — `teardown.yml`'s `s3-snapshot` pre-destroy step crashed with rc=2 on every fork where Spin-Up aborted before any `tofu apply` ever ran against `tofu/stack/` (e.g. Hetzner capacity exhausted at the `Select Hetzner capacity` step). The operator hit this on **16 forks simultaneously** during a class teardown, none of which could be cleaned up without falling back to `destroy-all.yml`.

Narrowly distinguish the two materially different failure modes that previously collapsed into one `PipelineError`:

- **No state to snapshot** (`tofu state list` stderr contains `"No state file was found!"`) — legitimate no-op. Return `S3SnapshotSkipped(reason="no_state_to_snapshot")`, CLI rc=0, teardown proceeds. The subsequent `tofu destroy` is also a no-op against the empty state.
- **Anything else** (binary missing, R2 backend timeout, auth error, rc=N with any other stderr) — still raises `PipelineError` → CLI rc=2 → teardown aborts. The RFC 0001 PR-4 atomicity contract (no `tofu destroy` against unverifiable state) is preserved.

## Changes

- [src/nexus_deploy/s3_restore.py](src/nexus_deploy/s3_restore.py): Add `"no_state_to_snapshot"` as a valid `S3SnapshotSkipped.reason` with operator-facing docstring explaining when it fires vs. the other two reasons.
- [src/nexus_deploy/pipeline.py](src/nexus_deploy/pipeline.py): In `run_snapshot()`'s tofu-state pre-flight, when `diagnose_state()` reason contains `"No state file was found"`, return the new skip outcome instead of raising. Skip path short-circuits before SSH / outputs / R2-side work.
- [src/nexus_deploy/__main__.py](src/nexus_deploy/__main__.py): CLI handler maps the new reason to rc=0 with a clear stderr log: `"stack has no Tofu state - nothing to snapshot (partial deploy?). Teardown will proceed."`
- [tests/unit/test_pipeline.py](tests/unit/test_pipeline.py): Two new tests:
  - `test_run_snapshot_skips_when_state_file_missing` — pins the new skip path; asserts `output_json` / `configure_ssh` / `wait_for_ssh` / `SSHClient` are all NOT called, so a partially-deployed fork can be torn down without an SSH round-trip to a server that doesn't exist.
  - `test_run_snapshot_aborts_on_other_state_failures` — pins the narrowness; `"tofu binary not found on PATH"` still raises `PipelineError`.

## Test plan

- [x] `uv run pytest tests/` — 1462 passed (60 → 62 in `test_pipeline.py`).
- [x] `uv run pre-commit run --files <changed>` — ruff format / ruff / mypy / shellcheck all clean.
- [ ] End-to-end verification once merged: trigger `teardown.yml` on a fork whose `tofu/stack` state is empty (either by manually wiping state or by reproducing the original "spin-up aborted before tofu apply" scenario). Expected: snapshot step logs `"stack has no Tofu state - nothing to snapshot"` and exits 0; teardown proceeds to `tofu destroy` (no-op against empty state); workflow completes green.
- [ ] Regression check: trigger `teardown.yml` on a fork that DOES have state. Expected: snapshot step still runs end-to-end, still aborts on any real snapshot failure.

## Why narrowly substring-match instead of a richer signal

`tofu` doesn't surface a typed "state empty" rc — both `state list` and `state show` use rc=1 for both "state truly empty" and "couldn't read state" (auth/timeout/etc.). The `"No state file was found!"` literal is the only thing that distinguishes the empty case from the unreachable case at the boundary we have. Tying the match to that exact substring keeps the carve-out as narrow as possible — any other rc=1 cause still aborts the teardown, preserving the atomicity contract.

Closes #564
