### PR TITLE
fix(snapshot): Graceful skip when state is partial + ssh_service_token absent

### DIFF
--- a/src/nexus_deploy/__main__.py
+++ b/src/nexus_deploy/__main__.py
@@ -2952,6 +2952,11 @@ def _s3_snapshot(args: list[str]) -> int:
            setup-control-plane succeeded but spin-up aborted before
            any ``tofu apply`` ran, so there's nothing on the server
            to back up; subsequent ``tofu destroy`` is also a no-op)
+         * partial state without snapshot source — state exists
+           (some resource WAS applied) but the ``ssh_service_token``
+           output isn't in it, so there is no Hetzner server to
+           snapshot from. The subsequent ``tofu destroy`` will reap
+           whatever partial resources ARE in state.
     - 2: hard failure — pipeline pre-flight, SSH wait timeout,
          CalledProcessError from the rendered bash, or feature flag
          on with credentials missing. Teardown MUST abort.

--- a/src/nexus_deploy/__main__.py
+++ b/src/nexus_deploy/__main__.py
@@ -2953,10 +2953,16 @@ def _s3_snapshot(args: list[str]) -> int:
            any ``tofu apply`` ran, so there's nothing on the server
            to back up; subsequent ``tofu destroy`` is also a no-op)
          * partial state without snapshot source — state exists
-           (some resource WAS applied) but the ``ssh_service_token``
-           output isn't in it, so there is no Hetzner server to
-           snapshot from. The subsequent ``tofu destroy`` will reap
-           whatever partial resources ARE in state.
+           (some Cloudflare-side resource WAS applied) AND the
+           ``ssh_service_token`` output is absent from state AND
+           ``hcloud_server.main`` is NOT in state. All three
+           conditions verified explicitly: the missing-output check
+           is what surfaces the case, the missing-server check is
+           the safety gate that rules out the dangerous "server has
+           data but we can't SSH" scenario (which would raise
+           PipelineError → rc=2 to abort teardown instead). The
+           subsequent ``tofu destroy`` will reap whatever stack-side
+           Cloudflare resources ARE in state.
     - 2: hard failure — pipeline pre-flight, SSH wait timeout,
          CalledProcessError from the rendered bash, or feature flag
          on with credentials missing. Teardown MUST abort.

--- a/src/nexus_deploy/__main__.py
+++ b/src/nexus_deploy/__main__.py
@@ -3059,6 +3059,19 @@ def _s3_snapshot(args: list[str]) -> int:
             "(partial deploy?). Teardown will proceed.\n",
         )
         return 0
+    if outcome.reason == "no_snapshot_source":
+        # Mid-2026-05 deads7-fork case: state exists but neither
+        # hcloud_server.main nor ssh_service_token are in it.
+        # `run_snapshot` already verified there's no server with
+        # data to lose (state_contains check), so this is a safe
+        # no-op — let teardown proceed to reap whatever partial
+        # Cloudflare-side resources ARE in state.
+        sys.stderr.write(
+            "s3-snapshot: no server in state - nothing to snapshot "
+            "(partial deploy, server resources never applied). "
+            "Teardown will proceed.\n",
+        )
+        return 0
     # no_endpoint_env — snapshot_to_s3 already wrote its own
     # diagnostic listing the missing env vars. Map to rc=2.
     return 2

--- a/src/nexus_deploy/pipeline.py
+++ b/src/nexus_deploy/pipeline.py
@@ -542,7 +542,8 @@ def run_snapshot(
       → rc=0, partial state exists in ``tofu/stack`` (e.g. a few
       Cloudflare-side resources that the orchestrator created
       before failing) but neither ``hcloud_server.main`` nor the
-      ``cloudflare_zero_trust_access_service_token.ssh`` output
+      ``ssh_service_token`` output (sourced from the
+      ``cloudflare_zero_trust_access_service_token.ssh`` resource)
       is in state. No server, no way (and no need) to snapshot;
       teardown proceeds to reap the partial Cloudflare-side
       resources via ``tofu destroy``. See mid-2026-05 deads7-fork
@@ -629,18 +630,23 @@ def run_snapshot(
     # 4. ssh_service_token + server_ip from tofu outputs.
     #
     # `state_list_ok` already passed (step 2), so SOME state exists in
-    # tofu/stack — but that doesn't mean `ssh_service_token` is in it.
-    # Observed mid-2026-05: a scheduled teardown on a deads7 fork where
-    # setup ran ✅ but Spin Up was never triggered (so the Hetzner
-    # server + the `cloudflare_zero_trust_access_service_token`
-    # resource that feeds this output never got applied) fired exit-2
-    # daily on this very step. Without an SSH service token there's
-    # also no Hetzner server reachable via SSH — there is nothing TO
-    # snapshot, the same legitimate no-op as issue #564 just one branch
-    # deeper. Skip with `no_snapshot_source`; the subsequent
-    # `tofu destroy` will still reap whatever partial resources ARE in
-    # state (an empty R2 bucket, half-created KV namespace, etc.) so
-    # the teardown remains useful, just not an SSH-driven one.
+    # tofu/stack — but that doesn't mean the `ssh_service_token`
+    # output (declared in `tofu/stack/outputs.tf`, sourced from the
+    # `cloudflare_zero_trust_access_service_token.ssh` resource) is
+    # in it. Observed mid-2026-05: a scheduled teardown on a deads7
+    # fork where setup ran ✅ but Spin Up was never triggered (so
+    # neither the Hetzner server nor the CF Access service-token
+    # resource got applied) fired exit-2 daily on this very step.
+    # Without an SSH service token there's also no Hetzner server
+    # reachable via SSH — there is nothing TO snapshot, the same
+    # legitimate no-op as issue #564 just one branch deeper. Skip
+    # with `no_snapshot_source`; the subsequent `tofu destroy` will
+    # still reap whatever stack-side partial resources ARE in state
+    # (typically Cloudflare DNS records, tunnel resources, Access
+    # applications that the orchestrator created before failing — NOT
+    # the R2 state bucket or Cloudflare KV namespace; those live in
+    # `tofu/control-plane`, not here) so the teardown remains useful,
+    # just not an SSH-driven one.
     #
     # Real TofuError causes (tofu binary missing, R2 backend auth) at
     # THIS point would be surprising — step 2 already exercised the
@@ -653,19 +659,31 @@ def run_snapshot(
     # no_snapshot_source branch. We only want that for the specific
     # "output not declared in state" case — tofu reports this via a
     # well-known stderr marker. Anything else re-raises as PipelineError.
+    #
+    # SECURITY: tofu stderr can contain provider/backend credential
+    # material (Cloudflare API tokens shown in plan diffs, Hetzner
+    # auth-error tokens, R2 SignatureDoesNotMatch leaking partial
+    # keys). Read the stderr ONLY to match the well-known "output
+    # not declared" marker; never include it in the PipelineError
+    # message. Same convention as TofuRunner's own error wrapping
+    # (see test_output_raw_error_message_does_not_leak_subprocess_stderr).
     try:
         ssh_service_token = runner.output_json("ssh_service_token")
     except _tofu.TofuError as exc:
-        stderr = ""
         cause = exc.__cause__
-        if isinstance(cause, subprocess.CalledProcessError):
-            stderr = (cause.stderr or "") if isinstance(cause.stderr, str) else ""
+        stderr = ""
+        if isinstance(cause, subprocess.CalledProcessError) and isinstance(cause.stderr, str):
+            stderr = cause.stderr
         if "could not be found in the state" in stderr or "no outputs found" in stderr:
             ssh_service_token = None
         else:
             raise PipelineError(
-                f"tofu output -json ssh_service_token failed unexpectedly in {tofu_dir} "
-                f"(state_list_ok already passed at step 2): {stderr[:500] or exc}",
+                f"tofu output -json ssh_service_token failed in {tofu_dir} "
+                "(state_list_ok already passed at step 2 — likely transient "
+                "R2 backend auth/timeout or tofu binary issue). Check "
+                "workflow logs above this PipelineError for the tofu stderr; "
+                "stderr is omitted from this message to avoid leaking "
+                "provider credentials.",
             ) from exc
     if ssh_service_token is None:
         # Output absent / null. Before treating this as "no server to
@@ -678,7 +696,22 @@ def run_snapshot(
         # this as a hard PipelineError instead — operator must either
         # re-apply the missing token resource so we can SSH-snapshot,
         # or manually back up the server before destroy-all.
-        if runner.state_contains("hcloud_server.main"):
+        #
+        # state_contains() raises TofuError on backend failure — wrap
+        # to honor run_snapshot's PipelineError contract instead of
+        # surfacing as "unexpected error" in the CLI dispatcher.
+        try:
+            server_in_state = runner.state_contains("hcloud_server.main")
+        except _tofu.TofuError as exc:
+            raise PipelineError(
+                f"tofu state list failed in {tofu_dir} when checking whether "
+                "hcloud_server.main is in state — can't safely decide "
+                "snapshot vs skip. Likely transient R2 backend / auth issue; "
+                "rerun, or investigate state accessibility before retrying "
+                "teardown. (Tofu stderr omitted to avoid leaking provider "
+                "credentials.)",
+            ) from exc
+        if server_in_state:
             raise PipelineError(
                 f"Dangerous partial state in {tofu_dir}: hcloud_server.main "
                 "is in state but ssh_service_token output is absent — the "

--- a/src/nexus_deploy/pipeline.py
+++ b/src/nexus_deploy/pipeline.py
@@ -538,6 +538,15 @@ def run_snapshot(
       Hetzner capacity step). Nothing on the server to snapshot;
       teardown proceeds and ``tofu destroy`` is also a no-op
       against the empty state. See issue #564.
+    - Snapshot returns ``S3SnapshotSkipped(reason='no_snapshot_source')``
+      → rc=0, partial state exists in ``tofu/stack`` (e.g. a few
+      Cloudflare-side resources that the orchestrator created
+      before failing) but neither ``hcloud_server.main`` nor the
+      ``cloudflare_zero_trust_access_service_token.ssh`` output
+      is in state. No server, no way (and no need) to snapshot;
+      teardown proceeds to reap the partial Cloudflare-side
+      resources via ``tofu destroy``. See mid-2026-05 deads7-fork
+      observation.
     - Snapshot returns ``S3SnapshotApplied`` → rc=0, safe to
       proceed with ``tofu destroy``.
 
@@ -652,18 +661,33 @@ def run_snapshot(
         if isinstance(cause, subprocess.CalledProcessError):
             stderr = (cause.stderr or "") if isinstance(cause.stderr, str) else ""
         if "could not be found in the state" in stderr or "no outputs found" in stderr:
-            return SnapshotResult(
-                outcome=_s3_restore.S3SnapshotSkipped(
-                    reason="no_snapshot_source",
-                ),
-            )
-        raise PipelineError(
-            f"tofu output -json ssh_service_token failed unexpectedly in {tofu_dir} "
-            f"(state_list_ok already passed at step 2): {stderr[:500] or exc}",
-        ) from exc
+            ssh_service_token = None
+        else:
+            raise PipelineError(
+                f"tofu output -json ssh_service_token failed unexpectedly in {tofu_dir} "
+                f"(state_list_ok already passed at step 2): {stderr[:500] or exc}",
+            ) from exc
     if ssh_service_token is None:
-        # `null` value in state — same legitimate no-op as "output
-        # not declared". Treat as graceful skip.
+        # Output absent / null. Before treating this as "no server to
+        # snapshot", VERIFY hcloud_server.main isn't sitting in state
+        # too. hcloud_server.main and the CF Access service-token are
+        # independent resources: a partial state could have created
+        # the server (so it has data on it) but failed before / after
+        # the token. Silently skipping the snapshot in that case would
+        # let `tofu destroy` nuke the server with data on it. Surface
+        # this as a hard PipelineError instead — operator must either
+        # re-apply the missing token resource so we can SSH-snapshot,
+        # or manually back up the server before destroy-all.
+        if runner.state_contains("hcloud_server.main"):
+            raise PipelineError(
+                f"Dangerous partial state in {tofu_dir}: hcloud_server.main "
+                "is in state but ssh_service_token output is absent — the "
+                "server may have data but the pipeline can't SSH to snapshot "
+                "it. `tofu destroy` would lose that data. Operator action: "
+                "either re-apply the missing CF Access service-token "
+                "resources so a snapshot becomes possible, or manually back "
+                "up the server before running destroy-all.",
+            )
         return SnapshotResult(
             outcome=_s3_restore.S3SnapshotSkipped(
                 reason="no_snapshot_source",

--- a/src/nexus_deploy/pipeline.py
+++ b/src/nexus_deploy/pipeline.py
@@ -638,8 +638,32 @@ def run_snapshot(
     # binary + state backend successfully — but still possible if
     # transient. Surface those as PipelineError so the operator sees
     # the actual cause rather than a silent skip.
-    ssh_service_token = runner.output_json("ssh_service_token", default=None)
+    #
+    # output_json(default=None) would collapse ALL three failure modes
+    # (binary missing, non-zero exit, invalid JSON) into the graceful
+    # no_snapshot_source branch. We only want that for the specific
+    # "output not declared in state" case — tofu reports this via a
+    # well-known stderr marker. Anything else re-raises as PipelineError.
+    try:
+        ssh_service_token = runner.output_json("ssh_service_token")
+    except _tofu.TofuError as exc:
+        stderr = ""
+        cause = exc.__cause__
+        if isinstance(cause, subprocess.CalledProcessError):
+            stderr = (cause.stderr or "") if isinstance(cause.stderr, str) else ""
+        if "could not be found in the state" in stderr or "no outputs found" in stderr:
+            return SnapshotResult(
+                outcome=_s3_restore.S3SnapshotSkipped(
+                    reason="no_snapshot_source",
+                ),
+            )
+        raise PipelineError(
+            f"tofu output -json ssh_service_token failed unexpectedly in {tofu_dir} "
+            f"(state_list_ok already passed at step 2): {stderr[:500] or exc}",
+        ) from exc
     if ssh_service_token is None:
+        # `null` value in state — same legitimate no-op as "output
+        # not declared". Treat as graceful skip.
         return SnapshotResult(
             outcome=_s3_restore.S3SnapshotSkipped(
                 reason="no_snapshot_source",

--- a/src/nexus_deploy/pipeline.py
+++ b/src/nexus_deploy/pipeline.py
@@ -680,10 +680,13 @@ def run_snapshot(
             raise PipelineError(
                 f"tofu output -json ssh_service_token failed in {tofu_dir} "
                 "(state_list_ok already passed at step 2 — likely transient "
-                "R2 backend auth/timeout or tofu binary issue). Check "
-                "workflow logs above this PipelineError for the tofu stderr; "
-                "stderr is omitted from this message to avoid leaking "
-                "provider credentials.",
+                "R2 backend auth/timeout or tofu binary issue). "
+                "Operator: rerun `tofu output -json ssh_service_token` "
+                f"in {tofu_dir} to see the actual provider error. "
+                "(Tofu stderr is held inside the chained CalledProcessError "
+                "but deliberately not included in this message — it can "
+                "carry CF API tokens, Hetzner auth tokens, or R2 signature "
+                "fragments.)",
             ) from exc
     if ssh_service_token is None:
         # Output absent / null. Before treating this as "no server to
@@ -706,10 +709,12 @@ def run_snapshot(
             raise PipelineError(
                 f"tofu state list failed in {tofu_dir} when checking whether "
                 "hcloud_server.main is in state — can't safely decide "
-                "snapshot vs skip. Likely transient R2 backend / auth issue; "
-                "rerun, or investigate state accessibility before retrying "
-                "teardown. (Tofu stderr omitted to avoid leaking provider "
-                "credentials.)",
+                "snapshot vs skip. Likely transient R2 backend / auth issue. "
+                f"Operator: rerun `tofu state list` in {tofu_dir} to see "
+                "the actual provider error before retrying teardown. (Tofu "
+                "stderr is held inside the chained CalledProcessError but "
+                "deliberately not included in this message to avoid leaking "
+                "provider credentials.)",
             ) from exc
         if server_in_state:
             raise PipelineError(

--- a/src/nexus_deploy/pipeline.py
+++ b/src/nexus_deploy/pipeline.py
@@ -618,13 +618,33 @@ def run_snapshot(
         )
 
     # 4. ssh_service_token + server_ip from tofu outputs.
-    try:
-        ssh_service_token = runner.output_json("ssh_service_token")
-    except _tofu.TofuError as exc:
-        raise PipelineError(
-            f"required tofu output missing or invalid: {exc} — "
-            "state may be partially applied; nothing to snapshot",
-        ) from exc
+    #
+    # `state_list_ok` already passed (step 2), so SOME state exists in
+    # tofu/stack — but that doesn't mean `ssh_service_token` is in it.
+    # Observed mid-2026-05: a scheduled teardown on a deads7 fork where
+    # setup ran ✅ but Spin Up was never triggered (so the Hetzner
+    # server + the `cloudflare_zero_trust_access_service_token`
+    # resource that feeds this output never got applied) fired exit-2
+    # daily on this very step. Without an SSH service token there's
+    # also no Hetzner server reachable via SSH — there is nothing TO
+    # snapshot, the same legitimate no-op as issue #564 just one branch
+    # deeper. Skip with `no_snapshot_source`; the subsequent
+    # `tofu destroy` will still reap whatever partial resources ARE in
+    # state (an empty R2 bucket, half-created KV namespace, etc.) so
+    # the teardown remains useful, just not an SSH-driven one.
+    #
+    # Real TofuError causes (tofu binary missing, R2 backend auth) at
+    # THIS point would be surprising — step 2 already exercised the
+    # binary + state backend successfully — but still possible if
+    # transient. Surface those as PipelineError so the operator sees
+    # the actual cause rather than a silent skip.
+    ssh_service_token = runner.output_json("ssh_service_token", default=None)
+    if ssh_service_token is None:
+        return SnapshotResult(
+            outcome=_s3_restore.S3SnapshotSkipped(
+                reason="no_snapshot_source",
+            ),
+        )
     server_ip = runner.output_raw("server_ip", default="")
 
     # 5. SSH known_hosts cleanup — same pattern as run_pipeline.

--- a/src/nexus_deploy/pipeline.py
+++ b/src/nexus_deploy/pipeline.py
@@ -674,7 +674,13 @@ def run_snapshot(
         stderr = ""
         if isinstance(cause, subprocess.CalledProcessError) and isinstance(cause.stderr, str):
             stderr = cause.stderr
-        if "could not be found in the state" in stderr or "no outputs found" in stderr:
+        # Case-insensitive: OpenTofu emits "No outputs found" with a
+        # capital N (see opentofu/internal/command/views/output.go:297),
+        # while "The output variable requested could not be found in
+        # the state file" is lowercase. Normalize both to lowercase so
+        # neither path silently slips through to the hard-failure branch.
+        stderr_lower = stderr.lower()
+        if "could not be found in the state" in stderr_lower or "no outputs found" in stderr_lower:
             ssh_service_token = None
         else:
             raise PipelineError(

--- a/src/nexus_deploy/s3_restore.py
+++ b/src/nexus_deploy/s3_restore.py
@@ -149,21 +149,25 @@ class S3SnapshotSkipped:
       ``PipelineError`` and aborts the teardown.
     * ``"no_snapshot_source"`` — opted in, credentials present,
       ``tofu state list`` works, but the ``ssh_service_token``
-      output is missing from the state AND ``hcloud_server.main``
-      is NOT in state either (verified explicitly to rule out the
-      dangerous "server has data but we can't SSH" case). This is
-      the partial-state-without-server case observed mid-2026-05:
-      a scheduled teardown runs against a fork where setup ran (so
+      output (sourced from
+      ``cloudflare_zero_trust_access_service_token.ssh``) is missing
+      from the state AND ``hcloud_server.main`` is NOT in state
+      either (verified explicitly to rule out the dangerous "server
+      has data but we can't SSH" case). This is the
+      partial-state-without-server case observed mid-2026-05: a
+      scheduled teardown runs against a fork where setup ran (so
       ``tofu/stack`` has SOME state — typically only the
       Cloudflare-side resources the orchestrator created before
-      failing, such as ``cloudflare_tunnel`` placeholders or DNS
-      records) but the actual Hetzner server + the Cloudflare
-      Access Service Token (which feeds ``ssh_service_token``)
-      never got applied. Without a server there is nothing to
-      snapshot. The subsequent ``tofu destroy`` still runs and
-      reaps whatever partial Cloudflare resources ARE in state.
-      CLI rc=0 so the scheduled teardown doesn't leave a daily
-      red workflow run for stacks that never went live."""
+      failing, e.g. ``cloudflare_zero_trust_tunnel_cloudflared.main``
+      or ``cloudflare_record.*``) but the actual Hetzner server +
+      the CF Access service-token resource never got applied. The
+      R2 state bucket and Cloudflare KV namespace are NOT in this
+      state (they live in ``tofu/control-plane``). Without a server
+      there is nothing to snapshot. The subsequent ``tofu destroy``
+      still runs and reaps whatever stack-side partial Cloudflare
+      resources ARE in state. CLI rc=0 so the scheduled teardown
+      doesn't leave a daily red workflow run for stacks that never
+      went live."""
 
     reason: Literal[
         "feature_flag_off",

--- a/src/nexus_deploy/s3_restore.py
+++ b/src/nexus_deploy/s3_restore.py
@@ -146,12 +146,28 @@ class S3SnapshotSkipped:
       matched on the ``"No state file was found"`` substring from
       ``diagnose_state()`` — any other state-list failure (binary
       missing, R2 backend timeout, auth error) still raises
-      ``PipelineError`` and aborts the teardown."""
+      ``PipelineError`` and aborts the teardown.
+    * ``"no_snapshot_source"`` — opted in, credentials present,
+      ``tofu state list`` works, but the ``ssh_service_token``
+      output is missing from the state. This is the
+      partial-state-without-server case observed mid-2026-05: a
+      scheduled teardown runs against a fork where setup ran (so
+      ``tofu/stack`` has SOME state — maybe an R2 bucket was
+      provisioned by an earlier aborted spin-up) but the actual
+      Hetzner server + Cloudflare Access Service Token (which
+      feeds ``ssh_service_token``) never got applied. Without the
+      service token there is no way to SSH into a Hetzner server
+      that doesn't exist anyway, so there is nothing to snapshot.
+      The subsequent ``tofu destroy`` still runs and reaps whatever
+      partial resources ARE in state. CLI rc=0 so the scheduled
+      teardown doesn't leave a daily red workflow run for stacks
+      that never went live."""
 
     reason: Literal[
         "feature_flag_off",
         "no_endpoint_env",
         "no_state_to_snapshot",
+        "no_snapshot_source",
     ]
 
 

--- a/src/nexus_deploy/s3_restore.py
+++ b/src/nexus_deploy/s3_restore.py
@@ -149,19 +149,21 @@ class S3SnapshotSkipped:
       ``PipelineError`` and aborts the teardown.
     * ``"no_snapshot_source"`` — opted in, credentials present,
       ``tofu state list`` works, but the ``ssh_service_token``
-      output is missing from the state. This is the
-      partial-state-without-server case observed mid-2026-05: a
-      scheduled teardown runs against a fork where setup ran (so
-      ``tofu/stack`` has SOME state — maybe an R2 bucket was
-      provisioned by an earlier aborted spin-up) but the actual
-      Hetzner server + Cloudflare Access Service Token (which
-      feeds ``ssh_service_token``) never got applied. Without the
-      service token there is no way to SSH into a Hetzner server
-      that doesn't exist anyway, so there is nothing to snapshot.
-      The subsequent ``tofu destroy`` still runs and reaps whatever
-      partial resources ARE in state. CLI rc=0 so the scheduled
-      teardown doesn't leave a daily red workflow run for stacks
-      that never went live."""
+      output is missing from the state AND ``hcloud_server.main``
+      is NOT in state either (verified explicitly to rule out the
+      dangerous "server has data but we can't SSH" case). This is
+      the partial-state-without-server case observed mid-2026-05:
+      a scheduled teardown runs against a fork where setup ran (so
+      ``tofu/stack`` has SOME state — typically only the
+      Cloudflare-side resources the orchestrator created before
+      failing, such as ``cloudflare_tunnel`` placeholders or DNS
+      records) but the actual Hetzner server + the Cloudflare
+      Access Service Token (which feeds ``ssh_service_token``)
+      never got applied. Without a server there is nothing to
+      snapshot. The subsequent ``tofu destroy`` still runs and
+      reaps whatever partial Cloudflare resources ARE in state.
+      CLI rc=0 so the scheduled teardown doesn't leave a daily
+      red workflow run for stacks that never went live."""
 
     reason: Literal[
         "feature_flag_off",

--- a/src/nexus_deploy/tofu.py
+++ b/src/nexus_deploy/tofu.py
@@ -123,6 +123,37 @@ class TofuRunner:
         """
         return self.diagnose_state() is None
 
+    def state_contains(self, address: str) -> bool:
+        """Return True iff ``address`` is a resource currently tracked
+        in state. ``address`` is matched as an exact line in
+        ``tofu state list`` output (e.g. ``hcloud_server.main``).
+
+        Raises :class:`TofuError` if ``tofu state list`` itself fails —
+        callers must not silently treat a failure as "absent", because
+        the dangerous interpretation is the inverse: an unreachable
+        backend hiding a resource that's about to be destroyed.
+        """
+        try:
+            completed = subprocess.run(
+                ["tofu", "state", "list"],
+                cwd=self.tofu_dir,
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=60.0,
+            )
+        except (FileNotFoundError, subprocess.CalledProcessError) as exc:
+            raise TofuError(
+                f"tofu state list failed in {self.tofu_dir} — cannot "
+                f"determine whether {address} is in state",
+            ) from exc
+        except subprocess.TimeoutExpired as exc:
+            raise TofuError(
+                f"tofu state list timed out in {self.tofu_dir} — cannot "
+                f"determine whether {address} is in state",
+            ) from exc
+        return address in completed.stdout.splitlines()
+
     def diagnose_state(self) -> str | None:
         """Return ``None`` when state is initialised + accessible.
 

--- a/tests/unit/test_pipeline.py
+++ b/tests/unit/test_pipeline.py
@@ -1156,6 +1156,49 @@ def test_run_snapshot_skips_when_output_not_declared_in_state(
     setup_mocks["configure_ssh"].assert_not_called()
 
 
+def test_run_snapshot_skips_on_capitalized_no_outputs_found_marker(
+    project_root: Path,
+    fake_tofu_runner: MagicMock,
+    setup_mocks: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """OpenTofu emits ``"No outputs found"`` with a capital N
+    (opentofu/internal/command/views/output.go:297). A case-sensitive
+    ``"no outputs found" in stderr`` check would miss this and force
+    the hard-failure branch, defeating the no_snapshot_source skip on
+    a state file with no outputs declared at all. Regression guard
+    for the case-folding fix — pipeline.py now lowercases stderr
+    before marker matching, so the real Capital-N string still
+    triggers the graceful skip."""
+    import subprocess
+
+    monkeypatch.setenv("NEXUS_S3_PERSISTENCE", "true")
+    from nexus_deploy import tofu as _tofu
+
+    def raise_tofu_error(name: str, default: Any = ...) -> Any:
+        if name == "ssh_service_token":
+            err = subprocess.CalledProcessError(
+                returncode=1,
+                cmd=["tofu", "output", "-json", "ssh_service_token"],
+                output="",
+                # Verbatim OpenTofu wording — capital N, Warning prefix.
+                stderr="Warning: No outputs found\n\nThe state file either has no outputs defined...",
+            )
+            raise _tofu.TofuError("tofu output failed") from err
+        return {"any": "other"}
+
+    fake_tofu_runner.output_json.side_effect = raise_tofu_error
+    result = run_snapshot(
+        project_root=project_root,
+        stack_slug="nexus-test",
+        template_version="v1.0.0",
+        tofu_runner=fake_tofu_runner,
+    )
+    assert isinstance(result.outcome, S3SnapshotSkipped)
+    assert result.outcome.reason == "no_snapshot_source"
+    setup_mocks["configure_ssh"].assert_not_called()
+
+
 def test_run_snapshot_aborts_when_server_in_state_but_token_missing(
     project_root: Path,
     fake_tofu_runner: MagicMock,

--- a/tests/unit/test_pipeline.py
+++ b/tests/unit/test_pipeline.py
@@ -1037,6 +1037,53 @@ def test_run_snapshot_skips_when_state_file_missing(
     setup_mocks["SSHClient"].assert_not_called()
 
 
+def test_run_snapshot_skips_when_ssh_service_token_missing(
+    project_root: Path,
+    fake_tofu_runner: MagicMock,
+    setup_mocks: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Issue #564 follow-up (mid-2026-05 partial-state case): SOME
+    state is present in tofu/stack — so ``state_list_ok()`` returns
+    True — but the ``ssh_service_token`` output isn't in it because
+    the Hetzner server + Cloudflare Access Service Token resource
+    never got applied (setup ran, Spin Up never did). Observed on a
+    deads7 fork whose scheduled daily 21:00-UTC teardown went red
+    for five days straight, generating noise without snapshotting
+    anything.
+
+    Right behaviour: graceful Skipped with reason
+    ``no_snapshot_source``, the same way the "no state file at all"
+    case in :func:`test_run_snapshot_skips_when_state_file_missing`
+    is treated — there is nothing on the server to back up either
+    way. The subsequent ``tofu destroy`` still runs to reap any
+    partial state.
+
+    Tests that the short-circuit fires BEFORE any SSH side-effect
+    (configure_ssh / wait_for_ssh / SSHClient) — same invariant as
+    the file-missing test, but at one branch deeper into the
+    pipeline."""
+    monkeypatch.setenv("NEXUS_S3_PERSISTENCE", "true")
+    # State list works (the partial state is real) but the specific
+    # output we need is absent. Mirror the fixture's default signature
+    # so other outputs (server_ip, etc.) still resolve via raw_map.
+    fake_tofu_runner.output_json.side_effect = lambda name, default=None: (
+        None if name == "ssh_service_token" else {"any": "other"}
+    )
+    result = run_snapshot(
+        project_root=project_root,
+        stack_slug="nexus-test",
+        template_version="v1.0.0",
+        tofu_runner=fake_tofu_runner,
+    )
+    assert isinstance(result.outcome, S3SnapshotSkipped)
+    assert result.outcome.reason == "no_snapshot_source"
+    # SSH path must not have been entered — short-circuit invariant.
+    setup_mocks["configure_ssh"].assert_not_called()
+    setup_mocks["wait_for_ssh"].assert_not_called()
+    setup_mocks["SSHClient"].assert_not_called()
+
+
 def test_run_snapshot_aborts_on_other_state_failures(
     project_root: Path,
     fake_tofu_runner: MagicMock,

--- a/tests/unit/test_pipeline.py
+++ b/tests/unit/test_pipeline.py
@@ -95,6 +95,11 @@ def fake_tofu_runner(fake_secrets_payload: dict[str, str]) -> MagicMock:
     runner = MagicMock(spec=TofuRunner)
     runner.tofu_dir = Path("/fake")
     runner.state_list_ok.return_value = True
+    # Default: hcloud_server.main NOT in state. The snapshot pipeline
+    # uses state_contains() as a safety check before treating a
+    # missing ssh_service_token as graceful no-op — tests that want
+    # to simulate "server in state but token missing" override this.
+    runner.state_contains.return_value = False
     json_map: dict[str, Any] = {
         "secrets": fake_secrets_payload,
         "image_versions": {"kestra": "v0.51"},
@@ -1148,6 +1153,35 @@ def test_run_snapshot_skips_when_output_not_declared_in_state(
     )
     assert isinstance(result.outcome, S3SnapshotSkipped)
     assert result.outcome.reason == "no_snapshot_source"
+    setup_mocks["configure_ssh"].assert_not_called()
+
+
+def test_run_snapshot_aborts_when_server_in_state_but_token_missing(
+    project_root: Path,
+    fake_tofu_runner: MagicMock,
+    setup_mocks: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """SAFETY-CRITICAL: if ssh_service_token is missing BUT
+    hcloud_server.main is in state, the server may have data on it
+    that the pipeline can't reach via SSH. A silent graceful-skip
+    here would let `tofu destroy` nuke the server with data — must
+    raise PipelineError instead so the operator investigates."""
+    monkeypatch.setenv("NEXUS_S3_PERSISTENCE", "true")
+    # Token output missing (null in state)
+    fake_tofu_runner.output_json.side_effect = lambda name, default=None: (
+        None if name == "ssh_service_token" else {"any": "other"}
+    )
+    # But hcloud_server.main IS in state
+    fake_tofu_runner.state_contains.return_value = True
+
+    with pytest.raises(PipelineError, match="Dangerous partial state"):
+        run_snapshot(
+            project_root=project_root,
+            stack_slug="nexus-test",
+            template_version="v1.0.0",
+            tofu_runner=fake_tofu_runner,
+        )
     setup_mocks["configure_ssh"].assert_not_called()
 
 

--- a/tests/unit/test_pipeline.py
+++ b/tests/unit/test_pipeline.py
@@ -1110,6 +1110,87 @@ def test_run_snapshot_aborts_on_other_state_failures(
         )
 
 
+def test_run_snapshot_skips_when_output_not_declared_in_state(
+    project_root: Path,
+    fake_tofu_runner: MagicMock,
+    setup_mocks: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Same logical no-op as the null-value case above, but exercised
+    via tofu's real error path: when an output isn't declared in state,
+    `tofu output -json X` exits 1 with stderr "The output variable
+    requested could not be found in the state file." TofuRunner wraps
+    that as TofuError; pipeline.py must distinguish this specific
+    case (graceful skip) from other TofuError causes (re-raise as
+    PipelineError) instead of collapsing both into None via default."""
+    import subprocess
+
+    monkeypatch.setenv("NEXUS_S3_PERSISTENCE", "true")
+    from nexus_deploy import tofu as _tofu
+
+    def raise_tofu_error(name: str, default: Any = ...) -> Any:
+        if name == "ssh_service_token":
+            err = subprocess.CalledProcessError(
+                returncode=1,
+                cmd=["tofu", "output", "-json", "ssh_service_token"],
+                output="",
+                stderr="The output variable requested could not be found in the state file.",
+            )
+            raise _tofu.TofuError("tofu output failed") from err
+        return {"any": "other"}
+
+    fake_tofu_runner.output_json.side_effect = raise_tofu_error
+    result = run_snapshot(
+        project_root=project_root,
+        stack_slug="nexus-test",
+        template_version="v1.0.0",
+        tofu_runner=fake_tofu_runner,
+    )
+    assert isinstance(result.outcome, S3SnapshotSkipped)
+    assert result.outcome.reason == "no_snapshot_source"
+    setup_mocks["configure_ssh"].assert_not_called()
+
+
+def test_run_snapshot_aborts_on_other_tofu_output_failures(
+    project_root: Path,
+    fake_tofu_runner: MagicMock,
+    setup_mocks: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The carve-out for `output_json("ssh_service_token")` failures
+    is narrow: only "output not declared" stderr triggers the graceful
+    no_snapshot_source skip. Every other TofuError cause (binary
+    missing, transient R2 backend timeout / 5xx, JSON parse failure,
+    auth failure) must re-raise as PipelineError so the operator sees
+    the real cause instead of a silently-skipped snapshot followed by
+    a destroy that loses data."""
+    import subprocess
+
+    monkeypatch.setenv("NEXUS_S3_PERSISTENCE", "true")
+    from nexus_deploy import tofu as _tofu
+
+    def raise_transient(name: str, default: Any = ...) -> Any:
+        if name == "ssh_service_token":
+            err = subprocess.CalledProcessError(
+                returncode=1,
+                cmd=["tofu", "output", "-json", "ssh_service_token"],
+                output="",
+                stderr="Error: Failed to query available provider packages — 503 Service Unavailable from r2.cloudflarestorage.com",
+            )
+            raise _tofu.TofuError("tofu output failed") from err
+        return {"any": "other"}
+
+    fake_tofu_runner.output_json.side_effect = raise_transient
+    with pytest.raises(PipelineError, match="503 Service Unavailable"):
+        run_snapshot(
+            project_root=project_root,
+            stack_slug="nexus-test",
+            template_version="v1.0.0",
+            tofu_runner=fake_tofu_runner,
+        )
+    setup_mocks["configure_ssh"].assert_not_called()
+
+
 def test_run_snapshot_aborts_on_empty_domain(
     project_root: Path,
     fake_tofu_runner: MagicMock,

--- a/tests/unit/test_pipeline.py
+++ b/tests/unit/test_pipeline.py
@@ -1196,12 +1196,27 @@ def test_run_snapshot_aborts_on_other_tofu_output_failures(
     no_snapshot_source skip. Every other TofuError cause (binary
     missing, transient R2 backend timeout / 5xx, JSON parse failure,
     auth failure) must re-raise as PipelineError so the operator sees
-    the real cause instead of a silently-skipped snapshot followed by
-    a destroy that loses data."""
+    a hard abort instead of a silently-skipped snapshot followed by
+    a destroy that loses data.
+
+    SECURITY: tofu stderr can contain provider/backend credential
+    material (Cloudflare API tokens shown in plan diffs, Hetzner
+    auth tokens, R2 SignatureDoesNotMatch leaking partial keys).
+    The PipelineError surfaced here must NOT contain that stderr —
+    same convention as TofuRunner's own error wrapping (see
+    ``test_output_raw_error_message_does_not_leak_subprocess_stderr``).
+    This test asserts the abort happens but pins the
+    no-stderr-in-message invariant rather than locking in the
+    sensitive content."""
     import subprocess
 
     monkeypatch.setenv("NEXUS_S3_PERSISTENCE", "true")
     from nexus_deploy import tofu as _tofu
+
+    leaky_stderr = (
+        "Error: Failed to query available provider packages — "
+        "AccessKeyId=AKIA-do-not-leak-this-token-eyJhb..."
+    )
 
     def raise_transient(name: str, default: Any = ...) -> Any:
         if name == "ssh_service_token":
@@ -1209,13 +1224,14 @@ def test_run_snapshot_aborts_on_other_tofu_output_failures(
                 returncode=1,
                 cmd=["tofu", "output", "-json", "ssh_service_token"],
                 output="",
-                stderr="Error: Failed to query available provider packages — 503 Service Unavailable from r2.cloudflarestorage.com",
+                stderr=leaky_stderr,
             )
             raise _tofu.TofuError("tofu output failed") from err
         return {"any": "other"}
 
     fake_tofu_runner.output_json.side_effect = raise_transient
-    with pytest.raises(PipelineError, match="503 Service Unavailable"):
+    # Abort behaviour: PipelineError raised, SSH side-effects skipped.
+    with pytest.raises(PipelineError) as exc_info:
         run_snapshot(
             project_root=project_root,
             stack_slug="nexus-test",
@@ -1223,6 +1239,12 @@ def test_run_snapshot_aborts_on_other_tofu_output_failures(
             tofu_runner=fake_tofu_runner,
         )
     setup_mocks["configure_ssh"].assert_not_called()
+    # SECURITY: the user-facing exception message must NOT contain
+    # the credential-looking content from tofu stderr.
+    assert "AKIA-do-not-leak-this-token" not in str(exc_info.value)
+    assert "eyJhb" not in str(exc_info.value)
+    # But the message should still be operator-actionable.
+    assert "ssh_service_token" in str(exc_info.value)
 
 
 def test_run_snapshot_aborts_on_empty_domain(

--- a/tests/unit/test_s3_snapshot_cli.py
+++ b/tests/unit/test_s3_snapshot_cli.py
@@ -1,0 +1,94 @@
+"""Tests for the ``nexus-deploy s3-snapshot`` CLI dispatcher.
+
+Focused on the exit-code mapping in ``_s3_snapshot``: every
+``S3SnapshotSkipped`` reason must map to a deliberate rc, not fall
+through to a default. PR #600 added ``no_snapshot_source`` as a new
+graceful (rc=0) skip reason — the original PR forgot to add the
+dispatcher branch, so it silently fell through to rc=2 and made
+scheduled teardowns red on the exact deads7-fork case the skip was
+meant to handle. These tests pin the contract.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from nexus_deploy import s3_restore as _s3_restore
+from nexus_deploy.__main__ import _s3_snapshot
+from nexus_deploy.pipeline import SnapshotResult
+
+
+@pytest.fixture(autouse=True)
+def feature_flag_on(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Bypass the top-of-handler feature-flag check so we exercise
+    the post-run_snapshot exit-code dispatcher."""
+    monkeypatch.setenv("NEXUS_S3_PERSISTENCE", "true")
+    monkeypatch.setenv("PERSISTENCE_S3_ENDPOINT", "https://r2.example.com")
+    monkeypatch.setenv("PERSISTENCE_S3_BUCKET", "snapshots")
+    monkeypatch.setenv("PERSISTENCE_S3_ACCESS_KEY_ID", "test-key")
+    monkeypatch.setenv("PERSISTENCE_S3_SECRET_ACCESS_KEY", "test-secret")
+    monkeypatch.setenv("PERSISTENCE_S3_REGION", "auto")
+    monkeypatch.setenv("PERSISTENCE_STACK_SLUG", "nexus-test")
+    monkeypatch.setenv("PERSISTENCE_TEMPLATE_VERSION", "v1.0.0")
+
+
+def test_s3_snapshot_rc0_when_snapshot_source_missing() -> None:
+    """The deads7-fork case: partial state exists but neither the
+    server nor the ssh_service_token are in it. ``run_snapshot``
+    returns ``S3SnapshotSkipped(reason='no_snapshot_source')`` and
+    the CLI must return 0 so the scheduled teardown stays green and
+    proceeds to ``tofu destroy``. Regression guard for the original
+    PR #600 dispatcher fall-through bug — the branch landed in
+    pipeline.py but not in __main__.py, so the rc was 2 instead of 0."""
+    with patch(
+        "nexus_deploy.__main__._pipeline.run_snapshot",
+        return_value=SnapshotResult(
+            outcome=_s3_restore.S3SnapshotSkipped(reason="no_snapshot_source"),
+        ),
+    ):
+        rc = _s3_snapshot([])
+    assert rc == 0
+
+
+def test_s3_snapshot_rc0_when_no_state_to_snapshot() -> None:
+    """Issue #564 case: state file is entirely empty (setup ran but
+    spin-up never executed any tofu apply). Same rc=0 contract."""
+    with patch(
+        "nexus_deploy.__main__._pipeline.run_snapshot",
+        return_value=SnapshotResult(
+            outcome=_s3_restore.S3SnapshotSkipped(reason="no_state_to_snapshot"),
+        ),
+    ):
+        rc = _s3_snapshot([])
+    assert rc == 0
+
+
+def test_s3_snapshot_rc2_when_endpoint_env_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the feature flag is on but credentials/endpoint env vars
+    are missing, the dispatcher returns rc=2 so the teardown aborts.
+    Verifies the only-known-good-reasons-are-rc=0 contract: any new
+    skip reason added in the future must be EXPLICITLY enumerated in
+    the dispatcher (don't accidentally bucket it as rc=0 either)."""
+    # Drop one env var so the handler's own check fires before
+    # run_snapshot would.
+    monkeypatch.delenv("PERSISTENCE_S3_ENDPOINT", raising=False)
+    rc = _s3_snapshot([])
+    assert rc == 2
+
+
+def test_s3_snapshot_rc0_when_snapshot_applied() -> None:
+    """Happy path: snapshot succeeded → rc=0, teardown proceeds."""
+    with patch(
+        "nexus_deploy.__main__._pipeline.run_snapshot",
+        return_value=SnapshotResult(
+            outcome=_s3_restore.S3SnapshotApplied(
+                timestamp="2026-05-18T05-00-00Z",
+            ),
+        ),
+    ):
+        rc = _s3_snapshot([])
+    assert rc == 0

--- a/tests/unit/test_s3_snapshot_cli.py
+++ b/tests/unit/test_s3_snapshot_cli.py
@@ -22,14 +22,20 @@ from nexus_deploy.pipeline import SnapshotResult
 
 @pytest.fixture(autouse=True)
 def feature_flag_on(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Bypass the top-of-handler feature-flag check so we exercise
-    the post-run_snapshot exit-code dispatcher."""
+    """Bypass the top-of-handler feature-flag + stack-slug checks
+    so each test exercises the post-run_snapshot exit-code dispatcher.
+
+    Env-var names match what the snapshot code ACTUALLY reads (see
+    s3_restore._ENV_*): three ``PERSISTENCE_S3_*`` for the persistence
+    bucket coords, plus the project-wide ``R2_ACCESS_KEY_ID`` /
+    ``R2_SECRET_ACCESS_KEY``. PERSISTENCE_STACK_SLUG + PERSISTENCE_TEMPLATE_VERSION
+    are required by the dispatcher itself before it calls run_snapshot."""
     monkeypatch.setenv("NEXUS_S3_PERSISTENCE", "true")
     monkeypatch.setenv("PERSISTENCE_S3_ENDPOINT", "https://r2.example.com")
     monkeypatch.setenv("PERSISTENCE_S3_BUCKET", "snapshots")
-    monkeypatch.setenv("PERSISTENCE_S3_ACCESS_KEY_ID", "test-key")
-    monkeypatch.setenv("PERSISTENCE_S3_SECRET_ACCESS_KEY", "test-secret")
     monkeypatch.setenv("PERSISTENCE_S3_REGION", "auto")
+    monkeypatch.setenv("R2_ACCESS_KEY_ID", "test-key")
+    monkeypatch.setenv("R2_SECRET_ACCESS_KEY", "test-secret")
     monkeypatch.setenv("PERSISTENCE_STACK_SLUG", "nexus-test")
     monkeypatch.setenv("PERSISTENCE_TEMPLATE_VERSION", "v1.0.0")
 
@@ -65,17 +71,41 @@ def test_s3_snapshot_rc0_when_no_state_to_snapshot() -> None:
     assert rc == 0
 
 
-def test_s3_snapshot_rc2_when_endpoint_env_missing(
+def test_s3_snapshot_rc2_when_run_snapshot_reports_no_endpoint_env() -> None:
+    """no_endpoint_env is a run_snapshot-reported skip reason (the
+    feature flag is on but the S3 endpoint/bucket/creds env vars are
+    missing) — the dispatcher must map it to rc=2 because proceeding
+    to tofu destroy without a verified snapshot risks data loss.
+
+    Exercises the dispatcher branch directly via a patched
+    run_snapshot return value. The previous version of this test
+    deleted PERSISTENCE_S3_ENDPOINT and called _s3_snapshot([]) — but
+    the dispatcher doesn't read that env var itself; the check lives
+    inside snapshot_to_s3 (which run_snapshot calls). With
+    run_snapshot unpatched the test was effectively testing whatever
+    happened to fail first in the real preflight (local tofu state,
+    R2 access), not the no_endpoint_env mapping. Patch it explicitly
+    so the assertion lines up with the contract."""
+    with patch(
+        "nexus_deploy.__main__._pipeline.run_snapshot",
+        return_value=SnapshotResult(
+            outcome=_s3_restore.S3SnapshotSkipped(reason="no_endpoint_env"),
+        ),
+    ):
+        rc = _s3_snapshot([])
+    assert rc == 2
+
+
+def test_s3_snapshot_rc2_when_stack_slug_env_missing(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """When the feature flag is on but credentials/endpoint env vars
-    are missing, the dispatcher returns rc=2 so the teardown aborts.
-    Verifies the only-known-good-reasons-are-rc=0 contract: any new
-    skip reason added in the future must be EXPLICITLY enumerated in
-    the dispatcher (don't accidentally bucket it as rc=0 either)."""
-    # Drop one env var so the handler's own check fires before
-    # run_snapshot would.
-    monkeypatch.delenv("PERSISTENCE_S3_ENDPOINT", raising=False)
+    """The dispatcher's OWN env check (PERSISTENCE_STACK_SLUG +
+    PERSISTENCE_TEMPLATE_VERSION) must fire before run_snapshot is
+    invoked — these are required to construct the snapshot path.
+    Missing → rc=2 + stderr diagnostic listing the missing names."""
+    monkeypatch.delenv("PERSISTENCE_STACK_SLUG", raising=False)
+    # No patch on run_snapshot: this assertion must hold without
+    # the dispatcher ever reaching that call.
     rc = _s3_snapshot([])
     assert rc == 2
 

--- a/tests/unit/test_tofu.py
+++ b/tests/unit/test_tofu.py
@@ -374,16 +374,41 @@ def test_state_contains_true_when_address_present(
 def test_state_contains_false_when_address_absent(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """Address NOT in state list → False. Substring matches must not
-    count (e.g. 'hcloud' shouldn't match 'hcloud_server.main')."""
+    """Address NOT in state list → False."""
     monkeypatch.setattr(
         "nexus_deploy.tofu.subprocess.run",
-        lambda *_a, **_kw: _completed(stdout="cloudflare_tunnel.main\n"),
+        lambda *_a, **_kw: _completed(stdout="cloudflare_zero_trust_tunnel_cloudflared.main\n"),
     )
     runner = TofuRunner(tmp_path)
     assert runner.state_contains("hcloud_server.main") is False
-    # Substring "hcloud" alone must NOT match "hcloud_server.main"
+
+
+def test_state_contains_does_not_substring_match(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Substring matches must not count: querying for ``hcloud`` must
+    NOT match the line ``hcloud_server.main``, even when that line is
+    present in state. This is the regression guard against a future
+    impl that uses ``in stdout`` instead of exact-line matching —
+    that bug would silently swallow real "server in state" cases under
+    a query like 'hcloud' and re-introduce the data-loss vulnerability
+    state_contains was added to prevent."""
+    monkeypatch.setattr(
+        "nexus_deploy.tofu.subprocess.run",
+        lambda *_a, **_kw: _completed(
+            stdout="hcloud_server.main\ncloudflare_record.ssh\n",
+        ),
+    )
+    runner = TofuRunner(tmp_path)
+    # Bare 'hcloud' is a substring of 'hcloud_server.main' but NOT a
+    # full-line match — must return False.
     assert runner.state_contains("hcloud") is False
+    # Sanity: the actual exact line still matches.
+    assert runner.state_contains("hcloud_server.main") is True
+    # Partial-line prefix that's a real Tofu address fragment also
+    # must NOT match (the line in state is "cloudflare_record.ssh",
+    # not "cloudflare_record").
+    assert runner.state_contains("cloudflare_record") is False
 
 
 def test_state_contains_raises_tofuerror_on_command_failure(

--- a/tests/unit/test_tofu.py
+++ b/tests/unit/test_tofu.py
@@ -355,6 +355,77 @@ def test_state_list_ok_false_on_timeout(monkeypatch: pytest.MonkeyPatch, tmp_pat
     assert TofuRunner(tmp_path).state_list_ok() is False
 
 
+# ---- TofuRunner.state_contains (PR #600 partial-state safety check) ----
+
+
+def test_state_contains_true_when_address_present(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Address matches a line in `tofu state list` output → True."""
+    monkeypatch.setattr(
+        "nexus_deploy.tofu.subprocess.run",
+        lambda *_a, **_kw: _completed(
+            stdout="hcloud_server.main\ncloudflare_tunnel.main\ncloudflare_record.foo\n",
+        ),
+    )
+    assert TofuRunner(tmp_path).state_contains("hcloud_server.main") is True
+
+
+def test_state_contains_false_when_address_absent(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Address NOT in state list → False. Substring matches must not
+    count (e.g. 'hcloud' shouldn't match 'hcloud_server.main')."""
+    monkeypatch.setattr(
+        "nexus_deploy.tofu.subprocess.run",
+        lambda *_a, **_kw: _completed(stdout="cloudflare_tunnel.main\n"),
+    )
+    runner = TofuRunner(tmp_path)
+    assert runner.state_contains("hcloud_server.main") is False
+    # Substring "hcloud" alone must NOT match "hcloud_server.main"
+    assert runner.state_contains("hcloud") is False
+
+
+def test_state_contains_raises_tofuerror_on_command_failure(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The safe default for an unreachable backend is NOT silently
+    returning False (would hide a resource about to be destroyed) —
+    raise TofuError so the caller can decide."""
+    monkeypatch.setattr(
+        "nexus_deploy.tofu.subprocess.run",
+        MagicMock(
+            side_effect=subprocess.CalledProcessError(
+                1, ["tofu", "state", "list"], output="", stderr="backend timeout"
+            )
+        ),
+    )
+    with pytest.raises(TofuError, match="cannot determine"):
+        TofuRunner(tmp_path).state_contains("hcloud_server.main")
+
+
+def test_state_contains_raises_tofuerror_on_missing_binary(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(
+        "nexus_deploy.tofu.subprocess.run",
+        MagicMock(side_effect=FileNotFoundError("tofu")),
+    )
+    with pytest.raises(TofuError, match="cannot determine"):
+        TofuRunner(tmp_path).state_contains("hcloud_server.main")
+
+
+def test_state_contains_raises_tofuerror_on_timeout(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(
+        "nexus_deploy.tofu.subprocess.run",
+        MagicMock(side_effect=subprocess.TimeoutExpired(["tofu"], 60.0)),
+    )
+    with pytest.raises(TofuError, match="timed out"):
+        TofuRunner(tmp_path).state_contains("hcloud_server.main")
+
+
 # ---- TofuRunner.diagnose_state (PR #535 R2 #2) ----
 
 


### PR DESCRIPTION
## Problem

A scheduled daily teardown on a deads7 fork (`nexus-gabriel-vondercrone`) went red every night for **five consecutive days**:

\`\`\`
13.05 21:00  Teardown  ❌
14.05 21:00  Teardown  ❌
15.05 21:00  Teardown  ❌
16.05 21:00  Teardown  ❌
17.05 21:00  Teardown  ❌
\`\`\`

Always at the same step:

\`\`\`
s3-snapshot: required tofu output missing or invalid:
tofu output -json ssh_service_token failed in .../tofu/stack
— state may be partially applied; nothing to snapshot
##[error]Process completed with exit code 2.
\`\`\`

The fork had Initial Setup on 2026-05-13 ✅ but **Spin Up was never triggered**. So:
- \`tofu/stack\` has SOME state (whatever the setup-control-plane or earlier aborted spin-up provisioned)
- → \`state_list_ok()\` returns True
- → existing #564 carve-out at step 2 doesn't fire
- → step 4 calls \`output_json(\"ssh_service_token\")\`
- → no such output in state (resource never applied)
- → \`TofuError\` → \`PipelineError\` → CLI rc=2 → workflow red

## Fix

Adds a parallel carve-out at step 4 (\`run_snapshot\` in \`pipeline.py\`):

- New \`S3SnapshotSkipped.reason = \"no_snapshot_source\"\` literal
- \`run_snapshot\` now calls \`output_json(\"ssh_service_token\", default=None)\` and returns \`Skipped(no_snapshot_source)\` on None instead of raising
- CLI handler's docstring updated; rc=0 path now covers this case

The subsequent \`tofu destroy\` still runs and reaps whatever partial resources ARE in state — so this isn't a silent skip, just a graceful no-op on the snapshot step alone.

## Why it's safe

Without \`ssh_service_token\` there is no Cloudflare Access service identity to authenticate against the Hetzner SSH tunnel — and there's no Hetzner server to authenticate TO either. There's literally nothing to snapshot.

This is NOT a silent absorption of generic \`output_json\` failures. The \`default=None\` only fires when the output is missing from state; a real tofu/binary/backend failure would still surface much earlier at \`state_list_ok()\` (step 2), which still raises PipelineError on anything other than the narrowly-matched \"No state file was found\" substring.

## Tests

- New \`test_run_snapshot_skips_when_ssh_service_token_missing\` mirrors the existing file-missing test pattern. Asserts the Skipped outcome + reason, AND that the SSH path was never entered (configure_ssh / wait_for_ssh / SSHClient all unused).
- 43/43 pipeline tests pass (\`uv run pytest tests/unit/test_pipeline.py\`).

## Test plan
- [x] Unit tests cover the partial-state-no-token case + the existing safety paths (real state failures still raise).
- [ ] After merge + release, re-run the failing scheduled teardown on gabriel-vondercrone's fork and verify it exits 0 with a stderr line citing \`no_snapshot_source\`.