### PR TITLE
ci: Bump release-please-action to v5 (Node 20 → Node 24)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,10 +17,10 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
       version: ${{ steps.release.outputs.version }}
-    
+
     steps:
       - name: Run Release Please
-        uses: googleapis/release-please-action@v4
+        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -32,7 +32,7 @@ jobs:
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created == 'true' }}
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Trigger nexus-stack.ch website update
         env:
@@ -44,7 +44,7 @@ jobs:
             echo "⚠️ WEBSITE_DISPATCH_TOKEN not configured, skipping website update"
             exit 0
           fi
-          
+
           # Trigger the update-content workflow in nexus-stack.ch repo
           if curl --fail -X POST \
             -H "Accept: application/vnd.github+json" \


### PR DESCRIPTION
## Summary

Bumps `googleapis/release-please-action` from `@v4` (Node.js 20) to `v5.0.0` (Node.js 24), pinned to the immutable commit SHA.

Closes #633.

## Why

`@v4` runs on Node.js 20, which GitHub force-migrates to Node 24 on **2026-06-02** and removes on **2026-09-16** — surfaced as a deprecation warning in the last release-please run log.

`v5.0.0` (2026-04-22) is exactly the Node 24 migration:

- `v4` → `using: 'node20'` (deprecated)
- `v5.0.0` → `using: 'node24'`

Its only breaking change is the runtime bump; no config/API changes for our usage, and the `release-please-config.json` / `.release-please-manifest.json` format is unchanged (v5 reads the same).

## SHA-pin rationale

Pinned to the commit SHA (`45996ed…` = v5.0.0) instead of the floating `@v5` tag. A floating major tag can be force-moved by the upstream maintainer — a SHA can't. SHA-pinning costs nothing today; the trade-off is that future patch releases (v5.0.1, v5.1.0) need a manual bump. Acceptable for a once-a-year-touched workflow.

## What this PR does NOT fix

The recent release-please run that failed mid-PR-creation (branch successfully created, PR-open step erroring out with an empty message, recovered via `gh run rerun`) is **not** addressed here. That's [googleapis/release-please-action#1203](https://github.com/googleapis/release-please-action/issues/1203) — a transient GraphQL failure in the action's second pass, reproducible on both v4 and v5. The Node 20 → 24 bump is purely the deprecation fix; if the race fires again, the workaround is the same (re-run the failed Actions run).

## Test plan

- [ ] Workflow YAML stays valid (the `Validate GitHub Actions Workflows` check passes)
- [ ] On the next merge to `main`, the Release Please run completes without the Node 20 deprecation warning and opens/updates the release PR as before

## Note about the diff

The pre-commit hook stripped three pre-existing trailing-whitespace lines in `release-please.yml` while preparing the commit — those are the additional unrelated lines visible in the diff. Functionally identical to the previous file modulo the action bump.
