### PR TITLE
fix(tofu): Validate cloudflare_account_id, cloudflare_zone_id, domain shapes

### DIFF
--- a/tofu/control-plane/variables.tf
+++ b/tofu/control-plane/variables.tf
@@ -13,16 +13,45 @@ variable "cloudflare_api_token" {
 variable "cloudflare_account_id" {
   description = "Cloudflare Account ID (set via TF_VAR_cloudflare_account_id)"
   type        = string
+
+  # 32-char lowercase hex — Cloudflare's canonical Account-ID shape. Catches
+  # the common operator mistakes of pasting the API token, the Zone-ID, or
+  # an empty string instead. Without this guard, an empty/wrong value
+  # surfaces as opaque 403/404s from random Cloudflare resources mid-apply
+  # rather than a clean validation failure before any state is touched.
+  validation {
+    condition     = can(regex("^[0-9a-f]{32}$", var.cloudflare_account_id))
+    error_message = "cloudflare_account_id must be a 32-character lowercase hex string (Cloudflare Dashboard → top-right → Account ID)."
+  }
 }
 
 variable "cloudflare_zone_id" {
   description = "Cloudflare Zone ID for your domain"
   type        = string
+
+  # Same 32-hex shape as account_id (Cloudflare uses identical formatting).
+  # The account_id vs zone_id swap is the most common copy-paste error
+  # because both appear on the same Dashboard sidebar.
+  validation {
+    condition     = can(regex("^[0-9a-f]{32}$", var.cloudflare_zone_id))
+    error_message = "cloudflare_zone_id must be a 32-character lowercase hex string (Cloudflare Dashboard → your domain → Overview → Zone ID)."
+  }
 }
 
 variable "domain" {
   description = "Your domain name (e.g., example.com)"
   type        = string
+
+  # FQDN shape: at least one dot, only ASCII alphanumerics + hyphens +
+  # dots, no leading/trailing dot or hyphen. Catches accidental
+  # protocol-prefixed input ("https://example.com"), trailing-slash
+  # paths ("example.com/"), whitespace, and empty strings — all of
+  # which would otherwise propagate into DNS records, Worker bindings,
+  # and Pages domains before failing late.
+  validation {
+    condition     = can(regex("^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)+[a-z]{2,}$", var.domain))
+    error_message = "domain must be a bare lowercase FQDN like 'example.com' or 'nexus.example.com' — no scheme, no trailing slash, no whitespace."
+  }
 }
 
 variable "base_domain" {

--- a/tofu/control-plane/variables.tf
+++ b/tofu/control-plane/variables.tf
@@ -48,13 +48,14 @@ variable "domain" {
   type        = string
 
   # FQDN shape: at least one dot, only ASCII alphanumerics + hyphens +
-  # dots, no leading/trailing dot or hyphen. Catches accidental
+  # dots, no leading/trailing dot or hyphen. Each label (including the
+  # final TLD) is capped at the DNS 63-char limit. Catches accidental
   # protocol-prefixed input ("https://example.com"), trailing-slash
   # paths ("example.com/"), whitespace, and empty strings — all of
   # which would otherwise propagate into DNS records, Worker bindings,
   # and Pages domains before failing late.
   validation {
-    condition     = can(regex("^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)+[a-z]{2,}$", var.domain))
+    condition     = can(regex("^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)+[a-z]{2,63}$", var.domain))
     error_message = "domain must be a bare lowercase FQDN like 'example.com' or 'nexus.example.com' — no scheme, no trailing slash, no whitespace."
   }
 }

--- a/tofu/control-plane/variables.tf
+++ b/tofu/control-plane/variables.tf
@@ -14,11 +14,15 @@ variable "cloudflare_account_id" {
   description = "Cloudflare Account ID (set via TF_VAR_cloudflare_account_id)"
   type        = string
 
-  # 32-char lowercase hex — Cloudflare's canonical Account-ID shape. Catches
-  # the common operator mistakes of pasting the API token, the Zone-ID, or
-  # an empty string instead. Without this guard, an empty/wrong value
-  # surfaces as opaque 403/404s from random Cloudflare resources mid-apply
-  # rather than a clean validation failure before any state is touched.
+  # 32-char lowercase hex — Cloudflare's canonical Account-ID shape.
+  # Catches empty strings, whitespace, pasted API tokens, and most
+  # truncation/extension typos. NOTE: does NOT catch an account_id ↔
+  # zone_id swap — both values share the same 32-hex shape; reliably
+  # distinguishing them would need a runtime API call against the
+  # Cloudflare API, which is out of scope for an input validation.
+  # Without this guard, a malformed value surfaces as opaque 403/404s
+  # from random Cloudflare resources mid-apply rather than a clean
+  # validation failure before any state is touched.
   validation {
     condition     = can(regex("^[0-9a-f]{32}$", var.cloudflare_account_id))
     error_message = "cloudflare_account_id must be a 32-character lowercase hex string (Cloudflare Dashboard → top-right → Account ID)."
@@ -29,9 +33,10 @@ variable "cloudflare_zone_id" {
   description = "Cloudflare Zone ID for your domain"
   type        = string
 
-  # Same 32-hex shape as account_id (Cloudflare uses identical formatting).
-  # The account_id vs zone_id swap is the most common copy-paste error
-  # because both appear on the same Dashboard sidebar.
+  # Same 32-hex shape as account_id — Cloudflare uses identical
+  # formatting for both. A swap between the two passes this check
+  # (see account_id's note above); the validation here still catches
+  # empty strings, whitespace, pasted API tokens, and truncation typos.
   validation {
     condition     = can(regex("^[0-9a-f]{32}$", var.cloudflare_zone_id))
     error_message = "cloudflare_zone_id must be a 32-character lowercase hex string (Cloudflare Dashboard → your domain → Overview → Zone ID)."


### PR DESCRIPTION
## Summary

Adds shape-validations to three Tofu input variables in `tofu/control-plane/variables.tf`:

- **`cloudflare_account_id`** — must match `^[0-9a-f]{32}$`
- **`cloudflare_zone_id`** — must match `^[0-9a-f]{32}$`
- **`domain`** — must be a bare lowercase FQDN (no scheme, no trailing slash, no whitespace)

## Why

These three variables had no input validation, so a typo or copy-paste mistake propagated all the way into resource creation and surfaced as opaque Cloudflare 403/404s or DNS-record garbage mid-apply. The account-id vs zone-id swap is the most common one because both appear on the same Cloudflare Dashboard sidebar with identical formatting.

Each `error_message` now points the operator at the exact Dashboard location that produces the right value, so the failure is self-resolving instead of requiring docs lookup.

## Test plan

- [ ] `cd tofu/control-plane && tofu validate` passes (after `tofu init`)
- [ ] `tofu plan -var cloudflare_account_id=garbage` produces the new validation error before any provider call
- [ ] Existing configs with correct 32-hex IDs continue to plan/apply unchanged
- [ ] Workflow `initial-setup.yaml` succeeds — the live values from the operator's GitHub secrets already match these shapes

## Scope note

Schema-only change. No resource diffs in `tofu plan` for already-valid inputs.

Addresses CRITICAL findings C15-C17 from the 2026-05-22 quality audit (`AUDIT_REPORT.md`).
