### PR TITLE
feat(code-server): Sync Infisical secrets into code-server env on spin-up

### DIFF
--- a/docs/stacks/code-server.md
+++ b/docs/stacks/code-server.md
@@ -36,9 +36,17 @@ Run VS Code on a remote server and access it through the browser. Provides a con
 Secrets stored in Infisical are auto-synced into the code-server container's env on every spin-up (issue #496). Reference them in scripts / dbt profiles / notebook cells exactly as named in Infisical — no manual export step needed:
 
 ```bash
-# In code-server's terminal:
-echo $POSTGRES_PASSWORD          # available
-psql -h postgres -U nexus-postgres -d postgres   # no PGPASSWORD export needed
+# In code-server's terminal — presence check (never echo a secret value,
+# scrollback/copy-paste leakage):
+[ -n "$POSTGRES_PASSWORD" ] && echo "POSTGRES_PASSWORD is set"
+
+# psql: libpq reads PGPASSWORD (not POSTGRES_PASSWORD), so either
+# pass the value inline for one command…
+PGPASSWORD="$POSTGRES_PASSWORD" psql -h postgres -U nexus-postgres -d postgres
+
+# …or export it once per session for repeated invocations.
+export PGPASSWORD="$POSTGRES_PASSWORD"
+psql -h postgres -U nexus-postgres -d postgres
 ```
 
 ```python

--- a/docs/stacks/code-server.md
+++ b/docs/stacks/code-server.md
@@ -31,6 +31,43 @@ Run VS Code on a remote server and access it through the browser. Provides a con
 3. Authentication is handled by Cloudflare Access (no additional password)
 4. Files are persisted in a Docker volume (`code-server-data`)
 
+### Infisical secrets
+
+Secrets stored in Infisical are auto-synced into the code-server container's env on every spin-up (issue #496). Reference them in scripts / dbt profiles / notebook cells exactly as named in Infisical — no manual export step needed:
+
+```bash
+# In code-server's terminal:
+echo $POSTGRES_PASSWORD          # available
+psql -h postgres -U nexus-postgres -d postgres   # no PGPASSWORD export needed
+```
+
+```python
+# In a Python file or Jupyter cell:
+import os
+pg_password = os.environ["POSTGRES_PASSWORD"]
+r2_key = os.environ["R2_ACCESS_KEY"]
+```
+
+```yaml
+# In ~/.dbt/profiles.yml:
+my_postgres:
+  target: dev
+  outputs:
+    dev:
+      type: postgres
+      host: postgres
+      port: 5432
+      user: nexus-postgres
+      password: "{{ env_var('POSTGRES_PASSWORD') }}"
+      dbname: postgres
+      schema: dbt_dev
+      threads: 4
+```
+
+The sync writes to a dedicated `.infisical.env` file (not `.env`) so secret keys can't accidentally collide with Compose's `${VAR}` interpolation. Multi-line values (e.g. PEM keys) are skipped with a warning — they need a different transport mechanism (mount-as-file). Re-running spin-up after editing a secret in Infisical refreshes the value automatically; code-server restarts to pick up the new env.
+
+**Not covered by this sync:** Databricks credentials (`databricks_host` / `databricks_token`) live in Cloudflare KV via the Control Plane's Databricks page, not in Infisical — see the Databricks caveat under "Pre-installed data tooling" below for the manual steps to wire them into `~/.dbt/profiles.yml`.
+
 ### Pre-installed data tooling
 
 The code-server image (`stacks/code-server/Dockerfile`) ships with a Python virtual environment at **`/opt/nexus-venv`** that's auto-activated in every terminal you open. Inspired by [stefanko-ch/dbt_codespace_demo](https://github.com/stefanko-ch/dbt_codespace_demo)'s devcontainer, adapted for Nexus-Stack:

--- a/src/nexus_deploy/orchestrator.py
+++ b/src/nexus_deploy/orchestrator.py
@@ -266,6 +266,7 @@ class Orchestrator:
                 self._phase_mirror_finalize,
                 self._phase_secret_sync_jupyter,
                 self._phase_secret_sync_marimo,
+                self._phase_secret_sync_code_server,
             ]
             for phase in phases:
                 result = phase(ssh)
@@ -732,6 +733,9 @@ class Orchestrator:
 
     def _phase_secret_sync_marimo(self, ssh: SSHClient) -> PhaseResult:
         return self._phase_secret_sync(ssh, "marimo")
+
+    def _phase_secret_sync_code_server(self, ssh: SSHClient) -> PhaseResult:
+        return self._phase_secret_sync(ssh, "code-server")
 
     # ---------------------------------------------------------------------
     # Pre-bootstrap pipeline phases.

--- a/stacks/code-server/docker-compose.yml
+++ b/stacks/code-server/docker-compose.yml
@@ -42,6 +42,14 @@ services:
     env_file:
       - path: .env
         required: false
+      # Infisical secrets land in a dedicated file (written by the
+      # orchestrator's secret-sync-code-server phase), not in `.env`.
+      # Same rationale as the Jupyter stack: keep `${VAR}` interpolation
+      # in this compose file isolated from secret values, and keep
+      # the config-hash that compose uses for restart-on-change
+      # detection scoped to actually-secret-relevant content.
+      - path: .infisical.env
+        required: false
     ports:
       - "8100:8080"
     deploy:

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -178,6 +178,7 @@ def test_state_handoff_gitea_token_reaches_seed(
         "_phase_mirror_finalize",
         "_phase_secret_sync_jupyter",
         "_phase_secret_sync_marimo",
+        "_phase_secret_sync_code_server",
     ):
         monkeypatch.setattr(orchestrator, phase_name, lambda _ssh, n=phase_name: _ok_phase(n))
     # Make examples/workspace-seeds/ "exist" so seed phase doesn't skip
@@ -213,6 +214,7 @@ def test_state_handoff_restart_services_populated_from_gitea(
         "_phase_mirror_finalize",
         "_phase_secret_sync_jupyter",
         "_phase_secret_sync_marimo",
+        "_phase_secret_sync_code_server",
     ):
         monkeypatch.setattr(orchestrator, phase_name, lambda _ssh, n=phase_name: _ok_phase(n))
 
@@ -251,6 +253,7 @@ def test_state_handoff_woodpecker_creds_populated(
         "_phase_mirror_finalize",
         "_phase_secret_sync_jupyter",
         "_phase_secret_sync_marimo",
+        "_phase_secret_sync_code_server",
     ):
         monkeypatch.setattr(orchestrator, phase_name, lambda _ssh, n=phase_name: _ok_phase(n))
 
@@ -295,6 +298,7 @@ def test_state_handoff_fork_populated_from_mirror(
         "_phase_mirror_finalize",
         "_phase_secret_sync_jupyter",
         "_phase_secret_sync_marimo",
+        "_phase_secret_sync_code_server",
     ):
         monkeypatch.setattr(orchestrator, phase_name, lambda _ssh, n=phase_name: _ok_phase(n))
 
@@ -424,6 +428,7 @@ def test_failed_phase_aborts_downstream_phases(
     monkeypatch.setattr(orchestrator, "_phase_mirror_setup", make_phase("mirror"))
     monkeypatch.setattr(orchestrator, "_phase_secret_sync_jupyter", make_phase("ss-j"))
     monkeypatch.setattr(orchestrator, "_phase_secret_sync_marimo", make_phase("ss-m"))
+    monkeypatch.setattr(orchestrator, "_phase_secret_sync_code_server", make_phase("ss-cs"))
 
     result = orchestrator.run_all()
     assert invoked == ["infisical", "services"]
@@ -463,10 +468,11 @@ def test_partial_phase_continues_to_downstream(
     monkeypatch.setattr(orchestrator, "_phase_mirror_finalize", make_phase("mirror-fin"))
     monkeypatch.setattr(orchestrator, "_phase_secret_sync_jupyter", make_phase("ss-j"))
     monkeypatch.setattr(orchestrator, "_phase_secret_sync_marimo", make_phase("ss-m"))
+    monkeypatch.setattr(orchestrator, "_phase_secret_sync_code_server", make_phase("ss-cs"))
 
     result = orchestrator.run_all()
-    # All 14 phases ran despite the partial in services-configure.
-    assert len(invoked) == 14
+    # All 15 phases ran despite the partial in services-configure.
+    assert len(invoked) == 15
     assert result.has_partial
     assert not result.has_hard_failure
 
@@ -509,6 +515,11 @@ def test_phases_run_in_deterministic_order(
     monkeypatch.setattr(orchestrator, "_phase_mirror_finalize", make_phase("12-mirror-fin"))
     monkeypatch.setattr(orchestrator, "_phase_secret_sync_jupyter", make_phase("13-ss-jupyter"))
     monkeypatch.setattr(orchestrator, "_phase_secret_sync_marimo", make_phase("14-ss-marimo"))
+    monkeypatch.setattr(
+        orchestrator,
+        "_phase_secret_sync_code_server",
+        make_phase("15-ss-code-server"),
+    )
 
     orchestrator.run_all()
     assert invoked == [
@@ -526,6 +537,7 @@ def test_phases_run_in_deterministic_order(
         "12-mirror-fin",
         "13-ss-jupyter",
         "14-ss-marimo",
+        "15-ss-code-server",
     ]
 
 
@@ -1359,13 +1371,14 @@ def test_run_all_resets_results_between_runs(
         "_phase_mirror_finalize",
         "_phase_secret_sync_jupyter",
         "_phase_secret_sync_marimo",
+        "_phase_secret_sync_code_server",
     ):
         monkeypatch.setattr(orchestrator, phase_name, lambda _ssh, n=phase_name: _ok_phase(n))
     r1 = orchestrator.run_all()
     r2 = orchestrator.run_all()
-    # 14 phases per ``run_all`` invocation.
-    assert len(r1.phases) == 14
-    assert len(r2.phases) == 14
+    # 15 phases per ``run_all`` invocation.
+    assert len(r1.phases) == 15
+    assert len(r2.phases) == 15
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -812,6 +812,19 @@ def test_phase_secret_sync_marimo_skipped_when_disabled(minimal_env: BootstrapEn
     assert result.status == "skipped"
 
 
+def test_phase_secret_sync_code_server_skipped_when_disabled(minimal_env: BootstrapEnv) -> None:
+    config = NexusConfig()
+    orch = Orchestrator(
+        config=config,
+        bootstrap_env=minimal_env,
+        enabled_services=[],
+        repo_name="r",
+        gitea_repo_owner="o",
+    )
+    result = orch._phase_secret_sync_code_server(MagicMock())
+    assert result.status == "skipped"
+
+
 def test_phase_secret_sync_partial_without_creds(minimal_env: BootstrapEnv) -> None:
     config = NexusConfig()
     orch = Orchestrator(

--- a/tests/unit/test_secret_sync.py
+++ b/tests/unit/test_secret_sync.py
@@ -115,6 +115,26 @@ def test_stack_target_jupyter_marimo_defaults_unchanged() -> None:
         assert target.force_recreate is False
 
 
+def test_stack_target_code_server_paths() -> None:
+    """code-server reuses the Jupyter/Marimo plaintext-dotenv default
+    (issue #496). Paths share the same convention; no force_recreate
+    needed since code-server reads env vars at container start and
+    compose detects env_file content changes on plain `up -d`."""
+    target = StackTarget(name="code-server")
+    assert target.env_file == "/opt/docker-server/stacks/code-server/.infisical.env"
+    assert target.legacy_env_file == "/opt/docker-server/stacks/code-server/.env"
+    assert target.compose_dir == "/opt/docker-server/stacks/code-server"
+    assert target.key_prefix == ""
+    assert target.use_base64_values is False
+    assert target.force_recreate is False
+
+
+def test_stack_target_code_server_begin_marker() -> None:
+    """Marker uses the capitalised stack name; ``"code-server".capitalize()``
+    produces ``"Code-server"``."""
+    assert "Infisical → Code-server env" in StackTarget(name="code-server").begin_marker
+
+
 # ---------------------------------------------------------------------------
 # Pure-logic helpers — direct tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #496. Mirror the Jupyter/Marimo Infisical secret-sync mechanism into the **code-server** stack so VS-Code-in-the-browser users can read Infisical-managed credentials directly without copy-pasting them from the Infisical UI every session.

## Why

Today: a student using `psql -h postgres -U nexus-postgres` from code-server's terminal has to:
1. Open `https://infisical.<domain>` in another tab
2. Navigate to folder `postgres`, copy `POSTGRES_PASSWORD`
3. Run `export PGPASSWORD='...'` in the code-server terminal
4. Repeat every session (no persistence in the `code-server-data` volume because the volume mount masks `~/.bashrc`)

After this PR: `$POSTGRES_PASSWORD` (and every other Infisical key) is just there. `psql` works directly, dbt's `profiles.yml` can use `{{ env_var('POSTGRES_PASSWORD') }}`, Python's `os.environ['R2_ACCESS_KEY']` works, etc.

## How

Mirrors the Jupyter wiring exactly — the underlying `secret_sync.py` machine (rendering, base64-transport for Kestra, plaintext for others, multi-line guard, marker-block strip-and-replace, outage gates) is unchanged. Three small additions:

| File | Change |
|---|---|
| `stacks/code-server/docker-compose.yml` | Add a second `env_file:` entry for `.infisical.env` (`required: false`), alongside the existing `.env`. Same rationale as Jupyter: separate `${VAR}` interpolation in the compose file from secret values, keep the compose config-hash scoped to secret-relevant content. |
| `src/nexus_deploy/orchestrator.py` | New `_phase_secret_sync_code_server` phase that delegates to the shared `_phase_secret_sync(stack='code-server')`. Registered in the post-bootstrap phase list right after `_phase_secret_sync_jupyter` + `_phase_secret_sync_marimo`. |
| `docs/stacks/code-server.md` | New "Infisical secrets" section mirroring the Marimo one, with Python / Bash / dbt-profile examples + an explicit note that Databricks credentials are NOT covered (they live in Cloudflare KV, separate plumbing). |

No changes needed in `secret_sync.py` — `StackTarget(name='code-server')` just works with the Jupyter/Marimo defaults (plaintext dotenv, `.infisical.env` basename, no `--force-recreate`; the container reads env vars at start and `docker compose up -d code-server` picks up the env_file content change).

## Tests

- `tests/unit/test_secret_sync.py`: 2 new tests for `StackTarget(name="code-server")` — paths, defaults, begin_marker.
- `tests/unit/test_orchestrator.py`: 6 phase-list mock-out spots + 2 phase-count assertions + the ordering test updated for 15 phases (was 14).

Full suite: **1468/1468** pass (1465 + 3 new).

## Test plan

- [x] `uv run pytest` — 1468/1468 pass, 19 snapshots
- [ ] After merge, manual: spin up + verify `ssh nexus 'docker exec code-server env | grep -E "POSTGRES_|R2_|GITEA_TOKEN"'` shows the expected keys with their actual Infisical values
- [ ] In a code-server terminal: `echo $POSTGRES_PASSWORD` returns the value
- [ ] Edit a secret in Infisical → next spin-up recreates code-server with the new value
- [ ] Re-running spin-up without changing any secret produces a no-op restart (compose hash unchanged)

## Notes

- The Databricks caveat in code-server.md remains accurate after this PR: `databricks_host` / `databricks_token` live in Cloudflare KV (not Infisical), so they're explicitly NOT covered by this sync. Manual `~/.dbt/profiles.yml` setup is still required for `dbt-databricks`.
- The first spin-up after merging this PR will see a `.infisical.env` content change (file goes from "doesn't exist" to "has block"), which triggers one extra `docker compose up -d code-server`. Subsequent runs are no-op restarts unless an Infisical secret actually changed.

Closes #496.
