### PR TITLE
feat(stacks): Add Dozzle — realtime Docker logs in the browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ After deployment you'll have:
 
 ![Quick Start Flow](docs/assets/architecture-quickstart.svg)
 
-## Available Stacks (67)
+## Available Stacks (68)
 
 [![AKHQ](https://img.shields.io/badge/AKHQ-000000?logo=apachekafka&logoColor=white)](https://akhq.io)
 [![Adminer](https://img.shields.io/badge/Adminer-34567C?logo=adminer&logoColor=white)](https://www.adminer.org)
@@ -85,6 +85,7 @@ After deployment you'll have:
 [![Debezium](https://img.shields.io/badge/Debezium-4E8CBF?logo=debezium&logoColor=white)](https://debezium.io)
 [![Dify](https://img.shields.io/badge/Dify-1677FF?logoColor=white)](https://dify.ai)
 [![Dinky](https://img.shields.io/badge/Dinky-1677FF?logo=apacheflink&logoColor=white)](https://www.dinky.org.cn/)
+[![Dozzle](https://img.shields.io/badge/Dozzle-7B16FF?logo=docker&logoColor=white)](https://dozzle.dev)
 [![Draw.io](https://img.shields.io/badge/Draw.io-F08705?logo=diagramsdotnet&logoColor=white)](https://www.diagrams.net)
 [![Excalidraw](https://img.shields.io/badge/Excalidraw-6965DB?logo=excalidraw&logoColor=white)](https://excalidraw.com)
 [![Filestash](https://img.shields.io/badge/Filestash-2B3A67?logo=files&logoColor=white)](https://www.filestash.app)
@@ -155,6 +156,7 @@ After deployment you'll have:
 | **Debezium** | Change data capture - streams database changes to Redpanda/Kafka in real time | [debezium.io](https://debezium.io) |
 | **Dify** | AI workflow builder for LLM applications, RAG pipelines, and agents | [dify.ai](https://dify.ai) |
 | **Dinky** | Web-based Flink SQL IDE with auto-completion and job management | [dinky.org.cn](https://www.dinky.org.cn/) |
+| **Dozzle** | Realtime Docker logs in the browser — tail every container without SSH | [dozzle.dev](https://dozzle.dev) |
 | **Draw.io** | Flowchart and diagramming tool for technical diagrams | [diagrams.net](https://www.diagrams.net) |
 | **Excalidraw** | Virtual whiteboard for sketching hand-drawn diagrams | [excalidraw.com](https://excalidraw.com) |
 | **Filestash** | Web-based file manager with S3/FTP/SFTP/WebDAV backend support | [filestash.app](https://www.filestash.app) |

--- a/docs/stacks/README.md
+++ b/docs/stacks/README.md
@@ -22,6 +22,7 @@ Images are pinned to **major versions** where supported for automatic security p
 | Dagster | dagster (custom build) | `1.12.21` | Exact ³ |
 | Debezium | `quay.io/debezium/connect` | `3.5.0` | Exact ¹ |
 | Dinky | `dinkydocker/dinky-standalone-server` | `1.2.5-flink1.20` | Exact ¹ |
+| Dozzle | `amir20/dozzle` | `v10.5.3` | Exact ¹ |
 | Draw.io | `jgraph/drawio` | `latest` | Latest ² |
 | Grafana | `grafana/grafana` | `12` | Major |
 | Hoppscotch | `hoppscotch/hoppscotch` | `latest` | Latest ² |
@@ -137,6 +138,7 @@ Images are pinned to **major versions** where supported for automatic security p
 | **Debezium** | Change data capture platform | [debezium.md](debezium.md) |
 | **Dify** | AI workflow builder for LLM applications | [dify.md](dify.md) |
 | **Dinky** | Flink SQL IDE with web editor | [dinky.md](dinky.md) |
+| **Dozzle** | Realtime Docker logs in the browser | [dozzle.md](dozzle.md) |
 | **Draw.io** | Flowchart and diagramming tool | [drawio.md](drawio.md) |
 | **Excalidraw** | Virtual whiteboard for diagrams | [excalidraw.md](excalidraw.md) |
 | **Filestash** | Web-based file manager | [filestash.md](filestash.md) |

--- a/docs/stacks/dozzle.md
+++ b/docs/stacks/dozzle.md
@@ -1,0 +1,48 @@
+---
+title: "Dozzle"
+---
+
+## Dozzle
+
+![Dozzle](https://img.shields.io/badge/Dozzle-7B16FF?logo=docker&logoColor=white)
+
+**Realtime Docker logs in the browser**
+
+Dozzle is a tiny web UI that streams `docker logs` for every running container live. No persistent state, no database — it subscribes to the Docker events stream via the read-only socket mount and follows container log files. Features:
+
+- Live log tail for every container on the host, all in one sidebar
+- Search + filter (substring, regex, plain text)
+- Jump between containers; multi-tab parallel tailing
+- Resource graphs per container (CPU, memory) on hover
+- Stat-the-container view: image, env, mounts, network, ports
+- Container list auto-updates as you spin services up/down
+
+| Setting | Value |
+|---------|-------|
+| Default Port | `8480` |
+| Suggested Subdomain | `dozzle` |
+| Public Access | No (Cloudflare Access via email OTP) |
+| Website | [dozzle.dev](https://dozzle.dev) |
+| Source | [GitHub](https://github.com/amir20/dozzle) |
+| Docker image | [`amir20/dozzle`](https://hub.docker.com/r/amir20/dozzle) |
+
+### Usage
+
+1. Enable **Dozzle** in the Control Plane → Spin Up
+2. Visit `https://dozzle.YOUR_DOMAIN`, authenticate via Cloudflare Access OTP
+3. The left sidebar lists every container on the host; click one to tail its logs
+4. Use the search bar (top right) to filter the active stream
+
+### Operator workflows it replaces
+
+- **"Why did metabase just restart?"** Old: `ssh nexus && docker logs metabase --tail 200`. New: open Dozzle, click `metabase`, scroll to the most recent stack trace.
+- **"Is the spin-up workflow done?"** Old: `ssh nexus && docker ps -a` and scan for restart-loops. New: open Dozzle, scan the container sidebar — restarting containers are highlighted.
+- **Multi-container debugging during a deploy:** open Dozzle in two browser tabs, one tailing `gitea`, one tailing `kestra-postgres`, watch them come up in order during a spin-up.
+
+### Auth model
+
+Dozzle has its own basic-auth and OIDC modes, but we disable them (`DOZZLE_NO_AUTH=true`) and rely on **Cloudflare Access (email OTP)** at the edge — same model as Grafana, Gitea, Infisical, every other admin UI in Nexus-Stack. CF Access in front + no second-layer auth in the container avoids double-prompting and a redundant password to manage in Infisical.
+
+### Security note
+
+The container mounts `/var/run/docker.sock:/var/run/docker.sock:ro` — **read-only**. Dozzle only needs the `events` and `logs` Docker API endpoints, both of which work over a read-only socket. The `:ro` flag is defence-in-depth in case a future Dozzle release adds a feature that would `exec`/`kill` containers — they wouldn't be reachable through a read-only socket. Anyone who can authenticate via CF Access can see all container logs (including any tokens/passwords that services log accidentally) — same exposure as `ssh nexus + docker logs` for the operator.

--- a/docs/stacks/overview.md
+++ b/docs/stacks/overview.md
@@ -156,6 +156,7 @@ Cloudflare Tunnels handle HTTPS perfectly, but a few services need raw TCP acces
 
 | Stack | Image | Description |
 |-------|-------|-------------|
+| **[Dozzle](https://github.com/stefanko-ch/Nexus-Stack/blob/main/docs/stacks/dozzle.md)** | `amir20/dozzle:v10.5.3` | Realtime Docker logs in the browser. The "no-SSH `docker logs -f`" — pick a container in the sidebar, stream its logs live, search/filter, open multiple in tabs. Subscribes to the Docker socket read-only. Stateless, ~30 MB image. |
 | **[Grafana](https://github.com/stefanko-ch/Nexus-Stack/blob/main/docs/stacks/grafana.md)** | `grafana/grafana:latest` | The observability stack, bundled: Grafana + Prometheus + Loki + Promtail + cAdvisor + Node Exporter. Ships with pre-provisioned dashboards for Docker containers, Loki logs, and host metrics — working observability out of the box. Always protected. |
 | **[Quickwit](https://github.com/stefanko-ch/Nexus-Stack/blob/main/docs/stacks/quickwit.md)** | `quickwit/quickwit:0.8.1` | Rust-based log search engine, designed to store indexes on cheap object storage (S3/MinIO) instead of expensive SSD. Elasticsearch alternative when you have terabytes of logs you rarely query. |
 | **[Telegraf](https://github.com/stefanko-ch/Nexus-Stack/blob/main/docs/stacks/telegraf.md)** | `telegraf:1.38.2` | InfluxData's metrics agent with 300+ input plugins. CLI-only — runs in the background, no web UI. Complements the Grafana stack when you need something Node Exporter doesn't cover. |

--- a/services.yaml
+++ b/services.yaml
@@ -207,6 +207,16 @@ services:
     long_description: "Dinky is a web-based IDE for Apache Flink SQL development. Write and execute Flink SQL with auto-completion, manage Flink jobs, debug SQL in real time, and monitor job execution. Supports both streaming and batch SQL with a visual data lineage graph."
     image: "nexus-dinky:1.2.5-flink1.20"
 
+  dozzle:
+    subdomain: "dozzle"
+    port: 8480
+    public: false
+    category: "observability"
+    website: "https://dozzle.dev"
+    description: "Realtime Docker logs in the browser — tail every container without SSH."
+    long_description: "Dozzle is a lightweight web UI that streams `docker logs` for every running container live. Search, filter, follow, jump between containers in tabs. No persistent state, no database, just a read-only bind on /var/run/docker.sock. Operator's go-to tool when something restart-loops and you'd otherwise reach for `ssh nexus && docker logs <name>`."
+    image: "amir20/dozzle:v10.5.3"
+
   drawio:
     subdomain: "drawio"
     port: 8083

--- a/stacks/dozzle/docker-compose.yml
+++ b/stacks/dozzle/docker-compose.yml
@@ -1,0 +1,67 @@
+# =============================================================================
+# Dozzle - Realtime Docker logs in the browser
+# =============================================================================
+# Lightweight web UI that streams `docker logs` for every running container
+# in real time. Search, filter, follow, jump between containers, no SSH
+# detour. The browser equivalent of `docker logs -f <name>` for the whole
+# host.
+#
+# Stateless container: ~30 MB image, ~15 MB RAM idle. No volumes for app
+# state, no database, no env vars beyond the auth-off flag. Single
+# bind-mount on /var/run/docker.sock (read-only) so Dozzle can subscribe
+# to the Docker events stream and tail container log files.
+#
+# Access: https://dozzle.YOUR_DOMAIN
+#
+# Operator use cases:
+#   - "Why is metabase restarting?" → open Dozzle, click `metabase` in
+#     the sidebar, see the OOM stack trace live without `ssh nexus`
+#   - "Did the spin-up workflow finish all stacks?" → open Dozzle,
+#     scan the container list, look for any in restart-loop
+#   - Multi-container debugging: open the same Dozzle URL in two tabs,
+#     one tailing `gitea`, one tailing `kestra-postgres` during a
+#     spin-up
+#
+# Multi-arch verified for v10.5.3 via `docker manifest inspect
+# amir20/dozzle:v10.5.3`: publishes linux/amd64, linux/arm64, linux/arm/v7.
+# Satisfies CLAUDE.md's "must support amd64; arm64 preferred" rule.
+#
+# Auth: --no-analytics + DOZZLE_NO_AUTH=true relies on Cloudflare Access
+# at the edge as the only auth layer (same model as Grafana, Gitea,
+# Infisical etc.). Dozzle has its own basic-auth / OIDC modes but they'd
+# be redundant double-auth behind CF Access.
+#
+# Security note: read-only docker.sock mount. Dozzle does NOT need write
+# access to the socket — only the `events` and `logs` API endpoints.
+# Mounting :ro is a defence-in-depth measure in case a future Dozzle
+# release adds a feature that would exec/kill containers.
+# =============================================================================
+
+services:
+  dozzle:
+    image: ${IMAGE_DOZZLE:-amir20/dozzle:v10.5.3}
+    container_name: dozzle
+    restart: unless-stopped
+    ports:
+      - "8480:8080"
+    environment:
+      - DOZZLE_NO_ANALYTICS=true
+      - DOZZLE_NO_AUTH=true
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    deploy:
+      resources:
+        limits:
+          memory: 128m
+    networks:
+      - app-network
+    healthcheck:
+      test: ["CMD", "/dozzle", "healthcheck"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+
+networks:
+  app-network:
+    external: true


### PR DESCRIPTION
## Summary

Adds **Dozzle** — a tiny web UI that streams `docker logs` for every running container live. Effectively replaces the operator's most common debug ritual:

```bash
ssh nexus && docker logs <container> --tail 200 -f
```

… with a Cloudflare-Access-protected page in the browser. Search/filter, jump between containers, open multiple in tabs, see CPU/memory graphs per container on hover.

Stateless, ~30 MB image, ~15 MB RAM idle. One read-only bind on `/var/run/docker.sock` so it can subscribe to the Docker events stream and tail container log files.

## Operator workflows it replaces

- **"Why did metabase just restart?"** — open Dozzle, click `metabase`, scroll to the most recent stack trace.
- **"Is the spin-up workflow done?"** — open Dozzle, scan the container sidebar (restarting containers are highlighted).
- **Multi-container debugging during a deploy** — open Dozzle in two tabs, one tailing `gitea`, one tailing `kestra-postgres`, watch them come up in order.

## Image + arch

Pinned `amir20/dozzle:v10.5.3` (current upstream release). Multi-arch verified via `docker manifest inspect`: publishes linux/amd64, linux/arm64, linux/arm/v7. Satisfies CLAUDE.md's "amd64 required; arm64 preferred" rule.

## Auth model

`DOZZLE_NO_AUTH=true` — Dozzle's own basic-auth and OIDC modes are off. Sole auth layer is **Cloudflare Access (email OTP)** at the edge, same model as Grafana / Gitea / Infisical / every other admin UI in the stack. No redundant double-auth.

## Security note

Read-only docker.sock mount (`:ro`). Dozzle only uses the `events` and `logs` API endpoints, both of which work over a read-only socket. The `:ro` flag is defence-in-depth in case a future Dozzle release adds a feature that would `exec`/`kill` containers — they wouldn't be reachable through a read-only socket. Anyone who can authenticate via CF Access can see all container logs (including any tokens/passwords that services log accidentally) — same exposure as `ssh nexus && docker logs` for the operator.

## Files

- `stacks/dozzle/docker-compose.yml` — new compose: pinned image, 128m memory, port 8480:8080, `dozzle healthcheck` subcommand
- `services.yaml` — category `observability`, port 8480 (verified free), inserted alphabetically between `dinky` and `drawio`
- `README.md` — stack count 67 → 68, badge + table row alphabetical between Dinky and Draw.io
- `docs/stacks/dozzle.md` — full reference: operator workflows, auth model, security note
- `docs/stacks/README.md` — image-versions + stack-docs tables both extended
- `docs/stacks/overview.md` — added to the Observability section

## Test plan

- [x] Pre-commit hooks all green (yaml check, ruff, mypy, shellcheck, json-check)
- [x] Port 8480 verified not in use by any other stack
- [x] Multi-arch verified: amd64 + arm64 + arm/v7
- [ ] After merge: enable in Control Plane → `gh workflow run spin-up.yml` → visit `https://dozzle.YOUR_DOMAIN`, authenticate via CF Access, verify the container sidebar shows all running containers + tailing a log stream works
