### PR TITLE
feat: Add guest_emails for multi-user Access

### DIFF
--- a/.github/workflows/destroy-all.yml
+++ b/.github/workflows/destroy-all.yml
@@ -115,6 +115,7 @@ jobs:
           subdomain_separator = "${{ secrets.SUBDOMAIN_SEPARATOR || '.' }}"
           admin_email         = "${{ secrets.TF_VAR_admin_email }}"
           user_email          = "${{ secrets.TF_VAR_user_email }}"
+          guest_emails        = "${{ secrets.TF_VAR_guest_emails }}"
           admin_username      = "admin"
           github_owner        = "${{ github.repository_owner }}"
           github_repo         = "${{ github.event.repository.name }}"
@@ -146,6 +147,7 @@ jobs:
           subdomain_separator = "${{ secrets.SUBDOMAIN_SEPARATOR || '.' }}"
           admin_email         = "${{ secrets.TF_VAR_admin_email }}"
           user_email          = "${{ secrets.TF_VAR_user_email }}"
+          guest_emails        = "${{ secrets.TF_VAR_guest_emails }}"
           github_owner        = "${{ github.repository_owner }}"
           github_repo         = "${{ github.event.repository.name }}"
           EOF

--- a/.github/workflows/setup-control-plane.yaml
+++ b/.github/workflows/setup-control-plane.yaml
@@ -170,6 +170,7 @@ jobs:
           subdomain_separator = "${{ secrets.SUBDOMAIN_SEPARATOR || '.' }}"
           admin_email         = "${{ secrets.TF_VAR_admin_email }}"
           user_email          = "${{ secrets.TF_VAR_user_email }}"
+          guest_emails        = "${{ secrets.TF_VAR_guest_emails }}"
           github_owner        = "${{ github.repository_owner }}"
           github_repo         = "${{ github.event.repository.name }}"
           allow_disable_auto_shutdown = ${{ vars.ALLOW_DISABLE_AUTO_SHUTDOWN == 'true' }}

--- a/.github/workflows/spin-up.yml
+++ b/.github/workflows/spin-up.yml
@@ -279,6 +279,7 @@ jobs:
           domain               = "${{ secrets.DOMAIN }}"
           admin_email          = "${{ secrets.TF_VAR_admin_email }}"
           user_email           = "${{ secrets.TF_VAR_user_email }}"
+          guest_emails         = "${{ secrets.TF_VAR_guest_emails }}"
           admin_username       = "admin"
           subdomain_separator  = "${{ secrets.SUBDOMAIN_SEPARATOR || '.' }}"
           github_owner         = "${{ github.repository_owner }}"

--- a/.github/workflows/teardown.yml
+++ b/.github/workflows/teardown.yml
@@ -164,6 +164,7 @@ jobs:
           subdomain_separator = "${{ secrets.SUBDOMAIN_SEPARATOR || '.' }}"
           admin_email         = "${{ secrets.TF_VAR_admin_email }}"
           user_email          = "${{ secrets.TF_VAR_user_email }}"
+          guest_emails        = "${{ secrets.TF_VAR_guest_emails }}"
           admin_username      = "admin"
           github_owner        = "${{ github.repository_owner }}"
           github_repo         = "${{ github.event.repository.name }}"

--- a/control-plane/functions/api/_utils/cf-access-email.js
+++ b/control-plane/functions/api/_utils/cf-access-email.js
@@ -4,9 +4,12 @@
 // app configurations also emit `Cf-Access-Authenticated-User-Email` as a
 // plain header — newer apps tend not to. Decoding the JWT's email claim is
 // the only universally reliable path. Origin-supplied `Cf-Access-*` headers
-// are stripped and re-set at Cloudflare's edge, so any value reaching the
-// Worker can only have been written by the edge — no signature verification
-// needed.
+// are stripped and re-set at Cloudflare's edge, so values reaching the
+// Worker were written by the edge — but only as long as the request
+// actually passed through Access. That holds for Pages Functions on this
+// project today; a misconfig or alternate route would break the assumption.
+// Proper defense-in-depth would verify the JWT signature against the
+// Access JWKS endpoint.
 export function getAccessUserEmail(request) {
   const direct = (request.headers.get('Cf-Access-Authenticated-User-Email') || '').trim();
   if (direct) return direct;

--- a/control-plane/functions/api/_utils/cf-access-email.js
+++ b/control-plane/functions/api/_utils/cf-access-email.js
@@ -1,0 +1,23 @@
+// Extract the authenticated user's email from a Cloudflare Access request.
+//
+// Cloudflare Access always injects `Cf-Access-Jwt-Assertion`, but only some
+// app configurations also emit `Cf-Access-Authenticated-User-Email` as a
+// plain header — newer apps tend not to. Decoding the JWT's email claim is
+// the only universally reliable path. We trust the value because only
+// Cloudflare's edge can write these headers (origin spoofing is replaced).
+export function getAccessUserEmail(request) {
+  const direct = (request.headers.get('Cf-Access-Authenticated-User-Email') || '').trim();
+  if (direct) return direct;
+
+  const jwt = request.headers.get('Cf-Access-Jwt-Assertion');
+  if (!jwt) return null;
+  const parts = jwt.split('.');
+  if (parts.length !== 3) return null;
+
+  try {
+    const payload = JSON.parse(atob(parts[1].replace(/-/g, '+').replace(/_/g, '/')));
+    return typeof payload.email === 'string' ? payload.email.trim() : null;
+  } catch {
+    return null;
+  }
+}

--- a/control-plane/functions/api/_utils/cf-access-email.js
+++ b/control-plane/functions/api/_utils/cf-access-email.js
@@ -3,8 +3,10 @@
 // Cloudflare Access always injects `Cf-Access-Jwt-Assertion`, but only some
 // app configurations also emit `Cf-Access-Authenticated-User-Email` as a
 // plain header — newer apps tend not to. Decoding the JWT's email claim is
-// the only universally reliable path. We trust the value because only
-// Cloudflare's edge can write these headers (origin spoofing is replaced).
+// the only universally reliable path. Origin-supplied `Cf-Access-*` headers
+// are stripped and re-set at Cloudflare's edge, so any value reaching the
+// Worker can only have been written by the edge — no signature verification
+// needed.
 export function getAccessUserEmail(request) {
   const direct = (request.headers.get('Cf-Access-Authenticated-User-Email') || '').trim();
   if (direct) return direct;

--- a/control-plane/functions/api/_utils/require-admin.js
+++ b/control-plane/functions/api/_utils/require-admin.js
@@ -4,8 +4,8 @@
 // every email on the Access whitelist (admin + users + guests) reaches every
 // endpoint with the same rights. This helper restricts an endpoint to the
 // single ADMIN_EMAIL identity by comparing it against the Access-authenticated
-// caller (extracted from the JWT). Emails are compared case-insensitively per
-// RFC 5321.
+// caller (extracted from the JWT). Comparison is case-insensitive to match
+// Cloudflare Access / identity-provider behaviour.
 //
 // Usage at the top of any admin-only handler:
 //   const denial = requireAdmin(context.env, context.request);
@@ -14,9 +14,18 @@ import { getAccessUserEmail } from './cf-access-email.js';
 
 export function requireAdmin(env, request) {
   const adminEmail = (env.ADMIN_EMAIL || '').trim().toLowerCase();
-  const caller = (getAccessUserEmail(request) || '').trim().toLowerCase();
+  if (!adminEmail) {
+    return new Response(JSON.stringify({
+      success: false,
+      error: 'Server misconfigured: ADMIN_EMAIL is not set'
+    }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' }
+    });
+  }
 
-  if (!adminEmail || !caller || caller !== adminEmail) {
+  const caller = (getAccessUserEmail(request) || '').trim().toLowerCase();
+  if (!caller || caller !== adminEmail) {
     return new Response(JSON.stringify({
       success: false,
       error: 'Forbidden: this endpoint requires admin access'

--- a/control-plane/functions/api/_utils/require-admin.js
+++ b/control-plane/functions/api/_utils/require-admin.js
@@ -1,0 +1,29 @@
+// Authorization guard for admin-only endpoints.
+//
+// Cloudflare Access authenticates the caller but doesn't authorize per-role:
+// every email on the Access whitelist (admin + users + guests) reaches every
+// endpoint with the same rights. This helper restricts an endpoint to the
+// single ADMIN_EMAIL identity by comparing it against the Access-authenticated
+// caller (extracted from the JWT). Emails are compared case-insensitively per
+// RFC 5321.
+//
+// Usage at the top of any admin-only handler:
+//   const denial = requireAdmin(context.env, context.request);
+//   if (denial) return denial;
+import { getAccessUserEmail } from './cf-access-email.js';
+
+export function requireAdmin(env, request) {
+  const adminEmail = (env.ADMIN_EMAIL || '').trim().toLowerCase();
+  const caller = (getAccessUserEmail(request) || '').trim().toLowerCase();
+
+  if (!adminEmail || !caller || caller !== adminEmail) {
+    return new Response(JSON.stringify({
+      success: false,
+      error: 'Forbidden: this endpoint requires admin access'
+    }), {
+      status: 403,
+      headers: { 'Content-Type': 'application/json' }
+    });
+  }
+  return null;
+}

--- a/control-plane/functions/api/databricks-config.js
+++ b/control-plane/functions/api/databricks-config.js
@@ -8,6 +8,7 @@
 
 import { logApiCall, logError } from './_utils/logger.js';
 import { fetchWithTimeout } from './_utils/fetch-with-timeout.js';
+import { requireAdmin } from './_utils/require-admin.js';
 
 export async function onRequestGet(context) {
   const { env } = context;
@@ -43,6 +44,8 @@ export async function onRequestGet(context) {
 
 export async function onRequestPost(context) {
   const { env, request } = context;
+  const denial = requireAdmin(env, request);
+  if (denial) return denial;
 
   try {
     if (!env.NEXUS_KV) {

--- a/control-plane/functions/api/databricks-sync.js
+++ b/control-plane/functions/api/databricks-sync.js
@@ -22,6 +22,7 @@ import { fetchWithTimeout } from './_utils/fetch-with-timeout.js';
 import { safeHttpsUrl } from './_utils/url.js';
 import { logApiCall, logError } from './_utils/logger.js';
 import { fetchAllInfisicalSecrets } from './_utils/infisical.js';
+import { requireAdmin } from './_utils/require-admin.js';
 
 const SCOPE_NAME = 'nexus';
 const UPSERT_BATCH = 10;
@@ -135,7 +136,10 @@ export async function onRequestGet(context) {
 }
 
 export async function onRequestPost(context) {
-  const { env } = context;
+  const { env, request } = context;
+  const denial = requireAdmin(env, request);
+  if (denial) return denial;
+
   const auth = await readDatabricksAuth(env);
   if (auth.error) {
     return jsonResponse({ success: false, error: auth.error }, 400);

--- a/control-plane/functions/api/destroy.js
+++ b/control-plane/functions/api/destroy.js
@@ -7,10 +7,13 @@
  */
 import { fetchWithTimeout } from './_utils/fetch-with-timeout.js';
 import { logApiCall, logError } from './_utils/logger.js';
+import { requireAdmin } from './_utils/require-admin.js';
 
 export async function onRequestPost(context) {
   const { env, request } = context;
-  
+  const denial = requireAdmin(env, request);
+  if (denial) return denial;
+
   // Validate environment variables
   if (!env.GITHUB_TOKEN || !env.GITHUB_OWNER || !env.GITHUB_REPO) {
     return new Response(JSON.stringify({ 

--- a/control-plane/functions/api/email-settings.js
+++ b/control-plane/functions/api/email-settings.js
@@ -6,6 +6,7 @@
  * Configuration stored in Cloudflare D1 database
  */
 import { logApiCall, logError } from './_utils/logger.js';
+import { requireAdmin } from './_utils/require-admin.js';
 
 async function getConfig(db, key, defaultValue = null) {
   try {
@@ -56,6 +57,9 @@ export async function onRequestGet(context) {
 }
 
 export async function onRequestPost(context) {
+  const denial = requireAdmin(context.env, context.request);
+  if (denial) return denial;
+
   const db = context.env.NEXUS_DB;
   if (!db) {
     return new Response(JSON.stringify({ success: false, error: 'D1 database not configured' }), {

--- a/control-plane/functions/api/firewall.js
+++ b/control-plane/functions/api/firewall.js
@@ -10,6 +10,7 @@
  */
 
 import { logApiCall, logError } from './_utils/logger.js';
+import { requireAdmin } from './_utils/require-admin.js';
 
 /**
  * Validate service name to prevent injection attacks
@@ -162,6 +163,8 @@ export async function onRequestGet(context) {
  */
 export async function onRequestPost(context) {
   const { env, request } = context;
+  const denial = requireAdmin(env, request);
+  if (denial) return denial;
 
   if (!env.NEXUS_DB) {
     return new Response(JSON.stringify({

--- a/control-plane/functions/api/scheduled-teardown.js
+++ b/control-plane/functions/api/scheduled-teardown.js
@@ -8,6 +8,7 @@
 
 import { logApiCall, logError } from './_utils/logger.js';
 import { getAccessUserEmail } from './_utils/cf-access-email.js';
+import { requireAdmin } from './_utils/require-admin.js';
 
 // D1 Helper Functions
 async function getConfig(db, key, defaultValue = null) {
@@ -236,6 +237,8 @@ export async function onRequestGet(context) {
 
 export async function onRequestPost(context) {
   const { env, request } = context;
+  const denial = requireAdmin(env, request);
+  if (denial) return denial;
   const userEmail = getAccessUserEmail(request) || '';
   const maxExtensionsPerDay = parsePositiveInt(env.MAX_EXTENSIONS_PER_DAY, 3);
   const maxDelayHours = parsePositiveInt(env.MAX_DELAY_HOURS, 4);

--- a/control-plane/functions/api/scheduled-teardown.js
+++ b/control-plane/functions/api/scheduled-teardown.js
@@ -7,6 +7,7 @@
  */
 
 import { logApiCall, logError } from './_utils/logger.js';
+import { getAccessUserEmail } from './_utils/cf-access-email.js';
 
 // D1 Helper Functions
 async function getConfig(db, key, defaultValue = null) {
@@ -134,7 +135,7 @@ function timeInTimezoneToUTC(timeStr, timezone, baseDate = new Date()) {
 
 export async function onRequestGet(context) {
   const { env, request } = context;
-  const userEmail = request.headers.get('CF-Access-Authenticated-User-Email') || '';
+  const userEmail = getAccessUserEmail(request) || '';
   const maxExtensionsPerDay = parsePositiveInt(env.MAX_EXTENSIONS_PER_DAY, 3);
   const maxDelayHours = parsePositiveInt(env.MAX_DELAY_HOURS, 4);
   
@@ -235,7 +236,7 @@ export async function onRequestGet(context) {
 
 export async function onRequestPost(context) {
   const { env, request } = context;
-  const userEmail = request.headers.get('CF-Access-Authenticated-User-Email') || '';
+  const userEmail = getAccessUserEmail(request) || '';
   const maxExtensionsPerDay = parsePositiveInt(env.MAX_EXTENSIONS_PER_DAY, 3);
   const maxDelayHours = parsePositiveInt(env.MAX_DELAY_HOURS, 4);
 

--- a/control-plane/functions/api/send-credentials.js
+++ b/control-plane/functions/api/send-credentials.js
@@ -8,6 +8,7 @@
 import { fetchWithTimeout } from './_utils/fetch-with-timeout.js';
 import { logApiCall, logError } from './_utils/logger.js';
 import { safeHttpsUrl } from './_utils/url.js';
+import { getAccessUserEmail } from './_utils/cf-access-email.js';
 
 // Resend-accepted email formats. Hoisted to module scope so the regex
 // objects are created once per Worker boot instead of once per request.
@@ -18,7 +19,7 @@ const BRACKETED_EMAIL_RE = /^\S[^<>]*<[^\s@<>]+@[^\s@<>]+\.[^\s@<>]+>$/;
 const isValidResendEmail = (e) => PLAIN_EMAIL_RE.test(e) || BRACKETED_EMAIL_RE.test(e);
 
 export async function onRequestPost(context) {
-  const { env } = context;
+  const { env, request } = context;
 
   // Validate environment variables
   const requiredEnv = ['RESEND_API_KEY', 'ADMIN_EMAIL', 'DOMAIN'];
@@ -60,18 +61,21 @@ export async function onRequestPost(context) {
     const fromDomain = env.BASE_DOMAIN || domain;
     const adminEmail = env.ADMIN_EMAIL;
 
-    // USER_EMAIL may be a single address or a comma-separated list
-    // (e.g. when multiple admin emails are piped through from the admin panel).
-    // Split + trim + validate against the Resend-accepted email regex
-    // (hoisted to module scope above).
+    // TO is the Access-authenticated caller, so each user gets their own copy.
+    // Falls back to USER_EMAIL[0] when no Access identity can be resolved.
+    const accessEmailRaw = getAccessUserEmail(request);
+    const accessEmail = accessEmailRaw && isValidResendEmail(accessEmailRaw) ? accessEmailRaw : null;
+
+    // USER_EMAIL may be a single address or a comma-separated list.
     const userEmails = (env.USER_EMAIL || '')
       .split(',')
       .map((e) => e.trim())
       .filter(isValidResendEmail);
-    const primaryUserEmail = userEmails[0] || null;
-    const extraUserEmails = userEmails.slice(1);
-    // Back-compat: keep `userEmail` as the primary for downstream logic.
-    const userEmail = primaryUserEmail;
+    const fallbackUserEmail = userEmails[0] || null;
+    const userEmail = accessEmail || fallbackUserEmail;
+    if (!accessEmail) {
+      console.warn('send-credentials: no Access identity resolved, falling back to USER_EMAIL[0]');
+    }
     const infisicalUrl = safeHttpsUrl(env.INFISICAL_URL, `https://infisical.${domain}`);
     const controlPlaneUrl = safeHttpsUrl(env.CONTROL_PLANE_URL, `https://control.${domain}`);
 
@@ -129,15 +133,14 @@ export async function onRequestPost(context) {
 </div>
     `;
 
-    // Send email via Resend (User as primary, Admin + extra users in CC)
     const emailPayload = {
       from: `Nexus-Stack <nexus@${fromDomain}>`,
       to: userEmail ? [userEmail] : [adminEmail],
       subject: '🔐 Nexus-Stack Credentials',
       html: emailHTML
     };
-    if (userEmail) {
-      emailPayload.cc = [adminEmail, ...extraUserEmails];
+    if (userEmail && userEmail.toLowerCase() !== adminEmail.toLowerCase()) {
+      emailPayload.cc = [adminEmail];
     }
 
     const resendResponse = await fetchWithTimeout('https://api.resend.com/emails', {

--- a/control-plane/functions/api/setup.js
+++ b/control-plane/functions/api/setup.js
@@ -7,10 +7,13 @@
  */
 import { fetchWithTimeout } from './_utils/fetch-with-timeout.js';
 import { logApiCall, logError } from './_utils/logger.js';
+import { requireAdmin } from './_utils/require-admin.js';
 
 export async function onRequestPost(context) {
-  const { env } = context;
-  
+  const { env, request } = context;
+  const denial = requireAdmin(env, request);
+  if (denial) return denial;
+
   // Validate environment variables
   if (!env.GITHUB_TOKEN || !env.GITHUB_OWNER || !env.GITHUB_REPO) {
     return new Response(JSON.stringify({ 

--- a/control-plane/functions/api/teardown.js
+++ b/control-plane/functions/api/teardown.js
@@ -8,10 +8,13 @@
 
 import { logApiCall, logError } from './_utils/logger.js';
 import { fetchWithTimeout } from './_utils/fetch-with-timeout.js';
+import { requireAdmin } from './_utils/require-admin.js';
 
 export async function onRequestPost(context) {
   const { env, request } = context;
-  
+  const denial = requireAdmin(env, request);
+  if (denial) return denial;
+
   // Validate environment variables
   if (!env.GITHUB_TOKEN || !env.GITHUB_OWNER || !env.GITHUB_REPO) {
     return new Response(JSON.stringify({ 

--- a/control-plane/src/pages/secrets.astro
+++ b/control-plane/src/pages/secrets.astro
@@ -11,7 +11,7 @@ import Layout from '../layouts/Layout.astro';
   <div class="email-credentials-panel">
     <div class="email-credentials-text">
       <strong>Email Credentials</strong>
-      <p>Sends an email with the <strong>Infisical admin URL, email, and password</strong> to your email, with the admin copied. All other service credentials live inside Infisical itself — log in there to view them.</p>
+      <p>Sends an email with the <strong>Infisical admin URL, email, and password</strong> to your email; admin is CC'd unless you are the admin. All other service credentials live inside Infisical itself — log in there to view them.</p>
     </div>
     <button class="email-credentials-btn" id="btn-email-credentials">
       <span class="icon">&#x1F4E7;</span>

--- a/control-plane/src/pages/secrets.astro
+++ b/control-plane/src/pages/secrets.astro
@@ -11,7 +11,7 @@ import Layout from '../layouts/Layout.astro';
   <div class="email-credentials-panel">
     <div class="email-credentials-text">
       <strong>Email Credentials</strong>
-      <p>Sends an email with the <strong>Infisical admin URL, email, and password</strong> to the stack owner. All other service credentials live inside Infisical itself — log in there to view them.</p>
+      <p>Sends an email with the <strong>Infisical admin URL, email, and password</strong> to your email, with the admin copied. All other service credentials live inside Infisical itself — log in there to view them.</p>
     </div>
     <button class="email-credentials-btn" id="btn-email-credentials">
       <span class="icon">&#x1F4E7;</span>

--- a/docs/admin-guides/setup-guide.md
+++ b/docs/admin-guides/setup-guide.md
@@ -133,7 +133,8 @@ Add these secrets to your GitHub repository:
 | Secret Name | Description |
 |-------------|-------------|
 | `GH_SECRETS_TOKEN` | GitHub PAT for R2 auto-save and Cloudflare runtime (see below) |
-| `TF_VAR_user_email` | User - all services except SSH |
+| `TF_VAR_user_email` | User - all services except SSH (also receives notifications) |
+| `TF_VAR_guest_emails` | Comma-separated guests - Access whitelist only, no notifications |
 | `RESEND_API_KEY` | Email notifications via Resend |
 | `DOCKERHUB_USERNAME` | Docker Hub username (higher pull limits) |
 | `DOCKERHUB_TOKEN` | Docker Hub access token |

--- a/tofu/control-plane/main.tf
+++ b/tofu/control-plane/main.tf
@@ -12,11 +12,12 @@ locals {
   # Resource prefix derived from domain (e.g., "example.com" → "nexus-example-com")
   resource_prefix = "nexus-${replace(var.domain, ".", "-")}"
 
-  # List of emails allowed to access control plane (admin + optional user)
-  # user_email may be comma-separated, so split and trim into individual entries
+  # List of emails allowed to access control plane (admin + optional user + optional guests)
+  # user_email and guest_emails may be comma-separated, so split and trim into individual entries
   allowed_emails = distinct(compact(concat(
     [trimspace(var.admin_email)],
-    [for email in split(",", var.user_email) : trimspace(email)]
+    [for email in split(",", var.user_email) : trimspace(email)],
+    [for email in split(",", var.guest_emails) : trimspace(email)]
   )))
 
   # Control Plane URLs. Built from the base domain and the subdomain separator

--- a/tofu/control-plane/variables.tf
+++ b/tofu/control-plane/variables.tf
@@ -60,6 +60,12 @@ variable "user_email" {
   default     = ""
 }
 
+variable "guest_emails" {
+  description = "Comma-separated guest emails for Cloudflare Access (no SSH, no notifications). Optional."
+  type        = string
+  default     = ""
+}
+
 variable "server_type" {
   description = "Hetzner server type (passed to Control Plane for display)"
   type        = string

--- a/tofu/stack/main.tf
+++ b/tofu/stack/main.tf
@@ -7,11 +7,12 @@ locals {
   # This ensures unique resource names when multiple users deploy Nexus-Stack
   resource_prefix = "nexus-${replace(var.domain, ".", "-")}"
 
-  # List of emails allowed to access services (admin + optional user)
-  # user_email may be comma-separated, so split and trim into individual entries
+  # List of emails allowed to access services (admin + optional user + optional guests)
+  # user_email and guest_emails may be comma-separated, so split and trim into individual entries
   allowed_emails = distinct(compact(concat(
     [trimspace(var.admin_email)],
-    [for email in split(",", var.user_email) : trimspace(email)]
+    [for email in split(",", var.user_email) : trimspace(email)],
+    [for email in split(",", var.guest_emails) : trimspace(email)]
   )))
 }
 

--- a/tofu/stack/variables.tf
+++ b/tofu/stack/variables.tf
@@ -150,6 +150,12 @@ variable "user_email" {
   default     = ""
 }
 
+variable "guest_emails" {
+  description = "Comma-separated guest emails for Cloudflare Access (no SSH, no notifications). Optional."
+  type        = string
+  default     = ""
+}
+
 variable "admin_username" {
   description = "Admin username for services like Portainer, Uptime Kuma (default: nexus)"
   type        = string


### PR DESCRIPTION
## Description

Per @stefanko-ch's guidance in #606, this bundles three related changes in
the suggested order (bugfix → security → feature):

1. **`fix(control-plane)`** — `_utils/cf-access-email.js` helper for JWT
   email extraction. Fixes the silently-broken per-user attribution in
   `scheduled-teardown` on Access apps that no longer emit
   `Cf-Access-Authenticated-User-Email` as a plain header.

2. **`feat(control-plane)`** — `_utils/require-admin.js` helper guarding
   POST handlers on `scheduled-teardown`, `teardown`, `destroy`, `setup`,
   `firewall`, `email-settings`. Closes the auth gap where guests inherit
   every write endpoint. GET handlers are left open so the settings page
   and `PendingBar` still render for non-admin users.

3. **`feat`** — `TF_VAR_guest_emails` variable feeding only the Cloudflare
   Access whitelist (not notification recipients), plus per-user
   `send-credentials` delivery (TO: caller from JWT, CC: admin, CC skipped
   when caller is admin).

### Refinement vs. the issue's matrix

The original endpoint matrix in #606 categorised whole endpoints as
admin-only. Implementing it that way silently broke the settings page for
guests because it auto-fires GETs to those endpoints on page load.
Refined to **guard POSTs only** — same security intent (no guest writes),
no UI breakage. Happy to revisit if you'd prefer something different.

### Endpoint role matrix (post-review)

After the first review round, the explicit split is:

**Admin-only POST handlers** (guarded with `requireAdmin`):

- `/api/scheduled-teardown` — config writes
- `/api/teardown`, `/api/destroy`, `/api/setup` — workflow triggers
- `/api/firewall`, `/api/email-settings` — rule + preference writes
- `/api/databricks-config`, `/api/databricks-sync` — added in da1ae5f
  (write account-wide Databricks credentials / bulk-sync every Infisical
  secret)

**Open to all authenticated roles** (admin + user + guest, deliberately
not guarded):

- `/api/spin-up`, `/api/services`, `/api/deploy` — the
  guests-can-spin-up-and-toggle-services interactions that are the whole
  point of `guest_emails`

All GET handlers stay open (reading current state is harmless and
required by UI auto-loads on every page).

### `/api/setup` aside

Guarded for consistency, but unreferenced by any UI fetch site. May be
orphaned — happy to file a follow-up to delete it if you confirm.

### Known UX gap (not addressed here)

The Control Plane UI still renders admin-only controls (teardown/destroy
buttons, firewall toggles) to non-admin users. Clicking produces a 403
toast rather than the button being hidden. Proper fix needs a `userRole`
field surfaced to the frontend — out of scope for this PR. Will file a
follow-up issue if accepted.

## Motivation and Context

A single Nexus-Stack operator wants to grant a small number of trusted
guests Control Plane access without CC'ing them on every operational
notification (teardown warnings, spin-up confirmations). `TF_VAR_user_email`
currently does double duty as the Access whitelist AND the notification
recipient list — using it for guests floods them with admin noise.

While prototyping on a fork, two underlying issues surfaced and were
bundled in (per the maintainer's "include them in the same PR" reply):

- `scheduled-teardown` per-user extension tracking was attributing every
  event to `user=''` because the plain Access email header isn't injected
  on newer Access app configs.
- Without per-role authorisation, any whitelisted guest could trigger
  teardown / destroy / configuration writes.

Closes #606

## How Has This Been Tested?

Tested end-to-end on a fork deployment at `odeslab.com`:

- Guest email added to `TF_VAR_guest_emails`, OTP login at the Control
  Plane succeeded
- Guest received a 403 toast when attempting teardown / destroy / setup /
  firewall toggles / email-settings writes / scheduled-teardown config
  writes
- Admin retained full access to all controls
- `send-credentials` delivered to the clicking user, admin CC'd, CC
  skipped when admin clicks
- `scheduled-teardown` extension log entries now record the actual caller
  email (no more `user=''`)

Both Control Plane (`tofu/control-plane/`) and stack (`tofu/stack/`) Access
apps were updated via `setup-control-plane.yaml` and `spin-up.yml`
respectively to verify the variable propagates through both modules.

No JS test infrastructure exists in the project, so unit tests were not
added for the new helpers.

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Guest email whitelisting for Cloudflare Access (stack & control-plane accept guest emails)
  * Admin-only authorization gates added to control-plane API endpoints
  * Email delivery now derives sender from Access identity and conditionally CCs the admin

* **Documentation**
  * Added guest email configuration guidance to setup guide
  * Clarified email credential delivery and admin CC behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->