### PR TITLE
fix(capacity): Legacy single-pair shorthand falls through to DEFAULT_PREFERENCES

### DIFF
--- a/src/nexus_deploy/__main__.py
+++ b/src/nexus_deploy/__main__.py
@@ -2684,18 +2684,9 @@ def _select_capacity(args: list[str]) -> int:
     else:
         legacy_pair = _read_single_pair_from_tfvars(text)
         if legacy_pair is not None:
-            # Class-config shorthand: put the operator's choice FIRST,
-            # then fall through to DEFAULT_PREFERENCES for stock fallback.
-            # Previously this was `preferences = (legacy_pair,)` — a one-
-            # entry tuple with no fallback, so a single sold-out region
-            # for the class-configured type aborted the whole spin-up.
-            # Empirically caught mid-2026-05 when a class of 16 with
-            # cx43:hel1 hit Hetzner's EU peak and every stack failed
-            # with "out of stock" despite cx53/cpx42/cpx52/cpx62 having
-            # ample capacity. The downstream tooling (the Education
-            # admin panel) was working around this by pushing its own
-            # 24-entry SERVER_PREFERENCES list — that workaround is now
-            # redundant and can be retired.
+            # Class-config shorthand: operator's choice FIRST, then
+            # DEFAULT_PREFERENCES (dedup'd) so a single sold-out region
+            # for the configured type doesn't abort the spin-up.
             default_specs = _hetzner.parse_preferences(
                 ",".join(_hetzner.DEFAULT_PREFERENCES),
             )

--- a/src/nexus_deploy/__main__.py
+++ b/src/nexus_deploy/__main__.py
@@ -2589,11 +2589,22 @@ def _select_capacity(args: list[str]) -> int:
     Preference source priority (first non-empty wins):
 
     1. ``SERVER_PREFERENCES`` env var (passed via spin-up.yml from
-       the ``vars.SERVER_PREFERENCES`` repo variable)
-    2. ``server_preferences = "..."`` line in ``config.tfvars``
+       the ``vars.SERVER_PREFERENCES`` repo variable). Used as-is —
+       the operator-provided list IS the full list, no fallback
+       appended (this is the "expert override" path).
+    2. ``server_preferences = "..."`` line in ``config.tfvars``.
+       Same as #1: used verbatim, no fallback.
     3. Legacy single-pair shorthand: ``server_type = "..."`` +
-       ``server_location = "..."`` lines in ``config.tfvars``
-    4. :data:`hetzner_capacity.DEFAULT_PREFERENCES`
+       ``server_location = "..."`` lines in ``config.tfvars``.
+       The class-config write-path lands here. The operator's pair
+       is used as the FIRST preference, then
+       :data:`hetzner_capacity.DEFAULT_PREFERENCES` is appended as
+       fallback (deduplicated). This way a single sold-out region
+       for the configured type doesn't fail the spin-up; the
+       deploy transparently falls through to the next region or
+       tier.
+    4. :data:`hetzner_capacity.DEFAULT_PREFERENCES` (nothing
+       configured anywhere).
 
     Required env: ``HCLOUD_TOKEN``. Without it the step exits 0 with
     a stderr warning — capacity-selection is opportunistic; a local-
@@ -2673,10 +2684,35 @@ def _select_capacity(args: list[str]) -> int:
     else:
         legacy_pair = _read_single_pair_from_tfvars(text)
         if legacy_pair is not None:
-            preferences = (legacy_pair,)
+            # Class-config shorthand: put the operator's choice FIRST,
+            # then fall through to DEFAULT_PREFERENCES for stock fallback.
+            # Previously this was `preferences = (legacy_pair,)` — a one-
+            # entry tuple with no fallback, so a single sold-out region
+            # for the class-configured type aborted the whole spin-up.
+            # Empirically caught mid-2026-05 when a class of 16 with
+            # cx43:hel1 hit Hetzner's EU peak and every stack failed
+            # with "out of stock" despite cx53/cpx42/cpx52/cpx62 having
+            # ample capacity. The downstream tooling (the Education
+            # admin panel) was working around this by pushing its own
+            # 24-entry SERVER_PREFERENCES list — that workaround is now
+            # redundant and can be retired.
+            default_specs = _hetzner.parse_preferences(
+                ",".join(_hetzner.DEFAULT_PREFERENCES),
+            )
+            seen: set[tuple[str, str]] = {(legacy_pair.server_type, legacy_pair.location)}
+            extended: list[_hetzner.ServerSpec] = [legacy_pair]
+            for spec in default_specs:
+                key = (spec.server_type, spec.location)
+                if key in seen:
+                    continue
+                seen.add(key)
+                extended.append(spec)
+            preferences = tuple(extended)
             sys.stderr.write(
                 f"select-capacity: no server_preferences set; using legacy "
-                f"single-pair shorthand from config.tfvars: {legacy_pair}\n",
+                f"single-pair shorthand from config.tfvars ({legacy_pair}) "
+                f"as primary, then DEFAULT_PREFERENCES as fallback "
+                f"({len(preferences)} entries total)\n",
             )
         else:
             preferences = _hetzner.parse_preferences(",".join(_hetzner.DEFAULT_PREFERENCES))

--- a/tests/unit/test_select_capacity_cli.py
+++ b/tests/unit/test_select_capacity_cli.py
@@ -200,14 +200,20 @@ def test_select_capacity_strips_whitespace_in_legacy_pair(
     assert rc == 0
 
 
-def test_select_capacity_falls_back_to_legacy_single_pair(
+def test_select_capacity_legacy_pair_appends_defaults(
     tfvars_with_legacy_pair: Path,
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     """Operator with only ``server_type`` + ``server_location`` set
-    (the pre-#536 shorthand) keeps working: 1-element preference
-    list, no fallback to the in-code default."""
+    (the pre-#536 shorthand): the pair is used as the FIRST preference,
+    then ``DEFAULT_PREFERENCES`` is appended as fallback (dedup'd).
+
+    Previously this branch produced a 1-element preference list with
+    no fallback — a single sold-out region for the class-configured
+    type aborted the whole spin-up. The current behaviour transparently
+    falls through to the next tier/region, which is what every
+    realistic class-config caller actually wants."""
     monkeypatch.setenv("HCLOUD_TOKEN", "t")
     monkeypatch.setattr(
         _hetzner,
@@ -219,6 +225,44 @@ def test_select_capacity_falls_back_to_legacy_single_pair(
     err = capsys.readouterr().err
     assert "legacy single-pair shorthand" in err
     assert "cx43:hel1" in err
+    # The new "primary + DEFAULT fallback" branch announces the total
+    # entry count so the operator knows the legacy pair isn't on its
+    # own — that wording is part of the contract.
+    assert "DEFAULT_PREFERENCES as fallback" in err
+
+
+def test_select_capacity_legacy_pair_falls_through_when_primary_oos(
+    tfvars_with_legacy_pair: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """When the legacy class-config pair is sold out, the appended
+    DEFAULT_PREFERENCES list keeps the spin-up working.
+
+    Regression test for the mid-2026-05 incident where a 16-user class
+    with ``cx43:hel1`` configured all failed simultaneously during
+    Hetzner EU peak — every stack aborted at "out of stock" despite
+    cx53 / cpx42 / cpx52 having ample capacity. The fixture marks
+    cx43:hel1 unavailable but cx53:hel1 available; the walk must pick
+    cx53:hel1 rather than abort."""
+    monkeypatch.setenv("HCLOUD_TOKEN", "t")
+    monkeypatch.setattr(
+        _hetzner,
+        "fetch_availability",
+        # cx43:hel1 (the class-configured legacy pair) is OOS;
+        # cx53:hel1 (Tier 2 of DEFAULT_PREFERENCES) is available.
+        lambda _t, http_get=None: {"hel1": {"cx53"}, "fsn1": set(), "nbg1": set()},
+    )
+    rc = _select_capacity(["--tfvars", str(tfvars_with_legacy_pair)])
+    assert rc == 0
+    err = capsys.readouterr().err
+    assert "chose cx53:hel1" in err
+    # The rewrite must update both lines in config.tfvars, not just
+    # one. The operator's view post-deploy should match what tofu
+    # actually provisioned.
+    rewritten = tfvars_with_legacy_pair.read_text()
+    assert 'server_type     = "cx53"' in rewritten
+    assert 'server_location = "hel1"' in rewritten
 
 
 def test_select_capacity_uses_default_when_nothing_configured(


### PR DESCRIPTION
## Problem
\`select-capacity\` used the class-config legacy shorthand (\`server_type\` + \`server_location\` in config.tfvars) as a **1-element preference list with no fallback**. If that exact (type, region) pair was sold out at Hetzner, the entire spin-up failed with *every preference is out of stock* — even though \`DEFAULT_PREFERENCES\` had 14 other entries that would have worked.

Live incident mid-2026-05: a 16-user class with \`cx43:hel1\` configured all failed simultaneously during EU peak. The downstream Education admin panel was working around this by pushing its own 24-entry \`SERVER_PREFERENCES\` list and keeping a duplicate \`TEMPLATE_DEFAULT_PREFERENCES\` constant in sync by hand. That workaround caused yesterday's regression where an admin-panel deploy with a stale duplicate-list overrode the template's authoritative list.

## Fix
In the *no env override, no \`server_preferences\` key, legacy shorthand present* branch, use the operator's pair as the **first** preference, then append \`DEFAULT_PREFERENCES\` (deduplicated). Same operator contract — the class-configured pair is still tried first — but a single sold-out region no longer aborts the spin-up.

The three other priority branches are unchanged:
- \`SERVER_PREFERENCES\` env var → used verbatim (operator expert override)
- \`server_preferences = "..."\` in config.tfvars → used verbatim
- Nothing configured → \`DEFAULT_PREFERENCES\` (unchanged)

Stderr now announces the total entry count so the operator sees the fallback is queued behind their pair, not used in place of it.

## Why this matters for downstream
Once this lands and the next template release is out, the Education admin panel's \`buildServerPreferences\` + \`TEMPLATE_DEFAULT_PREFERENCES\` constants become redundant. Education can stop pushing a 24-entry list and revert to just \`SERVER_TYPE\` + \`SERVER_LOCATION\` repo vars, letting the template be the single source of truth.

## Tests
- New: \`legacy_pair_appends_defaults\` — asserts the stderr contract that announces the appended fallback.
- New: \`legacy_pair_falls_through_when_primary_oos\` — regression test for the May incident.
- Replaced (asserted the old broken behaviour): \`falls_back_to_legacy_single_pair\`.
- Existing 17 tests pass unchanged.
- \`pytest tests/unit/test_select_capacity_cli.py -x\` → 19/19 pass.

## Test plan
- [x] Unit tests cover legacy-pair + OOS + fallback walk.
- [ ] After merge + release, manual: trigger a spin-up on a fork with \`cx99:bogus1\` legacy shorthand (intentionally invalid); verify it falls through to \`cx43:hel1\` from DEFAULT_PREFERENCES.