### PR TITLE
feat(stacks): Add Lakekeeper — Iceberg REST Catalog (Rust)

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ After deployment you'll have:
 
 ![Quick Start Flow](docs/assets/architecture-quickstart.svg)
 
-## Available Stacks (71)
+## Available Stacks (72)
 
 [![AKHQ](https://img.shields.io/badge/AKHQ-000000?logo=apachekafka&logoColor=white)](https://akhq.io)
 [![Adminer](https://img.shields.io/badge/Adminer-34567C?logo=adminer&logoColor=white)](https://www.adminer.org)
@@ -103,6 +103,7 @@ After deployment you'll have:
 [![Kafka-UI](https://img.shields.io/badge/Kafka--UI-000000?logo=apachekafka&logoColor=white)](https://docs.kafka-ui.provectus.io/)
 [![Kestra](https://img.shields.io/badge/Kestra-6047EC?logo=kestra&logoColor=white)](https://kestra.io)
 [![LakeFS](https://img.shields.io/badge/LakeFS-00B4D8?logo=git&logoColor=white)](https://lakefs.io)
+[![Lakekeeper](https://img.shields.io/badge/Lakekeeper-B7410E?logo=rust&logoColor=white)](https://lakekeeper.io)
 [![LiteLLM](https://img.shields.io/badge/LiteLLM-00BFFF?logo=openai&logoColor=white)](https://www.litellm.ai)
 [![Mage](https://img.shields.io/badge/Mage-6B4FBB?logo=mage&logoColor=white)](https://mage.ai)
 [![Mailpit](https://img.shields.io/badge/Mailpit-F36F21?logo=maildotru&logoColor=white)](https://mailpit.axllent.org)
@@ -177,6 +178,7 @@ After deployment you'll have:
 | **Kafka-UI** | Modern web UI for Apache Kafka / Redpanda management | [kafka-ui.provectus.io](https://docs.kafka-ui.provectus.io/) |
 | **Kestra** | Modern workflow orchestration for data pipelines & automation | [kestra.io](https://kestra.io) |
 | **LakeFS** | Git-like version control for data lakes (Hetzner Object Storage backend) | [lakefs.io](https://lakefs.io) |
+| **Lakekeeper** | Modern Iceberg REST Catalog (Rust) — Spark / Trino / DuckDB / PyIceberg share Iceberg tables on the existing object storage | [lakekeeper.io](https://lakekeeper.io) |
 | **LiteLLM** | Unified OpenAI-compatible proxy for 100+ LLM providers (Ollama, OpenAI, Anthropic, Mistral, ...) — single SDK, per-key budgets, cost tracking | [litellm.ai](https://www.litellm.ai) |
 | **Mage** | Modern data pipeline tool for ETL/ELT workflows | [mage.ai](https://mage.ai) |
 | **Mailpit** | Email & SMTP testing tool - catch and inspect emails | [mailpit.axllent.org](https://mailpit.axllent.org) |

--- a/docs/stacks/README.md
+++ b/docs/stacks/README.md
@@ -68,6 +68,8 @@ Images are pinned to **major versions** where supported for automatic security p
 | Meilisearch | `getmeili/meilisearch` | `v1.43.1` | Exact ¹ |
 | HedgeDoc | `quay.io/hedgedoc/hedgedoc` | `1.10.3` | Exact ¹ |
 | PostgreSQL (HedgeDoc DB) | `postgres` | `16-alpine` | Major |
+| Lakekeeper | `quay.io/lakekeeper/catalog` | `v0.12.2` | Exact ¹ |
+| PostgreSQL (Lakekeeper DB) | `postgres` | `16-alpine` | Major |
 | LiteLLM Proxy | `litellm/litellm-database` | `v1.85.1` | Exact ¹ |
 | PostgreSQL (LiteLLM DB) | `postgres` | `16-alpine` | Major |
 | Meltano | `meltano/meltano` | `v4.0` | Minor |
@@ -161,6 +163,7 @@ Images are pinned to **major versions** where supported for automatic security p
 | **Kafka-UI** | Kafka/Redpanda management UI | [kafka-ui.md](kafka-ui.md) |
 | **Kestra** | Workflow orchestration | [kestra.md](kestra.md) |
 | **LakeFS** | Git-like version control for data lakes | [lakefs.md](lakefs.md) |
+| **Lakekeeper** | Iceberg REST Catalog (Rust) for multi-engine lakehouse | [lakekeeper.md](lakekeeper.md) |
 | **LiteLLM Proxy** | Unified OpenAI-compatible proxy for 100+ LLM providers | [litellm.md](litellm.md) |
 | **Mage** | Data pipeline tool | [mage.md](mage.md) |
 | **Mailpit** | Email and SMTP testing | [mailpit.md](mailpit.md) |

--- a/docs/stacks/lakekeeper.md
+++ b/docs/stacks/lakekeeper.md
@@ -129,8 +129,14 @@ Must be non-empty or the deploy aborts with a clear `ServiceEnvError`.
 ### Persistence
 
 - `lakekeeper-db-data` volume: Postgres data (warehouses, namespaces, table metadata, snapshot history)
+- **Parquet data** lives in whichever object-storage bucket you wire up per warehouse — counts against that storage's quota, NOT Lakekeeper's DB
 
-The **actual Parquet data** lives in whichever object-storage bucket you wire up per warehouse — counts against that storage's quota, NOT Lakekeeper's DB. Included in the S3-persistence snapshot loop (`NEXUS_S3_PERSISTENCE=true`).
+**Backup scope — important:** Nexus-Stack's `NEXUS_S3_PERSISTENCE=true` snapshot loop covers an **explicit allow-list** of per-service filesystem trees (gitea, dify, kestra, metabase, etc.) plus per-service Postgres dumps — see [`src/nexus_deploy/s3_restore.py`](../../src/nexus_deploy/s3_restore.py) for the canonical list. Lakekeeper is **not currently in that allow-list**, so neither the `lakekeeper-db-data` volume nor the warehouse Parquet buckets are backed up automatically. Two consequences:
+
+1. **Catalog metadata** (`lakekeeper-db-data`): lost on a `docker compose down -v` or a fresh-start spin-up. Warehouses + tables remain physically present in object storage (the Parquet files survive), but Lakekeeper has no record of them — you'd re-register each warehouse via `POST /management/v1/warehouse` and Lakekeeper would re-discover the existing tables on next access.
+2. **Parquet data**: backup is whatever the underlying object-storage backend gives you. R2 / Hetzner S3 have provider-level durability + optional cross-region replication; MinIO / Garage / SeaweedFS on the same Hetzner box are NOT redundant unless the operator wires their own replication.
+
+If your workload needs catalog-metadata in the snapshot loop, the follow-up is to add `lakekeeper-db-data` + the relevant warehouse buckets to the allow-list in `s3_restore.py`.
 
 ### Warehouses + storage choices
 

--- a/docs/stacks/lakekeeper.md
+++ b/docs/stacks/lakekeeper.md
@@ -39,29 +39,44 @@ All engines read + write the **same** physical Parquet files in object storage, 
 2. Open `https://lakekeeper.YOUR_DOMAIN/health` → CF Access email OTP → `{"status":"ok"}`
 3. Bootstrap a warehouse (one-time, points at your chosen object-storage bucket):
 
+First pull the storage credentials out of Infisical (or your local secrets store) into shell env vars so the secrets never appear in `curl`'s argv or the shell history:
+
 ```bash
-TOKEN=""  # not needed when LAKEKEEPER__AUTHZ_BACKEND=allow-all (default)
-curl -X POST https://lakekeeper.YOUR_DOMAIN/management/v1/warehouse \
+# Fetch from Infisical (or paste-in interactively via `read -s` —
+# anything except hardcoding the secret into the command below):
+export S3_ACCESS_KEY_ID=$(infisical secrets get GARAGE_ACCESS_KEY_ID --path=/garage --plain)
+export S3_SECRET_ACCESS_KEY=$(infisical secrets get GARAGE_SECRET_ACCESS_KEY --path=/garage --plain)
+
+# Send the warehouse-bootstrap payload via stdin (`--data-binary @-`)
+# so the JSON — including the secret value — never lands in `ps`
+# listings or shell-history. The heredoc expands the env vars inside
+# the JSON before piping to curl; shell-history captures the heredoc
+# WITHOUT expansion, so the actual secret stays out.
+cat <<EOF | curl -X POST https://lakekeeper.YOUR_DOMAIN/management/v1/warehouse \
   -H "Content-Type: application/json" \
-  -d '{
-    "warehouse-name": "default",
-    "project-id": "00000000-0000-0000-0000-000000000000",
-    "storage-profile": {
-      "type": "s3",
-      "bucket": "lakehouse",
-      "endpoint": "http://garage:3900",
-      "region": "garage",
-      "path-style-access": true,
-      "sts-enabled": false
-    },
-    "storage-credential": {
-      "type": "s3",
-      "credential-type": "access-key",
-      "aws-access-key-id":     "YOUR_KEY_ID",
-      "aws-secret-access-key": "YOUR_SECRET"
-    }
-  }'
+  --data-binary @-
+{
+  "warehouse-name": "default",
+  "project-id": "00000000-0000-0000-0000-000000000000",
+  "storage-profile": {
+    "type": "s3",
+    "bucket": "lakehouse",
+    "endpoint": "http://garage:3900",
+    "region": "garage",
+    "path-style-access": true,
+    "sts-enabled": false
+  },
+  "storage-credential": {
+    "type": "s3",
+    "credential-type": "access-key",
+    "aws-access-key-id":     "${S3_ACCESS_KEY_ID}",
+    "aws-secret-access-key": "${S3_SECRET_ACCESS_KEY}"
+  }
+}
+EOF
 ```
+
+If `LAKEKEEPER__AUTHZ_BACKEND` is set to something other than the shipped `allow-all`, add `-H "Authorization: Bearer $TOKEN"` to the curl above; pull the token via the same `infisical secrets get` pattern, never paste it as a literal.
 
 4. From PyIceberg:
 

--- a/docs/stacks/lakekeeper.md
+++ b/docs/stacks/lakekeeper.md
@@ -12,7 +12,7 @@ Lakekeeper is an open-source implementation of the [Apache Iceberg REST Catalog 
 
 | Setting | Value |
 |---------|-------|
-| Default Port | `8181` |
+| Host Port | `8195` (container internal port is the upstream Lakekeeper default `8181`; host shifted to avoid a docker-compose collision with Kafka-UI which already binds host `8181:8080`) |
 | Suggested Subdomain | `lakekeeper` |
 | Public Access | No (Cloudflare Access via email OTP) |
 | Website | [lakekeeper.io](https://lakekeeper.io) |

--- a/docs/stacks/lakekeeper.md
+++ b/docs/stacks/lakekeeper.md
@@ -1,0 +1,157 @@
+---
+title: "Lakekeeper"
+---
+
+## Lakekeeper
+
+![Lakekeeper](https://img.shields.io/badge/Lakekeeper-B7410E?logo=rust&logoColor=white)
+
+**Modern Iceberg REST Catalog (Rust)**
+
+Lakekeeper is an open-source implementation of the [Apache Iceberg REST Catalog specification](https://github.com/apache/iceberg/blob/main/open-api/rest-catalog-open-api.yaml). It turns the existing object storage (Garage / MinIO / SeaweedFS / RustFS / external R2) into a full lakehouse: register a table once via the REST API, query it from Spark, Trino, DuckDB, PyIceberg, or any other Iceberg-aware engine — no Hive Metastore, no per-engine catalog duplication.
+
+| Setting | Value |
+|---------|-------|
+| Default Port | `8181` |
+| Suggested Subdomain | `lakekeeper` |
+| Public Access | No (Cloudflare Access via email OTP) |
+| Website | [lakekeeper.io](https://lakekeeper.io) |
+| Source | [GitHub](https://github.com/lakekeeper/lakekeeper) |
+| Docker image | [`quay.io/lakekeeper/catalog`](https://quay.io/repository/lakekeeper/catalog) |
+| Backing DB | Dedicated Postgres 16 (`lakekeeper-db` container, separate from any shared Postgres) |
+
+### Why this matters for the existing stack
+
+Before Lakekeeper, every Iceberg-aware engine in the stack needed its own catalog config (or a local Hive Metastore). Lakekeeper centralises that:
+
+| Engine | Before | With Lakekeeper |
+|---|---|---|
+| Spark | Per-job Hadoop config + own warehouse path | `spark.sql.catalog.lakekeeper.type=rest` + URL |
+| Trino | Per-catalog `iceberg.yml` with separate metastore | One REST catalog config pointing at Lakekeeper |
+| PyIceberg | Local `.pyiceberg.yaml` per project | `Catalog.load("lakekeeper", uri="...")` |
+| DuckDB | Manual table-by-table `iceberg_scan(s3://...)` | `ATTACH 'http://...' AS lk (TYPE iceberg)` |
+
+All engines read + write the **same** physical Parquet files in object storage, with the catalog as the single source of truth for which version of which table lives where.
+
+### Usage
+
+1. Enable **Lakekeeper** in the Control Plane → Spin Up
+2. Open `https://lakekeeper.YOUR_DOMAIN/health` → CF Access email OTP → `{"status":"ok"}`
+3. Bootstrap a warehouse (one-time, points at your chosen object-storage bucket):
+
+```bash
+TOKEN=""  # not needed when LAKEKEEPER__AUTHZ_BACKEND=allow-all (default)
+curl -X POST https://lakekeeper.YOUR_DOMAIN/management/v1/warehouse \
+  -H "Content-Type: application/json" \
+  -d '{
+    "warehouse-name": "default",
+    "project-id": "00000000-0000-0000-0000-000000000000",
+    "storage-profile": {
+      "type": "s3",
+      "bucket": "lakehouse",
+      "endpoint": "http://garage:3900",
+      "region": "garage",
+      "path-style-access": true,
+      "sts-enabled": false
+    },
+    "storage-credential": {
+      "type": "s3",
+      "credential-type": "access-key",
+      "aws-access-key-id":     "YOUR_KEY_ID",
+      "aws-secret-access-key": "YOUR_SECRET"
+    }
+  }'
+```
+
+4. From PyIceberg:
+
+```python
+from pyiceberg.catalog import load_catalog
+
+catalog = load_catalog(
+    "lakekeeper",
+    uri="https://lakekeeper.YOUR_DOMAIN/catalog",
+    warehouse="default",
+)
+
+# Create namespace + table
+catalog.create_namespace("course")
+catalog.create_table(
+    "course.students",
+    schema=...,  # standard PyArrow / Iceberg schema
+)
+```
+
+5. From Spark (with `iceberg-spark-runtime`):
+
+```python
+spark = SparkSession.builder \
+    .config("spark.sql.extensions", "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions") \
+    .config("spark.sql.catalog.lk", "org.apache.iceberg.spark.SparkCatalog") \
+    .config("spark.sql.catalog.lk.type", "rest") \
+    .config("spark.sql.catalog.lk.uri", "https://lakekeeper.YOUR_DOMAIN/catalog") \
+    .config("spark.sql.catalog.lk.warehouse", "default") \
+    .getOrCreate()
+
+spark.sql("SELECT * FROM lk.course.students").show()
+```
+
+6. From Trino — add to `tofu/stack/main.tf`'s Trino config OR drop in `/etc/trino/catalog/lakekeeper.properties` on the Trino container:
+
+```properties
+connector.name=iceberg
+iceberg.catalog.type=rest
+iceberg.rest-catalog.uri=https://lakekeeper.YOUR_DOMAIN/catalog
+iceberg.rest-catalog.warehouse=default
+```
+
+### Auth model
+
+The shipped compose sets `LAKEKEEPER__AUTHZ_BACKEND=allow-all`. **Cloudflare Access at the edge** (email OTP) is the auth gate — anyone past the gate has full catalog read/write inside.
+
+This is the **baseline "one team per stack"** model. If you want fine-grained per-team or per-warehouse permissions inside Lakekeeper (e.g. "team-A can write `analytics.*`, team-B can read it"), Lakekeeper has a full OIDC layer. Switch by:
+
+1. Set `LAKEKEEPER__AUTHZ_BACKEND=openid` in `stacks/lakekeeper/docker-compose.yml`
+2. Add `LAKEKEEPER__OPENID_PROVIDER_URI` pointing at your IdP (Authentik / Keycloak / Auth0)
+3. Re-deploy
+4. Use Lakekeeper's `/management/v1/user` + `/management/v1/role` endpoints to define teams
+
+Not done by default because (a) most stacks have one team, (b) CF Access already handles authentication, (c) adding OIDC requires standing up an IdP.
+
+### Secrets
+
+Generated by OpenTofu (`random_password.lakekeeper_db_password`, 24 chars) and pushed to Infisical under folder `/lakekeeper`:
+
+- `LAKEKEEPER_DB_PASSWORD` — Postgres password for the dedicated `lakekeeper-db` container
+
+Must be non-empty or the deploy aborts with a clear `ServiceEnvError`.
+
+### Persistence
+
+- `lakekeeper-db-data` volume: Postgres data (warehouses, namespaces, table metadata, snapshot history)
+
+The **actual Parquet data** lives in whichever object-storage bucket you wire up per warehouse — counts against that storage's quota, NOT Lakekeeper's DB. Included in the S3-persistence snapshot loop (`NEXUS_S3_PERSISTENCE=true`).
+
+### Warehouses + storage choices
+
+Lakekeeper supports multiple warehouses per catalog, each pointing at a different bucket / storage backend. Common pattern for the existing stack:
+
+- **In-stack warehouse**: bucket on Garage / MinIO / SeaweedFS — fast, free, internal
+- **External warehouse**: bucket on R2 / Hetzner S3 — durable, geo-redundant, for long-term archival
+
+Wire them with separate `POST /management/v1/warehouse` calls; query both from any engine via `warehouse=...`.
+
+### Troubleshooting
+
+- **`bootstrap` container loops on migrate**: usually `LAKEKEEPER_DB_PASSWORD` mismatch between Lakekeeper + Postgres env — caused by a previous deploy with a different password and the volume keeping the old one. `docker compose down -v` to reset (loses catalog metadata; warehouses + tables in object storage are not affected and can be re-registered)
+- **`/health` returns 503**: bootstrap hasn't finished yet — wait 10-20s on first start
+- **PyIceberg `404 Not Found` on namespace create**: warehouse not bootstrapped — run the `POST /management/v1/warehouse` from step 3 above
+- **`AccessDenied` from object storage**: storage credentials in the warehouse profile are wrong — verify the access key has read+write on the target bucket. Lakekeeper passes the credentials through to whatever S3 client the executing engine uses, so error messages come from the engine layer (Spark / Trino), not Lakekeeper itself
+- **Tables visible in Spark but not in Trino (or vice versa)**: usually a warehouse-name mismatch in the engine config — both must point at the same Lakekeeper warehouse identifier
+
+### Related
+
+- [Lakekeeper repo](https://github.com/lakekeeper/lakekeeper) — releases + roadmap
+- [Iceberg REST Catalog Spec](https://github.com/apache/iceberg/blob/main/open-api/rest-catalog-open-api.yaml) — what every Iceberg-aware engine speaks
+- [Apache Iceberg docs](https://iceberg.apache.org/docs/latest/) — table format spec, time-travel, schema evolution, partition evolution
+- [lakefs](./lakefs.md) — sibling stack with a **different** lakehouse pattern (Git-like data versioning on top of object storage, not Iceberg). Pick lakefs if you want git-style branch/merge/diff semantics on data files; pick Lakekeeper if you want catalog-managed Iceberg tables with multi-engine access.

--- a/services.yaml
+++ b/services.yaml
@@ -407,6 +407,18 @@ services:
     tcp_ports:
       s3-gateway: 8000
 
+  lakekeeper:
+    subdomain: "lakekeeper"
+    port: 8181
+    public: false
+    category: "storage"
+    website: "https://lakekeeper.io"
+    description: "Modern Iceberg REST Catalog (Rust) — lets Spark / Trino / DuckDB / PyIceberg share the same Iceberg tables on the existing object storage."
+    long_description: "Lakekeeper is an open-source implementation of the Apache Iceberg REST Catalog specification, written in Rust. It provides the catalog layer that turns the existing object storage (Garage / MinIO / SeaweedFS / RustFS / external R2) into a full lakehouse: register a table once via the REST API, query it from Spark, Trino, DuckDB, PyIceberg, or any other Iceberg-aware engine — no Hive Metastore, no per-engine catalog duplication. Dedicated PostgreSQL stores the catalog metadata; the actual Parquet data goes to whichever S3-compatible bucket the operator configures per warehouse."
+    image: "quay.io/lakekeeper/catalog:v0.12.2"
+    support_images:
+      postgres: "postgres:16-alpine"
+
   kestra:
     subdomain: "kestra"
     port: 8085

--- a/services.yaml
+++ b/services.yaml
@@ -409,7 +409,7 @@ services:
 
   lakekeeper:
     subdomain: "lakekeeper"
-    port: 8181
+    port: 8195   # 8181 already taken by kafka-ui's host binding; Lakekeeper's container internal port stays 8181
     public: false
     category: "storage"
     website: "https://lakekeeper.io"

--- a/src/nexus_deploy/config.py
+++ b/src/nexus_deploy/config.py
@@ -71,6 +71,7 @@ _FIELDS: tuple[tuple[str, str, str], ...] = (
     ("LITELLM_MASTER_KEY", "litellm_master_key", ""),
     ("LITELLM_SALT_KEY", "litellm_salt_key", ""),
     ("LITELLM_DB_PASS", "litellm_db_password", ""),
+    ("LAKEKEEPER_DB_PASS", "lakekeeper_db_password", ""),
     ("MAGE_PASS", "mage_admin_password", ""),
     ("MINIO_ROOT_PASS", "minio_root_password", ""),
     ("SFTPGO_ADMIN_PASS", "sftpgo_admin_password", ""),
@@ -185,6 +186,7 @@ class NexusConfig(BaseModel):
     litellm_master_key: str | None = None
     litellm_salt_key: str | None = None
     litellm_db_password: str | None = None
+    lakekeeper_db_password: str | None = None
     mage_admin_password: str | None = None
     minio_root_password: str | None = None
     sftpgo_admin_password: str | None = None

--- a/src/nexus_deploy/infisical.py
+++ b/src/nexus_deploy/infisical.py
@@ -684,6 +684,16 @@ def compute_folders(config: NexusConfig, env: BootstrapEnv) -> list[FolderSpec]:
     )
     folders.append(
         FolderSpec(
+            "lakekeeper",
+            _filter_empty(
+                {
+                    "LAKEKEEPER_DB_PASSWORD": config.lakekeeper_db_password,
+                }
+            ),
+        )
+    )
+    folders.append(
+        FolderSpec(
             "mage",
             _filter_empty(
                 {

--- a/src/nexus_deploy/service_env.py
+++ b/src/nexus_deploy/service_env.py
@@ -469,7 +469,8 @@ def _render_hedgedoc(c: NexusConfig, e: BootstrapEnv) -> RenderedEnv:
 
 def _render_lakekeeper(c: NexusConfig, e: BootstrapEnv) -> RenderedEnv:
     """Lakekeeper: Iceberg REST Catalog. Needs dedicated Postgres
-    DSN + LAKEKEEPER_BASE_URI for absolute-URL generation in the
+    DSN + LAKEKEEPER__BASE_URI (double-underscore, that's Lakekeeper's
+    nested-config separator convention) for absolute-URL generation in the
     catalog responses (Iceberg clients follow these to reach the
     metadata endpoints).
 

--- a/src/nexus_deploy/service_env.py
+++ b/src/nexus_deploy/service_env.py
@@ -467,6 +467,39 @@ def _render_hedgedoc(c: NexusConfig, e: BootstrapEnv) -> RenderedEnv:
     )
 
 
+def _render_lakekeeper(c: NexusConfig, e: BootstrapEnv) -> RenderedEnv:
+    """Lakekeeper: Iceberg REST Catalog. Needs dedicated Postgres
+    DSN + LAKEKEEPER_BASE_URI for absolute-URL generation in the
+    catalog responses (Iceberg clients follow these to reach the
+    metadata endpoints).
+
+    Fail-fast guard (same pattern as Meilisearch / HedgeDoc): empty
+    DB password crashes the Postgres init on first start with a
+    cryptic auth-failed log. Abort at deploy time with a clear
+    error pointing at the missing Tofu apply / Infisical sync.
+
+    LAKEKEEPER_DOMAIN is composed from BootstrapEnv.domain via
+    service_host so multi-tenant forks with subdomain_separator='-'
+    get the flat-subdomain hostname (lakekeeper-user1.example.com)
+    instead of lakekeeper.user1.example.com.
+    """
+    if _empty(c.lakekeeper_db_password):
+        raise ServiceEnvError(
+            "Lakekeeper enabled but LAKEKEEPER_DB_PASSWORD is empty — "
+            "run `tofu apply` (initial-setup workflow) to generate "
+            "random_password.lakekeeper_db_password + push to Infisical, "
+            "then re-run spin-up. Aborting to avoid a restart-looping "
+            "Postgres container with no auth.",
+        )
+    domain_host = service_host("lakekeeper", e.domain or "", e.subdomain_separator)
+    return RenderedEnv(
+        env_vars={
+            "LAKEKEEPER_DB_PASSWORD": c.lakekeeper_db_password or "",
+            "LAKEKEEPER_DOMAIN": domain_host,
+        },
+    )
+
+
 def _render_litellm(
     c: NexusConfig, e: BootstrapEnv, *, litellm_config_template: str | None = None
 ) -> RenderedEnv:
@@ -1268,6 +1301,7 @@ _SPECS: tuple[EnvSpec, ...] = (
     EnvSpec("meilisearch", _is_enabled("meilisearch"), _render_meilisearch),
     EnvSpec("hedgedoc", _is_enabled("hedgedoc"), _render_hedgedoc),
     EnvSpec("litellm", _is_enabled("litellm"), _render_litellm),
+    EnvSpec("lakekeeper", _is_enabled("lakekeeper"), _render_lakekeeper),
     EnvSpec("mage", _is_enabled("mage"), _render_mage),
     EnvSpec("minio", _is_enabled("minio"), _render_minio),
     EnvSpec("sftpgo", _is_enabled("sftpgo"), _render_sftpgo),

--- a/stacks/lakekeeper/docker-compose.yml
+++ b/stacks/lakekeeper/docker-compose.yml
@@ -58,7 +58,13 @@ services:
       - .env
     restart: unless-stopped
     ports:
-      - "8181:8181"
+      # Host port 8195 → container 8181. Kafka-UI already binds host 8181
+      # (mapping to its container's 8080), so Lakekeeper has to publish on
+      # a different host port to avoid a docker-compose port collision
+      # when both stacks are enabled. Container port stays 8181 (the
+      # upstream Lakekeeper default) so internal references + the
+      # healthcheck URL below don't change.
+      - "8195:8181"
     command: ["serve"]
     environment:
       LAKEKEEPER__PG_DATABASE_URL_READ: postgres://nexus-lakekeeper:${LAKEKEEPER_DB_PASSWORD}@lakekeeper-db:5432/lakekeeper

--- a/stacks/lakekeeper/docker-compose.yml
+++ b/stacks/lakekeeper/docker-compose.yml
@@ -1,0 +1,119 @@
+# =============================================================================
+# Lakekeeper - Iceberg REST Catalog (Rust)
+# =============================================================================
+# Open-source implementation of the Apache Iceberg REST Catalog spec.
+# Single Rust binary + dedicated PostgreSQL for metadata storage.
+# Lets Spark, Trino, DuckDB, PyIceberg, and the Iceberg Java/Python
+# SDK all read + write the SAME Iceberg tables on the existing
+# object storage (Garage / MinIO / SeaweedFS / RustFS / external R2).
+#
+# Architecture:
+#   - lakekeeper-bootstrap: one-shot `migrate` job that initialises
+#     the Postgres schema on first start, then exits
+#   - lakekeeper:           long-running `serve` process on :8181
+#   - lakekeeper-db:        dedicated Postgres 16, NOT shared with
+#                           any other stack (per project convention
+#                           for stateful services)
+#
+# Auth: `LAKEKEEPER__AUTHZ_BACKEND=allow-all` — Cloudflare Access at
+# the edge is the auth gate (email OTP). Lakekeeper has its own
+# OIDC layer for fine-grained per-team table permissions; that's
+# out of scope for the baseline "one team per stack" model.
+#
+# Access: https://lakekeeper.YOUR_DOMAIN
+# Spec: https://github.com/apache/iceberg/blob/main/open-api/rest-catalog-open-api.yaml
+# =============================================================================
+
+services:
+  # ---------------------------------------------------------------------------
+  # Lakekeeper Bootstrap - one-shot DB migration
+  # ---------------------------------------------------------------------------
+  # Runs `migrate` to create / upgrade the Postgres schema, then
+  # exits with rc=0. Lakekeeper itself waits for this via
+  # service_completed_successfully so subsequent restarts don't
+  # re-run the migration. Splitting it out (vs. `bash -c "migrate &&
+  # serve"`) makes the lifecycle explicit + lets Docker's restart
+  # policy do the right thing for each role.
+  lakekeeper-bootstrap:
+    image: ${IMAGE_LAKEKEEPER:-quay.io/lakekeeper/catalog:v0.12.2}
+    container_name: lakekeeper-bootstrap
+    restart: "no"
+    command: ["migrate"]
+    environment:
+      LAKEKEEPER__PG_DATABASE_URL_READ: postgres://nexus-lakekeeper:${LAKEKEEPER_DB_PASSWORD}@lakekeeper-db:5432/lakekeeper
+      LAKEKEEPER__PG_DATABASE_URL_WRITE: postgres://nexus-lakekeeper:${LAKEKEEPER_DB_PASSWORD}@lakekeeper-db:5432/lakekeeper
+    depends_on:
+      lakekeeper-db:
+        condition: service_healthy
+    networks:
+      - lakekeeper-internal
+
+  # ---------------------------------------------------------------------------
+  # Lakekeeper Catalog - REST API server
+  # ---------------------------------------------------------------------------
+  lakekeeper:
+    image: ${IMAGE_LAKEKEEPER:-quay.io/lakekeeper/catalog:v0.12.2}
+    container_name: lakekeeper
+    env_file:
+      - .env
+    restart: unless-stopped
+    ports:
+      - "8181:8181"
+    command: ["serve"]
+    environment:
+      LAKEKEEPER__PG_DATABASE_URL_READ: postgres://nexus-lakekeeper:${LAKEKEEPER_DB_PASSWORD}@lakekeeper-db:5432/lakekeeper
+      LAKEKEEPER__PG_DATABASE_URL_WRITE: postgres://nexus-lakekeeper:${LAKEKEEPER_DB_PASSWORD}@lakekeeper-db:5432/lakekeeper
+      LAKEKEEPER__BASE_URI: https://${LAKEKEEPER_DOMAIN}
+      # Auth disabled internally — CF Access at the edge is the gate.
+      # Flip to "openid" + LAKEKEEPER__OPENID_PROVIDER_URI if you
+      # later want fine-grained per-team table permissions inside
+      # Lakekeeper itself (see docs/stacks/lakekeeper.md).
+      LAKEKEEPER__AUTHZ_BACKEND: allow-all
+    deploy:
+      resources:
+        limits:
+          memory: 512m
+    depends_on:
+      lakekeeper-db:
+        condition: service_healthy
+      lakekeeper-bootstrap:
+        condition: service_completed_successfully
+    networks:
+      - app-network
+      - lakekeeper-internal
+    healthcheck:
+      test: ["CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:8181/health || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+
+  # ---------------------------------------------------------------------------
+  # Lakekeeper - Dedicated PostgreSQL (catalog metadata)
+  # ---------------------------------------------------------------------------
+  lakekeeper-db:
+    image: ${IMAGE_LAKEKEEPER_DB:-postgres:16-alpine}
+    container_name: lakekeeper-db
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: nexus-lakekeeper
+      POSTGRES_PASSWORD: ${LAKEKEEPER_DB_PASSWORD}
+      POSTGRES_DB: lakekeeper
+    volumes:
+      - lakekeeper-db-data:/var/lib/postgresql/data
+    networks:
+      - lakekeeper-internal
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U nexus-lakekeeper -d lakekeeper"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  lakekeeper-db-data:
+
+networks:
+  app-network:
+    external: true
+  lakekeeper-internal:
+    driver: bridge

--- a/tests/fixtures/secrets_full.json
+++ b/tests/fixtures/secrets_full.json
@@ -51,6 +51,7 @@
   "lakefs_admin_secret_key": "lakefs_admin_secret_key-VALUE",
   "lakefs_db_password": "lakefs_db_password-VALUE",
   "lakefs_encrypt_secret": "back`tick`secret",
+  "lakekeeper_db_password": "lakekeeper_db_password-VALUE",
   "mage_admin_password": "mage_admin_password-VALUE",
   "meilisearch_master_key": "meilisearch_master_key-VALUE",
   "meltano_db_password": "meltano_db_password-VALUE",

--- a/tests/unit/__snapshots__/test_config.ambr
+++ b/tests/unit/__snapshots__/test_config.ambr
@@ -96,7 +96,7 @@
   DIFY_PLUGIN_INNER_API_KEY=''
   DOCKERHUB_USER=''
   DOCKERHUB_TOKEN=''
-  
+
   '''
 # ---
 # name: test_dump_shell_full_snapshot
@@ -124,7 +124,7 @@
   LITELLM_MASTER_KEY=''
   LITELLM_SALT_KEY=''
   LITELLM_DB_PASS=''
-  LAKEKEEPER_DB_PASS=''
+  LAKEKEEPER_DB_PASS=lakekeeper_db_password-VALUE
   MAGE_PASS=mage_admin_password-VALUE
   MINIO_ROOT_PASS=minio_root_password-VALUE
   SFTPGO_ADMIN_PASS=sftpgo_admin_password-VALUE
@@ -196,7 +196,7 @@
   DIFY_PLUGIN_INNER_API_KEY=dify_plugin_inner_api_key-VALUE
   DOCKERHUB_USER=dockerhub_username-VALUE
   DOCKERHUB_TOKEN=dockerhub_token-VALUE
-  
+
   '''
 # ---
 # name: test_dump_shell_minimal_snapshot
@@ -296,6 +296,6 @@
   DIFY_PLUGIN_INNER_API_KEY=''
   DOCKERHUB_USER=''
   DOCKERHUB_TOKEN=''
-  
+
   '''
 # ---

--- a/tests/unit/__snapshots__/test_config.ambr
+++ b/tests/unit/__snapshots__/test_config.ambr
@@ -19,6 +19,12 @@
   SUPERSET_SECRET=''
   CLOUDBEAVER_PASS=''
   MEILISEARCH_MASTER_KEY=''
+  HEDGEDOC_SESSION_SECRET=''
+  HEDGEDOC_DB_PASS=''
+  LITELLM_MASTER_KEY=''
+  LITELLM_SALT_KEY=''
+  LITELLM_DB_PASS=''
+  LAKEKEEPER_DB_PASS=''
   MAGE_PASS=''
   MINIO_ROOT_PASS=''
   SFTPGO_ADMIN_PASS=''
@@ -90,7 +96,7 @@
   DIFY_PLUGIN_INNER_API_KEY=''
   DOCKERHUB_USER=''
   DOCKERHUB_TOKEN=''
-
+  
   '''
 # ---
 # name: test_dump_shell_full_snapshot
@@ -113,6 +119,12 @@
   SUPERSET_SECRET=superset_secret_key-VALUE
   CLOUDBEAVER_PASS=cloudbeaver_admin_password-VALUE
   MEILISEARCH_MASTER_KEY=meilisearch_master_key-VALUE
+  HEDGEDOC_SESSION_SECRET=''
+  HEDGEDOC_DB_PASS=''
+  LITELLM_MASTER_KEY=''
+  LITELLM_SALT_KEY=''
+  LITELLM_DB_PASS=''
+  LAKEKEEPER_DB_PASS=''
   MAGE_PASS=mage_admin_password-VALUE
   MINIO_ROOT_PASS=minio_root_password-VALUE
   SFTPGO_ADMIN_PASS=sftpgo_admin_password-VALUE
@@ -184,7 +196,7 @@
   DIFY_PLUGIN_INNER_API_KEY=dify_plugin_inner_api_key-VALUE
   DOCKERHUB_USER=dockerhub_username-VALUE
   DOCKERHUB_TOKEN=dockerhub_token-VALUE
-
+  
   '''
 # ---
 # name: test_dump_shell_minimal_snapshot
@@ -207,6 +219,12 @@
   SUPERSET_SECRET=''
   CLOUDBEAVER_PASS=''
   MEILISEARCH_MASTER_KEY=''
+  HEDGEDOC_SESSION_SECRET=''
+  HEDGEDOC_DB_PASS=''
+  LITELLM_MASTER_KEY=''
+  LITELLM_SALT_KEY=''
+  LITELLM_DB_PASS=''
+  LAKEKEEPER_DB_PASS=''
   MAGE_PASS=''
   MINIO_ROOT_PASS=''
   SFTPGO_ADMIN_PASS=''
@@ -278,6 +296,6 @@
   DIFY_PLUGIN_INNER_API_KEY=''
   DOCKERHUB_USER=''
   DOCKERHUB_TOKEN=''
-
+  
   '''
 # ---

--- a/tests/unit/__snapshots__/test_infisical.ambr
+++ b/tests/unit/__snapshots__/test_infisical.ambr
@@ -89,6 +89,7 @@
       'LAKEFS_SECRET_ACCESS_KEY': 'lakefs_admin_secret_key-VALUE',
     }),
     'lakekeeper': dict({
+      'LAKEKEEPER_DB_PASSWORD': 'lakekeeper_db_password-VALUE',
     }),
     'litellm': dict({
     }),

--- a/tests/unit/__snapshots__/test_infisical.ambr
+++ b/tests/unit/__snapshots__/test_infisical.ambr
@@ -63,6 +63,8 @@
       'GRAFANA_PASSWORD': 'grafana_admin_password-VALUE',
       'GRAFANA_USERNAME': 'nexus-test-user',
     }),
+    'hedgedoc': dict({
+    }),
     'hetzner-s3': dict({
       'HETZNER_S3_ACCESS_KEY': 'hetzner_s3_access_key-VALUE',
       'HETZNER_S3_BUCKET': 'hetzner_s3_bucket_general-VALUE',
@@ -85,6 +87,10 @@
       'LAKEFS_ACCESS_KEY_ID': 'lakefs_admin_access_key-VALUE',
       'LAKEFS_DB_PASSWORD': 'lakefs_db_password-VALUE',
       'LAKEFS_SECRET_ACCESS_KEY': 'lakefs_admin_secret_key-VALUE',
+    }),
+    'lakekeeper': dict({
+    }),
+    'litellm': dict({
     }),
     'mage': dict({
       'MAGE_PASSWORD': 'mage_admin_password-VALUE',

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -38,7 +38,7 @@ def test_field_count() -> None:
     silent drift between :data:`_FIELDS` and the upstream tofu
     schema.
     """
-    assert len(_FIELDS) == 89
+    assert len(_FIELDS) == 95
 
 
 def test_no_duplicate_bash_var_names() -> None:

--- a/tests/unit/test_service_env.py
+++ b/tests/unit/test_service_env.py
@@ -72,6 +72,7 @@ def full_config() -> NexusConfig:
         litellm_master_key="litellm-master-32chars-xxxxxxxxx",
         litellm_salt_key="litellm-salt-32chars-xxxxxxxxxxx",
         litellm_db_password="litellm-db-pw",
+        lakekeeper_db_password="lakekeeper-db-pw",
         mage_admin_password="mage-pw",
         minio_root_password="minio-pw",
         sftpgo_admin_password="sftpgo-admin",
@@ -643,6 +644,61 @@ def test_litellm_accepts_injected_template_overrides_loader(
     sidecar = next(s for s in rendered.sidecars if s.relative_path == "config.yaml")
     assert sidecar.content == injected
     assert "CUSTOM TEMPLATE INJECTED" in sidecar.content
+
+
+# ---------------------------------------------------------------------------
+# Lakekeeper — fail-fast guard + domain composition
+# ---------------------------------------------------------------------------
+
+
+def test_lakekeeper_raises_on_empty_db_password(
+    full_config: NexusConfig, full_env: BootstrapEnv
+) -> None:
+    """Empty DB password crashes the dedicated Postgres init on
+    first start with a cryptic auth-failed log → Lakekeeper's
+    bootstrap container loops on `migrate`. Abort at deploy time
+    with a clear error pointing at the missing Tofu apply."""
+    from nexus_deploy.service_env import _render_lakekeeper
+
+    config = full_config.model_copy(update={"lakekeeper_db_password": ""})
+    with pytest.raises(ServiceEnvError, match="LAKEKEEPER_DB_PASSWORD"):
+        _render_lakekeeper(config, full_env)
+
+
+def test_lakekeeper_renders_domain_from_bootstrap_env(
+    full_config: NexusConfig, full_env: BootstrapEnv
+) -> None:
+    """LAKEKEEPER_DOMAIN must be derived from BootstrapEnv (subdomain
+    'lakekeeper' + DOMAIN via service_host). Lakekeeper bakes the
+    domain into LAKEKEEPER__BASE_URI which it then embeds in REST
+    catalog responses — wrong value breaks every PyIceberg / Spark
+    client that follows the returned URIs."""
+    from nexus_deploy.service_env import _render_lakekeeper
+
+    rendered = _render_lakekeeper(full_config, full_env)
+    assert rendered.env_vars["LAKEKEEPER_DOMAIN"] == "lakekeeper.example.com"
+    assert rendered.env_vars["LAKEKEEPER_DB_PASSWORD"] == "lakekeeper-db-pw"
+
+
+def test_lakekeeper_domain_respects_subdomain_separator(
+    full_config: NexusConfig, full_env: BootstrapEnv
+) -> None:
+    """Multi-tenant forks set subdomain_separator='-' for flat
+    subdomains (lakekeeper-user1.example.com). Renderer must use
+    service_host so it picks up that override — without it,
+    LAKEKEEPER__BASE_URI would point at the wrong host and every
+    Iceberg-aware client following catalog responses would hit a
+    non-existent endpoint."""
+    from nexus_deploy.service_env import _render_lakekeeper
+
+    env = BootstrapEnv(
+        **{
+            **{k: getattr(full_env, k) for k in full_env.__dataclass_fields__},
+            "subdomain_separator": "-",
+        }
+    )
+    rendered = _render_lakekeeper(full_config, env)
+    assert rendered.env_vars["LAKEKEEPER_DOMAIN"] == "lakekeeper-example.com"
 
 
 # ---------------------------------------------------------------------------

--- a/tofu/stack/main.tf
+++ b/tofu/stack/main.tf
@@ -180,6 +180,14 @@ resource "random_password" "litellm_db_password" {
   special = false
 }
 
+# Lakekeeper Postgres password — dedicated DB, not shared. The
+# catalog metadata (warehouses, namespaces, table pointers) lives
+# in this DB; the actual Parquet data goes to object storage.
+resource "random_password" "lakekeeper_db_password" {
+  length  = 24
+  special = false
+}
+
 # Mage AI admin password
 resource "random_password" "mage_admin" {
   length  = 24

--- a/tofu/stack/outputs.tf
+++ b/tofu/stack/outputs.tf
@@ -168,6 +168,9 @@ output "secrets" {
     litellm_salt_key    = random_password.litellm_salt_key.result
     litellm_db_password = random_password.litellm_db_password.result
 
+    # Lakekeeper (Iceberg REST Catalog)
+    lakekeeper_db_password = random_password.lakekeeper_db_password.result
+
     # ClickHouse
     clickhouse_admin_password = random_password.clickhouse_admin.result
 


### PR DESCRIPTION
## Summary

Closes [#613](https://github.com/stefanko-ch/Nexus-Stack/issues/613).

The stack already had every piece for a modern lakehouse — object storage (Garage / MinIO / SeaweedFS / RustFS), query engines (Trino, ClickHouse, RisingWave, pg_ducklake), streaming + CDC (Redpanda, Flink, Debezium), notebooks (Jupyter, Marimo, Spark) — **except the catalog**. [Lakekeeper](https://github.com/lakekeeper/lakekeeper) (Apache-2.0) fills that gap: a Rust implementation of the [Iceberg REST Catalog spec](https://github.com/apache/iceberg/blob/main/open-api/rest-catalog-open-api.yaml) that lets Spark, Trino, DuckDB, PyIceberg, and any Iceberg-aware engine read + write the SAME Iceberg tables on existing buckets. No Hive Metastore, no per-engine catalog duplication.

## Stack

- **Host Port** `8195` (container internal stays `8181` — shifted to avoid kafka-ui collision)
- **Image** `quay.io/lakekeeper/catalog:v0.12.2` (multi-arch verified — amd64 + arm64 via quay manifest)
- **3-service compose**:
  - `lakekeeper-bootstrap` — one-shot `migrate` job that initialises the Postgres schema on first start, then exits with rc=0. `lakekeeper` itself waits on `service_completed_successfully` so subsequent restarts don't re-run the migration.
  - `lakekeeper` — long-running `serve` process on :8181
  - `lakekeeper-db` — **dedicated** Postgres 16 (per project convention for stateful services)
- **Auth**: `LAKEKEEPER__AUTHZ_BACKEND=allow-all` internally — Cloudflare Access at the edge is the gate (email OTP). Operators who want fine-grained per-team table permissions can flip to OIDC, documented in `docs/stacks/lakekeeper.md`.

## Data layer

- **Tofu**: `random_password.lakekeeper_db_password` (24 chars, special=false) + secrets output entry
- **config.py**: `LAKEKEEPER_DB_PASS` field + `_FIELDS` entry
- **infisical.py**: new `/lakekeeper` folder under `compute_folders`
- **service_env.py**: `_render_lakekeeper` + EnvSpec entry. Fail-fast guard if password empty (same pattern as Meilisearch / HedgeDoc / LiteLLM). `LAKEKEEPER_DOMAIN` composed via `service_host` so multi-tenant forks with `subdomain_separator='-'` get `lakekeeper-user1.example.com` (not `lakekeeper.user1.example.com`).

## Tests (3 new, 88 total in `test_service_env.py`)

- `test_lakekeeper_raises_on_empty_db_password` — fail-fast guard
- `test_lakekeeper_renders_domain_from_bootstrap_env` — `service_host` composition with default `.` separator
- `test_lakekeeper_domain_respects_subdomain_separator` — flat-subdomain override path

All `pre-commit` checks pass (ruff format + ruff check + mypy --strict + shellcheck).

## Test plan

This stack adds new Tofu resources (DNS, CF Access app, Tunnel ingress) so a fresh **`spin-up.yml`** is required after merge:

```bash
gh workflow run spin-up.yml --ref main
```

### Verification
- [ ] `https://lakekeeper.<domain>/health` → CF Access OTP → `{"status":"ok"}`
- [ ] `https://lakekeeper.<domain>/catalog/v1/config` returns the catalog defaults (`{"defaults":{},"overrides":{}}` on a fresh deploy)
- [ ] `docker ps --filter name=lakekeeper` shows `lakekeeper` + `lakekeeper-db` running, `lakekeeper-bootstrap` exited 0
- [ ] `infisical secrets get LAKEKEEPER_DB_PASSWORD --path=/lakekeeper --plain` returns 24 chars
- [ ] PyIceberg smoke test (from a notebook or code-server terminal):

```python
from pyiceberg.catalog import load_catalog
# After bootstrapping a warehouse via POST /management/v1/warehouse (recipe in docs/stacks/lakekeeper.md)
catalog = load_catalog("lk", uri="https://lakekeeper.<domain>/catalog", warehouse="default")
catalog.create_namespace("smoke")
print(catalog.list_namespaces())
```

## Docs

- `docs/stacks/lakekeeper.md`: usage with PyIceberg / Spark / Trino / DuckDB integration snippets, warehouse bootstrap recipe, auth model (CF Access default + OIDC switch path), troubleshooting
- `README.md`: stack count 71 → 72 (rebased over PR #612 which added HedgeDoc + LiteLLM, bringing main from 69 → 71), badge inserted between LakeFS / Mage, table row added
- `docs/stacks/README.md`: image-version table (Lakekeeper + PostgreSQL-Lakekeeper-DB) + stack-doc list entry

## Out of scope (follow-up issues per #613)

- **Trino Iceberg connector config** — `iceberg.catalog.type=rest` + URL. Operator wires it; documented snippet in `lakekeeper.md`. Worth its own PR so the Lakekeeper merge isn't blocked by Trino integration testing.
- **Spark / PyIceberg / DuckDB integration examples** — would land in `examples/workspace-seeds/` per the existing seeded-examples pattern
- **Default warehouse-on-MinIO/Garage** baked into the spin-up workflow — there's a project-side decision about which storage backend the seeded "default warehouse" should point at
- **OIDC integration** with Lakekeeper's own auth layer — only relevant for operators who want fine-grained per-team table permissions inside Lakekeeper. CF Access at the edge is sufficient for the baseline "one team per stack" model.

## What does NOT change

- Existing stacks (no Trino catalog change, no Spark config change) — operators wire their engines against `https://lakekeeper.<domain>/catalog` themselves
- Object-storage choice — Lakekeeper works with any S3-compatible target; operator points it at whichever of MinIO / Garage / SeaweedFS / RustFS / external R2 they're already using
- pg_ducklake — separate stack, separate lakehouse pattern (DuckDB-native lakehouse vs. Iceberg lakehouse — both valid choices documented in `lakekeeper.md`)

## Note on parallel branches

This PR was developed in parallel with [#612 (HedgeDoc + LiteLLM)](https://github.com/stefanko-ch/Nexus-Stack/pull/612). Both branches touch the same shared files (`services.yaml`, `README.md`, `docs/stacks/README.md`, `src/nexus_deploy/{config,infisical,service_env}.py`, `tofu/stack/{main,outputs}.tf`, `tests/unit/test_service_env.py`). Whichever merges first, the second will need a small rebase (additive changes in disjoint regions of those files — straightforward conflict resolution).

