### PR TITLE
fix(orchestrator): Drop subprocess stdout from woodpecker-apply phase result

### DIFF
--- a/src/nexus_deploy/orchestrator.py
+++ b/src/nexus_deploy/orchestrator.py
@@ -1889,14 +1889,22 @@ class Orchestrator:
         except subprocess.CalledProcessError as exc:
             # docker compose returned non-zero — service-level failure
             # (image pull failed, container crashed at startup, port
-            # collision, …). Forward the captured stdout to the
-            # detail so operators see the compose error inline.
-            stdout_excerpt = (exc.output or "").strip().splitlines()[-1:] if exc.output else []
-            tail = stdout_excerpt[0] if stdout_excerpt else "no stdout captured"
+            # collision, …). Earlier versions of this handler appended
+            # the tail of exc.output to the detail "so operators see
+            # the compose error inline", but exc.output is the captured
+            # stdout of `docker compose up -d` for the woodpecker stack
+            # — which can include env-var values quoted back inside
+            # compose's own error messages (e.g. when a service env
+            # block references a value that fails interpolation).
+            # Aligned with the other CalledProcessError handlers in this
+            # file (infisical-bootstrap, gitea-configure, kestra-register,
+            # …) which all surface only `type(exc).__name__` + rc and
+            # leave the full output to `docker logs woodpecker` on the
+            # server.
             return PhaseResult(
                 name="woodpecker-apply",
                 status="partial",
-                detail=f"docker compose up -d failed (rc={exc.returncode}): {tail[:120]}",
+                detail=f"docker compose up -d failed (rc={exc.returncode}, {type(exc).__name__})",
             )
         except subprocess.TimeoutExpired as exc:
             # Genuine ssh transport timeout — operator should


### PR DESCRIPTION
## Summary

`_phase_woodpecker_apply` was the only `CalledProcessError` handler in [src/nexus_deploy/orchestrator.py](src/nexus_deploy/orchestrator.py) that surfaced `exc.output` into the `PhaseResult.detail` (as a sliced last-line "tail", truncated to 120 chars). The six other handlers in the same file — `infisical-bootstrap`, `services-configure`, `gitea-configure`, `seed`, `kestra-register`, `woodpecker-oauth` — all stick to `type(exc).__name__` + `rc` and leave `docker logs` / `docker compose logs` as the source of truth for full output.

This PR aligns the woodpecker handler with the rest of the file.

## Why

`exc.output` here is the captured stdout of `docker compose up -d` for the **woodpecker stack**, which has a `.env` populated with Infisical-managed secrets. Modern compose prints mostly status lines (`Container … Started`), but its error branches can echo back values from the rendered env block (e.g. when interpolation fails for a malformed variable, the failing key=value can land in the error message). The risk of those landing in a `PhaseResult.detail` that gets logged or surfaced to the operator is non-zero — and inconsistent with the convention every other handler in this file already follows.

## What this does NOT lose

The new detail still tells the operator everything actionable from inside Python:

- which phase failed (`woodpecker-apply`)
- the return code (`rc=1`)
- the exception class (`CalledProcessError`)

For the full compose stack trace, the on-server `docker compose logs woodpecker` / `docker logs woodpecker-server` is the canonical place — which is also the convention for every other stack's deploy failure.

## Test plan

- [x] Existing `test_phase_woodpecker_apply_partial_on_compose_up_nonzero` still passes — it asserts `"docker compose up -d failed" in result.detail` and `"rc=1" in result.detail`, both substrings present in the new detail.
- [x] All 50 woodpecker-related unit tests pass (`uv run pytest tests/unit/ -q -k woodpecker` — `50 passed, 1525 deselected`).
- [ ] No regression on a real deploy where woodpecker compose-up actually fails — operator gets the clean partial-phase signal in stderr + the full diagnostic via `docker logs` on the server.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency in error reporting for Docker compose failures during deployment phases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->