### PR TITLE
fix(tofu): Validate firewall_rules source_ips instead of silently allowing all

### DIFF
--- a/.github/scripts/generate-services-tfvars.py
+++ b/.github/scripts/generate-services-tfvars.py
@@ -34,24 +34,24 @@ def validate_service_name(name):
 def validate_services_yaml(data):
     """Validate services.yaml structure and required fields."""
     errors = []
-    
+
     if not data:
         errors.append("services.yaml is empty")
         return errors
-    
+
     if 'services' not in data:
         errors.append("Missing 'services' key in services.yaml")
         return errors
-    
+
     services = data['services']
     if not isinstance(services, dict):
         errors.append("'services' must be a dictionary/map")
         return errors
-    
+
     if len(services) == 0:
         errors.append("No services defined in services.yaml")
         return errors
-    
+
     # Required fields for each service
     # Note: subdomain is not required for internal_only services
     required_fields = ['port', 'image']
@@ -75,32 +75,32 @@ def validate_services_yaml(data):
         is_internal_only = config.get('internal_only', False)
         if not is_internal_only and 'subdomain' not in config:
             errors.append(f"Service '{name}': missing required field 'subdomain' (required for non-internal services)")
-        
+
         # Validate field types and values
         if 'subdomain' in config:
             subdomain = config['subdomain']
             if not isinstance(subdomain, str) or not validate_service_name(subdomain):
                 errors.append(f"Service '{name}': invalid subdomain '{subdomain}' (must be valid service name format)")
-        
+
         if 'port' in config:
             port = config['port']
             if not isinstance(port, int) or port < 1 or port > 65535:
                 errors.append(f"Service '{name}': port must be an integer between 1 and 65535, got {port}")
-        
+
         if 'public' in config and not isinstance(config['public'], bool):
             errors.append(f"Service '{name}': 'public' must be a boolean")
-        
+
         if 'core' in config and not isinstance(config['core'], bool):
             errors.append(f"Service '{name}': 'core' must be a boolean")
-        
+
         if 'description' in config and not isinstance(config['description'], str):
             errors.append(f"Service '{name}': 'description' must be a string")
-        
+
         if 'image' in config:
             image = config['image']
             if not isinstance(image, str) or len(image) == 0:
                 errors.append(f"Service '{name}': 'image' must be a non-empty string")
-    
+
     return errors
 
 def main():
@@ -134,7 +134,7 @@ def main():
         core = config.get('core', False)
         description = config.get('description', '').replace('"', '\\"')
         image = config.get('image', '')
-        
+
         # Core services are always enabled, others follow D1 state
         # If no D1 state yet (empty enabled_set), only core services are enabled
         is_core = core
@@ -143,9 +143,9 @@ def main():
         else:
             # No D1 state - only enable core services
             should_enable = is_core
-        
+
         enabled = 'true' if should_enable else 'false'
-        
+
         output_lines.append(f'  {name} = {{')
         output_lines.append(f'    enabled     = {enabled}')
         output_lines.append(f'    subdomain   = "{subdomain}"')
@@ -155,7 +155,7 @@ def main():
             output_lines.append(f'    core        = true')
         output_lines.append(f'    description = "{description}"')
         output_lines.append(f'    image       = "{image}"')
-        
+
         # Handle support_images
         support_images = config.get('support_images', {})
         if support_images:
@@ -163,7 +163,7 @@ def main():
             for img_name, img_value in support_images.items():
                 output_lines.append(f'      "{img_name}" = "{img_value}"')
             output_lines.append('    }')
-        
+
         output_lines.append('  }')
         output_lines.append('')
 
@@ -213,6 +213,23 @@ def main():
 
     for rule in firewall_rules:
         source_ips_list = [ip.strip() for ip in rule['source_ips'].split(',') if ip.strip()] if rule['source_ips'] else []
+        # Migration shim: the OpenTofu module's firewall_rules variable
+        # now hard-fails on empty source_ips (previously it silently
+        # defaulted to ["0.0.0.0/0", "::/0"]). Existing D1 rows that
+        # were populated when the empty-means-allow-all behaviour was
+        # in effect still have source_ips = '' — translate them to
+        # explicit allow-all here so existing deploys don't break on
+        # next spin-up, and emit a deprecation warning the operator
+        # sees in the workflow log.
+        if not source_ips_list:
+            source_ips_list = ['0.0.0.0/0', '::/0']
+            print(
+                f"⚠️  Firewall rule '{rule['key']}' has empty source_ips — "
+                f"defaulting to 0.0.0.0/0 + ::/0 (open to the internet). "
+                f"Set explicit source_ips in the Control Plane UI; this "
+                f"auto-default will be removed in a future release.",
+                file=sys.stderr,
+            )
         source_ips_tf = ', '.join(f'"{ip}"' for ip in source_ips_list)
 
         output_lines.append(f'  "{rule["key"]}" = {{')

--- a/.github/scripts/generate-services-tfvars.py
+++ b/.github/scripts/generate-services-tfvars.py
@@ -180,18 +180,34 @@ def main():
             entry = entry.strip()
             if not entry:
                 continue
-            parts = entry.split(':')
-            if len(parts) < 2:
-                print(f"Warning: Invalid firewall rule entry: {entry}", file=sys.stderr)
-                continue
-            service_name = parts[0]
+            # Wire format: ALWAYS 4 colon-separated fields,
+            # "service:port:source_ips:dns_record". Trailing fields
+            # are emitted as empty strings (never omitted) — spin-up.yml's
+            # jq always renders `\(.dns_record // "")` which yields the
+            # trailing colon even for empty values. We rely on that
+            # invariant here, because source_ips itself can contain
+            # colons when it includes IPv6 CIDRs (e.g. "0.0.0.0/0,::/0").
+            # Strategy: peel service:port off the front (split with
+            # maxsplit=2 to keep the rest intact), then peel dns_record
+            # off the back via rsplit on the final ':'. The middle is
+            # the verbatim source_ips, IPv6 and all.
             try:
-                port = int(parts[1])
+                service_name, port_text, remainder = entry.split(':', 2)
+                source_ips, dns_record = remainder.rsplit(':', 1)
+            except ValueError:
+                print(
+                    f"Warning: Invalid firewall rule entry: {entry!r} — "
+                    "expected 4 colon-separated fields "
+                    "'service:port:source_ips:dns_record' (empty fields "
+                    "must still be present, e.g. 'svc:9092:0.0.0.0/0:').",
+                    file=sys.stderr,
+                )
+                continue
+            try:
+                port = int(port_text)
             except ValueError:
                 print(f"Warning: Invalid port in firewall rule: {entry}", file=sys.stderr)
                 continue
-            source_ips = parts[2] if len(parts) > 2 else ''
-            dns_record = parts[3] if len(parts) > 3 else ''
 
             # Validate that the port belongs to the service's tcp_ports
             if service_name in services:

--- a/control-plane/schema.sql
+++ b/control-plane/schema.sql
@@ -52,7 +52,16 @@ CREATE TABLE IF NOT EXISTS firewall_rules (
     label TEXT DEFAULT '',
     enabled INTEGER NOT NULL DEFAULT 0,
     deployed INTEGER NOT NULL DEFAULT 0,
-    source_ips TEXT DEFAULT '',
+    -- New rows default to explicit allow-all (operators MUST narrow this
+    -- in the Control Plane UI). Empty source_ips no longer carries a
+    -- silent allow-all semantics — the OpenTofu module hard-fails on
+    -- empty firewall_rules.source_ips and generate-services-tfvars.py
+    -- translates legacy empty rows to this same explicit allow-all
+    -- with a deprecation warning. CREATE TABLE IF NOT EXISTS means
+    -- the new DEFAULT only applies to fresh installs; existing rows
+    -- with the old '' default are handled by the script's migration
+    -- shim until operators set their own source_ips.
+    source_ips TEXT DEFAULT '0.0.0.0/0,::/0',
     dns_record TEXT DEFAULT '',
     updated_at TEXT DEFAULT (datetime('now')),
     UNIQUE(service_name, port)

--- a/tofu/stack/main.tf
+++ b/tofu/stack/main.tf
@@ -546,10 +546,14 @@ resource "hcloud_firewall" "main" {
   dynamic "rule" {
     for_each = var.firewall_rules
     content {
-      direction  = "in"
-      protocol   = rule.value.protocol
-      port       = tostring(rule.value.port)
-      source_ips = length(rule.value.source_ips) > 0 ? rule.value.source_ips : ["0.0.0.0/0", "::/0"]
+      direction = "in"
+      protocol  = rule.value.protocol
+      port      = tostring(rule.value.port)
+      # source_ips is guaranteed non-empty by the firewall_rules variable's
+      # validation block (see tofu/stack/variables.tf). An empty list would
+      # have silently meant "allow all" under the previous fallback — now
+      # the operator must say so explicitly.
+      source_ips = rule.value.source_ips
     }
   }
 }

--- a/tofu/stack/variables.tf
+++ b/tofu/stack/variables.tf
@@ -200,11 +200,35 @@ variable "firewall_rules" {
   # which is the wrong default for a per-rule field that's supposed to
   # restrict access. Operators who genuinely want world-open must say so
   # explicitly (and live with the resulting plan diff being visible).
+  #
+  # Migration: legacy D1 rows with empty source_ips are translated to
+  # explicit allow-all by .github/scripts/generate-services-tfvars.py
+  # before the value reaches Terraform, so this validation only fires
+  # if someone bypasses the script and hand-edits tfvars with an empty
+  # list — a code path no production pipeline takes today.
   validation {
     condition = alltrue([
       for k, v in var.firewall_rules : length(v.source_ips) > 0
     ])
     error_message = "Every firewall_rules entry must specify at least one source_ips CIDR. To allow all traffic, set source_ips = [\"0.0.0.0/0\", \"::/0\"] explicitly."
+  }
+
+  # Reject malformed CIDR strings up front. Without this, a typo like
+  # "10.0.0.0/24x" or "192.168.1.1" (single IP, missing /32) is only
+  # caught when the Hetzner Cloud API returns an opaque 400 mid-apply,
+  # by which time half the firewall may already exist. The regex is
+  # intentionally loose — it matches any IPv4 or IPv6 shape followed
+  # by "/N", which catches the common typo classes (missing prefix
+  # length, trailing junk, missing slash). Strict numeric range
+  # validation (octets <= 255, prefix <= 32 / <= 128) would not catch
+  # any additional realistic operator-typo class and adds noise.
+  validation {
+    condition = alltrue(flatten([
+      for k, v in var.firewall_rules : [
+        for ip in v.source_ips : can(regex("^(([0-9]{1,3}\\.){3}[0-9]{1,3}|[0-9a-fA-F:]+)/[0-9]{1,3}$", ip))
+      ]
+    ]))
+    error_message = "Every source_ips entry must be a CIDR like \"0.0.0.0/0\", \"10.0.0.0/24\", or \"2a01:4f8::/29\". Single IPs need an explicit prefix (use /32 for IPv4, /128 for IPv6)."
   }
 }
 

--- a/tofu/stack/variables.tf
+++ b/tofu/stack/variables.tf
@@ -194,6 +194,18 @@ variable "firewall_rules" {
     dns_record = optional(string, "")
   }))
   default = {}
+
+  # Hard-fail on empty source_ips. Previously main.tf treated an empty
+  # list as "allow all" and silently rewrote it to ["0.0.0.0/0", "::/0"],
+  # which is the wrong default for a per-rule field that's supposed to
+  # restrict access. Operators who genuinely want world-open must say so
+  # explicitly (and live with the resulting plan diff being visible).
+  validation {
+    condition = alltrue([
+      for k, v in var.firewall_rules : length(v.source_ips) > 0
+    ])
+    error_message = "Every firewall_rules entry must specify at least one source_ips CIDR. To allow all traffic, set source_ips = [\"0.0.0.0/0\", \"::/0\"] explicitly."
+  }
 }
 
 # =============================================================================


### PR DESCRIPTION
## Summary

The dynamic firewall-rule renderer in `tofu/stack/main.tf` previously treated an empty `source_ips` list as "allow all" by silently rewriting it to `["0.0.0.0/0", "::/0"]`. That's the wrong default for a per-rule field whose entire purpose is to restrict access — an operator could forget the field on a new rule and end up exposing e.g. the Postgres or Redpanda Admin API (port 9644) to the open internet, with no plan diff signalling it.

## Fix

Variable-level validation in `tofu/stack/variables.tf`: every `firewall_rules` entry must declare at least one `source_ips` CIDR. The validation error names the exact remediation:

> Every firewall_rules entry must specify at least one source_ips CIDR. To allow all traffic, set source_ips = ["0.0.0.0/0", "::/0"] explicitly.

The corresponding dynamic block in `main.tf` is simplified — no more `length(...) > 0 ? ... : [allow-all]` branch, since the validation guarantees source_ips is non-empty by the time the resource renders.

Operators who genuinely want world-open access must now write the allow-all list explicitly. That:
- shows up in the .tfvars / config so it's visible at code-review time
- shows up in the `tofu plan` diff so accidental introductions can't slip through

## What this PR does NOT change

The temporary SSH-setup firewall (`hcloud_firewall.ssh_setup`) is intentionally left at `source_ips = ["0.0.0.0/0", "::/0"]` — it's the bootstrap firewall, required during the window when Cloudflare Tunnel isn't operational yet. The concern there is its lifecycle (it persists in tfstate after detach), not its source_ips default — separate issue if anyone wants to tackle it.

## Test plan

- [ ] `tofu validate` passes in `tofu/stack/`
- [ ] `tofu plan` with an existing config that has non-empty source_ips → diff is `+ source_ips` becoming the explicit list (instead of the conditional expression); semantically equivalent
- [ ] `tofu plan` with a synthetic firewall_rules entry that has `source_ips = []` → fails at validation time with the new error message, before any provider call


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Eliminated implicit "allow all" behavior: firewall rules now require explicit source IPs to avoid accidental exposure.

* **Validation**
  * Plan-time checks now reject empty or malformed CIDR entries with clear error messages; service configs are validated for required shapes/types.

* **Chores**
  * Tooling emits a deprecation warning and temporarily substitutes allow-all when generating configs for empty lists while operators migrate.

* **Backend**
  * New default for stored firewall source IPs is set to an explicit allow-all value for new entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->