### PR TITLE
fix(ci): Stop overriding admin_username default in workflows

### DIFF
--- a/.github/workflows/destroy-all.yml
+++ b/.github/workflows/destroy-all.yml
@@ -116,7 +116,6 @@ jobs:
           admin_email         = "${{ secrets.TF_VAR_admin_email }}"
           user_email          = "${{ secrets.TF_VAR_user_email }}"
           guest_emails        = "${{ secrets.TF_VAR_guest_emails }}"
-          admin_username      = "admin"
           github_owner        = "${{ github.repository_owner }}"
           github_repo         = "${{ github.event.repository.name }}"
           EOF

--- a/.github/workflows/spin-up.yml
+++ b/.github/workflows/spin-up.yml
@@ -280,7 +280,6 @@ jobs:
           admin_email          = "${{ secrets.TF_VAR_admin_email }}"
           user_email           = "${{ secrets.TF_VAR_user_email }}"
           guest_emails         = "${{ secrets.TF_VAR_guest_emails }}"
-          admin_username       = "admin"
           subdomain_separator  = "${{ secrets.SUBDOMAIN_SEPARATOR || '.' }}"
           github_owner         = "${{ github.repository_owner }}"
           github_repo          = "${{ github.event.repository.name }}"

--- a/.github/workflows/teardown.yml
+++ b/.github/workflows/teardown.yml
@@ -165,7 +165,6 @@ jobs:
           admin_email         = "${{ secrets.TF_VAR_admin_email }}"
           user_email          = "${{ secrets.TF_VAR_user_email }}"
           guest_emails        = "${{ secrets.TF_VAR_guest_emails }}"
-          admin_username      = "admin"
           github_owner        = "${{ github.repository_owner }}"
           github_repo         = "${{ github.event.repository.name }}"
           EOF


### PR DESCRIPTION
## Summary

Three workflows (`spin-up.yml`, `teardown.yml`, `destroy-all.yml`) hard-coded `admin_username = "admin"` in their generated `config.tfvars`. The OpenTofu module's default value for that variable is `"nexus"` ([tofu/stack/variables.tf:159-163](tofu/stack/variables.tf#L159-L163)), so the workflows were silently overriding the module default with a more guessable username.

Removing the three lines lets the module default apply.

Closes #626.

## Why

This is the project's own service-account naming convention (CLAUDE.md: *"NEVER use default names like `admin`, `postgres`, `root`"*). The TF module already does the right thing — the workflows just had a leftover line undoing it.

A predictable admin username narrows the guesswork for an attacker who reaches a login form: half of the credential is already known. Removing it forces a `nexus`-prefixed account (the project's convention) and aligns the workflow-generated tfvars with the module's documented default.

## Behaviour change

On the next `tofu apply` after this lands, the admin username for stacks that flow `admin_username` into their config (Portainer, Uptime Kuma, CloudBeaver, etc.) will change from `admin` to `nexus`.

Operators who want to keep `admin` for any reason can set the value explicitly as an env var or repo secret: `TF_VAR_admin_username=admin`. That makes the choice visible at config-review time rather than baked into the workflow.

## Test plan

- [ ] `tofu plan` on a stack with TF_VAR_admin_username unset → admin_username diffs from "admin" to "nexus" on dependent resources
- [ ] After spin-up: login to Portainer / Uptime Kuma works with the `nexus` username and the Infisical-stored password
- [ ] No workflow YAML errors (the `Validate GitHub Actions Workflows` check passes)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated infrastructure configuration to use email-based user identity management instead of hardcoded default usernames. User email addresses are now sourced from secure configuration variables for deployment workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->