### PR TITLE
feat(control-plane): Spin Up button + category breakdown in pending banner

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -666,7 +666,16 @@ See [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md) for full details.
 
 **Do NOT automatically create Pull Requests.** Wait for the user to explicitly request a PR before creating one. The user may want to make additional changes, test locally, or review the commits first.
 
-**Only one feature branch at a time.** Always finish the current feature branch (PR merged or closed) before starting a new one. Working on multiple branches in parallel leads to cross-contamination of changes, merge conflicts, and confusion about which changes belong where. If a second task comes up, either add it to the current branch (if related) or wait until the current PR is merged.
+**Parallel feature branches are allowed if they touch disjoint files.** Concurrent PRs are fine when each branch operates on a different code area (e.g. one PR on `stacks/metabase/`, another on `control-plane/src/components/`, a third on `src/nexus_deploy/orchestrator.py`). Before starting a new branch, verify the file scope doesn't overlap with any in-flight branch — if it does, finish the existing one (or close it) first, otherwise the second branch will hit a rebase + manual merge-conflict resolution on a file you've already touched.
+
+**Practical guardrails when running parallel branches:**
+
+- Before creating each new branch, `git fetch --prune origin` + check open PRs (`gh pr list --state open`). Confirm none of them touch the same files you're about to.
+- Keep each branch single-purpose. Don't start adding new unrelated changes to a branch that's already in review — open a fresh branch instead.
+- When one of the parallel PRs merges, the others may need a quick `git fetch && git rebase origin/main` if `main` moved over a file they share (rare with disjoint scopes; common with broad refactors).
+- Don't run more than 3-4 PRs in flight at once — Copilot review threads accumulate cognitively, and you (the human) loses track of what's where. Sequential is still the right default for related work.
+
+**Same-file changes still need sequencing.** If two issues both need an edit to the same file (e.g. both modify `compose_runner.py`), do them in one branch as separate commits, or do one branch first and rebase the second after the first merges. Parallel branches racing on the same file are the failure mode the old "one at a time" rule was guarding against — that part is still real.
 
 ### Commit and Push Workflow
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -673,7 +673,7 @@ See [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md) for full details.
 - Before creating each new branch, `git fetch --prune origin` + check open PRs (`gh pr list --state open`). Confirm none of them touch the same files you're about to.
 - Keep each branch single-purpose. Don't start adding new unrelated changes to a branch that's already in review — open a fresh branch instead.
 - When one of the parallel PRs merges, the others may need a quick `git fetch && git rebase origin/main` if `main` moved over a file they share (rare with disjoint scopes; common with broad refactors).
-- Don't run more than 3-4 PRs in flight at once — Copilot review threads accumulate cognitively, and you (the human) loses track of what's where. Sequential is still the right default for related work.
+- Don't run more than 3-4 PRs in flight at once — Copilot review threads accumulate cognitively, and you (the human) lose track of what's where. Sequential is still the right default for related work.
 
 **Same-file changes still need sequencing.** If two issues both need an edit to the same file (e.g. both modify `compose_runner.py`), do them in one branch as separate commits, or do one branch first and rebase the second after the first merges. Parallel branches racing on the same file are the failure mode the old "one at a time" rule was guarding against — that part is still real.
 

--- a/control-plane/functions/api/firewall.js
+++ b/control-plane/functions/api/firewall.js
@@ -83,6 +83,10 @@ export async function onRequestGet(context) {
     // toggling enabled need to remember to Spin Up. Tracked for a
     // proper fix in a follow-up (schema migration to snapshot
     // source_ips on the most recent successful apply).
+    if (countOnly) {
+      const countResult = await env.NEXUS_DB.prepare(`
+        SELECT COUNT(*) AS c FROM firewall_rules WHERE enabled != deployed
+      `).first();
       // Number() coercion: D1's COUNT(*) result has been observed to
       // come back as a string in some runtimes. PendingBar.astro
       // requires `typeof pendingChangesCount === 'number'` or it

--- a/control-plane/functions/api/firewall.js
+++ b/control-plane/functions/api/firewall.js
@@ -77,9 +77,13 @@ export async function onRequestGet(context) {
       const countResult = await env.NEXUS_DB.prepare(`
         SELECT COUNT(*) AS c FROM firewall_rules WHERE enabled != deployed
       `).first();
+      // Number() coercion: D1's COUNT(*) result has been observed to
+      // come back as a string in some runtimes. PendingBar.astro
+      // requires `typeof pendingChangesCount === 'number'` or it
+      // falls back to 0, which would silently break the banner.
       return new Response(JSON.stringify({
         success: true,
-        pendingChangesCount: countResult?.c || 0,
+        pendingChangesCount: Number(countResult?.c) || 0,
       }), {
         headers: { 'Content-Type': 'application/json' },
       });
@@ -236,7 +240,10 @@ export async function onRequestPost(context) {
     const pendingResult = await env.NEXUS_DB.prepare(`
       SELECT COUNT(*) as count FROM firewall_rules WHERE enabled != deployed
     `).first();
-    const pendingChangesCount = pendingResult?.count || 0;
+    // Number() coercion — same rationale as the count_only GET path:
+    // D1 has been observed to return COUNT(*) as a string in some
+    // runtimes, and downstream clients check `typeof === 'number'`.
+    const pendingChangesCount = Number(pendingResult?.count) || 0;
 
     return new Response(JSON.stringify({
       success: true,

--- a/control-plane/functions/api/firewall.js
+++ b/control-plane/functions/api/firewall.js
@@ -52,7 +52,9 @@ function validateSourceIps(sourceIps) {
  *   ?count_only=true — short-circuit response: just `{success, pendingChangesCount}`,
  *   no `rules` payload. Used by PendingBar.astro which mounts on every page
  *   and only needs the count for the banner — full payload was ~5KB per page
- *   load. Avoid an extra round-trip but skip the per-rule fields.
+ *   load. Reduces response size and skips the per-rule iteration + payload
+ *   build (the HTTP request itself still happens, just cheaper on both
+ *   sides).
  */
 export async function onRequestGet(context) {
   const { env, request } = context;

--- a/control-plane/functions/api/firewall.js
+++ b/control-plane/functions/api/firewall.js
@@ -46,10 +46,18 @@ function validateSourceIps(sourceIps) {
 
 /**
  * GET /api/firewall
- * Returns all firewall rules from D1
+ * Returns all firewall rules from D1.
+ *
+ * Query params:
+ *   ?count_only=true — short-circuit response: just `{success, pendingChangesCount}`,
+ *   no `rules` payload. Used by PendingBar.astro which mounts on every page
+ *   and only needs the count for the banner — full payload was ~5KB per page
+ *   load. Avoid an extra round-trip but skip the per-rule fields.
  */
 export async function onRequestGet(context) {
-  const { env } = context;
+  const { env, request } = context;
+  const url = new URL(request.url);
+  const countOnly = url.searchParams.get('count_only') === 'true';
 
   if (!env.NEXUS_DB) {
     return new Response(JSON.stringify({
@@ -63,6 +71,20 @@ export async function onRequestGet(context) {
   }
 
   try {
+    // count_only path: SELECT COUNT(*) WHERE enabled != deployed.
+    // Doesn't load row data, doesn't iterate-and-build a JSON array.
+    if (countOnly) {
+      const countResult = await env.NEXUS_DB.prepare(`
+        SELECT COUNT(*) AS c FROM firewall_rules WHERE enabled != deployed
+      `).first();
+      return new Response(JSON.stringify({
+        success: true,
+        pendingChangesCount: countResult?.c || 0,
+      }), {
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
     const results = await env.NEXUS_DB.prepare(`
       SELECT service_name, port, protocol, label, enabled, deployed, source_ips, dns_record
       FROM firewall_rules

--- a/control-plane/functions/api/firewall.js
+++ b/control-plane/functions/api/firewall.js
@@ -73,10 +73,16 @@ export async function onRequestGet(context) {
   try {
     // count_only path: SELECT COUNT(*) WHERE enabled != deployed.
     // Doesn't load row data, doesn't iterate-and-build a JSON array.
-    if (countOnly) {
-      const countResult = await env.NEXUS_DB.prepare(`
-        SELECT COUNT(*) AS c FROM firewall_rules WHERE enabled != deployed
-      `).first();
+    //
+    // Known gap: pending detection only compares enabled vs deployed.
+    // A source_ips-only edit (saved via POST without flipping enabled)
+    // still requires a Spin Up to take effect — Terraform reads
+    // source_ips fresh from D1 on every apply — but the banner won't
+    // surface that because the schema has no `deployed_source_ips`
+    // column to diff against. Operators who change IPs without
+    // toggling enabled need to remember to Spin Up. Tracked for a
+    // proper fix in a follow-up (schema migration to snapshot
+    // source_ips on the most recent successful apply).
       // Number() coercion: D1's COUNT(*) result has been observed to
       // come back as a string in some runtimes. PendingBar.astro
       // requires `typeof pendingChangesCount === 'number'` or it

--- a/control-plane/src/components/PendingBar.astro
+++ b/control-plane/src/components/PendingBar.astro
@@ -83,8 +83,18 @@
   (function() {
     const bar = document.getElementById('pending-bar');
     const text = document.getElementById('pending-bar-text');
+    const view = document.getElementById('pending-bar-view');
     const btnSpinUp = document.getElementById('pending-bar-spinup');
-    if (!bar || !text || !btnSpinUp) return;
+    if (!bar || !text || !view || !btnSpinUp) return;
+
+    // Pick the View-link destination based on which source has pending
+    // changes. Firewall-only → /firewall (stacks page would show nothing
+    // pending and confuse the operator). Anything involving stacks →
+    // /stacks?filter=pending (the more common multi-item view).
+    function pickViewHref(stackCount, fwCount) {
+      if (stackCount === 0 && fwCount > 0) return '/firewall';
+      return '/stacks?filter=pending';
+    }
 
     // Issue #460: split the count by source so the operator sees WHAT
     // is pending. e.g. "3 stack changes + 2 firewall changes pending"
@@ -124,8 +134,10 @@
       // shouldn't hide a real firewall-only pending count, and vice
       // versa. Each source defaults to 0 on its own failure path so
       // the banner stays honest about the OTHER source that did
-      // respond — only when BOTH fail (both return 0) does the banner
-      // stay hidden, same as the no-changes case.
+      // respond. The banner hides whenever the sum is 0 — that covers
+      // both the legitimate no-changes case AND the (rare) case where
+      // both sources failed and defaulted to 0; we don't distinguish
+      // them because there's nothing useful to render either way.
       const [services, fwCount] = await Promise.all([
         window.NS.getServices(),
         fetchFirewallPending(),
@@ -137,6 +149,7 @@
 
       if (totalCount > 0) {
         text.textContent = formatBreakdown(stackCount, fwCount);
+        view.setAttribute('href', pickViewHref(stackCount, fwCount));
         bar.hidden = false;
       } else {
         bar.hidden = true;

--- a/control-plane/src/components/PendingBar.astro
+++ b/control-plane/src/components/PendingBar.astro
@@ -119,12 +119,19 @@
       // Shared cache in window.NS for services — if a stacks page also
       // requested /api/services on the same tick, we reuse its response
       // instead of firing a duplicate request.
+      //
+      // Both fetches are independent: a transient /api/services failure
+      // shouldn't hide a real firewall-only pending count, and vice
+      // versa. Each source defaults to 0 on its own failure path so
+      // the banner stays honest about the OTHER source that did
+      // respond — only when BOTH fail (both return 0) does the banner
+      // stay hidden, same as the no-changes case.
       const [services, fwCount] = await Promise.all([
         window.NS.getServices(),
         fetchFirewallPending(),
       ]);
-      if (!services) return; // silent on services failure — bg poll, no toast spam
-      const stackCount = (services.success && typeof services.pendingChangesCount === 'number')
+      const stackCount = (services && services.success
+        && typeof services.pendingChangesCount === 'number')
         ? services.pendingChangesCount : 0;
       const totalCount = stackCount + fwCount;
 
@@ -139,7 +146,9 @@
     // Issue #476: Spin Up button POSTs /api/spin-up directly, same
     // contract as the Dashboard button. Disable while the request is
     // in flight so a panicky double-click can't trigger two workflow
-    // runs. Re-enables on toast feedback OR after a 5s safety timeout.
+    // runs. After a successful trigger, re-enables after a 30s safety
+    // timeout (the workflow itself takes minutes, but the operator
+    // might want to retry if our API call silently failed).
     async function triggerSpinUp() {
       const originalHTML = btnSpinUp.innerHTML;
       btnSpinUp.disabled = true;

--- a/control-plane/src/components/PendingBar.astro
+++ b/control-plane/src/components/PendingBar.astro
@@ -1,17 +1,27 @@
 ---
 // Persistent pending-changes indicator. Visible on every page once mounted.
-// Shows nothing until /api/services reports pendingChangesCount > 0.
+// Shows nothing until /api/services or /api/firewall reports pending > 0.
+//
+// Renders the count broken down by source (stacks vs firewall) so the
+// operator can tell WHAT is pending at a glance (issue #460). Banner
+// also exposes a direct 'Spin Up' button that POSTs /api/spin-up
+// without forcing a detour through the Dashboard (issue #476).
+//
 // Re-fetches on:
 //   - initial mount
 //   - page becoming visible again (visibilitychange)
 //   - 'stacks:updated' event dispatched by toggleService()
+//   - 'firewall:updated' event dispatched by firewall-toggle handler
+//   - after a Spin Up click (so the button can return to baseline)
 ---
 
 <div id="pending-bar" class="pending-bar" role="status" aria-live="polite" hidden>
   <span class="pending-bar-dot" aria-hidden="true">◐</span>
   <span id="pending-bar-text" class="pending-bar-text">Loading...</span>
   <a id="pending-bar-view" class="pending-bar-action" href="/stacks?filter=pending">View</a>
-  <a class="pending-bar-action primary" href="/" title="Open the Dashboard and click Spin Up to deploy">Open Dashboard</a>
+  <button id="pending-bar-spinup" class="pending-bar-action primary" type="button" title="Trigger the spin-up workflow now to apply pending changes">
+    <span aria-hidden="true">&#x26A1;</span> Spin Up Now
+  </button>
 </div>
 
 <style>
@@ -41,11 +51,14 @@
   .pending-bar-action {
     color: var(--accent);
     text-decoration: none;
+    background: transparent;
     padding: 0.2rem 0.6rem;
     border: 1px solid rgba(0, 255, 136, 0.3);
     border-radius: 3px;
     font-size: 0.78rem;
     white-space: nowrap;
+    cursor: pointer;
+    font-family: inherit;
   }
 
   .pending-bar-action:hover {
@@ -56,8 +69,13 @@
     background: rgba(0, 255, 136, 0.1);
   }
 
-  .pending-bar-action.primary:hover {
+  .pending-bar-action.primary:hover:not(:disabled) {
     background: rgba(0, 255, 136, 0.2);
+  }
+
+  .pending-bar-action:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
   }
 </style>
 
@@ -65,28 +83,125 @@
   (function() {
     const bar = document.getElementById('pending-bar');
     const text = document.getElementById('pending-bar-text');
-    if (!bar || !text) return;
+    const btnSpinUp = document.getElementById('pending-bar-spinup');
+    if (!bar || !text || !btnSpinUp) return;
+
+    // Issue #460: split the count by source so the operator sees WHAT
+    // is pending. e.g. "3 stack changes + 2 firewall changes pending"
+    // rather than just "5 changes pending".
+    function formatBreakdown(stackCount, fwCount) {
+      const parts = [];
+      if (stackCount > 0) {
+        parts.push(stackCount + ' stack change' + (stackCount === 1 ? '' : 's'));
+      }
+      if (fwCount > 0) {
+        parts.push(fwCount + ' firewall change' + (fwCount === 1 ? '' : 's'));
+      }
+      // Fallback: should never hit (banner hidden when both 0), but keep
+      // a safe wording for defensive reads.
+      if (parts.length === 0) return '';
+      return parts.join(' + ') + ' pending. Spin Up to deploy.';
+    }
+
+    async function fetchFirewallPending() {
+      try {
+        const r = await fetch('/api/firewall', { credentials: 'same-origin' });
+        if (!r.ok) return 0;
+        const d = await r.json();
+        return (d && d.success && typeof d.pendingChangesCount === 'number')
+          ? d.pendingChangesCount : 0;
+      } catch (_) {
+        return 0;
+      }
+    }
 
     async function refresh() {
-      // Shared cache in window.NS — if a stacks page also requested
-      // /api/services on the same tick, we reuse its response instead of
-      // firing a duplicate request.
-      const data = await window.NS.getServices();
-      if (!data) return; // Silent on failure — don't spam toasts for a background poll
-      const count = (data.success && typeof data.pendingChangesCount === 'number')
-        ? data.pendingChangesCount : 0;
-      if (count > 0) {
-        text.textContent = count + ' change' + (count === 1 ? '' : 's') + ' pending. Spin Up to deploy.';
+      // Shared cache in window.NS for services — if a stacks page also
+      // requested /api/services on the same tick, we reuse its response
+      // instead of firing a duplicate request.
+      const [services, fwCount] = await Promise.all([
+        window.NS.getServices(),
+        fetchFirewallPending(),
+      ]);
+      if (!services) return; // silent on services failure — bg poll, no toast spam
+      const stackCount = (services.success && typeof services.pendingChangesCount === 'number')
+        ? services.pendingChangesCount : 0;
+      const totalCount = stackCount + fwCount;
+
+      if (totalCount > 0) {
+        text.textContent = formatBreakdown(stackCount, fwCount);
         bar.hidden = false;
       } else {
         bar.hidden = true;
       }
     }
 
+    // Issue #476: Spin Up button POSTs /api/spin-up directly, same
+    // contract as the Dashboard button. Disable while the request is
+    // in flight so a panicky double-click can't trigger two workflow
+    // runs. Re-enables on toast feedback OR after a 5s safety timeout.
+    async function triggerSpinUp() {
+      const originalHTML = btnSpinUp.innerHTML;
+      btnSpinUp.disabled = true;
+      btnSpinUp.innerHTML = '<span aria-hidden="true">&#x26A1;</span> Triggering…';
+      try {
+        const r = await fetch('/api/spin-up', {
+          method: 'POST',
+          credentials: 'same-origin',
+          headers: { 'Content-Type': 'application/json' },
+        });
+        const contentType = r.headers.get('content-type') || '';
+        if (!contentType.includes('application/json')) {
+          // Cloudflare Access expired — Astro session bounced.
+          showToast('Session expired - please refresh the page', 'error');
+          btnSpinUp.innerHTML = originalHTML;
+          btnSpinUp.disabled = false;
+          return;
+        }
+        const data = await r.json();
+        if (data.success) {
+          showToast('Spin Up triggered!');
+          // Re-fetch state — pending count usually stays the same until
+          // the workflow finishes + the deployed-state sync runs, but
+          // refreshing keeps us honest if anything else changed.
+          setTimeout(refresh, 2000);
+          btnSpinUp.innerHTML = '<span aria-hidden="true">&#x26A1;</span> Running…';
+          // Re-enable after 30s — the workflow takes minutes but the
+          // operator might want to retry if our API call itself failed
+          // silently somewhere.
+          setTimeout(function() {
+            btnSpinUp.innerHTML = originalHTML;
+            btnSpinUp.disabled = false;
+          }, 30000);
+        } else {
+          showToast(data.error || 'Failed to trigger Spin Up', 'error');
+          btnSpinUp.innerHTML = originalHTML;
+          btnSpinUp.disabled = false;
+        }
+      } catch (_) {
+        showToast('Network error - please try again', 'error');
+        btnSpinUp.innerHTML = originalHTML;
+        btnSpinUp.disabled = false;
+      }
+    }
+
+    // showToast defined globally by Layout.astro / ToastContainer; fall
+    // back to console for safety when this component runs without it.
+    function showToast(msg, level) {
+      if (typeof window.showToast === 'function') {
+        window.showToast(msg, level);
+      } else {
+        console[level === 'error' ? 'error' : 'log']('[pending-bar] ' + msg);
+      }
+    }
+
+    btnSpinUp.addEventListener('click', triggerSpinUp);
+
     refresh();
     document.addEventListener('visibilitychange', function() {
       if (!document.hidden) refresh();
     });
     window.addEventListener('stacks:updated', refresh);
+    window.addEventListener('firewall:updated', refresh);
   })();
 </script>

--- a/control-plane/src/components/PendingBar.astro
+++ b/control-plane/src/components/PendingBar.astro
@@ -88,9 +88,17 @@
     if (!bar || !text || !view || !btnSpinUp) return;
 
     // Pick the View-link destination based on which source has pending
-    // changes. Firewall-only → /firewall (stacks page would show nothing
-    // pending and confuse the operator). Anything involving stacks →
-    // /stacks?filter=pending (the more common multi-item view).
+    // changes:
+    //   - firewall-only (stackCount=0, fwCount>0)  → /firewall
+    //   - stack-only OR both pending                → /stacks?filter=pending
+    // For the both-pending case we deliberately route to /stacks because
+    // that's where the higher-cardinality changes usually live and where
+    // operators spend most of their time. The banner TEXT already names
+    // BOTH sources ("3 stack changes + 2 firewall changes pending"), so
+    // the operator knows firewall changes exist; the global nav has a
+    // direct /firewall link one click away. We don't try to surface both
+    // destinations in the banner itself — that would crowd the UI and
+    // make the "primary action" (Spin Up Now) less prominent.
     function pickViewHref(stackCount, fwCount) {
       if (stackCount === 0 && fwCount > 0) return '/firewall';
       return '/stacks?filter=pending';
@@ -115,7 +123,11 @@
 
     async function fetchFirewallPending() {
       try {
-        const r = await fetch('/api/firewall', { credentials: 'same-origin' });
+        // ?count_only=true short-circuits /api/firewall on the server:
+        // a single COUNT(*) query, no per-rule payload. PendingBar mounts
+        // on every page so we don't want to transfer the full ~5KB rules
+        // array each time — the banner only needs the integer count.
+        const r = await fetch('/api/firewall?count_only=true', { credentials: 'same-origin' });
         if (!r.ok) return 0;
         const d = await r.json();
         return (d && d.success && typeof d.pendingChangesCount === 'number')

--- a/control-plane/src/pages/firewall.astro
+++ b/control-plane/src/pages/firewall.astro
@@ -401,6 +401,10 @@ import Layout from '../layouts/Layout.astro';
       const data = await res.json();
       if (!data.success) throw new Error(data.error);
       showToast(data.message);
+      // Notify PendingBar that firewall state changed (it listens for
+      // this event to re-fetch /api/firewall and refresh the pending
+      // breakdown). Mirrors what toggleService() does for stacks.
+      window.dispatchEvent(new Event('firewall:updated'));
       await loadRules();
     } catch (err) {
       showToast('Error: ' + err.message, 'error');
@@ -419,6 +423,10 @@ import Layout from '../layouts/Layout.astro';
       const data = await res.json();
       if (!data.success) throw new Error(data.error);
       showToast('Source IPs saved');
+      // Same notification as toggleRule — saving IPs can flip the
+      // pending count if the rule was previously deployed without
+      // restricted IPs.
+      window.dispatchEvent(new Event('firewall:updated'));
       await loadRules();
     } catch (err) {
       showToast('Error: ' + err.message, 'error');

--- a/control-plane/src/pages/firewall.astro
+++ b/control-plane/src/pages/firewall.astro
@@ -423,9 +423,13 @@ import Layout from '../layouts/Layout.astro';
       const data = await res.json();
       if (!data.success) throw new Error(data.error);
       showToast('Source IPs saved');
-      // Same notification as toggleRule — saving IPs can flip the
-      // pending count if the rule was previously deployed without
-      // restricted IPs.
+      // Same notification as toggleRule. Note: today the pending
+      // count compares only enabled vs deployed (see firewall.js
+      // — schema has no deployed_source_ips column), so a pure IP
+      // edit doesn't actually flip the count. The dispatch is still
+      // useful for combined operations (toggle + IP saved in
+      // sequence) and keeps the banner in sync if the schema later
+      // gains source_ips tracking.
       window.dispatchEvent(new Event('firewall:updated'));
       await loadRules();
     } catch (err) {


### PR DESCRIPTION
## Summary

Two UX improvements to the persistent pending-changes banner in the Control Plane, plus a workflow-docs update bundled in (per operator request to avoid a separate one-line PR).

## Changes

### Closes #476 — Spin Up Now button directly in the banner

The old banner had `View` + `Open Dashboard` actions, so deploying a toggled change required:

1. Click "Open Dashboard"
2. Wait for page transition + render
3. Scroll to find the Spin Up button
4. Click

A pure detour through the Dashboard just to trigger the action the banner itself was prompting for. New **Spin Up Now** button POSTs `/api/spin-up` directly — same contract as the Dashboard's button.

UX details:
- Button disables while the request is in flight + shows "Triggering…" / "Running…" so a panicky double-click can't fire two workflow runs.
- Re-enables on toast feedback OR after a 30s safety timeout.
- Same error handling as the Dashboard handler: session-expired detection (content-type check), network-error fallback toast.

### Closes #460 — Category breakdown in the pending message

The old banner said `X changes pending` — but only counted **stack toggles** (only fetched `/api/services`). **Firewall-rule toggles were invisible**: an operator could toggle a firewall rule, see no banner, assume nothing was pending, and walk away with an undeployed rule.

The new banner fetches `/api/services` AND `/api/firewall` in parallel and renders:

> ⚠ **3 stack changes + 2 firewall changes** pending. Spin Up to deploy.

When only one source has pending changes, only that source is named:

> ⚠ **3 stack changes** pending. Spin Up to deploy.

Both at zero → banner stays hidden, exactly as before.

Also listens for a new `firewall:updated` window event so the Firewall page can dispatch the same refresh signal the Stacks page already does via `stacks:updated`.

### Bundled: `docs(claude): Allow parallel feature branches on disjoint files`

The old `Only one feature branch at a time` rule in CLAUDE.md was too strict for the actual workflow. Updated guidance:

- Parallel branches explicitly allowed when they touch disjoint files
- Same-file races stay the failure mode the old rule guarded against (still need sequencing)
- Practical guardrails: 3-4 PRs in flight max, single-purpose per branch

## Backend / API changes

This PR DOES change backend behavior (not "no backend changes" as an earlier draft of this description claimed). Specifically:

- **New query param: `GET /api/firewall?count_only=true`** — short-circuits with `{success, pendingChangesCount}` only, skipping the full `rules` payload. Used by `PendingBar.astro` which mounts on every page and only needs the integer count — saves ~5KB transfer per page load. The default (no param) behavior is unchanged: the full payload with `rules` array is still returned.
- **`Number()` coercion** on both `pendingChangesCount` paths (the new GET count_only and the existing POST), defensive against D1 occasionally returning aggregate `COUNT(*)` results as strings.

Both changes are backwards-compatible: existing clients that don't pass `count_only` get the same response shape as before; the Number() wrap is a type narrowing, not a semantic change.

## Known gap (out of scope, documented in the code)

Pending detection in `/api/firewall` only compares `enabled != deployed`. A `source_ips`-only edit still requires a Spin Up to take effect (Terraform reads `source_ips` fresh from D1 on every apply), but the banner doesn't surface that because the schema has no `deployed_source_ips` column to diff against. Proper fix is a schema migration tracked for a follow-up PR.

## What did NOT change

- **No database schema changes.**
- **No new dependencies.**
- **No changes to the spin-up workflow itself** — only the trigger path from the banner.

## Test plan

- [x] Pre-commit hook chain passes locally
- [ ] After merge: verify on a fresh deploy that the banner correctly shows breakdown + Spin Up Now triggers a workflow run
- [ ] Verify the Firewall page's saveSourceIps + toggleRule still trigger the banner refresh (via the new `firewall:updated` event)
