### PR TITLE
fix(deploy): Revise Hetzner DEFAULT_PREFERENCES + drop dead tracker URL

### DIFF
--- a/docs/admin-guides/setup-guide.md
+++ b/docs/admin-guides/setup-guide.md
@@ -37,7 +37,7 @@ This guide walks you through the complete setup of Nexus Stack.
 3. Name it `Nexus` (or whatever you prefer)
 4. Open the project
 
-> 💡 **Tip — check Hetzner stock before you deploy.** Hetzner periodically runs out of specific instance types (`cx43`, `cpx32`, `cax31`) in specific datacenters. The third-party tracker at [radar.iodev.org/cloud-status](https://radar.iodev.org/cloud-status) shows live availability per region and instance type. Worth a 10-second glance before your first `gh workflow run initial-setup.yaml` — if your default region (`hel1`) is empty, switch `SERVER_LOCATION` to one that's green (see [Optional Repository Variables](#optional-repository-variables) below).
+> 💡 **Tip — check Hetzner stock before you deploy.** Hetzner periodically runs out of specific instance types (`cx43`, `cx53`, `cpx42`, `cpx52`, `cpx62`) in specific datacenters. The [Hetzner Cloud Console](https://console.hetzner.cloud/) → **Add Server** UI greys out out-of-stock `<type>:<location>` combinations live, so a 10-second glance before your first `gh workflow run initial-setup.yaml` is worth it — if your default region (`hel1`) is dry for all five types, switch `SERVER_LOCATION` to one that's green (see [Optional Repository Variables](#optional-repository-variables) below). The capacity-fallback step in the workflow uses the same Hetzner data, so what the Console shows is exactly what spin-up will pick.
 
 ### Generate API Token
 
@@ -177,7 +177,7 @@ This token allows the initial setup workflow to automatically save R2 credential
 | `SERVER_LOCATION` | `hel1` | Hetzner datacenter region for the VM. EU options: `hel1` (Helsinki), `fsn1` (Falkenstein), `nbg1` (Nuremberg). US option: `ash` (Ashburn). Change if your preferred region has availability issues — see the troubleshooting note below. |
 | `HETZNER_S3_LOCATION` | `fsn1` | Hetzner Object Storage region (independent from server location). Propagated to OpenTofu and all S3 operations automatically. Only change if your buckets are in a different region. |
 
-> **Note:** Hetzner server availability fluctuates per region and instance type — both ARM (`cax*`) and x86 (`cx*` / `cpx*`) can hit `resource_unavailable` during capacity crunches. Check current stock before deploying via the third-party tracker [radar.iodev.org/cloud-status](https://radar.iodev.org/cloud-status). If your preferred region is empty, switch `SERVER_LOCATION` to one that shows green for your instance type. Common availability: `hel1` (Helsinki) and `fsn1` (Falkenstein) usually have the best stock for `cx43`; `nbg1` (Nuremberg) and `ash` (US-East) can be alternatives.
+> **Note:** Hetzner server availability fluctuates per region and instance type — both ARM (`cax*`) and x86 (`cx*` / `cpx*`) can hit `resource_unavailable` during capacity crunches. The spin-up workflow's `Select Hetzner capacity` step already walks a 15-pair fallback list (`cx43`, `cx53`, `cpx42`, `cpx52`, `cpx62` across `hel1`/`fsn1`/`nbg1` — see [hetzner_capacity.py](../../src/nexus_deploy/hetzner_capacity.py)), so a typical capacity crunch is handled automatically. If even those 15 combinations are dry, check the [Hetzner Cloud Console](https://console.hetzner.cloud/) → **Add Server** UI for what's currently green and override `SERVER_PREFERENCES` (repo variable) accordingly. Common availability: `hel1` (Helsinki) and `fsn1` (Falkenstein) usually have the best stock for `cx43`; `nbg1` (Nuremberg) and `ash` (US-East) can be alternatives.
 
 ---
 

--- a/docs/admin-guides/troubleshooting.md
+++ b/docs/admin-guides/troubleshooting.md
@@ -126,7 +126,7 @@ or, more generically, a `resource_unavailable` rejection during `tofu apply`.
 
 ### Automatic fallback (default since #536)
 
-The `Select Hetzner capacity` step that runs *before* `Apply infrastructure` queries Hetzner's Cloud API (`/v1/server_types` to resolve type-name to internal ID, then `/v1/datacenters` for per-datacenter live availability keyed by those IDs) and picks the first available `<server_type>:<location>` pair from a preference list. The default list — `cx43:hel1, cx43:fsn1, cx43:nbg1, ccx33:hel1, ccx33:fsn1, ccx33:nbg1` — covers three EU regions for two server-type classes, so a typical capacity crunch is handled without operator intervention. The order keeps the historical project-default region (`hel1`) first so a fresh install without `SERVER_PREFERENCES` lands in the same location (`hel1`) as before this feature was added. The actual datacenter within that location (`hel1-dc2`, etc.) is still chosen by Hetzner — `server_location` only pins the location, not a specific DC.
+The `Select Hetzner capacity` step that runs *before* `Apply infrastructure` queries Hetzner's Cloud API (`/v1/server_types` to resolve type-name to internal ID, then `/v1/datacenters` for per-datacenter live availability keyed by those IDs) and picks the first available `<server_type>:<location>` pair from a preference list. The default list — `cx43`, `cx53`, `cpx42`, `cpx52`, `cpx62`, each across `hel1`/`fsn1`/`nbg1` (15 combinations, see [src/nexus_deploy/hetzner_capacity.py](../../src/nexus_deploy/hetzner_capacity.py)) — covers three EU regions across five shared-CPU tiers (cheapest first, Intel→AMD silicon failover), so a typical capacity crunch is handled without operator intervention. The order keeps the historical project-default region (`hel1`) first so a fresh install without `SERVER_PREFERENCES` lands in the same location (`hel1`) as before this feature was added. The actual datacenter within that location (`hel1-dc2`, etc.) is still chosen by Hetzner — `server_location` only pins the location, not a specific DC.
 
 You can see what the step picked in the workflow log. The lines mirror the default preference list above (or whatever override is configured), one entry per pair, in priority order:
 
@@ -135,26 +135,26 @@ You can see what the step picked in the workflow log. The lines mirror the defau
   ✗ 1. cx43:hel1
   → 2. cx43:fsn1
   ✓ 3. cx43:nbg1
-  ✓ 4. ccx33:hel1
-  ✓ 5. ccx33:fsn1
-  ✓ 6. ccx33:nbg1
+  ✓ 4. cx53:hel1
+  ✓ 5. cx53:fsn1
+  ...
 ```
 
 `✗` = sold out, `✓` = available, `→` = picked.
 
 ### When every preference is out of stock
 
-If every entry in the preference list is sold out, the step fails the workflow with the per-pair status block AND a pointer to the live tracker. To unblock:
+If every entry in the preference list is sold out, the step fails the workflow with the per-pair status block AND a pointer to the Hetzner Cloud Console. To unblock:
 
-1. Open [radar.iodev.org/cloud-status](https://radar.iodev.org/cloud-status) and find a region × instance type combination that is green.
-2. Override the preference list by setting `SERVER_PREFERENCES` in your GitHub repository's variables (Settings → Secrets and variables → Actions → Variables → `SERVER_PREFERENCES`) to a comma-separated list, e.g. `cpx32:fsn1, cpx32:nbg1, cpx51:hel1`. The first available pair wins, so order entries by preference.
+1. Open the [Hetzner Cloud Console](https://console.hetzner.cloud/) → your project → **Add Server**. The create-server UI greys out out-of-stock `<type>:<location>` combinations live, so you immediately see what's available right now. (The Hetzner API the workflow queries is the same data source — but the Console adds it up visually.)
+2. Override the preference list by setting `SERVER_PREFERENCES` in your GitHub repository's variables (Settings → Secrets and variables → Actions → Variables → `SERVER_PREFERENCES`) to a comma-separated list, e.g. `cpx62:fsn1, cpx62:nbg1, cx53:hel1`. The first available pair wins, so order entries by preference.
 3. Re-run the workflow.
 
 ### Operator overrides
 
 | Variable | Effect |
 |---|---|
-| `SERVER_PREFERENCES` (repo variable, comma list) | Highest priority. `cx43:fsn1, ccx33:nbg1, cpx51:hel1` etc. |
+| `SERVER_PREFERENCES` (repo variable, comma list) | Highest priority. `cx43:fsn1, cpx52:nbg1, cpx62:hel1` etc. |
 | `server_preferences = "..."` line in `config.tfvars` | Used if `SERVER_PREFERENCES` is unset. |
 | `SERVER_TYPE` + `SERVER_LOCATION` (legacy single pair) | Used if neither of the above is set. Effectively a 1-element preference list — the workflow still hard-fails when that one pair is out of stock; widen to a list to get capacity-fallback. |
 | Built-in default | Last resort — see list above. |

--- a/src/nexus_deploy/__main__.py
+++ b/src/nexus_deploy/__main__.py
@@ -2728,9 +2728,12 @@ def _select_capacity(args: list[str]) -> int:
         sys.stderr.write(
             "Either widen the preference list — set `SERVER_PREFERENCES` repo "
             "variable (highest priority) or the `server_preferences` line in "
-            "config.tfvars to a longer comma list (try ccx*, fsn1/nbg1/hel1, "
-            "cpx32 fallbacks, etc.) — or wait. Hetzner stock fluctuates hour "
-            "by hour. Live tracker: https://radar.iodev.org/cloud-status\n",
+            "config.tfvars to a longer comma list — or wait. Hetzner stock "
+            "fluctuates hour by hour. Recommended fallback order: cx43, cx53, "
+            "cpx42, cpx52, cpx62 across hel1/fsn1/nbg1 (the built-in default). "
+            "Check live stock per region in the Hetzner Cloud Console "
+            "(https://console.hetzner.cloud/) — the create-server UI greys out "
+            "out-of-stock combinations.\n",
         )
         return 2
 

--- a/src/nexus_deploy/hetzner_capacity.py
+++ b/src/nexus_deploy/hetzner_capacity.py
@@ -52,22 +52,27 @@ _API_BASE = "https://api.hetzner.cloud/v1"
 _DEFAULT_TIMEOUT = 30.0
 
 # Default preference list — picked in Issue #536, expanded 2026-05
-# after the May stock crunch left whole tiers OOS in all three EU
-# locations simultaneously. Strategy: shared-only (no dedicated, no
-# ARM), four type-tiers in cost order, three regions per tier.
+# (post-May-stock-crunch tiers), revised mid-2026-05 by the operator
+# of the Education fork after a class-wide spin-up failed against
+# the prior list (cx43 / cpx41 / cx42 / cx52). Strategy unchanged:
+# shared-only (no dedicated, no ARM), five type-tiers in cost order,
+# three EU regions per tier.
 #
 #   Tier 1: cx43 (Intel shared, 8 vCPU / 16 GB / 160 GB, project
 #           default since 2026-05). The cheapest box that still fits
 #           the 40+ Docker stacks workload.
-#   Tier 2: cpx41 (AMD shared, 8 vCPU / 16 GB / 240 GB). Same
-#           workload class, different silicon — independent stock
-#           pool. linux/amd64 images run on Intel and AMD without
-#           distinction (per CLAUDE.md), so no compat risk.
-#   Tier 3: cx42 (Intel shared, prior generation, 8 vCPU / 16 GB).
-#           Cheap fallback if cx43 is out everywhere.
-#   Tier 4: cx52 (Intel shared, 16 vCPU / 32 GB / 240 GB). Last
-#           resort when nothing else has stock — bigger and pricier
-#           but keeps the spinup unblocked.
+#   Tier 2: cx53 (Intel shared, 16 vCPU / 32 GB / 320 GB). One step
+#           up if cx43 is dry across all three EU regions — keeps
+#           Intel + shared, just gives more headroom.
+#   Tier 3: cpx42 (AMD shared, 8 vCPU / 16 GB / 240 GB). Same
+#           8/16 class as cx43, different silicon → independent
+#           stock pool. linux/amd64 images run on Intel and AMD
+#           without distinction (per CLAUDE.md).
+#   Tier 4: cpx52 (AMD shared, 16 vCPU / 32 GB / 360 GB). AMD
+#           equivalent of cx53.
+#   Tier 5: cpx62 (AMD shared, 32 vCPU / 64 GB / 720 GB). Last
+#           resort when nothing else has stock — generously oversized
+#           but keeps the spin-up unblocked.
 #
 # Region order hel1 → fsn1 → nbg1 within every tier — matches the
 # historical project default ``server_location = "hel1"`` from
@@ -85,23 +90,30 @@ _DEFAULT_TIMEOUT = 30.0
 #     (typically 8-16 cores total), so a class of N students
 #     spinning up in parallel hits the cap immediately. Also ~2.5-3x
 #     the price of the equivalent shared tier.
+#   * Older shared gens (cx42, cpx41) — dropped from the default in
+#     this revision; if you need them as extra fallbacks, set
+#     ``SERVER_PREFERENCES`` on the repo to a longer list.
 DEFAULT_PREFERENCES = (
-    # Tier 1: cx43 (Intel shared, recommended)
+    # Tier 1: cx43 (Intel shared, 8/16, project default)
     "cx43:hel1",
     "cx43:fsn1",
     "cx43:nbg1",
-    # Tier 2: cpx41 (AMD shared, same 8/16 class)
-    "cpx41:hel1",
-    "cpx41:fsn1",
-    "cpx41:nbg1",
-    # Tier 3: cx42 (Intel shared, prior gen)
-    "cx42:hel1",
-    "cx42:fsn1",
-    "cx42:nbg1",
-    # Tier 4: cx52 (Intel shared, bigger 16/32) — last resort
-    "cx52:hel1",
-    "cx52:fsn1",
-    "cx52:nbg1",
+    # Tier 2: cx53 (Intel shared, 16/32, headroom)
+    "cx53:hel1",
+    "cx53:fsn1",
+    "cx53:nbg1",
+    # Tier 3: cpx42 (AMD shared, 8/16, independent stock pool)
+    "cpx42:hel1",
+    "cpx42:fsn1",
+    "cpx42:nbg1",
+    # Tier 4: cpx52 (AMD shared, 16/32)
+    "cpx52:hel1",
+    "cpx52:fsn1",
+    "cpx52:nbg1",
+    # Tier 5: cpx62 (AMD shared, 32/64) — last resort
+    "cpx62:hel1",
+    "cpx62:fsn1",
+    "cpx62:nbg1",
 )
 
 

--- a/tests/unit/test_select_capacity_cli.py
+++ b/tests/unit/test_select_capacity_cli.py
@@ -276,14 +276,18 @@ def test_select_capacity_aborts_when_all_unavailable(
     assert "every preference is out of stock" in err
     assert "✗ 1. cx43:fsn1" in err
     assert "✗ 2. cx43:nbg1" in err
-    # Assert against the full documentation URL rather than the bare
+    # Assert against the full Hetzner Console URL rather than the bare
     # hostname — same intent (verify the operator-facing pointer is
     # in the log) but more specific. Defensive against CodeQL's
     # py/incomplete-url-substring-sanitization rule, which flags
     # bare-domain matches as a class even in test assertions
     # (false-positive context — this is log-content verification,
-    # not URL validation).
-    assert "https://radar.iodev.org/cloud-status" in err
+    # not URL validation). Replaced radar.iodev.org with console.hetzner.cloud
+    # in 2026-05: the third-party tracker started bot-blocking
+    # (HTTP 403 to non-browser requests) and operators couldn't
+    # always reach it, while the official Hetzner Console always
+    # works for any operator who already has an HCLOUD_TOKEN.
+    assert "https://console.hetzner.cloud/" in err
     # Original file MUST stay untouched on failure.
     assert 'server_type     = "cx43"' in tfvars_with_legacy_pair.read_text()
 


### PR DESCRIPTION
## Summary

After the 2026-05 Hetzner EU stock crunch, a class-wide spin-up against the prior `DEFAULT_PREFERENCES` list (`cx43`, `cpx41`, `cx42`, `cx52` × `hel1`/`fsn1`/`nbg1`) hard-failed: every entry was out of stock across all three EU regions simultaneously. The bigger-headroom shared tiers that DO get stocked during such crunches (`cx53`, `cpx52`, `cpx62`) weren't in the fallback chain.

Also, the operator-facing exhaustion message pointed at a third-party tracker (`radar.iodev.org/cloud-status`) that now bot-blocks non-browser requests with HTTP 403 (verified via curl with realistic UAs). An operator following the link could end up bounced. The Hetzner Cloud Console reads the same Hetzner API the workflow does and stays permanently reachable for any operator who already has an `HCLOUD_TOKEN`.

## Changes

- [src/nexus_deploy/hetzner_capacity.py](src/nexus_deploy/hetzner_capacity.py): `DEFAULT_PREFERENCES` revised to **`cx43, cx53, cpx42, cpx52, cpx62`** × **`hel1, fsn1, nbg1`** (15 combinations, five shared-CPU tiers cheapest-first with Intel → AMD silicon failover). Drops `cpx41` / `cx42` / `cx52`, adds `cx53` / `cpx42` / `cpx52` / `cpx62`. Region order `hel1 → fsn1 → nbg1` within every tier preserved so a fresh install without `SERVER_PREFERENCES` still lands on Helsinki. Tier-block comment rewritten to match.
- [src/nexus_deploy/__main__.py:2728](src/nexus_deploy/__main__.py#L2728) (select-capacity exhaustion message): replace dead `radar.iodev.org` URL with `https://console.hetzner.cloud/` (the create-server UI greys out OOS combinations live, same data source as the workflow). Drop the stale `"try ccx*, cpx32 fallbacks"` wording — `cpx32` is below our sizing minimum and `ccx*` is gated by per-account dedicated-vCPU quotas the operator is unlikely to widen for a class.
- [tests/unit/test_select_capacity_cli.py:286](tests/unit/test_select_capacity_cli.py#L286): update URL assertion (log-content-only check; same intent, new domain).
- [docs/admin-guides/troubleshooting.md:129](docs/admin-guides/troubleshooting.md#L129): refresh the "default list" prose block. The prose was claiming the default was `cx43:hel1, …, ccx33:hel1, …` — actually outdated since the previous default revision; corrected here while the surrounding paragraph is being touched anyway.
- [docs/admin-guides/setup-guide.md:40, 180](docs/admin-guides/setup-guide.md#L40): same URL swap + reword the type list to match the new defaults (5 tiers, 15 combinations).

## Why these five tiers, in this order

| Tier | Type | Specs | Rationale |
|---|---|---|---|
| 1 | `cx43` | Intel shared, 8 vCPU / 16 GB / 160 GB | Cheapest box that fits the 40+ Docker stacks workload; project default since 2026-05. |
| 2 | `cx53` | Intel shared, 16 vCPU / 32 GB / 320 GB | One step up; same silicon (Intel-shared) as cx43, so if cx43 is dry Hetzner-wide, the cx53 capacity pool is the cheapest larger option in the same instance class. |
| 3 | `cpx42` | AMD shared, 8 vCPU / 16 GB / 240 GB | Same 8/16 size class as cx43, different silicon → independent stock pool. linux/amd64 images run on Intel and AMD without distinction (per CLAUDE.md). |
| 4 | `cpx52` | AMD shared, 16 vCPU / 32 GB / 360 GB | AMD equivalent of cx53. |
| 5 | `cpx62` | AMD shared, 32 vCPU / 64 GB / 720 GB | Last resort — generously oversized but keeps the spin-up unblocked when nothing else has stock. |

Each tier ships three pairs (hel1, fsn1, nbg1). Operators who need ARM (`cax*`), dedicated (`ccx*`), or the older `cpx41` / `cx42` / `cx52` tiers can add them explicitly via the `SERVER_PREFERENCES` repo variable — the built-in default is for the common case.

## Test plan

- [x] `uv run pytest tests/` — 1460 passed (the `DEFAULT_PREFERENCES` round-trip parser test in `test_hetzner_capacity.py:145` covers the new tuple shape; no asserts hardcode specific type names).
- [x] `uv run pre-commit run --files <changed>` — ruff format / ruff / mypy --strict clean.
- [ ] End-to-end: trigger `spin-up.yml` on a fork while the prior default list is dry (the 2026-05 crunch is ongoing for the Education fork the operator runs). Expected: workflow now picks one of `cx53`, `cpx42`, `cpx52`, or `cpx62` and proceeds to `tofu apply` instead of failing with the per-pair status block.

## What this does NOT change

- `tofu/stack/variables.tf`'s `server_type` default still says `"cx43"`. That's the OpenTofu input-default for direct local invocations without the workflow's `select-capacity` step; `select-capacity` rewrites the value in `config.tfvars` before `tofu apply` runs in CI.
- CLAUDE.md's narrative around why `cx43` was picked over `cpx32` / `cax31` is unchanged (historical context for the 2026-05 default-pick decision).
- The Hetzner Cloud API consumer code (`fetch_availability`, parser) is untouched.

Closes the operator's class-spin-up regression and the dead-URL UX foot-gun in one go.
