### PR TITLE
refactor(control-plane): Consolidate stack URL builders via window.NS

### DIFF
--- a/control-plane/src/pages/index.astro
+++ b/control-plane/src/pages/index.astro
@@ -408,8 +408,10 @@ import Layout from '../layouts/Layout.astro';
   let currentAction = null;
   let pendingChangesCount = 0;
   let wasInProgress = false;
-  let stackDomain = window.location.hostname.replace(/^control[.-]/, '');
-  let subdomainSeparator = '.';
+  // Domain + subdomain_separator are owned by window.NS.fetchDomain()
+  // (defined in StacksShared.astro, loaded globally via Layout.astro).
+  // window.NS.stackUrl(service) is the single URL builder both pages share —
+  // see #579 / "Honor landing_path in Active Stacks panel".
 
   const statusDescriptions = {
     'deployed': 'Infrastructure is running. All services are accessible.',
@@ -421,22 +423,6 @@ import Layout from '../layouts/Layout.astro';
 
   function enableFallbackState() {
     updateButtons({ infraState: 'unknown', inProgress: false, workflows: {} });
-  }
-
-  // Fetch domain for service links
-  async function fetchDomain() {
-    try {
-      const res = await fetch(`${API_URL}/api/info`, { credentials: 'same-origin' });
-      const ct = res.headers.get('content-type');
-      if (!ct || !ct.includes('application/json')) return;
-      const data = await res.json();
-      if (data.success && data.info?.server?.domain) {
-        stackDomain = data.info.server.domain;
-      }
-      if (data.success && data.info?.server?.subdomainSeparator) {
-        subdomainSeparator = data.info.server.subdomainSeparator;
-      }
-    } catch {}
   }
 
   // Fetch and display status
@@ -550,7 +536,10 @@ import Layout from '../layouts/Layout.astro';
   // Active stacks list
   async function loadActiveStacks() {
     try {
-      await fetchDomain();
+      // Wait for window.NS.fetchDomain() so window.NS.stackUrl() returns
+      // a populated URL (cachedDomain is loaded). The Promise is memoised
+      // so multiple callers across pages share one /api/info fetch.
+      await window.NS.fetchDomain();
       const response = await fetch(`${API_URL}/api/services`, { credentials: 'same-origin' });
       if (!response.ok) return;
       const data = await response.json();
@@ -597,13 +586,12 @@ import Layout from '../layouts/Layout.astro';
     let html = '<p class="stack-count">' + services.length + ' stack' + (services.length !== 1 ? 's' : '') + ' active</p>';
 
     services.forEach(s => {
-      if (s.subdomain && s.deployed) {
-        let url = 'https://' + s.subdomain + subdomainSeparator + stackDomain;
-        // Optional per-service landing path (e.g. /docs/ for Chroma's Swagger UI).
-        // Matches the behaviour of window.NS.stackUrl() in StacksShared.astro.
-        if (s.landing_path && typeof s.landing_path === 'string' && s.landing_path.length > 0) {
-          url = url + s.landing_path;
-        }
+      // window.NS.stackUrl() handles base URL + optional landing_path append.
+      // Returns '' when subdomain or cached domain is missing — fall through
+      // to the no-link chip in that case (same render path as services
+      // without a subdomain).
+      const url = s.deployed ? window.NS.stackUrl(s) : '';
+      if (url) {
         html += '<a href="' + url + '" target="_blank" rel="noopener" class="stack-chip">' +
           escapeHtml(s.name) + '<span class="arrow">&#8599;</span></a>';
       } else {

--- a/control-plane/src/pages/index.astro
+++ b/control-plane/src/pages/index.astro
@@ -598,7 +598,12 @@ import Layout from '../layouts/Layout.astro';
 
     services.forEach(s => {
       if (s.subdomain && s.deployed) {
-        const url = 'https://' + s.subdomain + subdomainSeparator + stackDomain;
+        let url = 'https://' + s.subdomain + subdomainSeparator + stackDomain;
+        // Optional per-service landing path (e.g. /docs/ for Chroma's Swagger UI).
+        // Matches the behaviour of window.NS.stackUrl() in StacksShared.astro.
+        if (s.landing_path && typeof s.landing_path === 'string' && s.landing_path.length > 0) {
+          url = url + s.landing_path;
+        }
         html += '<a href="' + url + '" target="_blank" rel="noopener" class="stack-chip">' +
           escapeHtml(s.name) + '<span class="arrow">&#8599;</span></a>';
       } else {


### PR DESCRIPTION
## Summary

Tail of #577. The `landing_path` field was wired through the Stacks page's URL builder ([StacksShared.astro `stackUrl()`](control-plane/src/components/StacksShared.astro)) but the **Dashboard's "Active Stacks" panel** has its own separate inline URL builder in [`index.astro` `renderActiveStacks()`](control-plane/src/pages/index.astro) that was missed. Hit live for Chroma: clicking the `chroma` chip on the Dashboard went to `https://chroma.<domain>/` (404) instead of `https://chroma.<domain>/docs/` (Swagger UI).

First commit on this branch (`d873d3b`) was a bandaid — duplicated the `landing_path` logic inline. Second commit (`cc43426`) is the proper fix: **consolidate both URL builders to share `window.NS.stackUrl()`**, eliminating the duplication that caused the bug in the first place.

## Why consolidate instead of just patch

The Dashboard panel and the Stacks page were doing **identical work** with **two separate code paths**:

- `https://<subdomain><sep><domain>` build → identical math, two implementations
- Optional `landing_path` append → would have needed to be added to both (the bandaid did exactly that)
- `/api/info` fetch for domain caching → also duplicated

Every future URL-shape change (query strings, service-token paths, etc.) would have needed to touch both places, with the obvious risk that one gets forgotten — exactly the bug pattern that started this PR.

## What changed

[control-plane/src/pages/index.astro](control-plane/src/pages/index.astro):

1. **Removed local `stackDomain` + `subdomainSeparator` state** — both lived as page-local vars, now sourced from `window.NS.fetchDomain()`'s cached state.
2. **Removed local `fetchDomain()` function** (15 lines) — replaced by `await window.NS.fetchDomain()` at the one call site. The shared version memoises the Promise, so no redundant `/api/info` fetch from the Dashboard.
3. **`renderActiveStacks()` URL build** — went from 5 lines inline (subdomain join + landing_path append + length check) to one call: `const url = s.deployed ? window.NS.stackUrl(s) : '';`.

Net: **-26 lines, +14 lines**, -3 local vars, -1 redundant API call per Dashboard load.

## What `window.NS.stackUrl()` does (unchanged from #577, now the single source of truth)

```javascript
window.NS.stackUrl = function(service) {
  if (!service || !service.subdomain || !cachedDomain) return '';
  var base = 'https://' + service.subdomain + cachedSeparator + cachedDomain;
  if (service.landing_path && typeof service.landing_path === 'string' && service.landing_path.length > 0) {
    return base + service.landing_path;
  }
  return base;
};
```

Empty-string return when `subdomain` or `cachedDomain` is missing maps cleanly to the Dashboard's existing `no-link chip` fallback — same render path as services that have no `subdomain` set.

## Test plan

- [x] `uv run pre-commit run` — clean.
- [x] `grep stackDomain|subdomainSeparator index.astro` — no stale references in the JS body, only descriptive comments mentioning the new owners.
- [ ] After merge + Pages auto-deploy: Dashboard's Active Stacks → click `chroma` chip → opens `https://chroma.<domain>/docs/`. Other stacks (no `landing_path`) → bare root (unchanged).
- [ ] Stacks page (`/stacks`) still works identically — same helper, no behaviour change there.

## Commit history

- `d873d3b` — bandaid (kept in history but superseded; squash-merge folds both into one final commit on main).
- `cc43426` — proper refactor.

Tail of #577.
