### PR TITLE
fix(pgadmin): One-click connect — nexus-postgres user + PassFile auto-load

### DIFF
--- a/docs/stacks/pgadmin.md
+++ b/docs/stacks/pgadmin.md
@@ -30,9 +30,29 @@ pgAdmin is the most popular and feature-rich Open Source administration and deve
 1. Access pgAdmin at `https://pgadmin.<domain>`
 2. Login with credentials from Infisical (`PGADMIN_USERNAME` / `PGADMIN_PASSWORD`)
 3. **Pre-configured server:** The "Nexus PostgreSQL" server appears automatically in the left sidebar
-4. Click on the server and enter the password from Infisical (`POSTGRES_PASSWORD`)
-   - Username is pre-configured as `postgres` (from `POSTGRES_USERNAME` in Infisical)
-   - You only need to enter the password
-5. The password is saved for future logins
+4. Click on the server — it connects directly. **No password prompt.**
 
-> ✅ **Auto-configured:** Both the admin account and PostgreSQL server connection (including username) are pre-configured. You only need to enter the PostgreSQL password once.
+> ✅ **Auto-configured:** Both the admin account AND the Postgres connection (username `nexus-postgres` + password) are pre-configured. One click to connect.
+
+### How the auto-connect works
+
+At spin-up time, `src/nexus_deploy/service_env.py::_render_pgadmin` writes a `pgpass` sidecar file next to the compose file: `stacks/pgadmin/pgpass`, containing one line in standard libpq pgpass format:
+
+```text
+postgres:5432:postgres:nexus-postgres:<actual-postgres-password-from-infisical>
+```
+
+The compose file bind-mounts this as `/pgpass:ro` inside the pgAdmin container, and `servers.json` references it via `PassFile: /pgpass`. pgAdmin reads the password from there on every connect — no prompt, no copy-paste from Infisical.
+
+#### Security note
+
+- The pgpass file lives only on the server at `/opt/docker-server/stacks/pgadmin/pgpass`, accessible exclusively via SSH (Cloudflare Tunnel + key auth, no public port).
+- pgAdmin itself is behind Cloudflare Access (email OTP) + a pgAdmin master password (`PGADMIN_PASSWORD` from Infisical) — anyone who could read the auto-connect password from inside pgAdmin could already retrieve it from Infisical (same access policy).
+- No net additional exposure compared to manual password entry; just one less manual step.
+
+#### Caveat: existing volumes
+
+pgAdmin loads `servers.json` **only on the first container start with an empty `pgadmin-data` volume**. If you already have a deployment from before this change, the old "Nexus PostgreSQL" entry with `Username: postgres` is still in the volume. To pick up the corrected config, either:
+
+- **Wipe the volume** (loses any other server configs you added): `ssh nexus "docker volume rm pgadmin_pgadmin-data"` then re-spin.
+- **Manually fix in pgAdmin UI:** Right-click "Nexus PostgreSQL" → Properties → Connection tab → Username = `nexus-postgres`, Password file = `/pgpass` → Save.

--- a/src/nexus_deploy/service_env.py
+++ b/src/nexus_deploy/service_env.py
@@ -394,11 +394,25 @@ SELECT pg_reload_conf();
 
 
 def _render_pgadmin(c: NexusConfig, e: BootstrapEnv) -> RenderedEnv:
+    """pgAdmin .env + a sidecar ``pgpass`` file consumed by the
+    pre-configured Nexus PostgreSQL server (servers.json references
+    ``PassFile: /pgpass``).
+
+    Format is the standard libpq pgpass: ``host:port:db:user:password``.
+    Written 0o644 (not 0o600) because the file is owned by the
+    deploy-runner user but read inside the container by the
+    ``pgadmin`` user (uid 5050) — libpq's 0o600 check doesn't
+    apply because pgAdmin uses the PassFile via its own loader,
+    not libpq. The file lives at /opt/docker-server/stacks/pgadmin/
+    on the host, only reachable via SSH (CF Tunnel + key auth).
+    """
+    pgpass_content = f"postgres:5432:postgres:nexus-postgres:{c.postgres_password or ''}\n"
     return RenderedEnv(
         env_vars={
             "ADMIN_EMAIL": e.admin_email or "",
             "PGADMIN_PASSWORD": c.pgadmin_password or "",
         },
+        sidecars=(SidecarFile(relative_path="pgpass", content=pgpass_content, mode=0o644),),
     )
 
 

--- a/stacks/pgadmin/docker-compose.yml
+++ b/stacks/pgadmin/docker-compose.yml
@@ -27,6 +27,12 @@ services:
     volumes:
       - pgadmin-data:/var/lib/pgadmin
       - ./servers.json:/pgadmin4/servers.json:ro
+      # pgpass file rendered by nexus_deploy.service_env._render_pgadmin
+      # at spin-up time: contains the nexus-postgres password so the
+      # Nexus PostgreSQL server in servers.json connects without
+      # prompting (PassFile references /pgpass). Mounted ro — never
+      # written from inside the container.
+      - ./pgpass:/pgpass:ro
     networks:
       - app-network
     healthcheck:

--- a/stacks/pgadmin/servers.json
+++ b/stacks/pgadmin/servers.json
@@ -6,9 +6,10 @@
       "Host": "postgres",
       "Port": 5432,
       "MaintenanceDB": "postgres",
-      "Username": "postgres",
+      "Username": "nexus-postgres",
       "SSLMode": "prefer",
-      "Comment": "Standalone PostgreSQL database server. Password available in Infisical."
+      "PassFile": "/pgpass",
+      "Comment": "Standalone PostgreSQL database server. Password auto-loaded from /pgpass (rendered at spin-up from Infisical-synced postgres_password). Full credentials also in Infisical."
     }
   }
 }

--- a/tests/unit/test_service_env.py
+++ b/tests/unit/test_service_env.py
@@ -1039,6 +1039,28 @@ def test_simple_render_functions_smoke(full_config: NexusConfig, full_env: Boots
             assert isinstance(v, str)
 
 
+def test_render_pgadmin_emits_pgpass_sidecar(
+    full_config: NexusConfig, full_env: BootstrapEnv
+) -> None:
+    """pgAdmin's pre-configured 'Nexus PostgreSQL' server references
+    PassFile=/pgpass in servers.json; this test pins that the sidecar
+    is rendered with libpq's pgpass format (host:port:db:user:pass)
+    and the nexus-postgres user (not 'postgres' — see CLAUDE.md
+    naming convention). Regression guard: without this sidecar the
+    pre-configured connection would prompt for a password on every
+    click."""
+    from nexus_deploy.service_env import _render_pgadmin
+
+    result = _render_pgadmin(full_config, full_env)
+    assert len(result.sidecars) == 1
+    pgpass = result.sidecars[0]
+    assert pgpass.relative_path == "pgpass"
+    assert pgpass.content == "postgres:5432:postgres:nexus-postgres:pg-pw\n"
+    # 0o644 so pgAdmin's uid 5050 can read it — libpq's 0o600 check
+    # doesn't apply here, see render docstring.
+    assert pgpass.mode == 0o644
+
+
 def test_appsmith_skipped_when_salt_missing(
     full_config: NexusConfig, full_env: BootstrapEnv
 ) -> None:


### PR DESCRIPTION
## Summary

The pre-configured "Nexus PostgreSQL" server in pgAdmin had two issues that made one-click connect impossible:

1. **Wrong username:** `servers.json` had `"Username": "postgres"`, but the actual Postgres user is `nexus-postgres` (per CLAUDE.md's service-account naming convention — there is no `postgres` user in the database). Every connection attempt hit `password authentication failed for user "postgres"`.
2. **No PassFile:** Even after fixing the username, the operator had to look up `POSTGRES_PASSWORD` in Infisical and paste it on every fresh connect.

This PR fixes both with pgAdmin's documented `PassFile` mechanism, so the pre-configured connection works on a single click.

## How the auto-connect works

- `_render_pgadmin` emits a `pgpass` sidecar file at spin-up time with the standard libpq format:
  ```
  postgres:5432:postgres:nexus-postgres:<actual-password-from-infisical>
  ```
- `docker-compose.yml` bind-mounts it as `/pgpass:ro` inside the container.
- `servers.json` references it via `"PassFile": "/pgpass"`.
- pgAdmin reads the password from there on every connect — no prompt.

## Security trade-off

- The pgpass file lives only on the server at `/opt/docker-server/stacks/pgadmin/pgpass`, reachable exclusively via SSH (CF Tunnel + key auth, no public port).
- pgAdmin is behind CF Access (email OTP) + pgAdmin master password. Anyone who could read the auto-loaded password from inside pgAdmin could already retrieve it from Infisical (same access policy).
- **Net additional exposure: none.** Just one fewer manual step.

This is the inverse of the SQLTools situation reverted in #593: there, the password was being written into `~/.local/share/code-server/User/settings.json` (a file with VS Code Settings Sync risk), via an undocumented hack. Here it's pgAdmin's official `PassFile` mechanism into a server-only file that never leaves the host.

## Caveat: existing volumes

pgAdmin loads `servers.json` only on the **first** container start with an empty `pgadmin-data` volume. Upgrading deployments have two options to pick up the fix:

- **Wipe the volume** (loses any other server configs added later): `ssh nexus "docker volume rm pgadmin_pgadmin-data"` then re-spin.
- **Manually fix in pgAdmin UI:** Right-click "Nexus PostgreSQL" → Properties → Connection → Username = `nexus-postgres`, Password file = `/pgpass` → Save.

Documented in the rewritten `docs/stacks/pgadmin.md`.

## Files

- `stacks/pgadmin/servers.json` — Username + PassFile fix
- `stacks/pgadmin/docker-compose.yml` — mount `./pgpass:/pgpass:ro`
- `src/nexus_deploy/service_env.py` — `_render_pgadmin` emits the pgpass SidecarFile
- `tests/unit/test_service_env.py` — regression test pinning sidecar path/content/mode
- `docs/stacks/pgadmin.md` — rewrote Usage + added "How the auto-connect works" + Security note + upgrade caveat

## Test plan

- [x] `uv run pytest tests/unit/test_service_env.py -k "pgadmin or pgpass"` — 1 passed
- [x] Pre-commit hooks (ruff format, ruff, mypy strict, json-check) — all green
- [ ] After merge: enable pgAdmin in Control Plane, `gh workflow run spin-up.yml`, log into pgAdmin, click "Nexus PostgreSQL" → should connect directly with no password prompt
