### PR TITLE
fix(control-plane): Fix workflow history styling in settings page

### DIFF
--- a/control-plane/src/pages/settings.astro
+++ b/control-plane/src/pages/settings.astro
@@ -92,10 +92,11 @@ import Layout from '../layouts/Layout.astro';
 
   .silent-banner.visible { display: block; }
 
-  .history-item {
-    display: flex;
-    justify-content: space-between;
+  :global(.history-item) {
+    display: grid;
+    grid-template-columns: 5.5rem 4.5rem 1fr auto;
     align-items: center;
+    gap: 0 1rem;
     padding: 0.6rem 0.8rem;
     background: rgba(0, 0, 0, 0.3);
     border: 1px solid rgba(0, 255, 136, 0.1);
@@ -103,13 +104,14 @@ import Layout from '../layouts/Layout.astro';
     font-size: 0.8rem;
   }
 
-  .history-item .name { color: var(--text-secondary); }
-  .history-item .status { font-weight: 700; }
-  .history-item .status.success { color: var(--accent); }
-  .history-item .status.failure { color: var(--error); }
-  .history-item .status.in_progress { color: var(--warning); }
-  .history-item a { color: var(--info); text-decoration: none; font-size: 0.75rem; }
-  .history-item a:hover { text-decoration: underline; }
+  :global(.history-item .name) { color: var(--text-secondary); }
+  :global(.history-item .status) { font-weight: 700; }
+  :global(.history-item .status.success) { color: var(--accent); }
+  :global(.history-item .status.failure) { color: var(--error); }
+  :global(.history-item .status.in_progress) { color: var(--warning); }
+  :global(.history-item .time) { color: var(--text-muted); font-size: 0.7rem; }
+  :global(.history-item a) { color: var(--text-muted); text-decoration: none; font-size: 0.75rem; justify-self: end; }
+  :global(.history-item a:hover) { color: var(--accent); }
 </style>
 
 <script is:inline>
@@ -349,7 +351,7 @@ import Layout from '../layouts/Layout.astro';
         div.innerHTML =
           '<span class="name">' + item.name + '</span>' +
           '<span class="status ' + statusClass + '">' + (status || 'unknown') + '</span>' +
-          '<span style="color: #607080; font-size: 0.7rem;">' + time + '</span>' +
+          '<span class="time">' + time + '</span>' +
           link;
         historyList.appendChild(div);
       });


### PR DESCRIPTION
## Description
Fix workflow history items in the Settings page rendering as unstyled inline text with browser-default blue/purple link colors and misaligned columns between rows.

## Motivation and Context
Astro scopes component styles by injecting `[data-astro-cid-*]` attribute selectors, which only match statically rendered elements — not elements created by JS at runtime. The `.history-item` CSS rules were silently not applying, causing layout and styling to fall back to browser defaults.

## How Has This Been Tested?
Deployed to a live Cloudflare Pages instance via `setup-control-plane.yaml` on the feature branch and verified the Settings page with real workflow history data.

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

---

## Summary

The Recent Workflows section in Settings rendered history items as unstyled inline text (`Spin Upsuccess10.5.2026, 19:22:01View`) with browser-default blue/purple link colors.

**Root cause:** Astro scopes component styles by injecting `[data-astro-cid-*]` attribute selectors, which only match statically rendered elements — not elements created by JS at runtime. The `.history-item` CSS rules were silently not applying, so the flex layout, link color, and timestamp style all fell back to browser defaults.

**Changes:**

- Wrapped all `.history-item` rules in `:global()` so they match the JS-generated DOM (same pattern as `.stack-row-url` in `StackTable.astro`)
- Switched layout from `display: flex` + `justify-content: space-between` to `display: grid` with fixed column widths (`5.5rem 4.5rem 1fr auto`), so name/status/time/link columns align across all rows
- Link color changed from `var(--info)` (bright blue) to `var(--text-muted)` with `var(--accent)` on hover — consistent with `.stack-row-url` in the stacks list view
- Timestamp inline style replaced with a `class="time"` handled by the global rule
