### PR TITLE
fix(stacks): Raise Metabase JVM heap to prevent OOM

### DIFF
--- a/stacks/metabase/docker-compose.yml
+++ b/stacks/metabase/docker-compose.yml
@@ -42,10 +42,15 @@ services:
       - MB_ADMIN_EMAIL=nexus@metabase.local
       - MB_ANON_TRACKING_ENABLED=false
       - JAVA_TIMEZONE=Europe/Zurich
+      # Without -Xmx the JVM picks ~25% of the container limit as max heap
+      # (~256 MB at 1g), which OOMs as soon as a user opens a dashboard
+      # against non-trivial Gold tables. 1.5 GB heap + 2 GB container leaves
+      # ~500 MB for non-heap JVM memory (Metaspace, direct buffers, stack).
+      - JAVA_OPTS=-Xmx1500m
     deploy:
       resources:
         limits:
-          memory: 1g
+          memory: 2g
     volumes:
       - /mnt/nexus-data/metabase:/metabase-data
     healthcheck:


### PR DESCRIPTION
## Summary

- Set `JAVA_OPTS=-Xmx1500m` on the Metabase container so the JVM picks a real heap size instead of the container-default ~25% (~256 MB at the old 1 GB limit).
- Bump container memory limit from 1 GB to 2 GB, leaving ~500 MB headroom for non-heap JVM memory (Metaspace, direct buffers, stack).
- Inline comment in the compose file explaining why both values are needed together.

## Why

User report from production usage: opening a Metabase dashboard against non-trivial Gold tables crashed with `Java OutOfMemoryError: 247 MB short`. Their in-container workaround — `sed -i 's/exec java $JAVA_OPTS/exec java -Xmx512m/' /app/run_metabase.sh` via Portainer console — fixed it for the session but was lost on every teardown, because `run_metabase.sh` lives in the image layer, not under the snapshotted `/metabase-data` volume.

Setting `JAVA_OPTS` via env var is the officially supported mechanism (the upstream `run_metabase.sh` already does `exec java $JAVA_OPTS …`) and persists across teardown + spin-up. 1.5 GB heap matches Metabase's own "at least 1 GB heap for production" recommendation with room for typical dashboard workloads.

## Footprint

+1 GB RAM on the cx43 (16 GB total, 40+ stacks). Acceptable given Metabase is one of the heavier stacks and the alternative is silent crashes under any real workload.

## Test plan

- [ ] `tofu plan` is unchanged (compose-only edit, no infra changes)
- [ ] Deploy on a stack with the issue: `gh workflow run spin-up.yml --ref fix/metabase-oom`
- [ ] Verify Metabase container starts and reports healthy: `ssh nexus "docker ps --filter name=metabase --format '{{.Status}}'"`
- [ ] Confirm JVM picked up the heap setting: `ssh nexus "docker exec metabase ps -ef | grep java"` should show `-Xmx1500m`
- [ ] Open a dashboard against a Databricks Gold table — should load without OOM
- [ ] Confirm memory usage stays inside the 2 GB container limit under sustained query load
