### PR TITLE
fix(redpanda): Remove Admin API (9644) from firewall-exposable tcp_ports

### DIFF
--- a/docs/stacks/redpanda.md
+++ b/docs/stacks/redpanda.md
@@ -18,10 +18,12 @@ Redpanda is a Kafka-compatible streaming data platform that is simpler, faster, 
 
 | Setting | Value |
 |---------|-------|
-| Default Port (Admin) | `9644` |
-| Kafka Port | `9092` |
-| Schema Registry Port | `18081` |
+| Admin Panel Port | `9644` — internal only, reached via Cloudflare-Tunnel-fronted `https://redpanda.<domain>` |
+| Kafka Port | `9092` — exposable via Hetzner firewall_rules |
+| Schema Registry Port | `18081` — exposable via Hetzner firewall_rules |
 | Suggested Subdomain | `redpanda` |
 | Public Access | No (streaming infrastructure) |
 | Website | [redpanda.com](https://redpanda.com) |
 | Source | [GitHub](https://github.com/redpanda-data/redpanda) |
+
+> ⚠️ The **Admin API on port 9644 cannot be opened via Hetzner firewall_rules** — only Kafka (9092) and Schema Registry (18081) appear in the Control Plane's firewall UI. The Admin API has no authentication of its own (anyone reaching it can create/delete SASL users, change cluster config, delete topics), so the only public access path is the Cloudflare-Tunnel-fronted admin panel, which is gated by Cloudflare Access at the edge.

--- a/services.yaml
+++ b/services.yaml
@@ -704,10 +704,18 @@ services:
     description: "Kafka-compatible streaming platform that is simpler, faster, and more cost-effective."
     long_description: "Redpanda is a Kafka-compatible streaming data platform built for modern workloads. It is faster, simpler to operate (no ZooKeeper/KRaft), and uses less resources than Apache Kafka. Features include built-in schema registry, HTTP proxy, and a Kafka-compatible API for seamless migration."
     image: "redpandadata/redpanda:v24.3"
+    # The Admin API on port 9644 is deliberately NOT listed in tcp_ports.
+    # The endpoint has no authentication of its own — anyone reaching it
+    # can create/delete SASL users, change cluster config, and delete
+    # topics. Operators can still reach the admin panel via the
+    # Cloudflare-Tunnel-fronted https://redpanda.<domain> (which is
+    # gated by Cloudflare Access at the edge), but the port cannot be
+    # opened to the public internet via Hetzner firewall_rules because
+    # the Control Plane UI / generate-services-tfvars.py only offer
+    # ports that appear in this map.
     tcp_ports:
       kafka: 9092
       schema-registry: 18081
-      admin: 9644
 
   seaweedfs:
     # Filer UI host port — moved 8888 → 8890 to resolve collision with


### PR DESCRIPTION
## Summary

Removes `admin: 9644` from `redpanda.tcp_ports` in `services.yaml`. The Control Plane firewall UI and `generate-services-tfvars.py` only offer ports that appear in this map, so 9644 can no longer be opened to the public internet via Hetzner firewall_rules.

Closes #431.

## Why

The Redpanda Admin API has **no authentication of its own**. Anyone reaching it can:
- create/delete/modify SASL users
- change cluster configuration
- delete topics and consumer groups
- view all cluster metadata

Until now the only protection was an optional source-IP restriction in the firewall rule. Now that PR #638 made empty `source_ips` hard-fail, the lower bound improved — but the API was still reachable by anyone the operator chose to allow, with no auth-layer between them and full cluster control.

## What this PR changes

- **`services.yaml`** — `admin: 9644` removed from `redpanda.tcp_ports`. `kafka: 9092` and `schema-registry: 18081` stay (both have their own auth — Kafka via SASL/SCRAM, schema-registry via its auth layer).
- **`docs/stacks/redpanda.md`** — table updated to call out the admin panel is internal-only, reachable via the Cloudflare-Tunnel-fronted `https://redpanda.<domain>` (gated by Cloudflare Access at the edge).

## Migration

Existing D1 `firewall_rules` rows that have `port = 9644` get skipped by `generate-services-tfvars.py` with its existing `Port {port} not in tcp_ports for {service}, skipping` warning. No manual cleanup required — those rules become no-ops on the next spin-up. Operators see a clear stderr line nudging them to drop the disabled rule from the Control Plane UI.

## What this PR does NOT change

- The redpanda container still listens on 9644 internally — that's needed for the in-cluster admin operations.
- The admin Web UI remains reachable via the Cloudflare-Tunnel-fronted subdomain (`https://redpanda.<domain>`).
- No change to other Redpanda ports, no change to the redpanda config templates, no change to the `redpanda` stack docker-compose.

## Test plan

- [ ] `gh workflow run spin-up.yml` succeeds; Redpanda container comes up and the admin panel at `https://redpanda.<domain>` is reachable.
- [ ] In the Control Plane firewall UI: port 9644 no longer appears as a togglable option for Redpanda.
- [ ] Kafka clients can still reach 9092 via firewall_rules.
- [ ] If an existing deployment had port 9644 enabled in D1: the next spin-up logs the "Port 9644 not in tcp_ports for redpanda, skipping" warning and the rule is effectively disabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Redpanda configuration documentation to clarify admin panel access method and port exposure strategy.
  * Added guidance on accessing the admin interface and associated security considerations.

* **Configuration**
  * Modified Redpanda service port configuration to adjust admin API availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->