### PR TITLE
fix(teardown): Wire subdomain_separator through stack tfvars

### DIFF
--- a/.github/workflows/destroy-all.yml
+++ b/.github/workflows/destroy-all.yml
@@ -111,12 +111,13 @@ jobs:
           server_image    = "ubuntu-24.04"
           ssh_public_key_path  = "~/.ssh/id_ed25519.pub"
           ssh_private_key_path = "~/.ssh/id_ed25519"
-          domain         = "${{ secrets.DOMAIN }}"
-          admin_email    = "${{ secrets.TF_VAR_admin_email }}"
-          user_email     = "${{ secrets.TF_VAR_user_email }}"
-          admin_username = "admin"
-          github_owner   = "${{ github.repository_owner }}"
-          github_repo    = "${{ github.event.repository.name }}"
+          domain              = "${{ secrets.DOMAIN }}"
+          subdomain_separator = "${{ secrets.SUBDOMAIN_SEPARATOR || '.' }}"
+          admin_email         = "${{ secrets.TF_VAR_admin_email }}"
+          user_email          = "${{ secrets.TF_VAR_user_email }}"
+          admin_username      = "admin"
+          github_owner        = "${{ github.repository_owner }}"
+          github_repo         = "${{ github.event.repository.name }}"
           EOF
 
           # Read services from D1 (single source of truth)

--- a/.github/workflows/teardown.yml
+++ b/.github/workflows/teardown.yml
@@ -160,12 +160,13 @@ jobs:
           server_image    = "ubuntu-24.04"
           ssh_public_key_path  = "~/.ssh/id_ed25519.pub"
           ssh_private_key_path = "~/.ssh/id_ed25519"
-          domain         = "${{ secrets.DOMAIN }}"
-          admin_email    = "${{ secrets.TF_VAR_admin_email }}"
-          user_email     = "${{ secrets.TF_VAR_user_email }}"
-          admin_username = "admin"
-          github_owner   = "${{ github.repository_owner }}"
-          github_repo    = "${{ github.event.repository.name }}"
+          domain              = "${{ secrets.DOMAIN }}"
+          subdomain_separator = "${{ secrets.SUBDOMAIN_SEPARATOR || '.' }}"
+          admin_email         = "${{ secrets.TF_VAR_admin_email }}"
+          user_email          = "${{ secrets.TF_VAR_user_email }}"
+          admin_username      = "admin"
+          github_owner        = "${{ github.repository_owner }}"
+          github_repo         = "${{ github.event.repository.name }}"
           EOF
           sed -i 's/^          //' tofu/stack/config.tfvars
 

--- a/tofu/stack/variables.tf
+++ b/tofu/stack/variables.tf
@@ -116,6 +116,24 @@ variable "domain" {
   }
 }
 
+# Mirror of tofu/control-plane/variables.tf:subdomain_separator. Issue
+# #567: stack-side workflows write this var into config.tfvars but the
+# stack variables file didn't declare it, so OpenTofu emitted a
+# "Value for undeclared variable" warning on every spin-up / teardown.
+# No stack-side resource references var.subdomain_separator today —
+# the Python pipeline reads it from config.tfvars directly to build
+# the SSH host DNS name. Declaring it here keeps the stack tfvars
+# surface in sync with control-plane and silences the warning.
+variable "subdomain_separator" {
+  description = "Separator between service subdomain and base domain. '.' for standard dot-subdomains (default, requires wildcard cert at 3rd level), '-' for flat subdomains used when provisioning tenants under a shared base domain."
+  type        = string
+  default     = "."
+  validation {
+    condition     = contains([".", "-"], var.subdomain_separator)
+    error_message = "subdomain_separator must be '.' or '-'."
+  }
+}
+
 variable "admin_email" {
   description = "Admin email for Cloudflare Access (full access including SSH)"
   type        = string


### PR DESCRIPTION
## Summary

Fixes #567 — `teardown.yml`'s s3-snapshot step fails on flat-subdomain forks (`SUBDOMAIN_SEPARATOR='-'`) with `lookup ssh.<user>.<base-domain>: no such host` because the SSH host DNS name is built with `.` (the default) instead of `-`.

Root cause was two cooperating drifts:

1. **`teardown.yml` and `destroy-all.yml`'s `Generate config.tfvars` steps for `tofu/stack/` didn't write `subdomain_separator` into the heredoc.** `spin-up.yml` and `migrate-volume-to-r2.yml` already did. The Python `_tfvars.parse()` reads the field from the file directly (independent of any OpenTofu variable declarations) and defaults to `"."` when the line is missing, so on a flat-subdomain fork the SSH DNS lookup went to the wrong record. **This is the actual symptom cause for the teardown failure.**
2. **`tofu/stack/variables.tf` did not declare `subdomain_separator`.** Harmless today (no stack-side resource references `var.subdomain_separator` — only `tofu/control-plane/main.tf` uses it, and that file has its own `variables.tf` with the declaration). But when the spin-up workflow writes `subdomain_separator = "-"` into `tofu/stack/config.tfvars`, OpenTofu emits a `"Value for undeclared variable"` warning on every spin-up / teardown. Ugly and drifted from `tofu/control-plane/variables.tf`.

## Changes

- [.github/workflows/teardown.yml:163](.github/workflows/teardown.yml#L163): write `subdomain_separator = "${{ secrets.SUBDOMAIN_SEPARATOR || '.' }}"` into the heredoc (matches the existing line at [spin-up.yml:283](.github/workflows/spin-up.yml#L283) exactly). **This unblocks teardown on flat-subdomain forks.**
- [.github/workflows/destroy-all.yml:115](.github/workflows/destroy-all.yml#L115): same addition to the `tofu/stack/config.tfvars` heredoc. No symptom today since destroy-all doesn't run the s3-snapshot path, but the same content drift would bite the next workflow that wires up an SSH-resolution step. The same workflow already writes `subdomain_separator` correctly into the `tofu/control-plane/config.tfvars` heredoc at line 146, so this is just bringing the two heredocs into parity.
- [tofu/stack/variables.tf:119-128](tofu/stack/variables.tf#L119): declare `variable "subdomain_separator"`, mirroring [tofu/control-plane/variables.tf:42-50](tofu/control-plane/variables.tf#L42) (same description, default, validation block). Suppresses the OpenTofu `"Value for undeclared variable"` warning that has been quietly accumulating since #540 added the variable to the control-plane side.

## What this does NOT touch

- `tofu/stack/main.tf` continues to not reference `var.subdomain_separator`. The Python pipeline (`pipeline.py:330` / `pipeline.py:631`) is the consumer; the OpenTofu declaration is purely for tfvars-file hygiene + future-proofing. Wiring stack-side resources to the variable is out of scope for this PR.
- No tests added. The existing `tests/unit/test_tfvars.py` suite already covers `_tfvars.parse()`'s behaviour when the file does / does not contain the line; the bug is content-drift in workflow YAML, not Python behaviour. The repo doesn't ship a workflow-content static test today, and adding one just for this rule would be heavier than the fix.

## Test plan

- [x] `uv run pytest tests/` — 1460 passed.
- [x] `uv run pre-commit run --files <changed>` — all hooks clean.
- [x] `tofu fmt -check tofu/stack/variables.tf` — clean.
- [ ] End-to-end verification: trigger `spin-up.yml` on a flat-subdomain fork (`SUBDOMAIN_SEPARATOR='-'`), then `teardown.yml`. Expected: the s3-snapshot step resolves `ssh-<user>.<base>` (flat form) and reaches the server; teardown completes green. Plus: the previously-emitted `"Value for undeclared variable: subdomain_separator"` OpenTofu warning is gone from the spin-up log.
- [ ] Regression: trigger spin-up + teardown on a dot-subdomain fork (`SUBDOMAIN_SEPARATOR='.'` or unset). Expected: SSH host resolves to `ssh.<base>` exactly as before; teardown still completes green.

## Why narrowly two workflows + one .tf file, no test infrastructure

The bug is content drift between four heredocs that should have stayed in sync but didn't. Auditing them all once and bringing them into parity solves the class of bug; building a workflow-content static-analysis test to prevent recurrence is much heavier than the fix and not the established pattern in this repo. If a third workflow drifts in the future, the same one-line audit catches it.

Closes #567
