### PR TITLE
feat(control-plane): Add back button to category page

### DIFF
--- a/control-plane/src/pages/category.astro
+++ b/control-plane/src/pages/category.astro
@@ -4,7 +4,7 @@ import Layout from '../layouts/Layout.astro';
 
 <Layout title="Category" activeNav="stacks">
   <div class="category-header">
-    <button class="btn-back" onclick="history.back()">&#8592; Back to Stacks</button>
+    <button type="button" class="btn-back" onclick="document.referrer && document.referrer.startsWith(location.origin) ? history.back() : (location.href='/stacks')">&#8592; Back to Stacks</button>
     <h2 id="page-title">Loading...</h2>
     <div id="category-description" class="category-description"></div>
     <div id="category-stats" class="category-stats"></div>
@@ -27,7 +27,7 @@ import Layout from '../layouts/Layout.astro';
     margin-bottom: 1rem;
     padding: 0.4rem 0.9rem;
     background: rgba(0, 170, 255, 0.1);
-    color: rgba(0, 170, 255, 0.9);
+    color: var(--info);
     border: 1px solid rgba(0, 170, 255, 0.3);
     border-radius: 6px;
     font-size: 0.85rem;

--- a/control-plane/src/pages/category.astro
+++ b/control-plane/src/pages/category.astro
@@ -4,6 +4,7 @@ import Layout from '../layouts/Layout.astro';
 
 <Layout title="Category" activeNav="stacks">
   <div class="category-header">
+    <button class="btn-back" onclick="history.back()">&#8592; Back to Stacks</button>
     <h2 id="page-title">Loading...</h2>
     <div id="category-description" class="category-description"></div>
     <div id="category-stats" class="category-stats"></div>
@@ -17,6 +18,26 @@ import Layout from '../layouts/Layout.astro';
 <style>
   .category-header {
     margin-bottom: 2rem;
+  }
+
+  .btn-back {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    margin-bottom: 1rem;
+    padding: 0.4rem 0.9rem;
+    background: rgba(0, 170, 255, 0.1);
+    color: rgba(0, 170, 255, 0.9);
+    border: 1px solid rgba(0, 170, 255, 0.3);
+    border-radius: 6px;
+    font-size: 0.85rem;
+    cursor: pointer;
+    transition: background 0.2s, border-color 0.2s;
+  }
+
+  .btn-back:hover {
+    background: rgba(0, 170, 255, 0.2);
+    border-color: rgba(0, 170, 255, 0.5);
   }
 
   .category-description {


### PR DESCRIPTION
## Description

Adds a "← Back to Stacks" button above the page title on the category page. Clicking it calls `history.back()`, which is instant and correctly restores the previous grid or list view — including scroll position in list mode.

## Motivation and Context

The category page had no way to navigate back to the stacks view other than clicking the nav menu (which causes a full reload) or using the browser back button. The browser back button already worked perfectly, so the button simply exposes that behaviour in the UI.

Styled in blue (`rgba(0, 170, 255, ...)`) to match the existing pattern used on `.badge-internal` and `.badge-category` on the same page, and consistent with the firewall page's "Apply & Spin Up" button.

## How Has This Been Tested?

- Navigated from grid view → category → back: returns to grid instantly
- Navigated from list view → category → back: returns to list at the same scroll position
- Verified button style matches existing blue accent on the page

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
