### PR TITLE
fix(stacks): Resolve host-port 8888 collision (adminer ⇔ seaweedfs)

### DIFF
--- a/docs/stacks/seaweedfs.md
+++ b/docs/stacks/seaweedfs.md
@@ -16,7 +16,7 @@ SeaweedFS is a lightweight distributed object storage system with S3 API compati
 
 | Setting | Value |
 |---------|-------|
-| Ports | `8888` (Filer UI), `9333` (Master UI), `8333` (S3 API) |
+| Ports | `8890` (Filer UI), `9333` (Master UI), `8333` (S3 API) |
 | Subdomains | `seaweedfs` (Filer), `seaweedfs-manager` (Master) |
 | Public Access | No (storage infrastructure) |
 | Website | [seaweedfs.com](https://seaweedfs.com) |

--- a/services.yaml
+++ b/services.yaml
@@ -699,7 +699,10 @@ services:
       admin: 9644
 
   seaweedfs:
-    port: 8888
+    # Filer UI host port — moved 8888 → 8890 to resolve collision with
+    # adminer (also on host 8888). Container-side port stays 8888 (see
+    # stacks/seaweedfs/docker-compose.yml's port mapping).
+    port: 8890
     public: false
     internal_only: true
     category: "storage"
@@ -710,7 +713,7 @@ services:
 
   seaweedfs-filer:
     subdomain: "seaweedfs"
-    port: 8888
+    port: 8890
     stack: "seaweedfs"
     public: false
     category: "storage"

--- a/stacks/seaweedfs/docker-compose.yml
+++ b/stacks/seaweedfs/docker-compose.yml
@@ -23,7 +23,7 @@ services:
     ports:
       - "9333:9333"  # Master UI (statistics only)
       - "8333:8333"  # S3 API
-      - "8888:8888"  # Filer Web UI (file browser/upload)
+      - "8890:8888"  # Filer Web UI (file browser/upload) — host 8890 to avoid collision with adminer's 8888
     command: >
       server
       -s3


### PR DESCRIPTION
## Summary

Resolves a 3-way collision on host port `8888` in `services.yaml` by moving SeaweedFS's Filer Web UI to host port `8890`. Container-side port stays at 8888 (the filer's actual listen port, also referenced by `-filer.port=8888` in the seaweedfs command line).

| Entry | Before | After |
|---|---|---|
| `adminer` (host bind 8888 → container 8080) | 8888 | **8888** (unchanged — registered first) |
| `seaweedfs` (internal_only base entry) | 8888 | **8890** |
| `seaweedfs-filer` (subdomain `seaweedfs`) | 8888 | **8890** |
| `stacks/seaweedfs/docker-compose.yml` port mapping | `"8888:8888"` | `"8890:8888"` |
| `docs/stacks/seaweedfs.md` ports row | `8888` (Filer UI) | `8890` (Filer UI) |

## Why

`stacks/adminer/docker-compose.yml` binds host 8888 → container 8080. `stacks/seaweedfs/docker-compose.yml` previously bound host 8888 → container 8888 for the Filer Web UI. When both stacks are enabled, the second container to start fails with `port already allocated` at the Docker daemon level — a hard error, not a degraded mode.

The fix chooses 8890 because 8889 is already taken by `dinky`. The 88xx range was densely packed; 8890 is the first free slot after the collision.

## What this does NOT change

- Container-internal port (8888) and the `-filer.port=8888` flag stay — those are the SeaweedFS daemon's own listening configuration, not the host-side binding. Changing them would require an upstream image rebuild.
- The other two seaweedfs ports (`9333` master UI, `8333` S3 API) were already free, no change.

## Test plan

- [ ] Enable both adminer and seaweedfs on a deploy — both containers come up green.
- [ ] `curl https://seaweedfs.<domain>/` reaches the Filer UI (the Cloudflare Tunnel ingress reads the port from `services.yaml`, so the move from 8888 → 8890 is transparent to the end user).
- [ ] `curl https://adminer.<domain>/` still works (unchanged).
- [ ] `docker port seaweedfs` on the server shows `8888/tcp → 0.0.0.0:8890`.

Addresses CRITICAL finding C19 from the 2026-05-22 quality audit (`AUDIT_REPORT.md`).
