### PR TITLE
feat(stacks): Add Crawl4AI LLM-friendly web crawler

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ After deployment you'll have:
 
 ![Quick Start Flow](docs/assets/architecture-quickstart.svg)
 
-## Available Stacks (64)
+## Available Stacks (65)
 
 [![AKHQ](https://img.shields.io/badge/AKHQ-000000?logo=apachekafka&logoColor=white)](https://akhq.io)
 [![Adminer](https://img.shields.io/badge/Adminer-34567C?logo=adminer&logoColor=white)](https://www.adminer.org)
@@ -78,6 +78,7 @@ After deployment you'll have:
 [![CloudBeaver](https://img.shields.io/badge/CloudBeaver-3776AB?logo=dbeaver&logoColor=white)](https://dbeaver.com/cloudbeaver/)
 [![ClickHouse](https://img.shields.io/badge/ClickHouse-FFCC00?logo=clickhouse&logoColor=black)](https://clickhouse.com)
 [![code-server](https://img.shields.io/badge/code--server-007ACC?logo=visualstudiocode&logoColor=white)](https://coder.com)
+[![Crawl4AI](https://img.shields.io/badge/Crawl4AI-1B6CA8?logo=googlechrome&logoColor=white)](https://github.com/unclecode/crawl4ai)
 [![Dagster](https://img.shields.io/badge/Dagster-4F43DD?logo=dagster&logoColor=white)](https://dagster.io)
 [![Debezium](https://img.shields.io/badge/Debezium-4E8CBF?logo=debezium&logoColor=white)](https://debezium.io)
 [![Dify](https://img.shields.io/badge/Dify-1677FF?logoColor=white)](https://dify.ai)
@@ -145,6 +146,7 @@ After deployment you'll have:
 | **CloudBeaver** | Web-based database management tool | [dbeaver.com/cloudbeaver](https://dbeaver.com/cloudbeaver/) |
 | **ClickHouse** | Fast columnar database for real-time analytics and OLAP queries | [clickhouse.com](https://clickhouse.com) |
 | **code-server** | VS Code in the browser for remote development | [coder.com](https://coder.com) |
+| **Crawl4AI** | LLM-friendly web crawler that returns clean Markdown for RAG ingestion (REST API + Playground UI) | [github.com/unclecode/crawl4ai](https://github.com/unclecode/crawl4ai) |
 | **Dagster** | Python-native data orchestration for data pipelines and Software-Defined Assets | [dagster.io](https://dagster.io) |
 | **Debezium** | Change data capture - streams database changes to Redpanda/Kafka in real time | [debezium.io](https://debezium.io) |
 | **Dify** | AI workflow builder for LLM applications, RAG pipelines, and agents | [dify.ai](https://dify.ai) |

--- a/docs/stacks/README.md
+++ b/docs/stacks/README.md
@@ -16,6 +16,7 @@ Images are pinned to **major versions** where supported for automatic security p
 | CloudBeaver | `dbeaver/cloudbeaver` | `24` | Major |
 | ClickHouse | `clickhouse/clickhouse-server` | `25.8.16.34` | Exact ¹ |
 | code-server | `codercom/code-server` | `latest` | Latest ² |
+| Crawl4AI | `unclecode/crawl4ai` | `0.8.6` | Exact ¹ |
 | Dagster | dagster (custom build) | `1.12.21` | Exact ³ |
 | Debezium | `quay.io/debezium/connect` | `3.5.0` | Exact ¹ |
 | Dinky | `dinkydocker/dinky-standalone-server` | `1.2.5-flink1.20` | Exact ¹ |
@@ -127,6 +128,7 @@ Images are pinned to **major versions** where supported for automatic security p
 | **CloudBeaver** | Web-based database management tool | [cloudbeaver.md](cloudbeaver.md) |
 | **ClickHouse** | Columnar database for real-time analytics | [clickhouse.md](clickhouse.md) |
 | **code-server** | VS Code in the browser | [code-server.md](code-server.md) |
+| **Crawl4AI** | LLM-friendly web crawler for RAG | [crawl4ai.md](crawl4ai.md) |
 | **Dagster** | Python data orchestration | [dagster.md](dagster.md) |
 | **Debezium** | Change data capture platform | [debezium.md](debezium.md) |
 | **Dify** | AI workflow builder for LLM applications | [dify.md](dify.md) |

--- a/docs/stacks/crawl4ai.md
+++ b/docs/stacks/crawl4ai.md
@@ -1,0 +1,42 @@
+---
+title: "Crawl4AI"
+---
+
+## Crawl4AI
+
+![Crawl4AI](https://img.shields.io/badge/Crawl4AI-1B6CA8?logo=googlechrome&logoColor=white)
+
+**LLM-friendly web crawler that returns clean Markdown for RAG ingestion**
+
+Crawl4AI scrapes web pages and emits clean Markdown, JSON, or structured extracts ready for LLM prompts and RAG pipelines. Exposes both a REST API (`/crawl`, `/extract`) and an interactive Playground UI for ad-hoc experiments. Features include:
+
+- Headless Chromium rendering (handles JS-heavy SPAs)
+- Markdown / JSON / structured-extract output formats
+- CSS-selector and LLM-driven extraction strategies
+- Concurrent multi-URL crawling
+- No database — stateless, in-memory cache only
+
+| Setting | Value |
+|---------|-------|
+| Default Port | `11235` |
+| Suggested Subdomain | `crawl4ai` |
+| Public Access | No (protected by Cloudflare Access) |
+| Persistence | None (stateless, in-memory cache only) |
+| Website | [github.com/unclecode/crawl4ai](https://github.com/unclecode/crawl4ai) |
+| Source | [GitHub](https://github.com/unclecode/crawl4ai) |
+
+### Usage
+
+1. Open `https://crawl4ai.<domain>` and authenticate via Cloudflare Access.
+2. Go to `/playground` for the interactive UI, or POST against the REST API at `/crawl` (e.g. `{ "url": "https://example.com" }`).
+3. Pipe the resulting Markdown into Big-AGI, Dify, Kestra, or any other LLM workflow as RAG context.
+
+### Security note
+
+The container ships with `CRAWL4AI_HOOKS_ENABLED=false`. Upstream Crawl4AI's "hooks" feature lets API callers execute arbitrary Python from request bodies — useful for custom extraction logic, but a remote-code-execution risk for any caller who reaches the API.
+
+Cloudflare Access ensures only authenticated users reach the API, but it does **not** constrain what those authenticated users can do once inside. For a multi-student class environment, hooks are therefore disabled by default. If you operate a single-user setup and explicitly want the hooks feature, flip the env var in [stacks/crawl4ai/docker-compose.yml](../../stacks/crawl4ai/docker-compose.yml) and re-spin-up.
+
+### Operational note: shared memory
+
+The container is started with `shm_size: 1g`. Crawl4AI bundles a Playwright browser pool for JS-heavy pages, which needs more than Docker's default 64 MB shared memory or it crashes on the first complex page render. The current 2 GB memory limit gives ~600 MB idle headroom and copes with parallel render bursts up to about a dozen concurrent crawls.

--- a/services.yaml
+++ b/services.yaml
@@ -125,6 +125,16 @@ services:
     long_description: "Code Server runs VS Code on a remote server, accessible through your browser. Full VS Code experience including extensions, terminal, Git integration, and IntelliSense. Access your development environment from any device with a consistent setup."
     image: "codercom/code-server:latest"
 
+  crawl4ai:
+    subdomain: "crawl4ai"
+    port: 11235
+    public: false
+    category: "ai-ml"
+    website: "https://github.com/unclecode/crawl4ai"
+    description: "LLM-friendly web crawler that returns clean Markdown for RAG pipelines."
+    long_description: "Crawl4AI is an open-source web crawler optimised for LLM workflows. It scrapes pages and returns clean Markdown, JSON, or structured extracts ready for RAG ingestion or LLM prompts. Exposes a REST API and an interactive Playground UI. Pairs naturally with Dify, Big-AGI, or Kestra flows that need to ingest external content. Stateless — no database, in-memory cache only."
+    image: "unclecode/crawl4ai:0.8.6"
+
   dagster:
     subdomain: "dagster"
     port: 3004

--- a/stacks/crawl4ai/docker-compose.yml
+++ b/stacks/crawl4ai/docker-compose.yml
@@ -1,0 +1,53 @@
+# =============================================================================
+# Crawl4AI - LLM-friendly Web Crawler
+# =============================================================================
+# Stateless REST API + Playground UI for scraping pages into clean Markdown,
+# JSON, or structured extracts for LLM / RAG pipelines.
+# Access via: https://crawl4ai.your-domain.com
+# Default port: 11235
+#
+# SECURITY:
+# - Protected by Cloudflare Access (email OTP authentication)
+# - HTTPS only via Cloudflare Tunnel
+# - No authentication required at application level
+# - CRAWL4AI_HOOKS_ENABLED=false: the upstream "hooks" feature lets API
+#   callers execute arbitrary Python from request bodies. Cloudflare
+#   Access ensures only authenticated users reach the API, but it does
+#   NOT constrain what those authenticated users can do — so the safer
+#   default for a class environment is to disable hooks. Operators who
+#   explicitly want hooks can flip this to "true".
+#
+# OPERATIONAL NOTES:
+# - shm_size: 1g — the embedded Playwright browser pool needs more
+#   than Docker's default 64 MB shared memory or it crashes on the
+#   first page render. Upstream's docker run recommendation.
+# - Memory limit 2g — idle ~600 MB, ~1.2 GB while rendering a complex
+#   JS-heavy SPA. 2 GB gives comfortable headroom.
+# =============================================================================
+
+services:
+  crawl4ai:
+    image: ${IMAGE_CRAWL4AI:-unclecode/crawl4ai:0.8.6}
+    container_name: crawl4ai
+    restart: unless-stopped
+    ports:
+      - "11235:11235"
+    shm_size: 1g
+    environment:
+      CRAWL4AI_HOOKS_ENABLED: "false"
+    deploy:
+      resources:
+        limits:
+          memory: 2g
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:11235/health >/dev/null || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+    networks:
+      - app-network
+
+networks:
+  app-network:
+    external: true


### PR DESCRIPTION
## Summary

Closes #391 — adds Crawl4AI as a new stack.

Crawl4AI is an open-source web crawler optimised for LLM workflows. It scrapes pages and emits clean Markdown, JSON, or structured extracts ready for RAG ingestion or LLM prompts. Exposes both a REST API (`/crawl`, `/extract`) and an interactive Playground UI. Pairs naturally with the just-shipped Big-AGI, with Dify, or with Kestra flows that need to ingest external content.

Same pattern as the previous add-stack PRs (Big-AGI #574, drawio, etc.) — single container, stateless, no Postgres, no admin login, no Infisical secrets, no auto-setup hook.

## Image

- **`unclecode/crawl4ai:0.8.6`** — most recent stable semver tag on Docker Hub (~2 months old).
- Multi-arch: **`linux/amd64` + `linux/arm64`**, verified at the tags page (1.37 GB / 2.11 GB).
- Not `:latest` — Crawl4AI doesn't fit CLAUDE.md's `latest`-exempt named set (drawio, it-tools, etc.). Pinning gives reproducibility; future bumps go through deliberate version-bump PRs.

## Port

- **Internal**: 11235 (Crawl4AI's default — REST + `/playground` + `/dashboard`).
- **Host**: 11235 — same number, free in `services.yaml` (existing ports max out around 9644).

## Two non-default Compose settings

Both are documented in the docker-compose.yml header comment + the docs page:

1. **`shm_size: 1g`** — Crawl4AI bundles a Playwright browser pool for JS-heavy SPAs. Docker's default 64 MB shared memory is too small; the browser pool crashes on the first complex page render. Upstream's recommended `docker run` flag, translated to Compose syntax.

2. **`CRAWL4AI_HOOKS_ENABLED=false`** — the upstream "hooks" feature lets API callers execute arbitrary Python from request bodies. Cloudflare Access only protects against unauthenticated drive-by exploitation; it does **not** constrain what authenticated students can do. Class-environment-safe default is hooks-off; single-operator setups that explicitly want hooks can flip the env var.

## Files touched (5)

| File | Change |
|---|---|
| [services.yaml](services.yaml) | New `crawl4ai:` entry, ai-ml category. Inserted alphabetically after `code-server:`. |
| [stacks/crawl4ai/docker-compose.yml](stacks/crawl4ai/docker-compose.yml) | New file. Mirrors the `big-agi` / `drawio` shape with `shm_size`, `CRAWL4AI_HOOKS_ENABLED=false`, and a 2g memory limit. |
| [README.md](README.md) | Stack count `(64)` → `(65)`. Badge + table row inserted alphabetically between code-server and Dagster (per CLAUDE.md "badge order MUST match table order"). |
| [docs/stacks/crawl4ai.md](docs/stacks/crawl4ai.md) | New doc page. Same shape as `docs/stacks/big-agi.md` with a security note about the disabled hooks feature + operational note about the shared-memory flag. |
| [docs/stacks/README.md](docs/stacks/README.md) | Rows added to both the Docker Image Versions table and the Stack Documentation table. |

## Not touched (deliberately, for stateless / CF-Access-fronted tools)

- `tofu/stack/main.tf` — no `random_password` resource (no admin UI / login).
- `tofu/stack/outputs.tf` — no secrets output.
- `src/nexus_deploy/services.py` `_SERVICE_HOOKS` registry — no auto-setup hook needed (container boots and serves without bootstrapping).
- Infisical secrets push — nothing to push.

## Test plan

- [x] `uv run pytest tests/` — 1460 passed.
- [x] `uv run pre-commit run --files <changed>` — clean.
- [x] `python -c "import yaml; yaml.safe_load(open('services.yaml'))"` — parses; new `crawl4ai:` entry round-trips at port 11235 with image `unclecode/crawl4ai:0.8.6`.
- [x] Manual verify: README stack count `(65)` matches post-add entry total.
- [x] Manual verify: badge order and table-row order both go `code-server → Crawl4AI → Dagster`.
- [ ] End-to-end (operator-side, post-merge): enable `crawl4ai` in the Control Plane → Spin Up → open `https://crawl4ai.<domain>` → authenticate via CF Access → `/playground` → submit a test URL (e.g. `https://example.com`) → confirm Markdown comes back.

## Risk notes

- Memory `2g` is sized for the Playwright workload with comfortable headroom; the host (`cx43`, 16 GB) easily accommodates it on top of Budibase's recent 4 GB bump.
- Healthcheck targets `/health` — if the upstream image doesn't ship that endpoint at 0.8.6, the container will be marked unhealthy and we'll need to swap to `/` (one-line follow-up).
- The `CRAWL4AI_HOOKS_ENABLED=false` default is documented prominently. Operators who flip it should be aware that authenticated students gain remote-code-execution.

Closes #391
