### PR TITLE
feat(stacks): Add Big-AGI multi-LLM web UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,11 +68,12 @@ After deployment you'll have:
 
 ![Quick Start Flow](docs/assets/architecture-quickstart.svg)
 
-## Available Stacks (63)
+## Available Stacks (64)
 
 [![AKHQ](https://img.shields.io/badge/AKHQ-000000?logo=apachekafka&logoColor=white)](https://akhq.io)
 [![Adminer](https://img.shields.io/badge/Adminer-34567C?logo=adminer&logoColor=white)](https://www.adminer.org)
 [![Appsmith](https://img.shields.io/badge/Appsmith-F86A2E?logo=appsmith&logoColor=white)](https://appsmith.com)
+[![Big-AGI](https://img.shields.io/badge/Big--AGI-FF6B35?logo=openai&logoColor=white)](https://github.com/enricoros/big-agi)
 [![Budibase](https://img.shields.io/badge/Budibase-9981F5?logo=budibase&logoColor=white)](https://budibase.com)
 [![CloudBeaver](https://img.shields.io/badge/CloudBeaver-3776AB?logo=dbeaver&logoColor=white)](https://dbeaver.com/cloudbeaver/)
 [![ClickHouse](https://img.shields.io/badge/ClickHouse-FFCC00?logo=clickhouse&logoColor=black)](https://clickhouse.com)
@@ -139,6 +140,7 @@ After deployment you'll have:
 | **AKHQ** | Kafka/Redpanda management GUI for topics, consumer groups, schema registry, and Kafka Connect | [akhq.io](https://akhq.io) |
 | **Adminer** | Lightweight database management tool (supports PostgreSQL, MySQL, SQLite, etc.) | [adminer.org](https://www.adminer.org) |
 | **Appsmith** | Open-source low-code platform for building admin panels, dashboards, and internal tools | [appsmith.com](https://appsmith.com) |
+| **Big-AGI** | Stateless multi-LLM web UI for OpenAI, Anthropic, and local LLM endpoints (browser-side state, no server DB) | [github.com/enricoros/big-agi](https://github.com/enricoros/big-agi) |
 | **Budibase** | Open-source low-code platform for building internal tools and dashboards | [budibase.com](https://budibase.com) |
 | **CloudBeaver** | Web-based database management tool | [dbeaver.com/cloudbeaver](https://dbeaver.com/cloudbeaver/) |
 | **ClickHouse** | Fast columnar database for real-time analytics and OLAP queries | [clickhouse.com](https://clickhouse.com) |

--- a/docs/stacks/README.md
+++ b/docs/stacks/README.md
@@ -11,6 +11,7 @@ Images are pinned to **major versions** where supported for automatic security p
 | AKHQ | `tchiotludo/akhq` | `0.27.0` | Exact ¹ |
 | Adminer | `adminer` | `latest` | Latest ² |
 | Appsmith | `appsmith/appsmith-ce` | `v1.98` | Minor |
+| Big-AGI | `ghcr.io/enricoros/big-agi` | `v2.0.4` | Exact ¹ |
 | Budibase | `budibase/budibase` | `latest` | Latest ² |
 | CloudBeaver | `dbeaver/cloudbeaver` | `24` | Major |
 | ClickHouse | `clickhouse/clickhouse-server` | `25.8.16.34` | Exact ¹ |
@@ -121,6 +122,7 @@ Images are pinned to **major versions** where supported for automatic security p
 | **Adminer** | Lightweight database management tool | [adminer.md](adminer.md) |
 | **Apache Spark** | Distributed data processing engine | [spark.md](spark.md) |
 | **Appsmith** | Low-code platform for admin panels and internal tools | [appsmith.md](appsmith.md) |
+| **Big-AGI** | Stateless multi-LLM web UI (OpenAI, Anthropic, local) | [big-agi.md](big-agi.md) |
 | **Budibase** | Low-code platform for internal tools | [budibase.md](budibase.md) |
 | **CloudBeaver** | Web-based database management tool | [cloudbeaver.md](cloudbeaver.md) |
 | **ClickHouse** | Columnar database for real-time analytics | [clickhouse.md](clickhouse.md) |

--- a/docs/stacks/big-agi.md
+++ b/docs/stacks/big-agi.md
@@ -32,4 +32,14 @@ Big-AGI is a browser-based UI for interacting with multiple large language model
 
 ### Note on API keys
 
-API keys for upstream LLM providers are stored **in the browser**, not on the server. Big-AGI never sees or persists them — each request from the browser to OpenAI / Anthropic / etc. is direct (proxied only by Cloudflare Tunnel for transport). This means the keys are gone if the browser's storage is cleared, but it also means there's no server-side secret to manage or leak.
+API keys for upstream LLM providers are entered in the browser UI and **persisted in the browser's LocalStorage only** — the Big-AGI container has no database, no env-var injection, and no on-disk store for these keys. So if you clear browser data, the keys are gone; there's no server-side secret to rotate or leak.
+
+**But — and this is the important nuance** — Big-AGI is a Next.js app, and browsers can't call OpenAI / Anthropic / etc. directly because of CORS. So when you send a message, the actual request flow is:
+
+1. Your browser POSTs the prompt **and** the API key to a server-side route on the Big-AGI container (e.g. `/api/llms/...`).
+2. The container's Next.js handler reads the key from the request body and uses it to call the upstream provider.
+3. The provider's response streams back through the container to your browser.
+
+Net consequence: the key **is** in the container's request path on every message. The container doesn't log it or persist it (it's in memory for the lifetime of one request), but anyone with shell access to the container during a request — or who could MITM container ↔ upstream-provider traffic — could observe it. Cloudflare Tunnel only protects the **browser ↔ container** segment, not the container ↔ OpenAI segment.
+
+For a classroom or self-hosted setup, this is usually acceptable — you're the only operator with shell access. If your threat model includes the operator being adversarial (e.g. multi-tenant Big-AGI for untrusted users), this stack is not the right choice.

--- a/docs/stacks/big-agi.md
+++ b/docs/stacks/big-agi.md
@@ -1,0 +1,35 @@
+---
+title: "Big-AGI"
+---
+
+## Big-AGI
+
+![Big-AGI](https://img.shields.io/badge/Big--AGI-FF6B35?logo=openai&logoColor=white)
+
+**Stateless multi-LLM web UI for OpenAI, Anthropic, and local LLM endpoints**
+
+Big-AGI is a browser-based UI for interacting with multiple large language model providers without a server-side database. Conversation history and API keys live in the browser's LocalStorage. Features include:
+- Support for OpenAI, Anthropic, local Ollama, and custom OpenAI-compatible endpoints
+- Model switching mid-conversation and side-by-side multi-model comparison
+- Prompt templates and persona management
+- Conversation export / import (JSON, Markdown)
+- Markdown rendering with code-block syntax highlighting
+
+| Setting | Value |
+|---------|-------|
+| Default Port | `3006` |
+| Suggested Subdomain | `big-agi` |
+| Public Access | No (protected by Cloudflare Access) |
+| Persistence | Browser LocalStorage (no server-side state) |
+| Website | [github.com/enricoros/big-agi](https://github.com/enricoros/big-agi) |
+| Source | [GitHub](https://github.com/enricoros/big-agi) |
+
+### Usage
+
+1. Open `https://big-agi.<domain>` and authenticate via Cloudflare Access.
+2. Open **Models** → **Add Model** → paste an API key for OpenAI, Anthropic, or point at a local Ollama endpoint.
+3. Start a new chat. Conversation history persists in the browser's LocalStorage; it does **not** sync across devices or survive a browser-data wipe.
+
+### Note on API keys
+
+API keys for upstream LLM providers are stored **in the browser**, not on the server. Big-AGI never sees or persists them — each request from the browser to OpenAI / Anthropic / etc. is direct (proxied only by Cloudflare Tunnel for transport). This means the keys are gone if the browser's storage is cleared, but it also means there's no server-side secret to manage or leak.

--- a/services.yaml
+++ b/services.yaml
@@ -73,6 +73,16 @@ services:
     long_description: "Appsmith is an open-source framework for building internal tools and custom UIs. Connect to 18+ data sources including PostgreSQL, MySQL, MongoDB, REST APIs, and GraphQL. Features drag-and-drop widgets, JavaScript business logic, Git-based version control, and granular access controls. All-in-one container with bundled MongoDB, PostgreSQL, and Redis."
     image: "appsmith/appsmith-ce:v1.98"
 
+  big-agi:
+    subdomain: "big-agi"
+    port: 3006
+    public: false
+    category: "ai-ml"
+    website: "https://github.com/enricoros/big-agi"
+    description: "Stateless multi-LLM web UI for OpenAI, Anthropic, and local LLM endpoints."
+    long_description: "Big-AGI is a stateless browser-based UI for interacting with multiple large language model providers. Connect to OpenAI, Anthropic, local Ollama, or custom OpenAI-compatible endpoints. Conversation history lives in the browser's LocalStorage — no server-side database. Features include conversation export/import, prompt templates, model switching, persona management, and markdown rendering."
+    image: "ghcr.io/enricoros/big-agi:v2.0.4"
+
   cloudbeaver:
     subdomain: "cloudbeaver"
     port: 8978

--- a/stacks/big-agi/docker-compose.yml
+++ b/stacks/big-agi/docker-compose.yml
@@ -11,8 +11,16 @@
 # - Protected by Cloudflare Access (email OTP authentication)
 # - HTTPS only via Cloudflare Tunnel
 # - No authentication required at application level
-# - API keys for LLM providers are entered in the browser and stored
-#   client-side only — they never touch the server.
+# - LLM provider API keys (OpenAI / Anthropic / etc.) are entered in
+#   the browser and persisted only in the browser's LocalStorage. The
+#   Big-AGI container does NOT have a database, env file, or any other
+#   on-disk store for these keys. However: Big-AGI is a Next.js app
+#   and uses server-side API routes to proxy LLM calls (browsers can't
+#   call OpenAI / Anthropic directly because of CORS), so the key is
+#   POSTed from the browser to the container in each request body and
+#   then forwarded from the container to the upstream provider. The
+#   container does not log or persist the key — it's in memory only
+#   for the duration of the request — but it is in the request path.
 # =============================================================================
 
 services:

--- a/stacks/big-agi/docker-compose.yml
+++ b/stacks/big-agi/docker-compose.yml
@@ -1,0 +1,40 @@
+# =============================================================================
+# Big-AGI - Multi-LLM Web UI
+# =============================================================================
+# Browser-based UI for interacting with multiple LLM providers (OpenAI,
+# Anthropic, local Ollama, custom endpoints). Stateless — conversation
+# history lives in the browser's LocalStorage, no server-side database.
+# Access via: https://big-agi.your-domain.com
+# Default port: 3006
+#
+# SECURITY:
+# - Protected by Cloudflare Access (email OTP authentication)
+# - HTTPS only via Cloudflare Tunnel
+# - No authentication required at application level
+# - API keys for LLM providers are entered in the browser and stored
+#   client-side only — they never touch the server.
+# =============================================================================
+
+services:
+  big-agi:
+    image: ${IMAGE_BIG_AGI:-ghcr.io/enricoros/big-agi:v2.0.4}
+    container_name: big-agi
+    restart: unless-stopped
+    ports:
+      - "3006:3000"
+    deploy:
+      resources:
+        limits:
+          memory: 512m
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:3000/ >/dev/null || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 15s
+    networks:
+      - app-network
+
+networks:
+  app-network:
+    external: true


### PR DESCRIPTION
## Summary

Closes #394 — adds Big-AGI as a new stack.

Big-AGI is a stateless browser-based UI for interacting with multiple LLM providers (OpenAI, Anthropic, local Ollama, custom OpenAI-compatible endpoints). Conversation history and API keys live in the browser's LocalStorage; **no server-side database**. The image stays a single Next.js container; Cloudflare Access fronts authentication.

This is one of the simpler queued add-stack requests (`#386`–`#397`) — single-container, no Postgres, no Redis, no admin login, no Infisical secrets, no auto-setup hook. Same shape as the existing `drawio`, `code-server`, `it-tools`, `excalidraw` stacks.

## Image

- **`ghcr.io/enricoros/big-agi:v2.0.4`** — pinned to the current stable tag (released 2026-03-25, ~17k version downloads on GHCR).
- Multi-arch: **`linux/amd64` + `linux/arm64`**, verified at the GHCR package page. Works on the current `cx43` (Intel) default and on a future ARM revert.
- Not `:latest` despite this being a stateless tool — Big-AGI doesn't fit the explicit `latest`-exempt list in [CLAUDE.md](CLAUDE.md) (drawio, it-tools, wetty, code-server, jupyter, marimo, adminer, excalidraw — named set, not "any stateless tool"). Pinning gives reproducibility; future bumps go through a deliberate version-bump PR.

## Port

- **Internal**: 3000 (Big-AGI's default).
- **Host**: 3006 — next free slot after the existing 3000–3005 range (verified by sweep of `services.yaml`).

## Files touched (5)

| File | Change |
|---|---|
| [services.yaml:76](services.yaml#L76) | New `big-agi:` entry, ai-ml category. Inserted alphabetically between `appsmith` and `cloudbeaver`. |
| [stacks/big-agi/docker-compose.yml](stacks/big-agi/docker-compose.yml) | New file. Skeleton mirrors `stacks/drawio/docker-compose.yml` with Big-AGI's image + port. |
| [README.md:71](README.md#L71) | Stack count `(63)` → `(64)`. Badge + table row inserted alphabetically between Appsmith and Budibase (per CLAUDE.md "badge order MUST match table order"). |
| [docs/stacks/big-agi.md](docs/stacks/big-agi.md) | New doc page. Shape matches `docs/stacks/drawio.md`. |
| [docs/stacks/README.md](docs/stacks/README.md) | Rows added to both the Docker Image Versions table and the Stack Documentation table. |

## Not touched (deliberately, for stateless / CF-Access-fronted tools)

- `tofu/stack/main.tf` — no `random_password` resource (no admin UI / login).
- `tofu/stack/outputs.tf` — no secrets output.
- `src/nexus_deploy/services.py` `_SERVICE_HOOKS` registry — no auto-setup hook needed (container boots and serves without bootstrapping).
- Infisical secrets push — nothing to push.

## Test plan

- [x] `uv run pytest tests/` — 1460 passed.
- [x] `uv run pre-commit run --files <changed>` — clean.
- [x] `python -c "import yaml; yaml.safe_load(open('services.yaml'))"` — parses; the new `big-agi:` entry round-trips with all expected fields.
- [x] Manual verify: README stack count = 64 matches the post-add entry total.
- [x] Manual verify: badge order and table row order are identical (both go `Appsmith → Big-AGI → Budibase`).
- [ ] End-to-end (operator-side, post-merge): enable `big-agi` in the Control Plane → Spin Up → open `https://big-agi.<domain>` → authenticate via Cloudflare Access → **Models → Add Model** → paste an OpenAI API key → send a test prompt. Expected: 200 response, model responds.

## Risk notes

- Alphabetic-insertion errors in README badge ↔ table-row order would be visually drift but CI-loadable. Manually verified the order is `Appsmith → Big-AGI → Budibase` in both places.
- The healthcheck uses `wget` rather than `curl` because Big-AGI's Node-Alpine base typically ships `wget`. If the upstream image drops it, the healthcheck will fail and the container will be marked unhealthy — falls back to `curl` is a one-line follow-up if that happens.
- Image is pinned to `v2.0.4`; if Big-AGI ships `v2.0.5+` we just bump in a separate PR — same flow as every other pinned stack.

Closes #394
