### PR TITLE
chore: Genericize multi-tenant fork references in public code

### DIFF
--- a/control-plane/functions/api/send-credentials.js
+++ b/control-plane/functions/api/send-credentials.js
@@ -1,7 +1,7 @@
 /**
  * Send infrastructure credentials via email
  * POST /api/send-credentials
- * 
+ *
  * Reads credentials from CREDENTIALS_JSON secret and sends them via Resend.
  * Email matches the style of the "Stack Online" notification.
  */
@@ -23,7 +23,7 @@ export async function onRequestPost(context) {
   // Validate environment variables
   const requiredEnv = ['RESEND_API_KEY', 'ADMIN_EMAIL', 'DOMAIN'];
   const missing = requiredEnv.filter(key => !env[key]);
-  
+
   if (missing.length > 0) {
     return new Response(JSON.stringify({
       success: false,
@@ -42,7 +42,7 @@ export async function onRequestPost(context) {
   try {
     // Get credentials from secret (already JSON string)
     const credentialsJson = env.CREDENTIALS_JSON;
-    
+
     if (!credentialsJson) {
       return new Response(JSON.stringify({
         success: false,
@@ -53,8 +53,8 @@ export async function onRequestPost(context) {
     const credentials = JSON.parse(credentialsJson);
     const domain = env.DOMAIN;
     // Resend requires the sender domain to be verified. On multi-tenant
-    // deployments (e.g. Nexus-Stack-for-Education) DOMAIN is a per-user
-    // subdomain that isn't registered with Resend, but BASE_DOMAIN is the
+    // deployments (e.g. an education / classroom admin panel) DOMAIN is a
+    // per-user subdomain that isn't registered with Resend, but BASE_DOMAIN is the
     // shared parent that IS verified. Fall back to DOMAIN for single-stack
     // installs where BASE_DOMAIN isn't set.
     const fromDomain = env.BASE_DOMAIN || domain;
@@ -87,9 +87,9 @@ export async function onRequestPost(context) {
     const emailHTML = `
 <div style="font-family:monospace;background:#0a0a0f;color:#00ff88;padding:20px;max-width:600px">
   <h1 style="color:#00ff88;margin-top:0">🔐 Nexus-Stack Credentials</h1>
-  
+
   <p style="color:#ccc">Your Nexus-Stack is ready at <strong style="color:#fff">${domain}</strong></p>
-  
+
   <h2 style="color:#00ff88;font-size:16px;margin-top:24px">🔑 Infisical (Secret Manager)</h2>
   <div style="background:#1a1a2e;padding:12px;margin:8px 0;border-radius:4px;border-left:3px solid #00ff88">
     <div style="color:#ccc;font-size:14px">
@@ -98,7 +98,7 @@ export async function onRequestPost(context) {
       <div>Password: <span style="color:#fff;font-family:monospace">${credentials.infisical_admin_password}</span></div>
     </div>
   </div>
-  
+
   <div style="background:#1a2e1a;padding:12px;margin:20px 0;border-radius:4px;border-left:3px solid #00ff88">
     <div style="color:#00ff88;font-weight:bold">📦 Other Service Credentials</div>
     <div style="color:#ccc;font-size:14px;margin-top:8px">
@@ -106,7 +106,7 @@ export async function onRequestPost(context) {
       Log in to Infisical to view them.
     </div>
   </div>
-  
+
   <div style="background:#2d1f1f;padding:12px;margin:20px 0;border-radius:4px;border-left:3px solid #ff6b6b">
     <div style="color:#ff6b6b;font-weight:bold">⚠️ Security Notice</div>
     <div style="color:#ccc;font-size:14px;margin-top:8px">
@@ -117,12 +117,12 @@ export async function onRequestPost(context) {
       </ul>
     </div>
   </div>
-  
+
   <h2 style="color:#00ff88;font-size:16px;margin-top:24px">🔗 Quick Links</h2>
   <ul style="color:#ccc;padding-left:20px">
     <li><a href="${controlPlaneUrl}" style="color:#00ff88">Control Panel</a> - Manage services &amp; view URLs</li>
   </ul>
-  
+
   <p style="color:#666;font-size:12px;margin-top:24px;border-top:1px solid #333;padding-top:16px">
     Sent from Nexus-Stack • <a href="https://github.com/stefanko-ch/Nexus-Stack" style="color:#00ff88">GitHub</a>
   </p>
@@ -180,9 +180,9 @@ export async function onRequestPost(context) {
     return new Response(JSON.stringify({
       success: false,
       error: `Failed to send email: ${error.message}`
-    }), { 
-      status: 500, 
-      headers: { 'Content-Type': 'application/json' } 
+    }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' }
     });
   }
 }

--- a/control-plane/functions/api/send-credentials.js
+++ b/control-plane/functions/api/send-credentials.js
@@ -53,7 +53,7 @@ export async function onRequestPost(context) {
     const credentials = JSON.parse(credentialsJson);
     const domain = env.DOMAIN;
     // Resend requires the sender domain to be verified. On multi-tenant
-    // deployments (e.g. an education / classroom admin panel) DOMAIN is a
+    // deployments (e.g. an education / classroom admin panel), DOMAIN is a
     // per-user subdomain that isn't registered with Resend, but BASE_DOMAIN is the
     // shared parent that IS verified. Fall back to DOMAIN for single-stack
     // installs where BASE_DOMAIN isn't set.

--- a/control-plane/worker/src/index.js
+++ b/control-plane/worker/src/index.js
@@ -514,7 +514,7 @@ async function sendNotification(env, config) {
     `;
 
     // Resend requires the sender domain to be verified. On multi-tenant
-    // deployments (e.g. an education / classroom admin panel) DOMAIN is a
+    // deployments (e.g. an education / classroom admin panel), DOMAIN is a
     // per-user subdomain that isn't registered with Resend, but BASE_DOMAIN is the
     // shared parent that IS verified. Fall back to DOMAIN for single-stack
     // installs where BASE_DOMAIN isn't set.

--- a/control-plane/worker/src/index.js
+++ b/control-plane/worker/src/index.js
@@ -1,10 +1,10 @@
 /**
  * Scheduled Teardown Worker
- * 
+ *
  * Runs daily to check if scheduled teardown is enabled and triggers:
  * 1. Email notification (15 minutes before teardown)
  * 2. Teardown workflow (at configured time)
- * 
+ *
  * Configuration stored in Cloudflare D1 database (NEXUS_DB)
  * - teardown_enabled: "true" | "false"
  * - teardown_timezone: "Europe/Zurich" (default)
@@ -195,16 +195,16 @@ function constantTimeEqual(a, b) {
 // Clean up logs older than 30 days
 async function cleanupOldLogs(env) {
   if (!env.NEXUS_DB) return;
-  
+
   try {
     const cutoff = new Date();
     cutoff.setDate(cutoff.getDate() - 30);
     const cutoffStr = cutoff.toISOString().replace('T', ' ').substring(0, 19);
-    
+
     const result = await env.NEXUS_DB.prepare(
       'DELETE FROM logs WHERE created_at < ?'
     ).bind(cutoffStr).run();
-    
+
     const deletedCount = result.meta?.changes || 0;
     if (deletedCount > 0) {
       console.log(`Cleaned up ${deletedCount} old log entries`);
@@ -239,7 +239,7 @@ async function handleScheduledTeardown(event, env) {
 
     // Get configuration from D1
     const config = await getConfig(env.NEXUS_DB);
-    
+
     if (config.enabled !== 'true') {
       await logToD1(env.NEXUS_DB, 'debug', 'Scheduled teardown is disabled');
       console.log('Scheduled teardown is disabled');
@@ -440,7 +440,7 @@ async function getConfig(db) {
   const teardownTime = await getConfigValue(db, 'teardown_time', '22:00');
   const notificationTime = await getConfigValue(db, 'notification_time', '21:45');
   const delayUntil = await getConfigValue(db, 'delay_until', null);
-  
+
   return { enabled, timezone, teardownTime, notificationTime, delayUntil };
 }
 
@@ -514,8 +514,8 @@ async function sendNotification(env, config) {
     `;
 
     // Resend requires the sender domain to be verified. On multi-tenant
-    // deployments (e.g. Nexus-Stack-for-Education) DOMAIN is a per-user
-    // subdomain that isn't registered with Resend, but BASE_DOMAIN is the
+    // deployments (e.g. an education / classroom admin panel) DOMAIN is a
+    // per-user subdomain that isn't registered with Resend, but BASE_DOMAIN is the
     // shared parent that IS verified. Fall back to DOMAIN for single-stack
     // installs where BASE_DOMAIN isn't set.
     const fromDomain = env.BASE_DOMAIN || env.DOMAIN;
@@ -634,13 +634,13 @@ async function triggerTeardown(env, config) {
  */
 function timeInTimezoneToUTC(timeStr, timezone, baseDate = new Date()) {
   const [hours, minutes] = timeStr.split(':').map(Number);
-  
+
   // Get the date string in the target timezone
   const dateStr = baseDate.toLocaleDateString('en-CA', { timeZone: timezone }); // YYYY-MM-DD
-  
+
   // Create a date assuming the time is in UTC
   const utcDate = new Date(`${dateStr}T${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}:00Z`);
-  
+
   // Now format this UTC date in the target timezone to see what time it represents there
   const tzFormatter = new Intl.DateTimeFormat('en', {
     timeZone: timezone,
@@ -648,18 +648,18 @@ function timeInTimezoneToUTC(timeStr, timezone, baseDate = new Date()) {
     minute: '2-digit',
     hour12: false,
   });
-  
+
   const tzTimeStr = tzFormatter.format(utcDate);
   const [tzHours, tzMinutes] = tzTimeStr.split(':').map(Number);
-  
+
   // Calculate the difference between desired time and actual time in timezone
   const desiredMinutes = hours * 60 + minutes;
   const actualMinutes = tzHours * 60 + tzMinutes;
   const diffMinutes = desiredMinutes - actualMinutes;
-  
+
   // Adjust UTC date by the difference
   const adjustedDate = new Date(utcDate.getTime() + diffMinutes * 60 * 1000);
-  
+
   return adjustedDate;
 }
 

--- a/src/nexus_deploy/config.py
+++ b/src/nexus_deploy/config.py
@@ -327,9 +327,10 @@ def service_host(prefix: str, domain: str, separator: str = ".") -> str:
     """Compose a service hostname under the configured subdomain separator.
 
     Standard single-tenant installs use ``separator='.'`` and produce
-    the dot form ``<prefix>.<domain>``. Multi-tenant forks (e.g.
-    Nexus-Stack-for-Education) provision tenants under a shared base
-    domain via flat subdomains: setting ``separator='-'`` on a tenant
+    the dot form ``<prefix>.<domain>``. Multi-tenant forks (e.g. an
+    education / classroom admin panel built on top of Nexus-Stack)
+    provision tenants under a shared base domain via flat subdomains:
+    setting ``separator='-'`` on a tenant
     whose ``DOMAIN`` is ``user1.example.com`` produces
     ``<prefix>-user1.example.com`` — which matches the DNS records
     Tofu provisions for that tenant.

--- a/src/nexus_deploy/tfvars.py
+++ b/src/nexus_deploy/tfvars.py
@@ -170,9 +170,9 @@ def derive_gitea_identity(config: TfvarsConfig) -> GiteaIdentity:
     Reasons (in priority order) for falling back:
     1. ``admin_email`` is empty after trim — self-provisioned tfvars
        commonly omit it.
-    2. ``admin_email`` equals ``gitea_user_email`` after trim — the
-       admin-panel caller (Nexus-Stack-for-Education) passes both
-       values from the same source field today.
+    2. ``admin_email`` equals ``gitea_user_email`` after trim — a
+       multi-tenant admin-panel caller (e.g. a classroom-provisioning
+       fork) passes both values from the same source field today.
 
     Without the fallback, Gitea's ``CREATE`` for the user row would
     fail with "e-mail already in use" because both Admin + User

--- a/tests/unit/test_service_env.py
+++ b/tests/unit/test_service_env.py
@@ -1156,7 +1156,7 @@ def test_cli_service_env_happy_path(
 # ---------------------------------------------------------------------------
 # SUBDOMAIN_SEPARATOR — Issue #540
 #
-# Multi-tenant forks (Nexus-Stack-for-Education etc.) provision
+# Multi-tenant forks (e.g. an education / classroom admin panel) provision
 # tenants under a shared base domain via flat subdomains. With
 # ``subdomain_separator='-'`` and ``DOMAIN='user1.example.com'``,
 # the rendered service URLs must compose to ``kestra-user1.example.com``


### PR DESCRIPTION
## Summary

The `Nexus-Stack-for-Education` fork is now private. The public repo has 5 places that mention it by repo-slug in code comments / docstrings — that creates "what is this?" friction for any public reader (they can't visit the link, and it dates the description). Replaced with generic, self-explanatory descriptions that preserve the design context.

## Changed

5 parenthetical mentions, ~1-2 lines each:

| File | Before | After |
|---|---|---|
| `tests/unit/test_service_env.py` | `Multi-tenant forks (Nexus-Stack-for-Education etc.) provision` | `Multi-tenant forks (e.g. an education / classroom admin panel) provision` |
| `src/nexus_deploy/config.py` | `Multi-tenant forks (e.g. Nexus-Stack-for-Education) provision tenants` | `Multi-tenant forks (e.g. an education / classroom admin panel built on top of Nexus-Stack) provision tenants` |
| `src/nexus_deploy/tfvars.py` | `the admin-panel caller (Nexus-Stack-for-Education) passes both` | `a multi-tenant admin-panel caller (e.g. a classroom-provisioning fork) passes both` |
| `control-plane/functions/api/send-credentials.js` | `multi-tenant deployments (e.g. Nexus-Stack-for-Education) DOMAIN is a per-user` | `multi-tenant deployments (e.g. an education / classroom admin panel) DOMAIN is a per-user` |
| `control-plane/worker/src/index.js` | same as above (mirrored comment) | same as above (mirrored fix) |

## NOT changed

`docs/proposals/0001-s3-persistence.md:337` keeps its explicit `### Education (\`stefanko-ch/Nexus-Stack-for-Education\`)` section header. That's an RFC migration plan — a historical document describing a coordinated change across two repos. Operators reading the RFC understand the cross-repo context; keeping the slug there preserves the document's accuracy. It's not user-facing in the way code comments are.

## Test plan

- [x] Searched for any remaining mentions: `grep -rn 'Nexus-Stack-for-Education' --include='*.py' --include='*.js' --include='*.ts' --include='*.astro' --include='*.tf' --include='*.yml' --include='*.yaml' --include='*.md' .` returns only the RFC line, as intended.
- [x] Pre-commit hook chain (ruff format, ruff, mypy strict, trailing-whitespace, etc.) — all green.
- [x] No behavioral changes — only comment/docstring text edits.
