### PR TITLE
fix(stacks): Remove hardcoded credential fallbacks (audit C1-C3)

### DIFF
--- a/stacks/grafana/docker-compose.yml
+++ b/stacks/grafana/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       - "3100:3000"
     environment:
       - GF_SECURITY_ADMIN_USER=${GRAFANA_ADMIN_USER:-admin}
-      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-admin}
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:?must be set in .env (rendered by service_env._render_grafana)}
       - GF_USERS_ALLOW_SIGN_UP=false
       - GF_AUTH_ANONYMOUS_ENABLED=true
       - GF_AUTH_ANONYMOUS_ORG_ROLE=Viewer

--- a/stacks/hoppscotch/docker-compose.yml
+++ b/stacks/hoppscotch/docker-compose.yml
@@ -43,7 +43,7 @@ services:
     restart: unless-stopped
     environment:
       - POSTGRES_USER=nexus-hoppscotch
-      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-hoppscotch}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:?must be set in .env (rendered by service_env._render_hoppscotch)}
       - POSTGRES_DB=hoppscotch
     volumes:
       - hoppscotch-db-data:/var/lib/postgresql/data

--- a/stacks/infisical/docker-compose.yml
+++ b/stacks/infisical/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       - AUTH_SECRET=${AUTH_SECRET:-}
       - SITE_URL=https://infisical.${DOMAIN:-localhost}
       # Database
-      - DB_CONNECTION_URI=postgres://nexus-infisical:${POSTGRES_PASSWORD:-infisical}@infisical-db:5432/infisical?sslmode=disable
+      - DB_CONNECTION_URI=postgres://nexus-infisical:${POSTGRES_PASSWORD:?must be set in .env (rendered by service_env._render_infisical)}@infisical-db:5432/infisical?sslmode=disable
       # Redis
       - REDIS_URL=redis://infisical-redis:6379
       # Disable telemetry
@@ -53,7 +53,7 @@ services:
     restart: unless-stopped
     environment:
       - POSTGRES_USER=nexus-infisical
-      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-infisical}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:?must be set in .env (rendered by service_env._render_infisical)}
       - POSTGRES_DB=infisical
     volumes:
       - infisical-db-data:/var/lib/postgresql/data


### PR DESCRIPTION
## Summary

Removes hardcoded credential fallbacks from three compose files. Each `${VAR:-default}` becomes `${VAR:?error}` so missing values fail fast at `docker compose up` instead of silently using a predictable password.

| File | Before | After |
|---|---|---|
| `stacks/infisical/docker-compose.yml` | `POSTGRES_PASSWORD:-infisical` (2 references) | `POSTGRES_PASSWORD:?must be set in .env (rendered by service_env._render_infisical)` |
| `stacks/hoppscotch/docker-compose.yml` | `POSTGRES_PASSWORD:-hoppscotch` | `POSTGRES_PASSWORD:?must be set in .env (rendered by service_env._render_hoppscotch)` |
| `stacks/grafana/docker-compose.yml` | `GRAFANA_ADMIN_PASSWORD:-admin` | `GRAFANA_ADMIN_PASSWORD:?must be set in .env (rendered by service_env._render_grafana)` |

## Why

In normal operation each variable is overridden by `src/nexus_deploy/service_env.py`'s `_render_<stack>` hook, which writes the Tofu-generated random password into `stacks/<stack>/.env`. The defaults were dead code at deploy time.

The risk is in the failure case: if `.env` is missing or the renderer didn't run for any reason (half-deployed setup, manual `docker compose up` for debugging, fork that skipped the orchestrator), each container would silently come up with a guessable credential. For Infisical that's the secret-management service itself, on a publicly-named host — and this is a public repository where the fallbacks are visible to attackers as reconnaissance.

Fail-fast `${VAR:?}` aborts compose-up with an explicit pointer at the renderer function that should have populated the value, before any container starts.

## What this does NOT change

- The Grafana admin **username** fallback (`GRAFANA_ADMIN_USER:-admin`) is intentionally left in place. It's a separate convention/naming finding (HIGH-tier in the audit, not CRITICAL); fixing the predictable PASSWORD already neutralises the `admin/admin`-login risk.
- No renderer changes — the production happy path is unaffected.

## Test plan

- [ ] Existing deploys where `.env` is populated via the renderer continue to work — no behaviour change for the happy path.
- [ ] `docker compose -f stacks/infisical/docker-compose.yml up` with empty `.env` (the failure case) now produces the explicit error "POSTGRES_PASSWORD must be set in .env (rendered by service_env._render_infisical)" instead of silently using `:-infisical`.
- [ ] Same verification for hoppscotch and grafana.

Addresses CRITICAL findings C1, C2, C3 from the 2026-05-22 quality audit (`AUDIT_REPORT.md`).
