### PR TITLE
perf(ci): Cache OpenTofu providers + Control-Plane node_modules in spin-up

### DIFF
--- a/.github/workflows/spin-up.yml
+++ b/.github/workflows/spin-up.yml
@@ -129,7 +129,7 @@ jobs:
         # add up to ~50 MB and only change when providers.tf or the
         # lockfile changes. Key on the file hashes so a provider bump
         # invalidates the cache automatically.
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: |
             tofu/stack/.terraform
@@ -143,7 +143,7 @@ jobs:
         # Cuts ~15-20s off `npm ci` in the Control Plane redeploy step.
         # package-lock.json is committed, so the cache key is
         # deterministic per dependency revision.
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: control-plane/node_modules
           key: node-${{ runner.os }}-${{ hashFiles('control-plane/package-lock.json') }}

--- a/.github/workflows/spin-up.yml
+++ b/.github/workflows/spin-up.yml
@@ -123,6 +123,33 @@ jobs:
         with:
           tofu_version: 1.10.0
 
+      - name: Cache OpenTofu providers
+        # Cuts ~30-45s off `tofu init` in steady-state — the providers
+        # (hetznercloud/hcloud, cloudflare/cloudflare, random, tls)
+        # add up to ~50 MB and only change when providers.tf or the
+        # lockfile changes. Key on the file hashes so a provider bump
+        # invalidates the cache automatically.
+        uses: actions/cache@v4
+        with:
+          path: |
+            tofu/stack/.terraform
+            tofu/control-plane/.terraform
+            ~/.terraform.d/plugin-cache
+          key: tofu-${{ runner.os }}-${{ hashFiles('tofu/**/providers.tf', 'tofu/**/.terraform.lock.hcl') }}
+          restore-keys: |
+            tofu-${{ runner.os }}-
+
+      - name: Cache Control-Plane node_modules
+        # Cuts ~15-20s off `npm ci` in the Control Plane redeploy step.
+        # package-lock.json is committed, so the cache key is
+        # deterministic per dependency revision.
+        uses: actions/cache@v4
+        with:
+          path: control-plane/node_modules
+          key: node-${{ runner.os }}-${{ hashFiles('control-plane/package-lock.json') }}
+          restore-keys: |
+            node-${{ runner.os }}-
+
       - name: Install uv
         # Required by the `nexus_deploy` Python package — since #505
         # Phase 4c, `python -m nexus_deploy run-pipeline` IS the


### PR DESCRIPTION
## Summary

Adds two `actions/cache@v4` steps in `spin-up.yml` for the two biggest steady-state download costs:

| Cache | Path | Saves | Invalidated by |
|---|---|---|---|
| OpenTofu providers | `tofu/{stack,control-plane}/.terraform` + `~/.terraform.d/plugin-cache` | 30-45s | `providers.tf` or `.terraform.lock.hcl` changes |
| Control-Plane node_modules | `control-plane/node_modules` | 15-20s | `package-lock.json` changes |

Combined steady-state saving: **~45-65 seconds per spin-up run** — brings a typical ~7-minute run under 6 minutes from the second deploy onward.

Partially addresses #489. Specifically the Parts B and C of the speedup plan there.

## What this PR does NOT do

- **Part A (deploy.sh CONFIG_JOBS parallelisation):** `scripts/deploy.sh` was replaced by `python -m nexus_deploy run-pipeline` in Phase 4c (#505). The Python `services-configure` phase already batches every service hook into one SSH round-trip, so the bash-level fan-out described in the issue is a different shape entirely now. Doing it on the Python side would be a much bigger refactor of `services.py` / `orchestrator.py` and is out of scope for a cache-only change.
- **Part D (parallel CP redeploy):** a closer reading of the workflow shows the redeploy step transitively depends on `Deploy stacks` — `Store credentials` (the predecessor of Redeploy) reads `/tmp/infisical-token` written *by* the Python pipeline during `Deploy stacks`. The issue body's claim that "redeploy depends only on tofu output" misses this hop. Parallelising would require restructuring how the infisical token is transferred from the server to the runner, which is its own piece of work.

Doing only Parts B and C here keeps the PR risk-free (cache-add is purely additive — first run is identical to today; subsequent runs are faster).

## Test plan

- [ ] First run after merge: caches are empty, behaviour is identical to today (no regression risk).
- [ ] Second run after merge: `Cache OpenTofu providers` and `Cache Control-Plane node_modules` steps report "Cache restored from key", and the `tofu init` + `npm ci` subsequent steps complete noticeably faster.
- [ ] When a real provider bump or package-lock.json change lands: cache key changes, fresh download, subsequent runs cache the new revision.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI spin-up performance by adding targeted caching of initialization artifacts and control-plane dependencies to significantly reduce setup time and speed up iterations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->