### PR TITLE
fix(gitea): Poll mirror HEAD until upstream-fetch lands; surface result

### DIFF
--- a/src/nexus_deploy/gitea.py
+++ b/src/nexus_deploy/gitea.py
@@ -1716,10 +1716,19 @@ def run_mirror_setup(
        d. On the FIRST mirror with a configured user, fork it
           into the user's namespace via a temp user-token
           (created + deleted on this call).
-       e. If the fork was created on this iteration: trigger
-          ``mirror-sync`` on the mirror, sleep
-          ``mirror_sync_settle_seconds``, then ``merge-upstream``
-          on the fork at ``workspace_branch``.
+       e. If the fork was created on this iteration: snapshot the
+          mirror's HEAD SHA, trigger ``mirror-sync`` on the mirror,
+          then poll the mirror's HEAD up to
+          ``mirror_sync_poll_seconds`` (with
+          ``mirror_sync_poll_interval_seconds`` between polls) waiting
+          for the upstream-fetch to land. Whether or not the SHA
+          actually changed, call ``merge-upstream`` on the fork at
+          ``workspace_branch`` (best-effort — the mirror may already
+          be ahead from Gitea's periodic cron-tick or the initial
+          migrate-fetch). The pre/post SHA + merge result land in
+          ``MirrorSetupResult.sync_detail`` so operators can tell
+          'sync landed', 'sync skipped (no change)', and 'sync
+          failed but merged anyway' apart.
 
     The fork creation (step c) and fork-sync (step e) happen ONLY
     on the first iteration that has both a successful migrate AND a
@@ -1967,10 +1976,19 @@ def run_mirror_setup(
                 elif before_sha is None:
                     # Mirror branch couldn't be read pre-sync (404 /
                     # transport) AND polling never observed a SHA
-                    # either — can't tell if sync landed. Skip merge to
-                    # avoid a misleading 200 against an unverifiable
-                    # mirror state.
-                    sync_detail = "could not snapshot mirror HEAD before sync (no SHA observed during poll either)"
+                    # either — we have no way to *verify* the sync,
+                    # but the mirror may still be ahead of the fork
+                    # from Gitea's periodic cron or the initial
+                    # migrate-fetch. Best-effort merge so fork_synced
+                    # (which is set unconditionally above) actually
+                    # corresponds to an attempted merge call —
+                    # otherwise the CLI would report "merge attempted"
+                    # when nothing happened.
+                    merge_status = client.merge_upstream(fork.owner, fork.name, workspace_branch)
+                    sync_detail = (
+                        "could not snapshot mirror HEAD before sync (no SHA observed during poll either); "
+                        f"merge_upstream against current mirror HEAD: {merge_status}"
+                    )
                 else:
                     # Sync was triggered but the mirror's HEAD didn't
                     # move within the timeout. Could be: (a) upstream

--- a/src/nexus_deploy/gitea.py
+++ b/src/nexus_deploy/gitea.py
@@ -56,6 +56,7 @@ from __future__ import annotations
 import re
 import shlex
 import time
+import urllib.parse
 from dataclasses import dataclass
 from typing import Literal
 
@@ -973,13 +974,19 @@ class GiteaClient:
         Used by :func:`run_mirror_setup` to poll for mirror-sync
         completion: trigger the sync, then watch the mirror's HEAD
         SHA until it changes from the pre-sync baseline.
+
+        Branch names may legitimately contain slashes (``feat/foo``,
+        ``release/1.2``); URL-encode the branch segment rather than
+        validating it as a single path segment so those don't raise
+        before the GET is even sent. Owner + repo name are still
+        single-segment-validated (no slashes allowed there).
         """
         _validate_path_segment(owner, kind="owner")
         _validate_path_segment(name, kind="repo_name")
-        _validate_path_segment(branch, kind="branch")
+        encoded_branch = urllib.parse.quote(branch, safe="")
         try:
             resp = requests.get(
-                f"{self.base_url}/api/v1/repos/{owner}/{name}/branches/{branch}",
+                f"{self.base_url}/api/v1/repos/{owner}/{name}/branches/{encoded_branch}",
                 timeout=_HTTP_TIMEOUT,
                 **self._request_kwargs(),  # type: ignore[arg-type]
             )
@@ -1935,13 +1942,23 @@ def run_mirror_setup(
                         landed = True
                         break
                     time.sleep(mirror_sync_poll_interval_seconds)
-                if before_sha is None:
-                    # Mirror branch couldn't be read pre-sync (404 or
-                    # auth glitch) → we can't tell if the sync landed.
-                    # Skip merge to avoid a misleading 200 against a
-                    # stale mirror.
-                    sync_detail = "could not snapshot mirror HEAD before sync"
-                elif not landed:
+                if landed:
+                    # Sync landed (after_sha differed from before_sha,
+                    # or before_sha was None but the poll observed any
+                    # SHA) — merge fork from the now-updated mirror.
+                    merge_status = client.merge_upstream(fork.owner, fork.name, workspace_branch)
+                    sync_detail = (
+                        f"mirror synced ({(before_sha or 'unknown')[:8]} -> "
+                        f"{(after_sha or '')[:8]}), merge_upstream={merge_status}"
+                    )
+                elif before_sha is None:
+                    # Mirror branch couldn't be read pre-sync (404 /
+                    # transport) AND polling never observed a SHA
+                    # either — can't tell if sync landed. Skip merge to
+                    # avoid a misleading 200 against an unverifiable
+                    # mirror state.
+                    sync_detail = "could not snapshot mirror HEAD before sync (no SHA observed during poll either)"
+                else:
                     # Sync was triggered but the mirror's HEAD didn't
                     # move within the timeout. Could be: (a) upstream
                     # unchanged (legitimate no-op), or (b) Gitea's
@@ -1953,13 +1970,6 @@ def run_mirror_setup(
                         f"mirror HEAD unchanged after {mirror_sync_poll_seconds:.0f}s "
                         f"(before={(before_sha or '')[:8]}, "
                         f"merge_upstream={merge_status})"
-                    )
-                else:
-                    # Sync landed — merge fork from updated mirror.
-                    merge_status = client.merge_upstream(fork.owner, fork.name, workspace_branch)
-                    sync_detail = (
-                        f"mirror synced ({(before_sha or '')[:8]} -> "
-                        f"{(after_sha or '')[:8]}), merge_upstream={merge_status}"
                     )
 
     # If every fork attempt across the loop failed, surface the last

--- a/src/nexus_deploy/gitea.py
+++ b/src/nexus_deploy/gitea.py
@@ -1921,7 +1921,20 @@ def run_mirror_setup(
             before_sha = client.get_branch_head_sha(admin_username, mirror_name, workspace_branch)
             triggered = client.trigger_mirror_sync(admin_username, mirror_name)
             if not triggered:
-                sync_detail = "trigger_mirror_sync returned non-200 (token / repo state)"
+                # Don't return early — the mirror may ALREADY be ahead
+                # of the fork from (a) Gitea's periodic mirror cron-tick
+                # that ran between spin-ups, or (b) the migrate that
+                # ran a few seconds ago (which performs an initial
+                # fetch as part of repo creation). Skipping merge here
+                # would regress the legacy bash's best-effort behavior
+                # for those cases. Record the trigger failure but
+                # still try merge_upstream against whatever's currently
+                # in the mirror.
+                merge_status = client.merge_upstream(fork.owner, fork.name, workspace_branch)
+                sync_detail = (
+                    "trigger_mirror_sync returned non-200 (token / repo state); "
+                    f"merge_upstream against current mirror HEAD: {merge_status}"
+                )
             else:
                 # Step 2: poll the mirror's branch HEAD until it changes
                 # from the pre-sync snapshot. The previous fixed 3-second

--- a/src/nexus_deploy/gitea.py
+++ b/src/nexus_deploy/gitea.py
@@ -965,6 +965,38 @@ class GiteaClient:
             return False
         return resp.status_code == 200
 
+    def get_branch_head_sha(self, owner: str, name: str, branch: str) -> str | None:
+        """``GET /api/v1/repos/<o>/<n>/branches/<branch>`` — return the
+        commit SHA of the branch tip, or ``None`` on any failure
+        (transport, 4xx, malformed response).
+
+        Used by :func:`run_mirror_setup` to poll for mirror-sync
+        completion: trigger the sync, then watch the mirror's HEAD
+        SHA until it changes from the pre-sync baseline.
+        """
+        _validate_path_segment(owner, kind="owner")
+        _validate_path_segment(name, kind="repo_name")
+        _validate_path_segment(branch, kind="branch")
+        try:
+            resp = requests.get(
+                f"{self.base_url}/api/v1/repos/{owner}/{name}/branches/{branch}",
+                timeout=_HTTP_TIMEOUT,
+                **self._request_kwargs(),  # type: ignore[arg-type]
+            )
+        except (requests.ConnectionError, requests.Timeout):
+            return None
+        if resp.status_code != 200:
+            return None
+        try:
+            payload = resp.json()
+        except ValueError:
+            return None
+        commit = payload.get("commit") if isinstance(payload, dict) else None
+        if not isinstance(commit, dict):
+            return None
+        sha = commit.get("id")
+        return sha if isinstance(sha, str) else None
+
     def merge_upstream(self, owner: str, name: str, branch: str) -> str:
         """``POST /api/v1/repos/<o>/<n>/merge-upstream`` — fast-forward fork
         from its parent's branch. Returns HTTP status code as a string
@@ -1633,6 +1665,13 @@ class MirrorSetupResult:
     fork: ForkResult | None
     collaborator_added_count: int
     fork_synced: bool
+    # Diagnostic for the mirror-sync + merge-upstream chain on the
+    # first iteration where the fork existed. Surfaced in the
+    # orchestrator's PhaseResult.detail so operators can see WHY a
+    # fork didn't pick up new upstream commits (most common cause:
+    # GitHub upstream took longer than the settle timeout). Empty
+    # string when no sync was attempted (no fork yet).
+    sync_detail: str = ""
 
     @property
     def is_success(self) -> bool:
@@ -1654,7 +1693,8 @@ def run_mirror_setup(
     gh_mirror_token: str,
     workspace_branch: str,
     fork_token_name: str = "nexus-workspace-fork",  # noqa: S107
-    mirror_sync_settle_seconds: float = 3.0,
+    mirror_sync_poll_seconds: float = 30.0,
+    mirror_sync_poll_interval_seconds: float = 1.5,
 ) -> MirrorSetupResult:
     """End-to-end GH_MIRROR_REPOS provisioning.
 
@@ -1727,6 +1767,7 @@ def run_mirror_setup(
     last_fork_failure: ForkResult | None = None
     fork_synced = False
     collaborator_added_count = 0
+    sync_detail = ""
 
     for repo_url in gh_mirror_repos:
         repo_url = repo_url.strip()
@@ -1867,12 +1908,59 @@ def run_mirror_setup(
         # Sync the fork from upstream — only on the first iteration
         # where the fork was actually created/already-existed.
         if fork is not None and fork.status in ("created", "already_exists") and not fork_synced:
-            fork_synced = True  # set even if the merge below soft-fails
-            client.trigger_mirror_sync(admin_username, mirror_name)
-            # Brief settle for Gitea's async mirror clone before the
-            # fast-forward attempt. legacy bash sleeps the same.
-            time.sleep(mirror_sync_settle_seconds)
-            client.merge_upstream(fork.owner, fork.name, workspace_branch)
+            fork_synced = True  # set even if the chain below soft-fails
+            # Step 1: snapshot the mirror's HEAD SHA so we can detect
+            # when the upstream-fetch lands.
+            before_sha = client.get_branch_head_sha(admin_username, mirror_name, workspace_branch)
+            triggered = client.trigger_mirror_sync(admin_username, mirror_name)
+            if not triggered:
+                sync_detail = "trigger_mirror_sync returned non-200 (token / repo state)"
+            else:
+                # Step 2: poll the mirror's branch HEAD until it changes
+                # from the pre-sync snapshot. The previous fixed 3-second
+                # sleep was too short for medium repos — GitHub's clone
+                # finished but Gitea's mirror-fetch hadn't propagated by
+                # the time merge_upstream ran, so the fork merged the OLD
+                # mirror state and silently returned 409 "already up to
+                # date". Polling catches a freshly-arrived commit even on
+                # slow upstream fetches; the cap (mirror_sync_poll_seconds)
+                # protects against a wedged mirror.
+                deadline = time.monotonic() + mirror_sync_poll_seconds
+                landed = False
+                while time.monotonic() < deadline:
+                    after_sha = client.get_branch_head_sha(
+                        admin_username, mirror_name, workspace_branch
+                    )
+                    if after_sha is not None and after_sha != before_sha:
+                        landed = True
+                        break
+                    time.sleep(mirror_sync_poll_interval_seconds)
+                if before_sha is None:
+                    # Mirror branch couldn't be read pre-sync (404 or
+                    # auth glitch) → we can't tell if the sync landed.
+                    # Skip merge to avoid a misleading 200 against a
+                    # stale mirror.
+                    sync_detail = "could not snapshot mirror HEAD before sync"
+                elif not landed:
+                    # Sync was triggered but the mirror's HEAD didn't
+                    # move within the timeout. Could be: (a) upstream
+                    # unchanged (legitimate no-op), or (b) Gitea's
+                    # fetcher is wedged / token rejected. We still
+                    # call merge_upstream — it'll return 409 in case
+                    # (a), giving us a clean diagnostic.
+                    merge_status = client.merge_upstream(fork.owner, fork.name, workspace_branch)
+                    sync_detail = (
+                        f"mirror HEAD unchanged after {mirror_sync_poll_seconds:.0f}s "
+                        f"(before={(before_sha or '')[:8]}, "
+                        f"merge_upstream={merge_status})"
+                    )
+                else:
+                    # Sync landed — merge fork from updated mirror.
+                    merge_status = client.merge_upstream(fork.owner, fork.name, workspace_branch)
+                    sync_detail = (
+                        f"mirror synced ({(before_sha or '')[:8]} -> "
+                        f"{(after_sha or '')[:8]}), merge_upstream={merge_status}"
+                    )
 
     # If every fork attempt across the loop failed, surface the last
     # one's diagnostic in the final result so the operator can see WHY
@@ -1889,4 +1977,5 @@ def run_mirror_setup(
         fork=fork,
         collaborator_added_count=collaborator_added_count,
         fork_synced=fork_synced,
+        sync_detail=sync_detail,
     )

--- a/src/nexus_deploy/orchestrator.py
+++ b/src/nexus_deploy/orchestrator.py
@@ -666,9 +666,13 @@ class Orchestrator:
                 status="partial",
                 detail=f"mirrors={len(result.mirrors)} (some failed)",
             )
-        return PhaseResult(
-            name="mirror-setup", status="ok", detail=f"mirrors={len(result.mirrors)}"
-        )
+        # Surface the sync-detail when present so operators can see whether
+        # the upstream fetch actually landed during this spin-up (vs. silently
+        # leaving the fork at a stale commit).
+        detail_parts = [f"mirrors={len(result.mirrors)}"]
+        if result.sync_detail:
+            detail_parts.append(result.sync_detail)
+        return PhaseResult(name="mirror-setup", status="ok", detail=" | ".join(detail_parts))
 
     def _phase_secret_sync(self, ssh: SSHClient, stack: str) -> PhaseResult:
         """Common impl for jupyter + marimo secret-sync."""

--- a/tests/unit/test_gitea.py
+++ b/tests/unit/test_gitea.py
@@ -2726,7 +2726,7 @@ def test_run_mirror_setup_happy_path_with_user() -> None:
         gh_mirror_repos=["https://github.com/o/myrepo.git"],
         gh_mirror_token="ghp_xxx",
         workspace_branch="main",
-        mirror_sync_settle_seconds=0.0,  # don't sleep in tests
+        mirror_sync_poll_seconds=0.0,  # don't poll in tests
     )
     assert result.is_success is True
     assert result.admin_uid == 1
@@ -2738,6 +2738,168 @@ def test_run_mirror_setup_happy_path_with_user() -> None:
     assert result.fork.status == "created"
     assert result.collaborator_added_count == 1
     assert result.fork_synced is True
+
+
+@responses.activate
+def test_run_mirror_setup_sync_detail_landed() -> None:
+    """When the mirror HEAD changes during the polling window, the
+    sync_detail surfaces the SHA transition and that merge_upstream
+    was called — this is the new diagnostic that makes 'why didn't
+    the fork pick up upstream commits' observable in PhaseResult."""
+    # Admin UID + mirror migrate
+    responses.add(responses.GET, f"{BASE_URL}/api/v1/users/admin", status=200, json={"id": 1})
+    responses.add(
+        responses.GET, f"{BASE_URL}/api/v1/repos/admin/mirror-readonly-myrepo", status=404
+    )
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/repos/migrate",
+        status=201,
+        json={"id": 42, "name": "mirror-readonly-myrepo"},
+    )
+    # User-token + fork
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/users/stefan/tokens",
+        status=201,
+        json={"sha1": "user-tok"},
+    )
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/repos/admin/mirror-readonly-myrepo/forks",
+        status=202,
+        json={"id": 99},
+    )
+    responses.add(
+        responses.DELETE,
+        f"{BASE_URL}/api/v1/users/stefan/tokens/nexus-workspace-fork",
+        status=204,
+    )
+    responses.add(
+        responses.PUT,
+        f"{BASE_URL}/api/v1/repos/admin/mirror-readonly-myrepo/collaborators/stefan",
+        status=204,
+    )
+    # First branch-HEAD lookup (before sync): old SHA.
+    responses.add(
+        responses.GET,
+        f"{BASE_URL}/api/v1/repos/admin/mirror-readonly-myrepo/branches/main",
+        status=200,
+        json={"commit": {"id": "old1234567890abcdef"}},
+    )
+    # trigger_mirror_sync → 200
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/repos/admin/mirror-readonly-myrepo/mirror-sync",
+        status=200,
+    )
+    # Second branch-HEAD lookup (poll iteration 1): NEW SHA — sync landed.
+    responses.add(
+        responses.GET,
+        f"{BASE_URL}/api/v1/repos/admin/mirror-readonly-myrepo/branches/main",
+        status=200,
+        json={"commit": {"id": "new9876543210fedcba"}},
+    )
+    # merge_upstream → 200
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/repos/stefan/myrepo_stefan/merge-upstream",
+        status=200,
+    )
+
+    result = run_mirror_setup(
+        base_url=BASE_URL,
+        admin_username="admin",
+        admin_password="admin-pw",
+        gitea_token="admin-tok",
+        gitea_user_username="stefan",
+        gh_mirror_repos=["https://github.com/o/myrepo.git"],
+        gh_mirror_token="ghp_xxx",
+        workspace_branch="main",
+        # 30s poll budget is fine — the loop returns on first successful
+        # SHA-change observation, not the full 30s.
+        mirror_sync_poll_seconds=30.0,
+        mirror_sync_poll_interval_seconds=0.0,
+    )
+    assert result.fork_synced is True
+    assert "mirror synced" in result.sync_detail
+    assert "old12345" in result.sync_detail
+    assert "new98765" in result.sync_detail
+    assert "merge_upstream=200" in result.sync_detail
+
+
+@responses.activate
+def test_run_mirror_setup_sync_detail_unchanged() -> None:
+    """When the mirror HEAD doesn't move within the poll window
+    (upstream genuinely unchanged, OR Gitea's fetch wedged), the
+    detail says so + still calls merge_upstream so the operator
+    sees the 409 'already up to date' case explicitly."""
+    responses.add(responses.GET, f"{BASE_URL}/api/v1/users/admin", status=200, json={"id": 1})
+    responses.add(
+        responses.GET, f"{BASE_URL}/api/v1/repos/admin/mirror-readonly-myrepo", status=404
+    )
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/repos/migrate",
+        status=201,
+        json={"id": 42},
+    )
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/users/stefan/tokens",
+        status=201,
+        json={"sha1": "user-tok"},
+    )
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/repos/admin/mirror-readonly-myrepo/forks",
+        status=202,
+        json={"id": 99},
+    )
+    responses.add(
+        responses.DELETE,
+        f"{BASE_URL}/api/v1/users/stefan/tokens/nexus-workspace-fork",
+        status=204,
+    )
+    responses.add(
+        responses.PUT,
+        f"{BASE_URL}/api/v1/repos/admin/mirror-readonly-myrepo/collaborators/stefan",
+        status=204,
+    )
+    # branch HEAD never changes across all poll iterations.
+    responses.add(
+        responses.GET,
+        f"{BASE_URL}/api/v1/repos/admin/mirror-readonly-myrepo/branches/main",
+        status=200,
+        json={"commit": {"id": "stable000000000abc"}},
+    )
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/repos/admin/mirror-readonly-myrepo/mirror-sync",
+        status=200,
+    )
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/repos/stefan/myrepo_stefan/merge-upstream",
+        status=409,
+    )
+
+    result = run_mirror_setup(
+        base_url=BASE_URL,
+        admin_username="admin",
+        admin_password="admin-pw",
+        gitea_token="admin-tok",
+        gitea_user_username="stefan",
+        gh_mirror_repos=["https://github.com/o/myrepo.git"],
+        gh_mirror_token="ghp_xxx",
+        workspace_branch="main",
+        # Tiny budget so the test doesn't actually wait — guaranteed
+        # to expire after one no-change observation.
+        mirror_sync_poll_seconds=0.1,
+        mirror_sync_poll_interval_seconds=0.0,
+    )
+    assert "mirror HEAD unchanged" in result.sync_detail
+    assert "merge_upstream=409" in result.sync_detail
 
 
 @responses.activate
@@ -2796,7 +2958,7 @@ def test_run_mirror_setup_idempotent_skips_existing_mirror() -> None:
         gh_mirror_repos=["https://github.com/o/myrepo.git"],
         gh_mirror_token="ghp",
         workspace_branch="main",
-        mirror_sync_settle_seconds=0.0,
+        mirror_sync_poll_seconds=0.0,
     )
     assert result.is_success is True
     assert result.mirrors[0].status == "already_exists"
@@ -2839,7 +3001,7 @@ def test_run_mirror_setup_no_user_skips_fork() -> None:
         gh_mirror_repos=["https://github.com/o/x.git"],
         gh_mirror_token="ghp",
         workspace_branch="main",
-        mirror_sync_settle_seconds=0.0,
+        mirror_sync_poll_seconds=0.0,
     )
     assert result.is_success is True
     assert result.fork is None
@@ -2862,7 +3024,7 @@ def test_run_mirror_setup_returns_no_admin_uid_early() -> None:
         gh_mirror_repos=["https://github.com/o/x.git"],
         gh_mirror_token="ghp",
         workspace_branch="main",
-        mirror_sync_settle_seconds=0.0,
+        mirror_sync_poll_seconds=0.0,
     )
     assert result.admin_uid is None
     assert result.mirrors == ()
@@ -2949,7 +3111,7 @@ def test_run_mirror_setup_fork_only_first_iteration() -> None:
         ],
         gh_mirror_token="ghp",
         workspace_branch="main",
-        mirror_sync_settle_seconds=0.0,
+        mirror_sync_poll_seconds=0.0,
     )
     assert result.is_success is True
     assert len(result.mirrors) == 2
@@ -3042,7 +3204,7 @@ def test_run_mirror_setup_fork_retries_on_next_iteration_after_transient_failure
         ],
         gh_mirror_token="ghp",
         workspace_branch="main",
-        mirror_sync_settle_seconds=0.0,
+        mirror_sync_poll_seconds=0.0,
     )
     # Final fork is the SECOND mirror's successful fork, NOT the
     # first iteration's transient failure.
@@ -3101,7 +3263,7 @@ def test_run_mirror_setup_surfaces_last_fork_failure_when_every_attempt_fails() 
         ],
         gh_mirror_token="ghp",
         workspace_branch="main",
-        mirror_sync_settle_seconds=0.0,
+        mirror_sync_poll_seconds=0.0,
     )
     # fork=last_fork_failure (the second iteration's attempt) so the
     # operator sees a diagnostic — not None.
@@ -3148,7 +3310,7 @@ def test_run_mirror_setup_unsafe_basename_marks_failed_and_continues() -> None:
         ],
         gh_mirror_token="ghp",
         workspace_branch="main",
-        mirror_sync_settle_seconds=0.0,
+        mirror_sync_poll_seconds=0.0,
     )
     # Loop did NOT abort — both URLs got processed.
     assert len(result.mirrors) == 2
@@ -3196,7 +3358,7 @@ def test_run_mirror_setup_partial_failure_continues_loop() -> None:
         ],
         gh_mirror_token="ghp",
         workspace_branch="main",
-        mirror_sync_settle_seconds=0.0,
+        mirror_sync_poll_seconds=0.0,
     )
     assert len(result.mirrors) == 2
     assert result.mirrors[0].status == "failed"
@@ -3245,7 +3407,7 @@ def test_run_mirror_setup_user_token_failure_marks_fork_failed() -> None:
         gh_mirror_repos=["https://github.com/o/r.git"],
         gh_mirror_token="ghp",
         workspace_branch="main",
-        mirror_sync_settle_seconds=0.0,
+        mirror_sync_poll_seconds=0.0,
     )
     assert result.fork is not None
     assert result.fork.status == "failed"

--- a/tests/unit/test_gitea.py
+++ b/tests/unit/test_gitea.py
@@ -3129,6 +3129,92 @@ def test_run_mirror_setup_idempotent_skips_existing_mirror() -> None:
 
 
 @responses.activate
+def test_run_mirror_setup_trigger_fail_still_attempts_merge_upstream() -> None:
+    """Regression (PR #589 review round 2): when trigger_mirror_sync
+    returns non-200 (e.g. token rejected, repo state), the orchestrator
+    must STILL attempt merge_upstream — the mirror may already be ahead
+    of the fork from Gitea's periodic cron-tick or from the initial
+    migrate that ran a few seconds ago. Skipping merge would regress
+    the legacy bash's best-effort behavior."""
+    responses.add(responses.GET, f"{BASE_URL}/api/v1/users/admin", status=200, json={"id": 1})
+    responses.add(
+        responses.GET,
+        f"{BASE_URL}/api/v1/repos/admin/mirror-readonly-myrepo",
+        status=404,
+    )
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/repos/migrate",
+        status=201,
+        json={"id": 42},
+    )
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/users/stefan/tokens",
+        status=201,
+        json={"sha1": "user-tok"},
+    )
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/repos/admin/mirror-readonly-myrepo/forks",
+        status=202,
+        json={"id": 99},
+    )
+    responses.add(
+        responses.DELETE,
+        f"{BASE_URL}/api/v1/users/stefan/tokens/nexus-workspace-fork",
+        status=204,
+    )
+    responses.add(
+        responses.PUT,
+        f"{BASE_URL}/api/v1/repos/admin/mirror-readonly-myrepo/collaborators/stefan",
+        status=204,
+    )
+    # Pre-sync HEAD lookup (doesn't matter for this test, returns 200).
+    responses.add(
+        responses.GET,
+        f"{BASE_URL}/api/v1/repos/admin/mirror-readonly-myrepo/branches/main",
+        status=200,
+        json={"commit": {"id": "anysha000000000000"}},
+    )
+    # trigger_mirror_sync FAILS (e.g. 403 because GH_MIRROR_TOKEN lost
+    # access to the upstream repo).
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/repos/admin/mirror-readonly-myrepo/mirror-sync",
+        status=403,
+    )
+    # merge_upstream MUST still be called against the current mirror HEAD.
+    # The mirror could already be ahead from the periodic cron-tick or the
+    # initial migrate's fetch; merge_upstream surfaces that with 200.
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/repos/stefan/myrepo_stefan/merge-upstream",
+        status=200,
+    )
+
+    result = run_mirror_setup(
+        base_url=BASE_URL,
+        admin_username="admin",
+        admin_password="admin-pw",
+        gitea_token="admin-tok",
+        gitea_user_username="stefan",
+        gh_mirror_repos=["https://github.com/o/myrepo.git"],
+        gh_mirror_token="ghp_xxx",
+        workspace_branch="main",
+        mirror_sync_poll_seconds=0.0,
+    )
+    # sync_detail must record both the trigger-failure AND the merge attempt.
+    assert "trigger_mirror_sync returned non-200" in result.sync_detail
+    assert "merge_upstream against current mirror HEAD: 200" in result.sync_detail
+    # merge_upstream actually got hit.
+    assert any(
+        c.request.url == f"{BASE_URL}/api/v1/repos/stefan/myrepo_stefan/merge-upstream"
+        for c in responses.calls
+    )
+
+
+@responses.activate
 def test_run_mirror_setup_no_user_skips_fork() -> None:
     """gitea_user_username=None → mirror+collab branches skipped where
     user-dependent. fork=None.

--- a/tests/unit/test_gitea.py
+++ b/tests/unit/test_gitea.py
@@ -2903,6 +2903,166 @@ def test_run_mirror_setup_sync_detail_unchanged() -> None:
 
 
 @responses.activate
+def test_run_mirror_setup_sync_lands_even_when_pre_snapshot_failed() -> None:
+    """Edge case (PR #589 review): if the pre-sync HEAD lookup returns
+    None (transient 404 / transport), but the polling loop later
+    observes a real after_sha, we should still call merge_upstream —
+    a transient pre-snapshot failure shouldn't leave the fork stale
+    when the mirror actually did update."""
+    responses.add(responses.GET, f"{BASE_URL}/api/v1/users/admin", status=200, json={"id": 1})
+    responses.add(
+        responses.GET,
+        f"{BASE_URL}/api/v1/repos/admin/mirror-readonly-myrepo",
+        status=404,
+    )
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/repos/migrate",
+        status=201,
+        json={"id": 42},
+    )
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/users/stefan/tokens",
+        status=201,
+        json={"sha1": "user-tok"},
+    )
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/repos/admin/mirror-readonly-myrepo/forks",
+        status=202,
+        json={"id": 99},
+    )
+    responses.add(
+        responses.DELETE,
+        f"{BASE_URL}/api/v1/users/stefan/tokens/nexus-workspace-fork",
+        status=204,
+    )
+    responses.add(
+        responses.PUT,
+        f"{BASE_URL}/api/v1/repos/admin/mirror-readonly-myrepo/collaborators/stefan",
+        status=204,
+    )
+    # Pre-sync HEAD lookup: 404 -> before_sha=None.
+    responses.add(
+        responses.GET,
+        f"{BASE_URL}/api/v1/repos/admin/mirror-readonly-myrepo/branches/main",
+        status=404,
+    )
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/repos/admin/mirror-readonly-myrepo/mirror-sync",
+        status=200,
+    )
+    # Poll iteration: HEAD resolvable now -> after_sha != None != before_sha
+    # -> landed=True. Must still call merge_upstream.
+    responses.add(
+        responses.GET,
+        f"{BASE_URL}/api/v1/repos/admin/mirror-readonly-myrepo/branches/main",
+        status=200,
+        json={"commit": {"id": "actuallyhere1234567"}},
+    )
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/repos/stefan/myrepo_stefan/merge-upstream",
+        status=200,
+    )
+
+    result = run_mirror_setup(
+        base_url=BASE_URL,
+        admin_username="admin",
+        admin_password="admin-pw",
+        gitea_token="admin-tok",
+        gitea_user_username="stefan",
+        gh_mirror_repos=["https://github.com/o/myrepo.git"],
+        gh_mirror_token="ghp_xxx",
+        workspace_branch="main",
+        mirror_sync_poll_seconds=30.0,
+        mirror_sync_poll_interval_seconds=0.0,
+    )
+    assert "mirror synced" in result.sync_detail
+    assert "unknown" in result.sync_detail
+    assert "actually" in result.sync_detail
+    assert "merge_upstream=200" in result.sync_detail
+
+
+@responses.activate
+def test_run_mirror_setup_sync_branch_with_slash_does_not_raise() -> None:
+    """Regression (PR #589 review): get_branch_head_sha must accept
+    branch names containing '/' (e.g. 'feat/foo'). Previously
+    _validate_path_segment rejected them before the GET was sent,
+    raising GiteaError. Fix: URL-encode the branch segment."""
+    responses.add(responses.GET, f"{BASE_URL}/api/v1/users/admin", status=200, json={"id": 1})
+    responses.add(
+        responses.GET,
+        f"{BASE_URL}/api/v1/repos/admin/mirror-readonly-myrepo",
+        status=404,
+    )
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/repos/migrate",
+        status=201,
+        json={"id": 42},
+    )
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/users/stefan/tokens",
+        status=201,
+        json={"sha1": "user-tok"},
+    )
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/repos/admin/mirror-readonly-myrepo/forks",
+        status=202,
+        json={"id": 99},
+    )
+    responses.add(
+        responses.DELETE,
+        f"{BASE_URL}/api/v1/users/stefan/tokens/nexus-workspace-fork",
+        status=204,
+    )
+    responses.add(
+        responses.PUT,
+        f"{BASE_URL}/api/v1/repos/admin/mirror-readonly-myrepo/collaborators/stefan",
+        status=204,
+    )
+    # URL-encoded branch in the GET path: 'feat/foo' -> 'feat%2Ffoo'.
+    responses.add(
+        responses.GET,
+        f"{BASE_URL}/api/v1/repos/admin/mirror-readonly-myrepo/branches/feat%2Ffoo",
+        status=200,
+        json={"commit": {"id": "samesha000000abcdef"}},
+    )
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/repos/admin/mirror-readonly-myrepo/mirror-sync",
+        status=200,
+    )
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/repos/stefan/myrepo_stefan/merge-upstream",
+        status=409,
+    )
+
+    result = run_mirror_setup(
+        base_url=BASE_URL,
+        admin_username="admin",
+        admin_password="admin-pw",
+        gitea_token="admin-tok",
+        gitea_user_username="stefan",
+        gh_mirror_repos=["https://github.com/o/myrepo.git"],
+        gh_mirror_token="ghp_xxx",
+        workspace_branch="feat/foo",
+        mirror_sync_poll_seconds=0.1,
+        mirror_sync_poll_interval_seconds=0.0,
+    )
+    # No GiteaError raised => success. Sync didn't land (same SHA),
+    # but the slash-branch didn't blow up.
+    assert result.is_success is True
+    assert "mirror HEAD unchanged" in result.sync_detail
+
+
+@responses.activate
 def test_run_mirror_setup_idempotent_skips_existing_mirror() -> None:
     """Mirror already exists → skip migrate, still do fork+collab+sync."""
     responses.add(

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -1250,6 +1250,65 @@ def test_phase_mirror_setup_partial_when_some_mirrors_failed(
     assert result.status == "partial"
 
 
+def test_phase_mirror_setup_surfaces_sync_detail_in_phase_result(
+    orchestrator: Orchestrator, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Regression (PR #589 review): the sync_detail from run_mirror_setup
+    must reach PhaseResult.detail so operators can see whether the
+    upstream-fetch landed during this spin-up. Without this plumbing,
+    a regression that drops sync_detail from the phase output would
+    pass the lower-level test_run_mirror_setup_* tests but silently
+    leave the operator without their diagnostic."""
+    orchestrator.gh_mirror_repos = ["https://github.com/x/y"]
+    orchestrator.gh_mirror_token = "gh-tok"
+    orchestrator.state.gitea_token = "tok"
+
+    def fake_mirror(*_a: Any, **_kw: Any) -> MirrorSetupResult:
+        return MirrorSetupResult(
+            admin_uid=1,
+            admin_uid_error="",
+            mirrors=(MirrorResult(name="y", status="created"),),
+            fork=ForkResult(owner="user", name="user-fork", status="created"),
+            collaborator_added_count=1,
+            fork_synced=True,
+            sync_detail="mirror synced (oldsha12 -> newsha34), merge_upstream=200",
+        )
+
+    monkeypatch.setattr("nexus_deploy.orchestrator._gitea.run_mirror_setup", fake_mirror)
+    result = orchestrator._phase_mirror_setup(_ssh_with_tunnel())
+    assert result.status == "ok"
+    assert "mirrors=1" in result.detail
+    assert "mirror synced (oldsha12 -> newsha34)" in result.detail
+    assert "merge_upstream=200" in result.detail
+
+
+def test_phase_mirror_setup_omits_sync_detail_when_empty(
+    orchestrator: Orchestrator, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """sync_detail is empty when no fork-sync was attempted (e.g. no
+    user configured); PhaseResult.detail should NOT contain a trailing
+    ' | ' separator for an absent diagnostic."""
+    orchestrator.gh_mirror_repos = ["https://github.com/x/y"]
+    orchestrator.gh_mirror_token = "gh-tok"
+    orchestrator.state.gitea_token = "tok"
+
+    def fake_mirror(*_a: Any, **_kw: Any) -> MirrorSetupResult:
+        return MirrorSetupResult(
+            admin_uid=1,
+            admin_uid_error="",
+            mirrors=(MirrorResult(name="y", status="created"),),
+            fork=None,
+            collaborator_added_count=0,
+            fork_synced=False,
+            sync_detail="",
+        )
+
+    monkeypatch.setattr("nexus_deploy.orchestrator._gitea.run_mirror_setup", fake_mirror)
+    result = orchestrator._phase_mirror_setup(_ssh_with_tunnel())
+    assert result.status == "ok"
+    assert result.detail == "mirrors=1"
+
+
 def test_phase_secret_sync_jupyter_skipped_when_not_enabled(
     minimal_config: NexusConfig, minimal_env: BootstrapEnv
 ) -> None:


### PR DESCRIPTION
## Summary

Fixes the silent-stale-fork bug: pushing a commit to a GitHub upstream and then running spin-up no longer leaves the user-fork pointing at last-night's HEAD. The mirror-setup phase now polls Gitea's mirror until the upstream-fetch actually lands, and surfaces the outcome in the orchestrator's phase output so "fork didn't update" failures are observable instead of silent.

## The bug

In `run_mirror_setup`:

```python
# Old behavior:
client.trigger_mirror_sync(admin_username, mirror_name)
time.sleep(3.0)  # ← fixed settle
client.merge_upstream(fork.owner, fork.name, workspace_branch)
```

For a medium-sized GitHub repo, the async mirror-clone often took longer than 3 seconds. By the time `merge_upstream` ran, the mirror's HEAD was still at the pre-sync commit, so the fork merged the **stale** mirror state and got a 409 "already up to date". The orchestrator reported `mirror-setup: ok — mirrors=1` and the user saw no error — but their fork stayed at the old SHA.

Live-debugged today: pushed `dbt` folder commit `f8c3992` to GitHub upstream, ran spin-up. Workflow returned green. Fork's `main` was still `85ad3ee` (pre-push). `git pull` from code-server returned "already up to date". On-disk inspection showed mirror AND fork both at `85ad3ee` — the mirror itself never updated.

## The fix

Three layers:

| Layer | Change |
|---|---|
| **Active polling** | Snapshot mirror HEAD before `trigger_mirror_sync`, then poll the same branch endpoint until the SHA changes or the budget expires. Default budget: **30 s** (was 3 s sleep), polling every 1.5 s. Both configurable via new `mirror_sync_poll_seconds` + `mirror_sync_poll_interval_seconds` params. |
| **Observable diagnostic** | New `MirrorSetupResult.sync_detail` field with pre/post SHAs + `merge_upstream` return code. The orchestrator pipes it into `PhaseResult.detail` so the operator sees: `mirrors=1 \| mirror synced (85ad3ee → f8c3992), merge_upstream=200` (success) or `mirrors=1 \| mirror HEAD unchanged after 30s (before=85ad3ee, merge_upstream=409)` (stuck — token issue or upstream genuinely unchanged). |
| **New helper** | `GiteaClient.get_branch_head_sha(owner, name, branch) → str \| None`. Returns the commit SHA of a branch tip; None on transport / 4xx / malformed response. Used by the poll loop; the None-tolerant signature means transport hiccups during polling fall through to "kept polling" rather than crashing the phase. |

## Breaking change (minor)

Renamed the param: `mirror_sync_settle_seconds` (sleep duration) → `mirror_sync_poll_seconds` (total poll budget). Tests in this repo updated; out-of-tree callers (if any) would get a clean `TypeError` on the next call, not a silent behavior change.

## Tests

- **`test_run_mirror_setup_sync_detail_landed`**: mirror HEAD changes during polling → `sync_detail` contains `mirror synced (old → new), merge_upstream=200`.
- **`test_run_mirror_setup_sync_detail_unchanged`**: mirror HEAD never changes within budget → `sync_detail` contains `mirror HEAD unchanged after 0s, merge_upstream=409`.
- 8 existing `test_run_mirror_setup_*` tests updated for the new param name.
- Full suite: **1471/1471** pass.

## Test plan

- [x] `uv run pytest tests/unit/test_gitea.py` — 192/192 pass
- [x] `uv run pytest` — 1471/1471 pass, 19 snapshots
- [ ] After merge, verify on the live stack: push a commit to a mirrored GitHub upstream → run `gh workflow run spin-up.yml` → user-fork shows the new commit, `mirror-setup` phase output shows the SHA transition.

## Why this matters operationally

Without this fix, the mirror-sync chain is non-deterministic — it works for small repos / fast CI runners, fails silently for larger ones. The new `sync_detail` makes the failure mode debuggable: an operator who sees `mirror HEAD unchanged after 30s` immediately knows to check `GH_MIRROR_TOKEN` access or look at Gitea's mirror queue, instead of staring at a green `mirror-setup: ok`.

## Related

- Bug discovered while investigating "why doesn't `git pull` show my new GitHub commits in code-server?" — pushed PR #588's branch, then upstream Bsc_EDS push, then spin-up; fork stale. Diagnosed today via on-disk SHA comparison.
- Independent from PR #588 (code-server SQLTools auto-connect); can be merged any order.
