### PR TITLE
fix(ci): Wire ALLOW_DISABLE_AUTO_SHUTDOWN through Control Plane deployment

### DIFF
--- a/.github/workflows/setup-control-plane.yaml
+++ b/.github/workflows/setup-control-plane.yaml
@@ -172,6 +172,7 @@ jobs:
           user_email          = "${{ secrets.TF_VAR_user_email }}"
           github_owner        = "${{ github.repository_owner }}"
           github_repo         = "${{ github.event.repository.name }}"
+          allow_disable_auto_shutdown = ${{ vars.ALLOW_DISABLE_AUTO_SHUTDOWN == 'true' }}
           EOF
           sed -i 's/^          //' tofu/control-plane/config.tfvars
 
@@ -1146,6 +1147,12 @@ jobs:
           if ! echo "${{ vars.SERVER_LOCATION || 'hel1' }}" | npx wrangler@4 pages secret put SERVER_LOCATION \
             --project-name="$PROJECT_NAME" 2>&1; then
             echo "⚠️  Failed to set SERVER_LOCATION"
+          fi
+
+          echo "  Setting ALLOW_DISABLE_AUTO_SHUTDOWN secret..."
+          if ! echo "${{ vars.ALLOW_DISABLE_AUTO_SHUTDOWN == 'true' }}" | npx wrangler@4 pages secret put ALLOW_DISABLE_AUTO_SHUTDOWN \
+            --project-name="$PROJECT_NAME" 2>&1; then
+            echo "⚠️  Failed to set ALLOW_DISABLE_AUTO_SHUTDOWN"
           fi
 
           if [ -n "$RESEND_API_KEY" ]; then

--- a/docs/admin-guides/setup-guide.md
+++ b/docs/admin-guides/setup-guide.md
@@ -294,7 +294,7 @@ See the **[SSH Access Guide](ssh-access.md)**.
 
 By default, users cannot disable the automatic daily teardown feature via the Control Plane. This ensures cost control for shared environments (e.g., student labs).
 
-**To change this behavior**, edit `tofu/control-plane/variables.tf` or set via environment variable:
+**To change this behavior**, edit `tofu/control-plane/variables.tf` or set the GitHub Actions repository variable `ALLOW_DISABLE_AUTO_SHUTDOWN=true`:
 
 ```hcl
 # Allow users to disable auto-shutdown


### PR DESCRIPTION
## Description

`ALLOW_DISABLE_AUTO_SHUTDOWN` was introduced in 9014c1b but never wired into the deployment workflow, so the auto-shutdown toggle was always locked regardless of any variable configured.

Two fixes in `setup-control-plane.yaml`:
1. Added `allow_disable_auto_shutdown` to the `config.tfvars` generation step so Tofu picks up the GitHub Actions repository variable `ALLOW_DISABLE_AUTO_SHUTDOWN`
2. Added a `wrangler pages secret put` step alongside `SERVER_TYPE`/`SERVER_LOCATION` — `wrangler pages deploy` wipes Tofu-managed env vars from the production Pages environment, so Tofu alone is not sufficient

Also updated `docs/admin-guides/setup-guide.md` to replace the vague "set via environment variable" with the correct GitHub Actions variable name.

## Motivation and Context

The toggle in the Control Plane UI was permanently greyed out. Setting a GitHub Actions variable had no effect because the workflow never forwarded it to Tofu or to the Pages production environment.

## How Has This Been Tested?

- Set `ALLOW_DISABLE_AUTO_SHUTDOWN=true` as a GitHub Actions repository variable
- Ran `setup-control-plane.yaml` on the feature branch
- Confirmed the variable appeared in the production Pages environment (not just preview)
- Confirmed the toggle is unlocked in the Control Plane UI

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
