### PR TITLE
feat(ci): Add snapshot-based teardown lifecycle

### DIFF
--- a/.github/workflows/teardown-snapshot.yml
+++ b/.github/workflows/teardown-snapshot.yml
@@ -1,0 +1,482 @@
+name: Teardown Nexus-Stack (Snapshot)
+
+# =============================================================================
+# Snapshot-based teardown — the counterpart to spin-up-snapshot.yml.
+#
+# Runs ALONGSIDE the classic teardown.yml, which is left untouched.
+# Difference in one line: instead of destroying the whole stack state,
+# this takes a Hetzner disk snapshot of the server and then destroys
+# ONLY the server.
+#
+# Why targeted destroy rather than the untargeted one:
+#
+#   * All 81 random_password/random_id/random_string resources survive,
+#     so service credentials stay stable. A disk snapshot captures
+#     Postgres roles and app admin accounts as they were; restoring it
+#     against regenerated credentials produces a stack that boots and
+#     then fails to authenticate anywhere.
+#   * The tunnel, its config, every DNS record and every Access
+#     app/policy survive too, so the restored server's baked-in
+#     cloudflared config still matches and the next spin-up skips that
+#     work entirely.
+#   * State stays truthful. Deleting the server out of band would leave
+#     hcloud_server.main in state and wedge the next teardown.
+#
+# The only resource that goes with the server is
+# cloudflare_record.firewall_tcp, which depends on its IPv4 address.
+# That is desirable: the address is about to be handed to another
+# Hetzner customer.
+#
+# ⚠️ Do NOT mix this with the classic teardown.yml on the same stack.
+# That one runs an untargeted destroy, rotating all 81 credentials and
+# invalidating every existing snapshot. spin-up-snapshot.yml detects
+# this via the credential epoch and falls back to a fresh build, so it
+# is safe rather than silent — but it throws away the snapshot.
+# =============================================================================
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: 'Type "TEARDOWN" to confirm (keeps control plane)'
+        required: true
+        type: string
+      skip_destroy:
+        description: 'Snapshot only — power the server back on afterwards and destroy nothing. Use this for the first verification run.'
+        required: false
+        default: false
+        type: boolean
+      strict_snapshot:
+        description: 'Abort instead of destroying if the snapshot fails (leaves the server running, and billing).'
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: infrastructure
+  cancel-in-progress: false
+
+jobs:
+  teardown:
+    name: Snapshot + Teardown Hetzner Server
+    runs-on: ubuntu-latest
+    if: github.event.inputs.confirm == 'TEARDOWN'
+    env:
+      TF_VAR_cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      TF_VAR_cloudflare_account_id: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      TF_VAR_cloudflare_zone_id: ${{ secrets.CLOUDFLARE_ZONE_ID }}
+      TF_VAR_hcloud_token: ${{ secrets.HCLOUD_TOKEN }}
+      TF_VAR_domain: ${{ secrets.DOMAIN }}
+      TF_VAR_access_emails: ${{ secrets.ACCESS_EMAILS }}
+      TF_VAR_infisical_token: ${{ secrets.INFISICAL_TOKEN }}
+      TF_VAR_github_owner: ${{ github.repository_owner }}
+      TF_VAR_github_repo: ${{ github.event.repository.name }}
+      HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}
+
+    steps:
+      - name: Validate confirmation
+        run: |
+          if [ "${{ github.event.inputs.confirm }}" != "TEARDOWN" ]; then
+            echo "❌ Teardown cancelled. You must type 'TEARDOWN' to confirm."
+            exit 1
+          fi
+          echo "⚠️  SNAPSHOT TEARDOWN CONFIRMED"
+          if [ "${{ github.event.inputs.skip_destroy }}" = "true" ]; then
+            echo "   Mode: SNAPSHOT ONLY (skip_destroy=true)"
+            echo "   - Snapshot the server, then power it back on"
+            echo "   - Nothing is destroyed"
+          else
+            echo "   Mode: SNAPSHOT + DESTROY"
+            echo "   - Snapshot the server disk"
+            echo "   - Destroy ONLY hcloud_server.main"
+            echo "   - Credentials, tunnel, DNS and Access are preserved"
+          fi
+
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Log teardown start
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          DOMAIN: ${{ secrets.DOMAIN }}
+        run: |
+          if [ -f .github/scripts/log-to-d1.sh ]; then
+            chmod +x .github/scripts/log-to-d1.sh
+            .github/scripts/log-to-d1.sh warn "Snapshot teardown workflow started"
+          fi
+
+      - name: Install OpenTofu
+        uses: opentofu/setup-opentofu@v2
+        with:
+          tofu_version: 1.10.0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          version: "0.11.7"
+          enable-cache: true
+
+      - name: Sync nexus_deploy runtime deps
+        run: uv sync --frozen --no-dev
+
+      - name: Install cloudflared
+        # Needed by nexus_deploy.pipeline.run_snapshot, which SSHes to
+        # the live server over Cloudflare Access for the R2 snapshot.
+        run: |
+          curl -fsSL https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64 -o cloudflared
+          chmod +x cloudflared
+          sudo mv cloudflared /usr/local/bin/
+
+      - name: Install SSH key from GitHub Secrets
+        # The R2 snapshot step needs real SSH into the live server
+        # (docker exec pg_dump + rclone sync), so this must be the
+        # PERSISTENT key that is already in the server's
+        # authorized_keys — not a freshly generated one.
+        run: |
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          umask 077
+          if [ -z "${{ secrets.SSH_PRIVATE_KEY }}" ]; then
+            echo "❌ SSH_PRIVATE_KEY secret not set — the pre-snapshot R2 step needs SSH access to the live server."
+            echo "   Run 'Initial Setup' first to bootstrap the key pair, or set SSH_PRIVATE_KEY manually."
+            exit 1
+          fi
+          # Expression placeholders must NOT start at column 0 or the
+          # Actions YAML parser breaks; strip the indent afterwards.
+          sed 's/^[[:space:]]*//' > ~/.ssh/id_ed25519 <<'EOF_PRIVATE_KEY'
+          ${{ secrets.SSH_PRIVATE_KEY }}
+          EOF_PRIVATE_KEY
+          chmod 600 ~/.ssh/id_ed25519
+          if [ -n "${{ secrets.SSH_PUBLIC_KEY }}" ]; then
+            echo "${{ secrets.SSH_PUBLIC_KEY }}" > ~/.ssh/id_ed25519.pub
+          else
+            ssh-keygen -y -f ~/.ssh/id_ed25519 > ~/.ssh/id_ed25519.pub
+          fi
+          chmod 644 ~/.ssh/id_ed25519.pub
+          echo "✅ SSH key installed from secrets"
+
+      - name: Create R2 credentials from secrets
+        run: |
+          mkdir -p tofu
+          R2_ACCESS_KEY_ID=$(echo -n "${{ secrets.R2_ACCESS_KEY_ID }}" | tr -d '[:space:]')
+          R2_SECRET_ACCESS_KEY=$(echo -n "${{ secrets.R2_SECRET_ACCESS_KEY }}" | tr -d '[:space:]')
+          BUCKET_NAME=$(echo "${{ secrets.DOMAIN }}" | tr '.' '-')-terraform-state
+          echo "📦 Using bucket: $BUCKET_NAME"
+
+          cat > tofu/.r2-credentials << EOF
+          R2_ACCESS_KEY_ID="${R2_ACCESS_KEY_ID}"
+          R2_SECRET_ACCESS_KEY="${R2_SECRET_ACCESS_KEY}"
+          EOF
+          sed -i 's/^          //' tofu/.r2-credentials
+
+          cat > tofu/backend.hcl << EOF
+          endpoints = {
+            s3 = "https://${{ secrets.CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com"
+          }
+          bucket = "${BUCKET_NAME}"
+          EOF
+          sed -i 's/^          //' tofu/backend.hcl
+
+      - name: Generate config.tfvars
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          DOMAIN: ${{ secrets.DOMAIN }}
+        run: |
+          cat > tofu/stack/config.tfvars << EOF
+          server_type     = "${{ vars.SERVER_TYPE || 'cx43' }}"
+          server_location = "${{ vars.SERVER_LOCATION || 'hel1' }}"
+          server_image    = "ubuntu-24.04"
+          ssh_public_key_path  = "~/.ssh/id_ed25519.pub"
+          ssh_private_key_path = "~/.ssh/id_ed25519"
+          domain              = "${{ secrets.DOMAIN }}"
+          subdomain_separator = "${{ secrets.SUBDOMAIN_SEPARATOR || '.' }}"
+          admin_email         = "${{ secrets.TF_VAR_admin_email }}"
+          user_email          = "${{ secrets.TF_VAR_user_email }}"
+          guest_emails        = "${{ secrets.TF_VAR_guest_emails }}"
+          github_owner        = "${{ github.repository_owner }}"
+          github_repo         = "${{ github.event.repository.name }}"
+          EOF
+          sed -i 's/^          //' tofu/stack/config.tfvars
+
+          echo "📋 Reading services from D1..."
+          D1_DATABASE_NAME="nexus-${DOMAIN//./-}-db"
+          ENABLED_SERVICES=$(npx wrangler@4 d1 execute "$D1_DATABASE_NAME" --remote --json \
+            --command "SELECT name FROM services WHERE enabled = 1" 2>/dev/null \
+            | jq -r '.[0].results | map(.name) | join(",")' 2>/dev/null || echo "")
+
+          if [ -n "$ENABLED_SERVICES" ]; then
+            echo "📋 Enabled services from D1: $ENABLED_SERVICES"
+          else
+            echo "📋 No services in D1 yet - core services will be enabled by default"
+          fi
+
+          chmod +x .github/scripts/generate-services-tfvars.py
+          ENABLED_SERVICES="$ENABLED_SERVICES" python3 .github/scripts/generate-services-tfvars.py
+
+      - name: Initialize OpenTofu
+        run: |
+          cd tofu/stack
+          source ../.r2-credentials
+          export AWS_ACCESS_KEY_ID="$R2_ACCESS_KEY_ID"
+          export AWS_SECRET_ACCESS_KEY="$R2_SECRET_ACCESS_KEY"
+          tofu init -backend-config=../backend.hcl
+
+      - name: Snapshot persistent state to R2 (atomic, pre-destroy)
+        # Runs FIRST, while the containers are still up — it needs
+        # `docker exec ... pg_dump`. Kept even though the disk snapshot
+        # is strictly more complete, because it is the portable escape
+        # hatch: it survives a lost or arch-incompatible snapshot, a
+        # rotated credential epoch, and it is logically consistent
+        # where a disk image is not. Any failure aborts before
+        # anything is destroyed, same contract as teardown.yml.
+        env:
+          NEXUS_S3_PERSISTENCE: ${{ secrets.NEXUS_S3_PERSISTENCE || 'true' }}
+          PERSISTENCE_S3_ENDPOINT: https://${{ secrets.CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com
+          PERSISTENCE_S3_REGION: auto
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          PERSISTENCE_STACK_SLUG: ${{ secrets.PERSISTENCE_STACK_SLUG || github.event.repository.name }}
+          PERSISTENCE_TEMPLATE_VERSION: ${{ github.ref_name }}
+        run: |
+          DOMAIN_SLUG=$(echo "${{ secrets.DOMAIN }}" | tr '.' '-')
+          export PERSISTENCE_S3_BUCKET="nexus-${DOMAIN_SLUG}-persistence"
+          PERSISTENCE_STACK_SLUG=$(echo "$PERSISTENCE_STACK_SLUG" | tr '[:upper:]' '[:lower:]')
+          export PERSISTENCE_STACK_SLUG
+
+          uv run --quiet --project "$GITHUB_WORKSPACE" \
+            python -m nexus_deploy s3-snapshot
+
+      - name: Create Hetzner disk snapshot
+        id: snapshot
+        # Power-off and snapshot happen in one step so the credential
+        # fingerprint never has to travel through a step output. It is
+        # a one-way digest rather than a secret, but tofu marks it
+        # sensitive and there is no reason to widen its blast radius.
+        #
+        # Never fails the job directly: the outcome is reported through
+        # the `ok` output so the destroy step can apply the
+        # strict_snapshot policy. A failed snapshot with
+        # strict_snapshot=false still destroys, because the R2 snapshot
+        # above already protects the data and leaving a paid server
+        # running is the worse outcome.
+        env:
+          DOMAIN: ${{ secrets.DOMAIN }}
+        run: |
+          set +e
+          cd tofu/stack
+          source ../.r2-credentials
+          export AWS_ACCESS_KEY_ID="$R2_ACCESS_KEY_ID"
+          export AWS_SECRET_ACCESS_KEY="$R2_SECRET_ACCESS_KEY"
+
+          SERVER_ID=$(tofu output -raw server_id 2>/dev/null)
+          if [ -z "$SERVER_ID" ]; then
+            echo "❌ Could not read server_id from tofu state — is the stack deployed?"
+            echo "ok=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Optional: a stack created before credential_fingerprint
+          # existed simply gets an unlabelled snapshot, which
+          # spin-up-snapshot treats as epoch-less and usable only when
+          # no epoch is expected.
+          EPOCH=$(tofu output -raw credential_fingerprint 2>/dev/null || echo "")
+          if [ -n "$EPOCH" ]; then
+            echo "::add-mask::$EPOCH"
+          fi
+
+          SERVER_TYPE=$(grep -E '^\s*server_type\s*=' config.tfvars | head -1 | sed 's/.*=\s*"\(.*\)"/\1/')
+          cd ../..
+
+          DOMAIN_SLUG=$(echo "$DOMAIN" | tr '.' '-')
+          TIMESTAMP=$(date -u +%Y%m%dT%H%M%SZ)
+
+          echo "🔌 Powering off server $SERVER_ID for a consistent disk..."
+          if ! uv run --quiet --project "$GITHUB_WORKSPACE" \
+            python -m nexus_deploy server-poweroff --server-id "$SERVER_ID"; then
+            echo "❌ Power-off failed — refusing to snapshot a running disk"
+            echo "ok=false" >> "$GITHUB_OUTPUT"
+            echo "server_id=$SERVER_ID" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "📸 Creating snapshot..."
+          if ! uv run --quiet --project "$GITHUB_WORKSPACE" \
+            python -m nexus_deploy snapshot-create \
+              --server-id "$SERVER_ID" \
+              --domain-slug "$DOMAIN_SLUG" \
+              --timestamp "$TIMESTAMP" \
+              --epoch "$EPOCH" \
+              --server-type "$SERVER_TYPE" > /tmp/snapshot.out; then
+            echo "❌ Snapshot creation failed"
+            cat /tmp/snapshot.out || true
+            echo "ok=false" >> "$GITHUB_OUTPUT"
+            echo "server_id=$SERVER_ID" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          cat /tmp/snapshot.out
+          # shellcheck disable=SC1091
+          . /tmp/snapshot.out
+          {
+            echo "ok=true"
+            echo "server_id=$SERVER_ID"
+            echo "image_id=$SNAPSHOT_IMAGE_ID"
+            echo "disk_gb=$SNAPSHOT_DISK_GB"
+            echo "arch=$SNAPSHOT_ARCH"
+            echo "timestamp=$TIMESTAMP"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Abort — snapshot failed and strict_snapshot is set
+        if: steps.snapshot.outputs.ok != 'true' && github.event.inputs.strict_snapshot == 'true'
+        run: |
+          echo "❌ Snapshot failed and strict_snapshot=true — nothing was destroyed."
+          echo "   The server is still running (and still billing). Investigate,"
+          echo "   then re-run, or use teardown.yml to tear down without a snapshot."
+          exit 1
+
+      - name: Mirror snapshot metadata to D1
+        if: steps.snapshot.outputs.ok == 'true'
+        # D1 is a mirror for the Control Plane UI and for humans — the
+        # Hetzner labels are the source of truth. spin-up-snapshot
+        # re-resolves against the API rather than trusting these rows,
+        # so a stale or missing mirror cannot cause a wrong restore.
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          cd tofu/control-plane
+          source ../.r2-credentials
+          export AWS_ACCESS_KEY_ID="$R2_ACCESS_KEY_ID"
+          export AWS_SECRET_ACCESS_KEY="$R2_SECRET_ACCESS_KEY"
+          tofu init -backend-config=../backend.hcl -backend-config="key=control-plane.tfstate" -input=false
+          D1_DATABASE_NAME=$(tofu output -raw d1_database_name 2>/dev/null || echo "")
+          cd ../..
+
+          if [ -z "$D1_DATABASE_NAME" ]; then
+            echo "⚠️  Could not resolve D1 database name — skipping the mirror (not fatal)"
+            exit 0
+          fi
+
+          npx wrangler@4 d1 execute "$D1_DATABASE_NAME" --remote --command "
+            INSERT OR REPLACE INTO config (key, value, updated_at) VALUES
+              ('snapshot_image_id',  '${{ steps.snapshot.outputs.image_id }}', datetime('now')),
+              ('snapshot_disk_gb',   '${{ steps.snapshot.outputs.disk_gb }}',  datetime('now')),
+              ('snapshot_arch',      '${{ steps.snapshot.outputs.arch }}',     datetime('now')),
+              ('snapshot_created_at','${{ steps.snapshot.outputs.timestamp }}',datetime('now')),
+              ('snapshot_state',     'fresh',                                  datetime('now'))
+          " || echo "⚠️  D1 mirror write failed (not fatal)"
+
+      - name: Power the server back on (skip_destroy)
+        if: github.event.inputs.skip_destroy == 'true' && steps.snapshot.outputs.server_id != ''
+        # The verification path: prove the snapshot mechanism end to end
+        # against the real stack without destroying anything. The server
+        # was powered off for consistency, so it has to come back.
+        run: |
+          SERVER_ID="${{ steps.snapshot.outputs.server_id }}"
+          echo "🔌 Powering server $SERVER_ID back on..."
+          RESPONSE=$(curl -sS -X POST \
+            -H "Authorization: Bearer ${{ secrets.HCLOUD_TOKEN }}" \
+            -H "Content-Type: application/json" \
+            "https://api.hetzner.cloud/v1/servers/$SERVER_ID/actions/poweron")
+          if echo "$RESPONSE" | jq -e '.action.id' >/dev/null 2>&1; then
+            echo "✅ Power-on requested — the stack will come back by itself"
+            echo "   (every stacks/*/docker-compose.yml uses restart: unless-stopped)"
+          else
+            echo "❌ Power-on failed. The server is OFF and needs manual attention:"
+            echo "$RESPONSE" | jq -r '.error.message // .' 2>/dev/null || echo "$RESPONSE"
+            exit 1
+          fi
+
+      - name: Destroy the server only
+        if: github.event.inputs.skip_destroy != 'true'
+        # -target=hcloud_server.main destroys the server and its
+        # dependents — which is only cloudflare_record.firewall_tcp.
+        # Everything else in the state, above all the 81 generated
+        # secrets, survives untouched. That is what keeps the snapshot
+        # restorable.
+        run: |
+          cd tofu/stack
+          source ../.r2-credentials
+          export AWS_ACCESS_KEY_ID="$R2_ACCESS_KEY_ID"
+          export AWS_SECRET_ACCESS_KEY="$R2_SECRET_ACCESS_KEY"
+
+          if [ "${{ steps.snapshot.outputs.ok }}" != "true" ]; then
+            echo "⚠️  Proceeding without a disk snapshot."
+            echo "   The R2 snapshot ran before this point, so stack data is"
+            echo "   still protected; the next spin-up will build fresh."
+          fi
+
+          if ! tofu destroy -target=hcloud_server.main -var-file=config.tfvars -auto-approve; then
+            echo "❌ ERROR: Failed to destroy the server"
+            echo "   It may still be running — check the log above"
+            exit 1
+          fi
+          echo "✅ Server destroyed; credentials, tunnel, DNS and Access preserved"
+
+      - name: Prune old snapshots
+        if: steps.snapshot.outputs.ok == 'true'
+        # AFTER a successful create, never before — pruning first could
+        # leave nothing to restore from if the new snapshot failed.
+        env:
+          DOMAIN: ${{ secrets.DOMAIN }}
+        run: |
+          DOMAIN_SLUG=$(echo "$DOMAIN" | tr '.' '-')
+          uv run --quiet --project "$GITHUB_WORKSPACE" \
+            python -m nexus_deploy snapshot-prune \
+              --domain-slug "$DOMAIN_SLUG" --keep 2 --apply \
+            || echo "⚠️  Prune failed (not fatal — the new snapshot is already available)"
+
+      - name: Write teardown timestamp to D1
+        if: github.event.inputs.skip_destroy != 'true'
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          cd tofu/control-plane
+          source ../.r2-credentials
+          export AWS_ACCESS_KEY_ID="$R2_ACCESS_KEY_ID"
+          export AWS_SECRET_ACCESS_KEY="$R2_SECRET_ACCESS_KEY"
+          tofu init -backend-config=../backend.hcl -backend-config="key=control-plane.tfstate" -input=false
+          D1_DATABASE_NAME=$(tofu output -raw d1_database_name 2>/dev/null || echo "")
+          cd ../..
+
+          if [ -z "$D1_DATABASE_NAME" ]; then
+            echo "⚠️  Could not get D1 database name - skipping timestamp write"
+            exit 0
+          fi
+
+          npx wrangler@4 d1 execute "$D1_DATABASE_NAME" --remote --command "INSERT OR REPLACE INTO config (key, value, updated_at) VALUES ('last_teardown', datetime('now'), datetime('now'))"
+          npx wrangler@4 d1 execute "$D1_DATABASE_NAME" --remote --command "UPDATE firewall_rules SET enabled = 0, deployed = 0, updated_at = datetime('now')" 2>/dev/null || true
+          echo "✅ Teardown timestamp written, firewall rules reset"
+
+      - name: Summary
+        if: always()
+        run: |
+          echo ""
+          if [ "${{ steps.snapshot.outputs.ok }}" = "true" ]; then
+            echo "📸 Snapshot #${{ steps.snapshot.outputs.image_id }} (${{ steps.snapshot.outputs.disk_gb }}GB ${{ steps.snapshot.outputs.arch }})"
+          else
+            echo "📸 No snapshot was created"
+          fi
+          if [ "${{ github.event.inputs.skip_destroy }}" = "true" ]; then
+            echo "💤 skip_destroy — nothing destroyed, server powered back on"
+          else
+            echo "💤 Server destroyed. Preserved: credentials, tunnel, DNS, Access, Control Plane"
+            echo "📋 Re-deploy: https://control.${{ secrets.DOMAIN }}"
+          fi
+
+      - name: Log teardown completed
+        if: always()
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          DOMAIN: ${{ secrets.DOMAIN }}
+        run: |
+          if [ -f .github/scripts/log-to-d1.sh ]; then
+            .github/scripts/log-to-d1.sh info "Snapshot teardown workflow completed"
+          fi

--- a/.github/workflows/teardown-snapshot.yml
+++ b/.github/workflows/teardown-snapshot.yml
@@ -320,8 +320,27 @@ jobs:
           fi
 
           cat /tmp/snapshot.out
-          # shellcheck disable=SC1091
-          . /tmp/snapshot.out
+
+          # Parse as data, never `source`. The values originate from
+          # Hetzner API fields (architecture in particular), and
+          # sourcing would execute whatever they contain as shell.
+          # The CLI constrains its own output, but an unvalidated
+          # upstream string should not be one bug away from arbitrary
+          # execution in a workflow that holds every deploy secret.
+          read_kv() {
+            grep -m1 "^$1=" /tmp/snapshot.out | cut -d= -f2- | tr -dc 'A-Za-z0-9_.-'
+          }
+          SNAPSHOT_IMAGE_ID=$(read_kv SNAPSHOT_IMAGE_ID)
+          SNAPSHOT_DISK_GB=$(read_kv SNAPSHOT_DISK_GB)
+          SNAPSHOT_ARCH=$(read_kv SNAPSHOT_ARCH)
+
+          if [ -z "$SNAPSHOT_IMAGE_ID" ]; then
+            echo "❌ snapshot-create returned no image id"
+            echo "ok=false" >> "$GITHUB_OUTPUT"
+            echo "server_id=$SERVER_ID" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           {
             echo "ok=true"
             echo "server_id=$SERVER_ID"

--- a/src/nexus_deploy/__main__.py
+++ b/src/nexus_deploy/__main__.py
@@ -28,6 +28,7 @@ import requests
 
 from nexus_deploy import __version__, hello
 from nexus_deploy import hetzner_capacity as _hetzner
+from nexus_deploy import hetzner_snapshot as _hsnap
 from nexus_deploy import pipeline as _pipeline
 from nexus_deploy import s3_persistence as _s3_persistence
 from nexus_deploy import s3_restore as _s3_restore
@@ -2790,6 +2791,274 @@ def _select_capacity(args: list[str]) -> int:
     return 0
 
 
+# ---------------------------------------------------------------------------
+# Hetzner disk snapshots
+#
+# Four small handlers used by the snapshot-based teardown/spin-up
+# workflows. They share one output convention:
+#
+#   stdout  KEY=value lines, meant to be appended to $GITHUB_OUTPUT or
+#           eval'd by the workflow. Nothing else goes to stdout.
+#   stderr  human-facing progress, same as select-capacity.
+#
+# Exit codes are 0 / 2 like the other handlers, except snapshot-resolve
+# which also uses 1 — see its docstring for why that distinction earns
+# its keep.
+# ---------------------------------------------------------------------------
+
+
+class _FlagError(Exception):
+    """A required flag was missing or malformed."""
+
+
+def _flag(args: list[str], name: str) -> str | None:
+    """Read ``--name VALUE`` out of a crude arg list.
+
+    Matches the hand-rolled parsing the other handlers use rather than
+    pulling in argparse for four flags. Raises :class:`_FlagError` when
+    the flag is present but has no value, so the operator sees which
+    flag is wrong instead of a generic "unknown argument".
+    """
+    for i, arg in enumerate(args):
+        if arg == f"--{name}":
+            if i + 1 >= len(args):
+                raise _FlagError(f"--{name} requires a value")
+            return args[i + 1]
+    return None
+
+
+def _required_flag(args: list[str], name: str) -> str:
+    value = _flag(args, name)
+    if value is None:
+        raise _FlagError(f"--{name} is required")
+    return value
+
+
+def _int_flag(args: list[str], name: str, *, default: int | None = None) -> int:
+    raw = _flag(args, name)
+    if raw is None:
+        if default is None:
+            raise _FlagError(f"--{name} is required")
+        return default
+    try:
+        return int(raw)
+    except ValueError as exc:
+        raise _FlagError(f"--{name} must be an integer, got {raw!r}") from exc
+
+
+def _snapshot_token() -> str:
+    token = os.environ.get("HCLOUD_TOKEN", "")
+    if not token:
+        raise _FlagError("HCLOUD_TOKEN not set")
+    return token
+
+
+def _server_poweroff(args: list[str]) -> int:
+    """`nexus-deploy server-poweroff --server-id N`.
+
+    Graceful ACPI shutdown polled until Hetzner reports ``off``, with a
+    hard power-off once half the budget is gone. Run immediately before
+    ``snapshot-create`` so the captured disk is consistent — in
+    particular so Postgres has been stopped cleanly rather than
+    captured mid-write.
+
+    Exit codes: 0 the server is off, 2 anything else (including a
+    server that never stopped, which must not be snapshotted).
+    """
+    try:
+        server_id = _int_flag(args, "server-id")
+        token = _snapshot_token()
+    except _FlagError as exc:
+        print(f"server-poweroff: {exc}", file=sys.stderr)
+        return 2
+
+    sys.stderr.write(f"server-poweroff: shutting down server {server_id}...\n")
+    try:
+        _hsnap.poweroff_server(server_id, token)
+    except _hsnap.HetznerSnapshotError as exc:
+        print(f"server-poweroff: {exc}", file=sys.stderr)
+        return 2
+    sys.stderr.write(f"✓ server-poweroff: server {server_id} is off\n")
+    return 0
+
+
+def _snapshot_create(args: list[str]) -> int:
+    """`nexus-deploy snapshot-create --server-id N --domain-slug S ...`.
+
+    Creates a labelled disk snapshot and waits until it is actually
+    usable, then emits its coordinates on stdout:
+
+        SNAPSHOT_IMAGE_ID=12345678
+        SNAPSHOT_DISK_GB=160
+        SNAPSHOT_ARCH=x86
+
+    ``--epoch`` is the ``credential_fingerprint`` tofu output. It is
+    stamped onto the image so a later restore can detect that the
+    credentials were rotated in between (which the legacy untargeted
+    ``tofu destroy`` does) and refuse the snapshot rather than bring up
+    a stack that cannot authenticate. Optional, because a stack that
+    predates the output should still be snapshottable.
+
+    ``--timestamp`` is supplied by the caller rather than generated
+    here, so the description is deterministic and the workflow controls
+    the clock.
+
+    Exit codes: 0 snapshot available, 2 anything else. A failure here
+    must leave the server intact — the teardown only destroys after
+    this returns 0.
+    """
+    try:
+        server_id = _int_flag(args, "server-id")
+        domain_slug = _required_flag(args, "domain-slug")
+        timestamp = _required_flag(args, "timestamp")
+        server_type = _flag(args, "server-type") or ""
+        epoch = _flag(args, "epoch") or ""
+        token = _snapshot_token()
+    except _FlagError as exc:
+        print(f"snapshot-create: {exc}", file=sys.stderr)
+        return 2
+
+    # Pre-flight the project-wide cap. Hetzner rejects the create call
+    # itself when the real limit is hit, but a specific warning here is
+    # far more actionable than a generic API error mid-teardown.
+    try:
+        total = _hsnap.count_snapshots(token)
+    except _hsnap.HetznerSnapshotError as exc:
+        print(f"snapshot-create: could not count existing snapshots: {exc}", file=sys.stderr)
+        return 2
+    if total >= _hsnap.DEFAULT_SNAPSHOT_LIMIT - 2:
+        sys.stderr.write(
+            f"⚠ snapshot-create: {total} snapshots exist project-wide "
+            f"(default limit {_hsnap.DEFAULT_SNAPSHOT_LIMIT}). Prune old "
+            "generations or ask Hetzner to raise the limit.\n",
+        )
+
+    sys.stderr.write(f"snapshot-create: creating snapshot of server {server_id}...\n")
+    try:
+        snapshot = _hsnap.create_snapshot(
+            server_id,
+            token,
+            domain_slug=domain_slug,
+            epoch=epoch,
+            server_type=server_type,
+            timestamp=timestamp,
+        )
+    except _hsnap.HetznerSnapshotError as exc:
+        print(f"snapshot-create: {exc}", file=sys.stderr)
+        return 2
+
+    sys.stderr.write(f"✓ snapshot-create: {snapshot}\n")
+    print(f"SNAPSHOT_IMAGE_ID={snapshot.image_id}")
+    print(f"SNAPSHOT_DISK_GB={snapshot.disk_gb}")
+    print(f"SNAPSHOT_ARCH={snapshot.architecture}")
+    return 0
+
+
+def _snapshot_resolve(args: list[str]) -> int:
+    """`nexus-deploy snapshot-resolve --domain-slug S [--expect-epoch E]`.
+
+    Finds the newest restorable snapshot for a stack and emits its
+    coordinates on stdout, same keys as ``snapshot-create``.
+
+    Exit codes are three-valued here, and the distinction matters:
+
+    - 0: a usable snapshot was found; restore from it.
+    - 1: no usable snapshot. NOT an error — a first-ever spin-up, a
+      pruned image and a rotated credential epoch all land here, and
+      all three must degrade to a normal ``ubuntu-24.04`` build. The
+      workflow branches on this rather than failing.
+    - 2: the lookup itself failed (auth, network, schema). The
+      workflow should stop, because "cannot tell" is not the same as
+      "there is none" — silently rebuilding fresh would discard a
+      snapshot that may hold the only copy of most stacks' data.
+    """
+    try:
+        domain_slug = _required_flag(args, "domain-slug")
+        expect_epoch = _flag(args, "expect-epoch")
+        token = _snapshot_token()
+    except _FlagError as exc:
+        print(f"snapshot-resolve: {exc}", file=sys.stderr)
+        return 2
+
+    try:
+        snapshot = _hsnap.resolve_latest(
+            token,
+            domain_slug=domain_slug,
+            expect_epoch=expect_epoch or None,
+        )
+    except _hsnap.HetznerSnapshotError as exc:
+        print(f"snapshot-resolve: {exc}", file=sys.stderr)
+        return 2
+
+    if snapshot is None:
+        detail = f" matching epoch {expect_epoch}" if expect_epoch else ""
+        sys.stderr.write(
+            f"snapshot-resolve: no usable snapshot for {domain_slug}{detail} "
+            "— spin-up should build fresh\n",
+        )
+        return 1
+
+    sys.stderr.write(f"✓ snapshot-resolve: {snapshot}\n")
+    print(f"SNAPSHOT_IMAGE_ID={snapshot.image_id}")
+    print(f"SNAPSHOT_DISK_GB={snapshot.disk_gb}")
+    print(f"SNAPSHOT_ARCH={snapshot.architecture}")
+    return 0
+
+
+def _snapshot_prune(args: list[str]) -> int:
+    """`nexus-deploy snapshot-prune --domain-slug S [--keep 2] [--apply]`.
+
+    Deletes all but the newest ``--keep`` snapshots of one stack.
+    Label-scoped, so it can never touch another tenant's images.
+
+    Dry-run by default: without ``--apply`` it only reports what it
+    would delete. Deleting a snapshot is irreversible and may be the
+    only copy of most stacks' data, so the destructive form is opt-in.
+
+    Run only AFTER a new snapshot has reached ``available`` — pruning
+    first could leave nothing to restore from if the new one fails.
+
+    Exit codes: 0 done (or nothing to do), 2 on API failure.
+    """
+    try:
+        domain_slug = _required_flag(args, "domain-slug")
+        keep = _int_flag(args, "keep", default=2)
+        token = _snapshot_token()
+    except _FlagError as exc:
+        print(f"snapshot-prune: {exc}", file=sys.stderr)
+        return 2
+    apply_changes = "--apply" in args
+
+    try:
+        snapshots = _hsnap.list_snapshots(token, domain_slug=domain_slug)
+        prunable = _hsnap.select_prunable(snapshots, keep=keep)
+    except _hsnap.HetznerSnapshotError as exc:
+        print(f"snapshot-prune: {exc}", file=sys.stderr)
+        return 2
+
+    if not prunable:
+        sys.stderr.write(
+            f"snapshot-prune: {len(snapshots)} snapshot(s) for {domain_slug}, "
+            f"keep={keep} — nothing to prune\n",
+        )
+        return 0
+
+    for snapshot in prunable:
+        if not apply_changes:
+            sys.stderr.write(f"snapshot-prune: would delete {snapshot}\n")
+            continue
+        try:
+            _hsnap.delete_snapshot(snapshot.image_id, token)
+        except _hsnap.HetznerSnapshotError as exc:
+            print(f"snapshot-prune: failed to delete {snapshot}: {exc}", file=sys.stderr)
+            return 2
+        sys.stderr.write(f"✓ snapshot-prune: deleted {snapshot}\n")
+
+    if not apply_changes:
+        sys.stderr.write("snapshot-prune: dry run — pass --apply to delete\n")
+    return 0
+
+
 def _run_pipeline(args: list[str]) -> int:
     """`nexus-deploy run-pipeline`.
 
@@ -3401,6 +3670,14 @@ def main() -> int:
         return _run_pre_bootstrap(args[1:])
     if args[:1] == ["select-capacity"]:
         return _select_capacity(args[1:])
+    if args[:1] == ["server-poweroff"]:
+        return _server_poweroff(args[1:])
+    if args[:1] == ["snapshot-create"]:
+        return _snapshot_create(args[1:])
+    if args[:1] == ["snapshot-resolve"]:
+        return _snapshot_resolve(args[1:])
+    if args[:1] == ["snapshot-prune"]:
+        return _snapshot_prune(args[1:])
     if args[:1] == ["run-pipeline"]:
         return _run_pipeline(args[1:])
     if args[:1] == ["s3-snapshot"]:
@@ -3441,6 +3718,15 @@ def main() -> int:
         "check; reads HCLOUD_TOKEN + optional SERVER_PREFERENCES env, walks "
         "<type>:<location> preference list, rewrites server_type+server_location "
         "in PATH to first available pair; rc=2 if every preference is out of stock), "
+        "server-poweroff --server-id N (graceful ACPI shutdown polled to status=off, "
+        "hard poweroff as fallback; env: HCLOUD_TOKEN), "
+        "snapshot-create --server-id N --domain-slug SLUG --timestamp TS "
+        "[--epoch FINGERPRINT] [--server-type TYPE] (labelled Hetzner disk snapshot, "
+        "waits until available; emits SNAPSHOT_IMAGE_ID/_DISK_GB/_ARCH on stdout), "
+        "snapshot-resolve --domain-slug SLUG [--expect-epoch FINGERPRINT] "
+        "(newest restorable snapshot; rc=0 found, rc=1 none — build fresh, rc=2 lookup failed), "
+        "snapshot-prune --domain-slug SLUG [--keep 2] [--apply] "
+        "(drop all but the newest N; dry-run unless --apply), "
         "run-pipeline (top-level deploy entry; reads tofu state + "
         "config.tfvars; optional env: SSH_PRIVATE_KEY_CONTENT, "
         "GH_MIRROR_TOKEN, GH_MIRROR_REPOS, DOCKERHUB_USER, DOCKERHUB_TOKEN, "

--- a/src/nexus_deploy/hetzner_capacity.py
+++ b/src/nexus_deploy/hetzner_capacity.py
@@ -138,6 +138,107 @@ class ServerSpec:
         return f"{self.server_type}:{self.location}"
 
 
+@dataclass(frozen=True)
+class ServerTypeInfo:
+    """Restore-relevant shape of one Hetzner server type.
+
+    ``disk_gb`` and ``architecture`` are the two constraints that decide
+    whether a disk snapshot can be restored onto this type: Hetzner
+    requires the target disk to be at least as large as the image's and
+    the architecture to match exactly. Both are silent until ``tofu
+    apply`` fails, which is why the snapshot spin-up filters on them
+    before choosing.
+    """
+
+    name: str
+    disk_gb: int
+    architecture: str
+
+
+def fetch_server_types(
+    token: str,
+    *,
+    http_get: HttpGet | None = None,
+) -> dict[str, ServerTypeInfo]:
+    """Query ``/v1/server_types`` and return ``{name: ServerTypeInfo}``.
+
+    Deliberately a separate call rather than extra return values on
+    :func:`fetch_availability`. That function's signature is monkeypatched
+    in a dozen CLI tests and consumed by the legacy spin-up path; widening
+    it to serve the snapshot path would put churn on the one code path
+    that must not regress. The duplicated request is a few KB against an
+    endpoint we already hit, and only on the snapshot path.
+    """
+    if not token:
+        raise HetznerCapacityError("HCLOUD_TOKEN not set")
+    get = http_get if http_get is not None else _default_http_get
+
+    payload = get(f"{_API_BASE}/server_types?per_page=200", token)
+    server_types = payload.get("server_types") if isinstance(payload, dict) else None
+    if not isinstance(server_types, list):
+        raise HetznerCapacityError(
+            "Hetzner /v1/server_types response missing 'server_types' list",
+        )
+
+    out: dict[str, ServerTypeInfo] = {}
+    for st in server_types:
+        if not isinstance(st, dict):
+            continue
+        name = st.get("name")
+        if not isinstance(name, str):
+            continue
+        disk = st.get("disk")
+        arch = st.get("architecture")
+        out[name.lower()] = ServerTypeInfo(
+            name=name.lower(),
+            disk_gb=int(disk) if isinstance(disk, (int, float)) else 0,
+            architecture=arch if isinstance(arch, str) else "",
+        )
+    return out
+
+
+def filter_specs(
+    preferences: tuple[ServerSpec, ...],
+    types: dict[str, ServerTypeInfo],
+    *,
+    min_disk_gb: int = 0,
+    arch: str | None = None,
+) -> tuple[tuple[ServerSpec, ...], dict[ServerSpec, str]]:
+    """Drop preferences a snapshot could not be restored onto.
+
+    Returns ``(kept, excluded)`` where ``excluded`` maps each dropped
+    spec to a human-readable reason, so the operator can see *why* a
+    tier was skipped rather than just watching it vanish.
+
+    The defaults (``min_disk_gb=0``, ``arch=None``) are a no-op: every
+    preference is kept and ``excluded`` is empty. That is what keeps the
+    legacy spin-up path byte-for-byte unchanged.
+
+    A type absent from ``types`` is kept, not dropped. Hetzner
+    occasionally lists a type in a datacenter's ``available`` set before
+    it appears in ``/v1/server_types``; failing open leaves that case to
+    :func:`select`, which is where "unknown type" is already handled.
+    """
+    if min_disk_gb <= 0 and arch is None:
+        return preferences, {}
+
+    kept: list[ServerSpec] = []
+    excluded: dict[ServerSpec, str] = {}
+    for spec in preferences:
+        info = types.get(spec.server_type)
+        if info is None:
+            kept.append(spec)
+            continue
+        if arch is not None and info.architecture and info.architecture != arch:
+            excluded[spec] = f"architecture {info.architecture} != {arch}"
+            continue
+        if min_disk_gb > 0 and info.disk_gb < min_disk_gb:
+            excluded[spec] = f"disk {info.disk_gb}GB < {min_disk_gb}GB required"
+            continue
+        kept.append(spec)
+    return tuple(kept), excluded
+
+
 def parse_preferences(value: str) -> tuple[ServerSpec, ...]:
     """Parse a comma-list of ``<server_type>:<location>`` tokens.
 
@@ -348,6 +449,7 @@ def render_status_lines(
     preferences: tuple[ServerSpec, ...],
     availability: dict[str, set[str]],
     selected: ServerSpec | None,
+    excluded: dict[ServerSpec, str] | None = None,
 ) -> list[str]:
     """Build a per-preference status block for operator-facing logs.
 
@@ -369,12 +471,24 @@ def render_status_lines(
       Suffix ``(unknown location)`` is appended so the failure
       message is actionable without the operator having to know
       the marker convention.
+    * ``⊘`` — excluded before the availability walk because the type
+      cannot host the snapshot being restored (disk too small, or
+      wrong architecture). Only appears when ``excluded`` is passed,
+      i.e. on the snapshot spin-up path; the reason is appended so a
+      skipped tier does not look like a capacity problem.
+
+    ``excluded`` defaults to ``None`` so the legacy call site renders
+    exactly as before.
     """
+    excluded = excluded or {}
     lines: list[str] = []
     for idx, spec in enumerate(preferences, start=1):
         if spec == selected:
             marker = "→"
             suffix = ""
+        elif spec in excluded:
+            marker = "⊘"
+            suffix = f" ({excluded[spec]})"
         elif spec.location not in availability:
             marker = "?"
             suffix = " (unknown location)"

--- a/src/nexus_deploy/hetzner_snapshot.py
+++ b/src/nexus_deploy/hetzner_snapshot.py
@@ -112,6 +112,13 @@ class Snapshot:
     restoring it would produce a stack that boots and then fails to
     authenticate anywhere. Empty string when the label is absent
     (a snapshot from before this mechanism existed).
+
+    ``status`` matters because ``/v1/images`` also lists images that
+    are still ``creating`` — e.g. from a teardown that was interrupted
+    between ``create_image`` and completion. Such an image is the
+    newest one in the listing but cannot be restored from, so
+    selecting it would fail a spin-up that had a perfectly good older
+    snapshot available.
     """
 
     image_id: int
@@ -121,6 +128,12 @@ class Snapshot:
     architecture: str
     epoch: str
     server_type: str
+    status: str = ""
+
+    @property
+    def is_available(self) -> bool:
+        """Whether this image can actually be used to create a server."""
+        return self.status == "available"
 
     def __str__(self) -> str:
         return f"#{self.image_id} {self.description} ({self.disk_gb}GB {self.architecture})"
@@ -244,6 +257,7 @@ def _parse_snapshot(image: dict[str, Any]) -> Snapshot | None:
         architecture=arch if isinstance(arch, str) else "",
         epoch=str(labels.get(LABEL_EPOCH, "")),
         server_type=str(labels.get(LABEL_SERVER_TYPE, "")),
+        status=str(image.get("status", "")),
     )
 
 
@@ -345,6 +359,12 @@ def create_snapshot(
     validate_label_value(domain_slug, field=LABEL_DOMAIN)
     if epoch:
         validate_label_value(epoch, field=LABEL_EPOCH)
+    # server_type is grepped out of config.tfvars by the workflow, so it
+    # is the one label value that has not already been through a regex.
+    # A stray space there would make Hetzner reject the whole create
+    # call and leave the teardown without a snapshot.
+    if server_type:
+        validate_label_value(server_type, field=LABEL_SERVER_TYPE)
 
     labels = {
         LABEL_ROLE: ROLE_VALUE,
@@ -431,19 +451,29 @@ def list_snapshots(
 ) -> tuple[Snapshot, ...]:
     """Return this project's snapshots, newest first.
 
-    With ``domain_slug`` the query is narrowed by label selector to one
-    stack, which is what makes the whole mechanism multi-tenant-safe:
-    two stacks in the same Hetzner project never see each other's
-    images.
+    Both label keys are always required in the selector, never just the
+    domain. ``nexus_role`` is what makes an image ours; without it, any
+    snapshot in the project that happened to carry a matching
+    ``nexus_domain`` would be enumerated for retention — and prune
+    deletes what it enumerates. Together they are also what makes the
+    mechanism multi-tenant-safe: two stacks in one Hetzner project
+    never see each other's images.
+
+    Non-``available`` images are returned too. They are excluded where
+    it matters (:func:`resolve_latest`, :func:`select_prunable`) rather
+    than here, because :func:`count_snapshots` needs the true total —
+    an image still being created counts against the project cap.
     """
     req = _request(http_request)
     url = f"{_API_BASE}/images?type=snapshot&per_page=100&sort=created:desc"
+    selector = f"{LABEL_ROLE}%3D{ROLE_VALUE}"
     if domain_slug is not None:
         if not _IDENT.match(domain_slug):
             raise HetznerSnapshotError(
                 f"domain_slug {domain_slug!r} must be lowercase alphanumeric with dashes",
             )
-        url += f"&label_selector={LABEL_DOMAIN}%3D{domain_slug}"
+        selector += f",{LABEL_DOMAIN}%3D{domain_slug}"
+    url += f"&label_selector={selector}"
 
     payload = req("GET", url, token, None)
     images = payload.get("images") if isinstance(payload, dict) else None
@@ -486,9 +516,17 @@ def resolve_latest(
     destroy``: it regenerates all 81 credentials, so the Postgres roles
     and admin accounts inside an older snapshot no longer match the
     state the pipeline will use.
+
+    Images that are not ``available`` are skipped rather than returned.
+    A teardown interrupted between ``create_image`` and completion
+    leaves a ``creating`` image behind; it sorts newest, so without this
+    it would be picked and fail the spin-up even though a perfectly
+    good older snapshot was sitting right behind it.
     """
     snapshots = list_snapshots(token, domain_slug=domain_slug, http_request=http_request)
     for snapshot in snapshots:
+        if not snapshot.is_available:
+            continue
         if expect_epoch is not None and snapshot.epoch != expect_epoch:
             continue
         return snapshot
@@ -504,10 +542,18 @@ def select_prunable(
 
     Pure function so the retention decision is testable on its own —
     an off-by-one here deletes the snapshot the next spin-up needs.
+
+    Only ``available`` images count towards ``keep``, and only
+    ``available`` images are ever returned as prunable. Both halves
+    matter: an interrupted create leaves a ``creating`` image that
+    would otherwise occupy a keep slot and evict a good snapshot, while
+    deleting an image mid-creation is not something to attempt from a
+    retention pass.
     """
     if keep < 1:
         raise HetznerSnapshotError(f"keep must be >= 1, got {keep}")
-    ordered = sorted(snapshots, key=lambda s: (s.created, s.image_id), reverse=True)
+    available = [s for s in snapshots if s.is_available]
+    ordered = sorted(available, key=lambda s: (s.created, s.image_id), reverse=True)
     return tuple(ordered[keep:])
 
 

--- a/src/nexus_deploy/hetzner_snapshot.py
+++ b/src/nexus_deploy/hetzner_snapshot.py
@@ -1,0 +1,535 @@
+"""Hetzner Cloud disk-snapshot lifecycle for the snapshot-based
+teardown/spin-up cycle.
+
+The default lifecycle destroys the whole stack on teardown and rebuilds
+it from ``ubuntu-24.04`` on the next spin-up. Most of that rebuild is
+repetition: patching Ubuntu, installing Docker, and pulling the same
+container images again — the single largest block of a spin-up.
+
+This module implements the alternative: take a Hetzner disk snapshot of
+the server before destroying it, then create the next server directly
+from that image. Two properties make it work:
+
+* Hetzner snapshots **survive deletion of the server they came from**
+  (unlike Hetzner *backups*, which are deleted with the server).
+* Every ``stacks/*/docker-compose.yml`` uses ``restart:
+  unless-stopped``, so containers come back on their own at boot.
+
+A snapshot also captures the data of *every* stack, where the R2
+persistence layer (:mod:`nexus_deploy.s3_persistence`) only covers a
+hard-coded five-stack subset. The two are complements: R2 is the
+portable, logically-consistent escape hatch used whenever a snapshot is
+unavailable, mismatched, or unusable.
+
+Public surface:
+
+* :class:`Snapshot` — one snapshot image with the metadata needed to
+  decide whether it can be restored.
+* :class:`HetznerSnapshotError` — API/auth/network/schema failure.
+* :func:`poweroff_server` — graceful ACPI shutdown, polled to ``off``.
+* :func:`create_snapshot` — create an image and wait until usable.
+* :func:`list_snapshots` — all snapshots for one stack, newest first.
+* :func:`resolve_latest` — the newest usable snapshot, epoch-checked.
+* :func:`select_prunable` — which snapshots a ``keep=N`` policy drops.
+* :func:`delete_snapshot` — remove one image.
+* :func:`count_snapshots` — project-wide total, for the 30-image cap.
+
+Every network call goes through an injectable ``http_request`` seam so
+the whole module is unit-testable without touching the network, mirroring
+:mod:`nexus_deploy.hetzner_capacity`.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import re
+import urllib.error
+import urllib.request
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+_API_BASE = "https://api.hetzner.cloud/v1"
+_DEFAULT_TIMEOUT = 30.0
+
+# Hetzner caps the number of snapshots per project. The value is a
+# default that support can raise on request, so treat it as a warning
+# threshold rather than a hard truth — the API is authoritative and
+# will reject the create call itself when the real limit is hit.
+DEFAULT_SNAPSHOT_LIMIT = 30
+
+# Label keys used to make a snapshot self-describing. The Hetzner
+# labels are the source of truth for "which snapshot belongs to this
+# stack" — unlike a D1 row they cannot go stale relative to reality,
+# and they survive a D1 loss.
+LABEL_ROLE = "nexus_role"
+LABEL_DOMAIN = "nexus_domain"
+LABEL_EPOCH = "nexus_epoch"
+LABEL_SERVER_TYPE = "nexus_server_type"
+
+ROLE_VALUE = "stack-snapshot"
+
+# Hetzner label values: at most 63 characters, first and last character
+# alphanumeric, ``-``, ``_`` and ``.`` allowed in between. This is the
+# reason `credential_fingerprint` in tofu/stack/outputs.tf is truncated
+# to 32 characters — a full sha256 hex digest is 64 and would be
+# rejected here.
+_LABEL_VALUE = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9._-]{0,61}[A-Za-z0-9])?$")
+
+# The credential epoch is the truncated sha256 from tofu's
+# `credential_fingerprint` output.
+_EPOCH = re.compile(r"^[0-9a-f]{32}$")
+
+# Same identifier gate as hetzner_capacity: values reach a label
+# selector and a tfvars rewrite, so anything outside this character set
+# is refused at the boundary rather than escaped downstream.
+_IDENT = re.compile(r"^[a-z0-9-]+$")
+
+# (method, url, token, payload) -> parsed JSON (or None for 204)
+HttpRequest = Callable[[str, str, str, "dict[str, Any] | None"], Any]
+
+# () -> None; injected so tests do not actually wait.
+Sleep = Callable[[float], None]
+
+
+class HetznerSnapshotError(Exception):
+    """Hetzner API call failed (auth / network / schema drift / timeout)."""
+
+
+@dataclass(frozen=True)
+class Snapshot:
+    """A Hetzner snapshot image plus what we need to judge it.
+
+    ``disk_gb`` is the image's ``disk_size``: the **minimum** disk a
+    target server type must have to restore this image. It is not the
+    billed figure — that is ``image_size``, which reflects used space
+    only and is typically far smaller.
+
+    ``epoch`` is the credential fingerprint that was current when the
+    snapshot was taken. A snapshot whose epoch no longer matches the
+    live tofu state was taken before the credentials rotated, so
+    restoring it would produce a stack that boots and then fails to
+    authenticate anywhere. Empty string when the label is absent
+    (a snapshot from before this mechanism existed).
+    """
+
+    image_id: int
+    description: str
+    created: str
+    disk_gb: int
+    architecture: str
+    epoch: str
+    server_type: str
+
+    def __str__(self) -> str:
+        return f"#{self.image_id} {self.description} ({self.disk_gb}GB {self.architecture})"
+
+
+def _default_http_request(
+    method: str,
+    url: str,
+    token: str,
+    payload: dict[str, Any] | None = None,
+) -> Any:
+    """Production HTTP call against the Hetzner API. Returns parsed JSON.
+
+    Raises :class:`HetznerSnapshotError` for every failure mode (HTTP
+    4xx/5xx, network, timeout, non-UTF-8 body, malformed JSON) so
+    callers have a single error class to handle. The original exception
+    is chained via ``__cause__`` so a debugger pass keeps the detail.
+
+    A ``204 No Content`` (what DELETE returns) yields ``None`` rather
+    than a JSON parse error.
+    """
+    data = None
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/json",
+    }
+    if payload is not None:
+        data = json.dumps(payload).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+
+    req = urllib.request.Request(  # noqa: S310 — URL built from literal _API_BASE
+        url,
+        data=data,
+        headers=headers,
+        method=method,
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=_DEFAULT_TIMEOUT) as resp:  # noqa: S310
+            raw = resp.read()
+    except urllib.error.HTTPError as exc:
+        # Hetzner puts a machine-readable reason in the body; surfacing
+        # it turns "HTTP 403" into something an operator can act on
+        # (missing token scope vs. resource_limit_exceeded).
+        # Best-effort: reading the body must never mask the HTTP error
+        # we are already reporting.
+        detail = ""
+        with contextlib.suppress(Exception):
+            detail = exc.read().decode("utf-8", errors="replace")[:400]
+        raise HetznerSnapshotError(
+            f"Hetzner API HTTP {exc.code} for {method} {url}: {exc.reason}"
+            + (f" — {detail}" if detail else ""),
+        ) from exc
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        raise HetznerSnapshotError(
+            f"Hetzner API request failed for {method} {url}: {type(exc).__name__}: {exc}",
+        ) from exc
+
+    if not raw:
+        return None
+    try:
+        body = raw.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise HetznerSnapshotError(
+            f"Hetzner API returned non-UTF-8 body for {method} {url}: {exc}",
+        ) from exc
+    try:
+        return json.loads(body)
+    except json.JSONDecodeError as exc:
+        raise HetznerSnapshotError(
+            f"Hetzner API returned non-JSON for {method} {url}: {exc}",
+        ) from exc
+
+
+def _request(http_request: HttpRequest | None) -> HttpRequest:
+    return http_request if http_request is not None else _default_http_request
+
+
+def validate_label_value(value: str, *, field: str) -> str:
+    """Gate a value that is about to become a Hetzner label.
+
+    Raises rather than truncating: a silently shortened epoch would
+    compare unequal forever and send every restore down the fresh path
+    for no visible reason.
+    """
+    if not _LABEL_VALUE.match(value):
+        raise HetznerSnapshotError(
+            f"{field} {value!r} is not a valid Hetzner label value "
+            "(max 63 chars, must start and end alphanumeric, "
+            "only '-', '_' and '.' in between)",
+        )
+    return value
+
+
+def _parse_snapshot(image: dict[str, Any]) -> Snapshot | None:
+    """Build a :class:`Snapshot` from one ``/v1/images`` entry.
+
+    Returns ``None`` for anything malformed rather than raising: a
+    single odd image in a list response should not take down a prune or
+    a resolve.
+    """
+    image_id = image.get("id")
+    if not isinstance(image_id, int):
+        return None
+    labels = image.get("labels")
+    labels = labels if isinstance(labels, dict) else {}
+
+    disk = image.get("disk_size")
+    # Hetzner reports disk_size in GB as a number; it has been seen as
+    # both int and float across API versions.
+    disk_gb = int(disk) if isinstance(disk, (int, float)) else 0
+
+    arch = image.get("architecture")
+    description = image.get("description")
+    created = image.get("created")
+
+    return Snapshot(
+        image_id=image_id,
+        description=description if isinstance(description, str) else "",
+        created=created if isinstance(created, str) else "",
+        disk_gb=disk_gb,
+        architecture=arch if isinstance(arch, str) else "",
+        epoch=str(labels.get(LABEL_EPOCH, "")),
+        server_type=str(labels.get(LABEL_SERVER_TYPE, "")),
+    )
+
+
+def poweroff_server(
+    server_id: int,
+    token: str,
+    *,
+    http_request: HttpRequest | None = None,
+    sleep: Sleep | None = None,
+    poll_attempts: int = 48,
+    poll_interval_s: float = 5.0,
+) -> None:
+    """Shut the server down gracefully and wait until it reports ``off``.
+
+    Hetzner recommends powering off before snapshotting so the disk is
+    consistent. ``shutdown`` sends ACPI, which gives systemd a chance to
+    stop the Docker containers cleanly — that graceful stop is what
+    makes the captured Postgres data directories trustworthy.
+
+    Falls back to a hard ``poweroff`` if ACPI has not taken effect
+    within the poll budget (default 4 minutes). A hung guest must not
+    leave a paid server running forever; a hard power-off is still
+    safer than snapshotting a running disk, and the R2 logical snapshot
+    has already been taken at that point in the teardown.
+
+    Raises :class:`HetznerSnapshotError` if the server never reaches
+    ``off`` even after the hard power-off.
+    """
+    req = _request(http_request)
+    if sleep is None:
+        import time as _time
+
+        sleep = _time.sleep
+
+    req("POST", f"{_API_BASE}/servers/{server_id}/actions/shutdown", token, None)
+
+    hard_tried = False
+    for attempt in range(1, poll_attempts + 1):
+        payload = req("GET", f"{_API_BASE}/servers/{server_id}", token, None)
+        server = payload.get("server") if isinstance(payload, dict) else None
+        status = server.get("status") if isinstance(server, dict) else None
+        if status == "off":
+            return
+        # Halfway through the budget, stop hoping ACPI will land.
+        if not hard_tried and attempt >= poll_attempts // 2:
+            req("POST", f"{_API_BASE}/servers/{server_id}/actions/poweroff", token, None)
+            hard_tried = True
+        sleep(poll_interval_s)
+
+    raise HetznerSnapshotError(
+        f"server {server_id} did not reach status 'off' after "
+        f"{poll_attempts * poll_interval_s:.0f}s (ACPI shutdown and hard "
+        "poweroff both attempted) — refusing to snapshot a running disk",
+    )
+
+
+def create_snapshot(
+    server_id: int,
+    token: str,
+    *,
+    domain_slug: str,
+    epoch: str,
+    server_type: str,
+    timestamp: str,
+    http_request: HttpRequest | None = None,
+    sleep: Sleep | None = None,
+    poll_attempts: int = 120,
+    poll_interval_s: float = 10.0,
+) -> Snapshot:
+    """Create a snapshot of ``server_id`` and wait until it is usable.
+
+    ``timestamp`` is passed in rather than generated here so the caller
+    controls it and the function stays deterministic under test.
+
+    Waits for two separate things, which is not redundant: the *action*
+    reaching ``success`` means Hetzner accepted and finished the copy,
+    while the *image* reaching ``available`` means it can actually be
+    used to create a server. Returning after only the first would let a
+    teardown destroy the server while the image is still ``creating``.
+    """
+    req = _request(http_request)
+    if sleep is None:
+        import time as _time
+
+        sleep = _time.sleep
+
+    if not _IDENT.match(domain_slug):
+        raise HetznerSnapshotError(
+            f"domain_slug {domain_slug!r} must be lowercase alphanumeric with dashes",
+        )
+    if epoch and not _EPOCH.match(epoch):
+        raise HetznerSnapshotError(
+            f"epoch {epoch!r} must be 32 lowercase hex characters "
+            "(tofu output credential_fingerprint)",
+        )
+
+    description = f"nexus-{domain_slug}-{timestamp}"
+    validate_label_value(description, field="description")
+    validate_label_value(domain_slug, field=LABEL_DOMAIN)
+    if epoch:
+        validate_label_value(epoch, field=LABEL_EPOCH)
+
+    labels = {
+        LABEL_ROLE: ROLE_VALUE,
+        LABEL_DOMAIN: domain_slug,
+        LABEL_EPOCH: epoch,
+        LABEL_SERVER_TYPE: server_type,
+    }
+    # Drop empties — Hetzner accepts an empty label value but it makes
+    # the selector below behave surprisingly.
+    labels = {k: v for k, v in labels.items() if v}
+
+    payload = req(
+        "POST",
+        f"{_API_BASE}/servers/{server_id}/actions/create_image",
+        token,
+        {"type": "snapshot", "description": description, "labels": labels},
+    )
+    action = payload.get("action") if isinstance(payload, dict) else None
+    image = payload.get("image") if isinstance(payload, dict) else None
+    action_id = action.get("id") if isinstance(action, dict) else None
+    image_id = image.get("id") if isinstance(image, dict) else None
+    if not isinstance(action_id, int) or not isinstance(image_id, int):
+        raise HetznerSnapshotError(
+            "Hetzner create_image response missing action.id or image.id",
+        )
+
+    _wait_for_action(action_id, token, req, sleep, poll_attempts, poll_interval_s)
+    return _wait_for_image(image_id, token, req, sleep, poll_attempts, poll_interval_s)
+
+
+def _wait_for_action(
+    action_id: int,
+    token: str,
+    req: HttpRequest,
+    sleep: Sleep,
+    poll_attempts: int,
+    poll_interval_s: float,
+) -> None:
+    for _ in range(poll_attempts):
+        payload = req("GET", f"{_API_BASE}/actions/{action_id}", token, None)
+        action = payload.get("action") if isinstance(payload, dict) else None
+        status = action.get("status") if isinstance(action, dict) else None
+        if status == "success":
+            return
+        if status == "error":
+            error = action.get("error") if isinstance(action, dict) else None
+            message = error.get("message") if isinstance(error, dict) else "unknown"
+            raise HetznerSnapshotError(f"snapshot action {action_id} failed: {message}")
+        sleep(poll_interval_s)
+    raise HetznerSnapshotError(
+        f"snapshot action {action_id} still running after {poll_attempts * poll_interval_s:.0f}s",
+    )
+
+
+def _wait_for_image(
+    image_id: int,
+    token: str,
+    req: HttpRequest,
+    sleep: Sleep,
+    poll_attempts: int,
+    poll_interval_s: float,
+) -> Snapshot:
+    for _ in range(poll_attempts):
+        payload = req("GET", f"{_API_BASE}/images/{image_id}", token, None)
+        image = payload.get("image") if isinstance(payload, dict) else None
+        if isinstance(image, dict) and image.get("status") == "available":
+            snapshot = _parse_snapshot(image)
+            if snapshot is None:
+                raise HetznerSnapshotError(
+                    f"image {image_id} is available but its payload is unparseable",
+                )
+            return snapshot
+        sleep(poll_interval_s)
+    raise HetznerSnapshotError(
+        f"image {image_id} did not become 'available' after {poll_attempts * poll_interval_s:.0f}s",
+    )
+
+
+def list_snapshots(
+    token: str,
+    *,
+    domain_slug: str | None = None,
+    http_request: HttpRequest | None = None,
+) -> tuple[Snapshot, ...]:
+    """Return this project's snapshots, newest first.
+
+    With ``domain_slug`` the query is narrowed by label selector to one
+    stack, which is what makes the whole mechanism multi-tenant-safe:
+    two stacks in the same Hetzner project never see each other's
+    images.
+    """
+    req = _request(http_request)
+    url = f"{_API_BASE}/images?type=snapshot&per_page=100&sort=created:desc"
+    if domain_slug is not None:
+        if not _IDENT.match(domain_slug):
+            raise HetznerSnapshotError(
+                f"domain_slug {domain_slug!r} must be lowercase alphanumeric with dashes",
+            )
+        url += f"&label_selector={LABEL_DOMAIN}%3D{domain_slug}"
+
+    payload = req("GET", url, token, None)
+    images = payload.get("images") if isinstance(payload, dict) else None
+    if not isinstance(images, list):
+        raise HetznerSnapshotError("Hetzner /v1/images response missing 'images' list")
+
+    out = [s for s in (_parse_snapshot(i) for i in images if isinstance(i, dict)) if s]
+    # The API is asked to sort, but do not depend on it: a wrong order
+    # here would make prune() delete the newest snapshot.
+    out.sort(key=lambda s: (s.created, s.image_id), reverse=True)
+    return tuple(out)
+
+
+def count_snapshots(token: str, *, http_request: HttpRequest | None = None) -> int:
+    """Total snapshots in the project, for the pre-flight cap check.
+
+    Counts *all* snapshots, not just this stack's, because the limit is
+    project-wide — a stack that only ever prunes its own images can
+    still be blocked by a sibling's.
+    """
+    return len(list_snapshots(token, http_request=http_request))
+
+
+def resolve_latest(
+    token: str,
+    *,
+    domain_slug: str,
+    expect_epoch: str | None = None,
+    http_request: HttpRequest | None = None,
+) -> Snapshot | None:
+    """Newest usable snapshot for one stack, or ``None``.
+
+    ``None`` is the ordinary "take the fresh path" answer, not an error:
+    a first-ever spin-up, a pruned-away snapshot and a rotated
+    credential epoch are all normal states that must degrade to a
+    regular ``ubuntu-24.04`` build rather than fail the workflow.
+
+    When ``expect_epoch`` is given, a snapshot whose epoch differs is
+    rejected. That is the guard against the legacy untargeted ``tofu
+    destroy``: it regenerates all 81 credentials, so the Postgres roles
+    and admin accounts inside an older snapshot no longer match the
+    state the pipeline will use.
+    """
+    snapshots = list_snapshots(token, domain_slug=domain_slug, http_request=http_request)
+    for snapshot in snapshots:
+        if expect_epoch is not None and snapshot.epoch != expect_epoch:
+            continue
+        return snapshot
+    return None
+
+
+def select_prunable(
+    snapshots: tuple[Snapshot, ...],
+    *,
+    keep: int,
+) -> tuple[Snapshot, ...]:
+    """Which snapshots a ``keep=N`` retention drops, newest kept first.
+
+    Pure function so the retention decision is testable on its own —
+    an off-by-one here deletes the snapshot the next spin-up needs.
+    """
+    if keep < 1:
+        raise HetznerSnapshotError(f"keep must be >= 1, got {keep}")
+    ordered = sorted(snapshots, key=lambda s: (s.created, s.image_id), reverse=True)
+    return tuple(ordered[keep:])
+
+
+def delete_snapshot(
+    image_id: int,
+    token: str,
+    *,
+    http_request: HttpRequest | None = None,
+) -> None:
+    """Delete one snapshot image permanently."""
+    req = _request(http_request)
+    req("DELETE", f"{_API_BASE}/images/{image_id}", token, None)
+
+
+def can_restore_onto(snapshot: Snapshot, *, disk_gb: int, architecture: str) -> bool:
+    """Whether ``snapshot`` can be restored onto a type of this shape.
+
+    Hetzner requires the target disk to be at least as large as the
+    image's ``disk_size`` and the architecture to match exactly. Both
+    constraints are silent until ``tofu apply`` fails, which is why
+    capacity selection filters on them up front.
+    """
+    if snapshot.architecture and architecture and snapshot.architecture != architecture:
+        return False
+    return disk_gb >= snapshot.disk_gb

--- a/tests/unit/test_hetzner_capacity.py
+++ b/tests/unit/test_hetzner_capacity.py
@@ -24,7 +24,10 @@ from nexus_deploy.hetzner_capacity import (
     DEFAULT_PREFERENCES,
     HetznerCapacityError,
     ServerSpec,
+    ServerTypeInfo,
     fetch_availability,
+    fetch_server_types,
+    filter_specs,
     parse_preferences,
     render_status_lines,
     select,
@@ -616,3 +619,126 @@ def test_default_http_get_wraps_malformed_json(monkeypatch: pytest.MonkeyPatch) 
     monkeypatch.setattr("urllib.request.urlopen", _fake_urlopen)
     with pytest.raises(HetznerCapacityError, match=r"non-JSON"):
         _default_http_get("https://api.hetzner.cloud/v1/datacenters", "t")
+
+
+# ---------------------------------------------------------------------------
+# fetch_server_types + filter_specs — snapshot restore constraints
+# ---------------------------------------------------------------------------
+
+# Disk sizes are the real ones for these types; the whole point of the
+# filter is that DEFAULT_PREFERENCES mixes them, so a snapshot taken on
+# one tier cannot necessarily be restored onto another.
+_FAKE_TYPES_WITH_DISK = {
+    "server_types": [
+        {"id": 22, "name": "cx43", "disk": 160, "architecture": "x86"},
+        {"id": 23, "name": "cx53", "disk": 320, "architecture": "x86"},
+        {"id": 24, "name": "cpx42", "disk": 240, "architecture": "x86"},
+        {"id": 9, "name": "cax31", "disk": 160, "architecture": "arm"},
+    ],
+}
+
+
+def test_fetch_server_types_parses_disk_and_architecture() -> None:
+    fake = _make_http_get(_FAKE_TYPES_WITH_DISK, _FAKE_DATACENTERS)
+    types = fetch_server_types("t", http_get=fake)
+    assert types["cx43"] == ServerTypeInfo(name="cx43", disk_gb=160, architecture="x86")
+    assert types["cax31"].architecture == "arm"
+
+
+def test_fetch_server_types_rejects_empty_token() -> None:
+    with pytest.raises(HetznerCapacityError, match="HCLOUD_TOKEN not set"):
+        fetch_server_types("")
+
+
+def test_fetch_server_types_raises_on_schema_drift() -> None:
+    fake = _make_http_get({"nope": []}, _FAKE_DATACENTERS)
+    with pytest.raises(HetznerCapacityError, match="missing 'server_types' list"):
+        fetch_server_types("t", http_get=fake)
+
+
+def test_fetch_server_types_skips_malformed_entries() -> None:
+    fake = _make_http_get(
+        {"server_types": [{"id": 1, "name": "cx43", "disk": 160}, {"id": 2}, "junk"]},
+        _FAKE_DATACENTERS,
+    )
+    types = fetch_server_types("t", http_get=fake)
+    assert list(types) == ["cx43"]
+    # Missing architecture must not become a bogus value.
+    assert types["cx43"].architecture == ""
+
+
+def test_filter_specs_defaults_are_a_no_op() -> None:
+    """The regression guard for the legacy spin-up path.
+
+    select-capacity calls this with no constraints; if the defaults ever
+    started filtering, a normal deploy could silently lose tiers.
+    """
+    prefs = parse_preferences("cx43:fsn1, cax31:hel1, cx53:nbg1")
+    kept, excluded = filter_specs(prefs, {})
+    assert kept == prefs
+    assert excluded == {}
+
+
+def test_filter_specs_drops_types_with_too_small_a_disk() -> None:
+    """A 240GB snapshot cannot be restored onto a 160GB cx43."""
+    fake = _make_http_get(_FAKE_TYPES_WITH_DISK, _FAKE_DATACENTERS)
+    types = fetch_server_types("t", http_get=fake)
+    prefs = parse_preferences("cx43:fsn1, cpx42:fsn1, cx53:fsn1")
+    kept, excluded = filter_specs(prefs, types, min_disk_gb=240)
+    assert [str(s) for s in kept] == ["cpx42:fsn1", "cx53:fsn1"]
+    assert "disk 160GB < 240GB required" in excluded[ServerSpec("cx43", "fsn1")]
+
+
+def test_filter_specs_drops_mismatched_architecture() -> None:
+    fake = _make_http_get(_FAKE_TYPES_WITH_DISK, _FAKE_DATACENTERS)
+    types = fetch_server_types("t", http_get=fake)
+    prefs = parse_preferences("cx43:fsn1, cax31:hel1")
+    kept, excluded = filter_specs(prefs, types, arch="x86")
+    assert [str(s) for s in kept] == ["cx43:fsn1"]
+    assert "architecture arm != x86" in excluded[ServerSpec("cax31", "hel1")]
+
+
+def test_filter_specs_keeps_unknown_types() -> None:
+    """Fail open: Hetzner can list a type as available before it shows
+    up in /v1/server_types. Dropping it here would turn a transient API
+    lag into a failed spin-up; select() already handles unknown types.
+    """
+    prefs = parse_preferences("brandnew:fsn1")
+    kept, excluded = filter_specs(prefs, {}, min_disk_gb=999)
+    assert kept == prefs
+    assert excluded == {}
+
+
+def test_filter_specs_tolerates_unknown_architecture_on_the_type() -> None:
+    """Only enforce what is actually known."""
+    types = {"cx43": ServerTypeInfo(name="cx43", disk_gb=160, architecture="")}
+    prefs = parse_preferences("cx43:fsn1")
+    kept, _excluded = filter_specs(prefs, types, arch="x86")
+    assert kept == prefs
+
+
+def test_render_status_lines_marks_excluded_with_reason() -> None:
+    prefs = parse_preferences("cx43:fsn1, cpx42:fsn1")
+    excluded = {ServerSpec("cx43", "fsn1"): "disk 160GB < 240GB required"}
+    lines = render_status_lines(
+        prefs,
+        {"fsn1": {"cx43", "cpx42"}},
+        ServerSpec("cpx42", "fsn1"),
+        excluded,
+    )
+    assert "⊘" in lines[0]
+    assert "disk 160GB < 240GB required" in lines[0]
+    assert lines[1].strip().startswith("→")
+
+
+def test_render_status_lines_without_excluded_is_unchanged() -> None:
+    """Byte-for-byte identical to the pre-change output."""
+    prefs = parse_preferences("cx43:fsn1, ccx33:nbg1")
+    availability = {"fsn1": {"cx43"}, "nbg1": set()}
+    selected = ServerSpec("cx43", "fsn1")
+    assert render_status_lines(prefs, availability, selected) == render_status_lines(
+        prefs,
+        availability,
+        selected,
+        None,
+    )

--- a/tests/unit/test_hetzner_snapshot.py
+++ b/tests/unit/test_hetzner_snapshot.py
@@ -27,7 +27,9 @@ import pytest
 from nexus_deploy.hetzner_snapshot import (
     LABEL_DOMAIN,
     LABEL_EPOCH,
+    LABEL_ROLE,
     LABEL_SERVER_TYPE,
+    ROLE_VALUE,
     HetznerSnapshotError,
     Snapshot,
     can_restore_onto,
@@ -110,7 +112,12 @@ def _no_sleep(_seconds: float) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _snap(image_id: int, created: str, epoch: str = EPOCH_A) -> Snapshot:
+def _snap(
+    image_id: int,
+    created: str,
+    epoch: str = EPOCH_A,
+    status: str = "available",
+) -> Snapshot:
     return Snapshot(
         image_id=image_id,
         description=f"snap-{image_id}",
@@ -119,6 +126,7 @@ def _snap(image_id: int, created: str, epoch: str = EPOCH_A) -> Snapshot:
         architecture="x86",
         epoch=epoch,
         server_type="cx43",
+        status=status,
     )
 
 
@@ -189,7 +197,8 @@ def test_list_snapshots_scopes_by_label_selector() -> None:
     http = _Recorder({"/images": {"images": []}})
     list_snapshots("tok", domain_slug="example-com", http_request=http)
     _method, url, _payload = http.calls[0]
-    assert f"label_selector={LABEL_DOMAIN}%3Dexample-com" in url
+    assert f"{LABEL_ROLE}%3D{ROLE_VALUE}" in url
+    assert f"{LABEL_DOMAIN}%3Dexample-com" in url
     assert "type=snapshot" in url
 
 
@@ -236,7 +245,10 @@ def test_count_snapshots_counts_project_wide() -> None:
     )
     assert count_snapshots("tok", http_request=http) == 2
     _method, url, _payload = http.calls[0]
-    assert "label_selector" not in url
+    # Role-scoped (only ours count against our retention decisions) but
+    # deliberately NOT domain-scoped: the cap is project-wide.
+    assert f"{LABEL_ROLE}%3D{ROLE_VALUE}" in url
+    assert LABEL_DOMAIN not in url
 
 
 # ---------------------------------------------------------------------------
@@ -924,3 +936,145 @@ def test_default_http_request_wraps_non_json_body(monkeypatch: pytest.MonkeyPatc
     )
     with pytest.raises(HetznerSnapshotError, match=r"non-JSON"):
         _default_http_request("GET", "https://api.hetzner.cloud/v1/images", "tok")
+
+
+# ---------------------------------------------------------------------------
+# Non-available images (PR #649 review)
+#
+# /v1/images lists snapshots that are still `creating` — e.g. from a
+# teardown interrupted between create_image and completion. Such an
+# image sorts newest, so anything that trusts the ordering blindly will
+# pick it.
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_latest_skips_creating_image() -> None:
+    """A half-finished image must not shadow a good older one.
+
+    Without the status check, an interrupted teardown would fail the
+    NEXT spin-up: the `creating` image resolves as newest, tofu tries to
+    build from an unusable image, and the perfectly good snapshot right
+    behind it is never considered.
+    """
+    http = _Recorder(
+        {
+            "/images": {
+                "images": [
+                    _image(9, created="2026-08-09T21:00:00+00:00", status="creating"),
+                    _image(4, created="2026-08-04T21:00:00+00:00"),
+                ],
+            },
+        },
+    )
+    snap = resolve_latest("tok", domain_slug="example-com", http_request=http)
+    assert snap is not None
+    assert snap.image_id == 4
+
+
+def test_resolve_latest_none_when_only_creating() -> None:
+    http = _Recorder(
+        {
+            "/images": {
+                "images": [_image(9, created="2026-08-09T21:00:00+00:00", status="creating")]
+            }
+        },
+    )
+    assert resolve_latest("tok", domain_slug="example-com", http_request=http) is None
+
+
+def test_select_prunable_does_not_count_creating_towards_keep() -> None:
+    """A `creating` image must not occupy a keep slot.
+
+    If it did, keep=2 would retain one good snapshot plus one unusable
+    one — halving the actual retention without saying so.
+    """
+    snaps = (
+        _snap(9, "2026-08-09T21:00:00+00:00", status="creating"),
+        _snap(3, "2026-08-03T21:00:00+00:00"),
+        _snap(2, "2026-08-02T21:00:00+00:00"),
+        _snap(1, "2026-08-01T21:00:00+00:00"),
+    )
+    prunable = select_prunable(snaps, keep=2)
+    # 3 and 2 are kept; only 1 is dropped. 9 is neither kept nor pruned.
+    assert [s.image_id for s in prunable] == [1]
+
+
+def test_select_prunable_never_returns_creating() -> None:
+    """Deleting an in-flight image is not a retention pass's job."""
+    snaps = (
+        _snap(3, "2026-08-03T21:00:00+00:00"),
+        _snap(2, "2026-08-02T21:00:00+00:00"),
+        _snap(9, "2026-07-01T21:00:00+00:00", status="creating"),
+    )
+    prunable = select_prunable(snaps, keep=2)
+    assert prunable == ()
+
+
+def test_parse_carries_status() -> None:
+    http = _Recorder(
+        {
+            "/images": {
+                "images": [_image(1, created="2026-08-01T21:00:00+00:00", status="creating")]
+            }
+        },
+    )
+    snaps = list_snapshots("tok", domain_slug="example-com", http_request=http)
+    assert snaps[0].status == "creating"
+    assert snaps[0].is_available is False
+
+
+# ---------------------------------------------------------------------------
+# Label-selector scoping and server_type validation (PR #649 review)
+# ---------------------------------------------------------------------------
+
+
+def test_list_snapshots_always_scopes_by_role() -> None:
+    """Without the role, prune could enumerate — and delete — a foreign
+    snapshot that merely carried a matching nexus_domain label."""
+    http = _Recorder({"/images": {"images": []}})
+    list_snapshots("tok", http_request=http)
+    _method, url, _payload = http.calls[0]
+    assert f"{LABEL_ROLE}%3D{ROLE_VALUE}" in url
+
+
+def test_create_snapshot_rejects_malformed_server_type() -> None:
+    """server_type is grepped out of config.tfvars, so it is the one
+    label value that has not already been through a regex."""
+    with pytest.raises(HetznerSnapshotError, match="valid Hetzner label value"):
+        create_snapshot(
+            42,
+            "tok",
+            domain_slug="example-com",
+            epoch=EPOCH_A,
+            server_type="cx43 with spaces",
+            timestamp="20260805T210000Z",
+            http_request=_Recorder({}),
+            sleep=_no_sleep,
+        )
+
+
+def test_create_snapshot_allows_empty_server_type() -> None:
+    """Empty is fine — the label is simply dropped."""
+    http = _Recorder(
+        {
+            "actions/create_image": {
+                "action": {"id": 7, "status": "success"},
+                "image": {"id": 99},
+            },
+            "/actions/7": {"action": {"id": 7, "status": "success"}},
+            "/images/99": {"image": _image(99, created="2026-08-05T21:00:00+00:00")},
+        },
+    )
+    create_snapshot(
+        42,
+        "tok",
+        domain_slug="example-com",
+        epoch=EPOCH_A,
+        server_type="",
+        timestamp="20260805T210000Z",
+        http_request=http,
+        sleep=_no_sleep,
+    )
+    _method, _url, payload = http.calls[0]
+    assert payload is not None
+    assert LABEL_SERVER_TYPE not in payload["labels"]

--- a/tests/unit/test_hetzner_snapshot.py
+++ b/tests/unit/test_hetzner_snapshot.py
@@ -19,6 +19,7 @@ than time:
 
 from __future__ import annotations
 
+import json
 from typing import Any
 
 import pytest
@@ -749,3 +750,177 @@ def test_can_restore_onto_tolerates_unknown_architecture() -> None:
         server_type="cx43",
     )
     assert can_restore_onto(snap, disk_gb=160, architecture="x86") is True
+
+
+# ---------------------------------------------------------------------------
+# _default_http_request — the real urllib path
+#
+# Mirrors the _default_http_get tests in test_hetzner_capacity.py: the
+# production HTTP seam is exercised by monkeypatching urlopen, not left
+# uncovered. This module adds POST/DELETE and an error-body read on top
+# of that, so those get their own cases.
+# ---------------------------------------------------------------------------
+
+
+class _FakeUrlopenContext:
+    """Stand-in for ``urllib.request.urlopen()`` — the ``with ... as
+    resp`` pattern needs both ``__enter__`` and ``__exit__``."""
+
+    def __init__(self, body: bytes) -> None:
+        self._body = body
+
+    def __enter__(self) -> _FakeUrlopenContext:
+        return self
+
+    def __exit__(self, *_a: object) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return self._body
+
+
+def test_default_http_request_get(monkeypatch: pytest.MonkeyPatch) -> None:
+    from nexus_deploy.hetzner_snapshot import _default_http_request
+
+    captured: dict[str, Any] = {}
+
+    def _fake_urlopen(req: Any, timeout: float = 0) -> _FakeUrlopenContext:
+        captured["url"] = req.full_url
+        captured["method"] = req.get_method()
+        captured["auth"] = req.headers.get("Authorization")
+        captured["timeout"] = timeout
+        captured["data"] = req.data
+        return _FakeUrlopenContext(b'{"ok": true}')
+
+    monkeypatch.setattr("urllib.request.urlopen", _fake_urlopen)
+    result = _default_http_request("GET", "https://api.hetzner.cloud/v1/images/1", "tok")
+    assert result == {"ok": True}
+    assert captured["method"] == "GET"
+    assert captured["auth"] == "Bearer tok"
+    assert captured["timeout"] == 30.0
+    assert captured["data"] is None
+
+
+def test_default_http_request_post_sends_json_body(monkeypatch: pytest.MonkeyPatch) -> None:
+    from nexus_deploy.hetzner_snapshot import _default_http_request
+
+    captured: dict[str, Any] = {}
+
+    def _fake_urlopen(req: Any, timeout: float = 0) -> _FakeUrlopenContext:
+        captured["method"] = req.get_method()
+        captured["body"] = json.loads(req.data.decode())
+        captured["content_type"] = req.headers.get("Content-type")
+        return _FakeUrlopenContext(b'{"action": {"id": 1}}')
+
+    monkeypatch.setattr("urllib.request.urlopen", _fake_urlopen)
+    _default_http_request(
+        "POST",
+        "https://api.hetzner.cloud/v1/servers/1/actions/create_image",
+        "tok",
+        {"type": "snapshot"},
+    )
+    assert captured["method"] == "POST"
+    assert captured["body"] == {"type": "snapshot"}
+    assert captured["content_type"] == "application/json"
+
+
+def test_default_http_request_empty_body_is_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    """DELETE returns 204 No Content — must not raise a JSON error."""
+    from nexus_deploy.hetzner_snapshot import _default_http_request
+
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        lambda _req, timeout=0: _FakeUrlopenContext(b""),
+    )
+    assert _default_http_request("DELETE", "https://api.hetzner.cloud/v1/images/1", "tok") is None
+
+
+def test_default_http_request_wraps_http_error_with_body(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Hetzner puts a machine-readable reason in the error body.
+
+    Surfacing it is what turns a bare "HTTP 403" into something an
+    operator can act on — a missing token scope reads very differently
+    from resource_limit_exceeded.
+    """
+    import io
+    import urllib.error
+
+    from nexus_deploy.hetzner_snapshot import _default_http_request
+
+    def _fake_urlopen(_req: Any, timeout: float = 0) -> _FakeUrlopenContext:
+        raise urllib.error.HTTPError(
+            url="https://api.hetzner.cloud/v1/images",
+            code=403,
+            msg="Forbidden",
+            hdrs=None,  # type: ignore[arg-type]
+            fp=io.BytesIO(b'{"error":{"code":"resource_limit_exceeded"}}'),
+        )
+
+    monkeypatch.setattr("urllib.request.urlopen", _fake_urlopen)
+    with pytest.raises(HetznerSnapshotError, match=r"HTTP 403.*resource_limit_exceeded"):
+        _default_http_request("GET", "https://api.hetzner.cloud/v1/images", "tok")
+
+
+def test_default_http_request_survives_unreadable_error_body(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Reading the body is best-effort and must never mask the HTTP error."""
+    import urllib.error
+
+    from nexus_deploy.hetzner_snapshot import _default_http_request
+
+    class _Exploding:
+        def read(self) -> bytes:
+            raise OSError("socket gone")
+
+    def _fake_urlopen(_req: Any, timeout: float = 0) -> _FakeUrlopenContext:
+        err = urllib.error.HTTPError(
+            url="https://api.hetzner.cloud/v1/images",
+            code=500,
+            msg="Server Error",
+            hdrs=None,  # type: ignore[arg-type]
+            fp=None,
+        )
+        err.read = _Exploding().read  # type: ignore[assignment]
+        raise err
+
+    monkeypatch.setattr("urllib.request.urlopen", _fake_urlopen)
+    with pytest.raises(HetznerSnapshotError, match=r"HTTP 500"):
+        _default_http_request("GET", "https://api.hetzner.cloud/v1/images", "tok")
+
+
+def test_default_http_request_wraps_network_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    import urllib.error
+
+    from nexus_deploy.hetzner_snapshot import _default_http_request
+
+    def _fake_urlopen(_req: Any, timeout: float = 0) -> _FakeUrlopenContext:
+        raise urllib.error.URLError("connection refused")
+
+    monkeypatch.setattr("urllib.request.urlopen", _fake_urlopen)
+    with pytest.raises(HetznerSnapshotError, match=r"request failed.*URLError"):
+        _default_http_request("GET", "https://api.hetzner.cloud/v1/images", "tok")
+
+
+def test_default_http_request_wraps_non_utf8_body(monkeypatch: pytest.MonkeyPatch) -> None:
+    from nexus_deploy.hetzner_snapshot import _default_http_request
+
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        lambda _req, timeout=0: _FakeUrlopenContext(b"\xff\xfe\x00binary"),
+    )
+    with pytest.raises(HetznerSnapshotError, match=r"non-UTF-8"):
+        _default_http_request("GET", "https://api.hetzner.cloud/v1/images", "tok")
+
+
+def test_default_http_request_wraps_non_json_body(monkeypatch: pytest.MonkeyPatch) -> None:
+    from nexus_deploy.hetzner_snapshot import _default_http_request
+
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        lambda _req, timeout=0: _FakeUrlopenContext(b"<html>502 Bad Gateway</html>"),
+    )
+    with pytest.raises(HetznerSnapshotError, match=r"non-JSON"):
+        _default_http_request("GET", "https://api.hetzner.cloud/v1/images", "tok")

--- a/tests/unit/test_hetzner_snapshot.py
+++ b/tests/unit/test_hetzner_snapshot.py
@@ -1,0 +1,751 @@
+"""Tests for nexus_deploy.hetzner_snapshot.
+
+Every network call goes through the ``http_request`` DI seam, so all of
+this runs offline against hard-coded fixture payloads shaped like the
+real Hetzner responses. A future API schema change therefore shows up
+as a focused failure rather than a runtime surprise during a teardown.
+
+The tests are weighted towards the paths where a bug costs data rather
+than time:
+
+* :func:`select_prunable` deleting the snapshot the next spin-up needs.
+* :func:`resolve_latest` accepting a snapshot from a different
+  credential epoch, which restores a stack that cannot authenticate.
+* :func:`create_snapshot` returning before the image is usable, which
+  would let a teardown destroy the server too early.
+* :func:`poweroff_server` reporting success on a running server, which
+  would snapshot a live disk.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from nexus_deploy.hetzner_snapshot import (
+    LABEL_DOMAIN,
+    LABEL_EPOCH,
+    LABEL_SERVER_TYPE,
+    HetznerSnapshotError,
+    Snapshot,
+    can_restore_onto,
+    count_snapshots,
+    create_snapshot,
+    delete_snapshot,
+    list_snapshots,
+    poweroff_server,
+    resolve_latest,
+    select_prunable,
+    validate_label_value,
+)
+
+EPOCH_A = "0123456789abcdef0123456789abcdef"
+EPOCH_B = "fedcba9876543210fedcba9876543210"
+
+
+def _image(
+    image_id: int,
+    *,
+    created: str,
+    epoch: str = EPOCH_A,
+    disk: int = 160,
+    arch: str = "x86",
+    status: str = "available",
+) -> dict[str, Any]:
+    """One ``/v1/images`` entry, shaped like the real API."""
+    return {
+        "id": image_id,
+        "type": "snapshot",
+        "status": status,
+        "description": f"nexus-example-com-2026080{image_id}T210000Z",
+        "created": created,
+        "disk_size": disk,
+        "image_size": 12.5,
+        "architecture": arch,
+        "labels": {
+            LABEL_DOMAIN: "example-com",
+            LABEL_EPOCH: epoch,
+            LABEL_SERVER_TYPE: "cx43",
+        },
+    }
+
+
+class _Recorder:
+    """Canned-response http_request that records every call.
+
+    ``responses`` maps a substring of the URL to either a single payload
+    or a list of payloads consumed in order (for polling).
+    """
+
+    def __init__(self, responses: dict[str, Any]) -> None:
+        self.responses = responses
+        self.calls: list[tuple[str, str, dict[str, Any] | None]] = []
+
+    def __call__(
+        self,
+        method: str,
+        url: str,
+        token: str,
+        payload: dict[str, Any] | None = None,
+    ) -> Any:
+        self.calls.append((method, url, payload))
+        for fragment, response in self.responses.items():
+            if fragment in url:
+                if isinstance(response, list):
+                    # Repeat the last entry once exhausted so a poll
+                    # loop that runs long does not IndexError.
+                    return response.pop(0) if len(response) > 1 else response[0]
+                return response
+        raise AssertionError(f"unexpected request: {method} {url}")
+
+
+def _no_sleep(_seconds: float) -> None:
+    return None
+
+
+# ---------------------------------------------------------------------------
+# select_prunable — retention
+# ---------------------------------------------------------------------------
+
+
+def _snap(image_id: int, created: str, epoch: str = EPOCH_A) -> Snapshot:
+    return Snapshot(
+        image_id=image_id,
+        description=f"snap-{image_id}",
+        created=created,
+        disk_gb=160,
+        architecture="x86",
+        epoch=epoch,
+        server_type="cx43",
+    )
+
+
+def test_select_prunable_keeps_newest() -> None:
+    """keep=2 drops everything older than the two newest."""
+    snaps = (
+        _snap(1, "2026-08-01T21:00:00+00:00"),
+        _snap(2, "2026-08-02T21:00:00+00:00"),
+        _snap(3, "2026-08-03T21:00:00+00:00"),
+    )
+    prunable = select_prunable(snaps, keep=2)
+    assert [s.image_id for s in prunable] == [1]
+
+
+def test_select_prunable_ignores_input_order() -> None:
+    """Retention must not depend on the order the API returned.
+
+    This is the one that costs data: if the caller passes an
+    oldest-first list and prune trusted it, keep=2 would delete the two
+    NEWEST snapshots and leave the stack restoring from an ancient one.
+    """
+    snaps = (
+        _snap(3, "2026-08-03T21:00:00+00:00"),
+        _snap(1, "2026-08-01T21:00:00+00:00"),
+        _snap(2, "2026-08-02T21:00:00+00:00"),
+    )
+    prunable = select_prunable(snaps, keep=2)
+    assert [s.image_id for s in prunable] == [1]
+
+
+def test_select_prunable_nothing_to_drop() -> None:
+    snaps = (_snap(1, "2026-08-01T21:00:00+00:00"),)
+    assert select_prunable(snaps, keep=2) == ()
+
+
+def test_select_prunable_rejects_keep_zero() -> None:
+    """keep=0 would delete every snapshot including the one just made."""
+    with pytest.raises(HetznerSnapshotError, match="keep must be >= 1"):
+        select_prunable((_snap(1, "2026-08-01T21:00:00+00:00"),), keep=0)
+
+
+# ---------------------------------------------------------------------------
+# list_snapshots / count_snapshots
+# ---------------------------------------------------------------------------
+
+
+def test_list_snapshots_parses_and_sorts_newest_first() -> None:
+    http = _Recorder(
+        {
+            "/images": {
+                "images": [
+                    _image(1, created="2026-08-01T21:00:00+00:00"),
+                    _image(3, created="2026-08-03T21:00:00+00:00"),
+                    _image(2, created="2026-08-02T21:00:00+00:00"),
+                ],
+            },
+        },
+    )
+    snaps = list_snapshots("tok", domain_slug="example-com", http_request=http)
+    assert [s.image_id for s in snaps] == [3, 2, 1]
+    assert snaps[0].disk_gb == 160
+    assert snaps[0].architecture == "x86"
+    assert snaps[0].epoch == EPOCH_A
+
+
+def test_list_snapshots_scopes_by_label_selector() -> None:
+    """Multi-tenant safety: one stack must not see another's images."""
+    http = _Recorder({"/images": {"images": []}})
+    list_snapshots("tok", domain_slug="example-com", http_request=http)
+    _method, url, _payload = http.calls[0]
+    assert f"label_selector={LABEL_DOMAIN}%3Dexample-com" in url
+    assert "type=snapshot" in url
+
+
+def test_list_snapshots_skips_malformed_entries() -> None:
+    """One odd image must not take down a prune or a resolve."""
+    http = _Recorder(
+        {
+            "/images": {
+                "images": [
+                    _image(1, created="2026-08-01T21:00:00+00:00"),
+                    {"no_id": True},
+                    "not-a-dict",
+                ],
+            },
+        },
+    )
+    snaps = list_snapshots("tok", domain_slug="example-com", http_request=http)
+    assert [s.image_id for s in snaps] == [1]
+
+
+def test_list_snapshots_rejects_bad_slug() -> None:
+    http = _Recorder({"/images": {"images": []}})
+    with pytest.raises(HetznerSnapshotError, match="domain_slug"):
+        list_snapshots("tok", domain_slug="Example Com", http_request=http)
+
+
+def test_list_snapshots_schema_drift_raises() -> None:
+    http = _Recorder({"/images": {"unexpected": []}})
+    with pytest.raises(HetznerSnapshotError, match="missing 'images' list"):
+        list_snapshots("tok", http_request=http)
+
+
+def test_count_snapshots_counts_project_wide() -> None:
+    """The cap is per project, so the count must not be label-scoped."""
+    http = _Recorder(
+        {
+            "/images": {
+                "images": [
+                    _image(1, created="2026-08-01T21:00:00+00:00"),
+                    _image(2, created="2026-08-02T21:00:00+00:00"),
+                ],
+            },
+        },
+    )
+    assert count_snapshots("tok", http_request=http) == 2
+    _method, url, _payload = http.calls[0]
+    assert "label_selector" not in url
+
+
+# ---------------------------------------------------------------------------
+# resolve_latest — the credential-epoch guard
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_latest_returns_newest_matching_epoch() -> None:
+    http = _Recorder(
+        {
+            "/images": {
+                "images": [
+                    _image(1, created="2026-08-01T21:00:00+00:00"),
+                    _image(2, created="2026-08-02T21:00:00+00:00"),
+                ],
+            },
+        },
+    )
+    snap = resolve_latest(
+        "tok",
+        domain_slug="example-com",
+        expect_epoch=EPOCH_A,
+        http_request=http,
+    )
+    assert snap is not None
+    assert snap.image_id == 2
+
+
+def test_resolve_latest_rejects_rotated_epoch() -> None:
+    """The guard against the legacy untargeted `tofu destroy`.
+
+    That path regenerates all 81 credentials, so an older snapshot's
+    Postgres roles and admin accounts no longer match the state the
+    pipeline will use. Restoring it yields a stack that boots and then
+    fails to authenticate anywhere — returning None sends the workflow
+    down the fresh path instead.
+    """
+    http = _Recorder(
+        {"/images": {"images": [_image(1, created="2026-08-01T21:00:00+00:00", epoch=EPOCH_A)]}},
+    )
+    assert (
+        resolve_latest(
+            "tok",
+            domain_slug="example-com",
+            expect_epoch=EPOCH_B,
+            http_request=http,
+        )
+        is None
+    )
+
+
+def test_resolve_latest_skips_mismatched_but_takes_older_match() -> None:
+    """A newer foreign-epoch image must not hide an older valid one."""
+    http = _Recorder(
+        {
+            "/images": {
+                "images": [
+                    _image(9, created="2026-08-09T21:00:00+00:00", epoch=EPOCH_B),
+                    _image(4, created="2026-08-04T21:00:00+00:00", epoch=EPOCH_A),
+                ],
+            },
+        },
+    )
+    snap = resolve_latest(
+        "tok",
+        domain_slug="example-com",
+        expect_epoch=EPOCH_A,
+        http_request=http,
+    )
+    assert snap is not None
+    assert snap.image_id == 4
+
+
+def test_resolve_latest_none_when_no_snapshots() -> None:
+    """First-ever spin-up: not an error, just the fresh path."""
+    http = _Recorder({"/images": {"images": []}})
+    assert resolve_latest("tok", domain_slug="example-com", http_request=http) is None
+
+
+def test_resolve_latest_without_expected_epoch_accepts_any() -> None:
+    http = _Recorder(
+        {"/images": {"images": [_image(1, created="2026-08-01T21:00:00+00:00", epoch=EPOCH_B)]}},
+    )
+    snap = resolve_latest("tok", domain_slug="example-com", http_request=http)
+    assert snap is not None
+    assert snap.image_id == 1
+
+
+# ---------------------------------------------------------------------------
+# poweroff_server
+# ---------------------------------------------------------------------------
+
+
+def test_poweroff_returns_when_status_off() -> None:
+    http = _Recorder(
+        {
+            "actions/shutdown": {"action": {"id": 1, "status": "running"}},
+            "/servers/42": [
+                {"server": {"id": 42, "status": "running"}},
+                {"server": {"id": 42, "status": "off"}},
+            ],
+        },
+    )
+    poweroff_server(42, "tok", http_request=http, sleep=_no_sleep, poll_attempts=6)
+    methods = [c[0] for c in http.calls]
+    assert methods[0] == "POST"
+    assert any("actions/shutdown" in c[1] for c in http.calls)
+
+
+def test_poweroff_escalates_to_hard_poweroff() -> None:
+    """A guest that ignores ACPI must not keep a paid server alive."""
+    http = _Recorder(
+        {
+            "actions/shutdown": {"action": {"id": 1, "status": "running"}},
+            "actions/poweroff": {"action": {"id": 2, "status": "running"}},
+            "/servers/42": [
+                {"server": {"id": 42, "status": "running"}},
+                {"server": {"id": 42, "status": "running"}},
+                {"server": {"id": 42, "status": "off"}},
+            ],
+        },
+    )
+    poweroff_server(42, "tok", http_request=http, sleep=_no_sleep, poll_attempts=4)
+    assert any("actions/poweroff" in c[1] for c in http.calls)
+
+
+def test_poweroff_raises_when_never_off() -> None:
+    """Refuse to snapshot a running disk rather than risk corruption."""
+    http = _Recorder(
+        {
+            "actions/shutdown": {"action": {"id": 1, "status": "running"}},
+            "actions/poweroff": {"action": {"id": 2, "status": "running"}},
+            "/servers/42": {"server": {"id": 42, "status": "running"}},
+        },
+    )
+    with pytest.raises(HetznerSnapshotError, match="did not reach status 'off'"):
+        poweroff_server(42, "tok", http_request=http, sleep=_no_sleep, poll_attempts=4)
+
+
+# ---------------------------------------------------------------------------
+# create_snapshot
+# ---------------------------------------------------------------------------
+
+
+def test_create_snapshot_waits_for_action_and_image() -> None:
+    """Both waits matter: action success != image usable.
+
+    Returning after only the action would let the teardown destroy the
+    server while the image is still 'creating'.
+    """
+    http = _Recorder(
+        {
+            "actions/create_image": {
+                "action": {"id": 7, "status": "running"},
+                "image": {"id": 99},
+            },
+            "/actions/7": [
+                {"action": {"id": 7, "status": "running"}},
+                {"action": {"id": 7, "status": "success"}},
+            ],
+            "/images/99": [
+                {"image": dict(_image(99, created="2026-08-05T21:00:00+00:00"), status="creating")},
+                {"image": _image(99, created="2026-08-05T21:00:00+00:00")},
+            ],
+        },
+    )
+    snap = create_snapshot(
+        42,
+        "tok",
+        domain_slug="example-com",
+        epoch=EPOCH_A,
+        server_type="cx43",
+        timestamp="20260805T210000Z",
+        http_request=http,
+        sleep=_no_sleep,
+    )
+    assert snap.image_id == 99
+    assert snap.disk_gb == 160
+
+
+def test_create_snapshot_sends_labels_and_description() -> None:
+    http = _Recorder(
+        {
+            "actions/create_image": {
+                "action": {"id": 7, "status": "success"},
+                "image": {"id": 99},
+            },
+            "/actions/7": {"action": {"id": 7, "status": "success"}},
+            "/images/99": {"image": _image(99, created="2026-08-05T21:00:00+00:00")},
+        },
+    )
+    create_snapshot(
+        42,
+        "tok",
+        domain_slug="example-com",
+        epoch=EPOCH_A,
+        server_type="cx43",
+        timestamp="20260805T210000Z",
+        http_request=http,
+        sleep=_no_sleep,
+    )
+    _method, _url, payload = http.calls[0]
+    assert payload is not None
+    assert payload["type"] == "snapshot"
+    assert payload["description"] == "nexus-example-com-20260805T210000Z"
+    assert payload["labels"][LABEL_DOMAIN] == "example-com"
+    assert payload["labels"][LABEL_EPOCH] == EPOCH_A
+    assert payload["labels"][LABEL_SERVER_TYPE] == "cx43"
+
+
+def test_create_snapshot_surfaces_action_error() -> None:
+    http = _Recorder(
+        {
+            "actions/create_image": {
+                "action": {"id": 7, "status": "running"},
+                "image": {"id": 99},
+            },
+            "/actions/7": {
+                "action": {
+                    "id": 7,
+                    "status": "error",
+                    "error": {"code": "limit", "message": "snapshot limit reached"},
+                },
+            },
+        },
+    )
+    with pytest.raises(HetznerSnapshotError, match="snapshot limit reached"):
+        create_snapshot(
+            42,
+            "tok",
+            domain_slug="example-com",
+            epoch=EPOCH_A,
+            server_type="cx43",
+            timestamp="20260805T210000Z",
+            http_request=http,
+            sleep=_no_sleep,
+        )
+
+
+def test_create_snapshot_rejects_bad_epoch() -> None:
+    """A malformed epoch would compare unequal forever."""
+    with pytest.raises(HetznerSnapshotError, match="32 lowercase hex"):
+        create_snapshot(
+            42,
+            "tok",
+            domain_slug="example-com",
+            epoch="not-a-fingerprint",
+            server_type="cx43",
+            timestamp="20260805T210000Z",
+            http_request=_Recorder({}),
+            sleep=_no_sleep,
+        )
+
+
+def test_create_snapshot_raises_on_schema_drift() -> None:
+    """A response without action.id/image.id must fail loudly.
+
+    Silently continuing would leave the teardown believing a snapshot
+    exists when none does.
+    """
+    http = _Recorder({"actions/create_image": {"action": {}, "image": {}}})
+    with pytest.raises(HetznerSnapshotError, match=r"missing action\.id or image\.id"):
+        create_snapshot(
+            42,
+            "tok",
+            domain_slug="example-com",
+            epoch=EPOCH_A,
+            server_type="cx43",
+            timestamp="20260805T210000Z",
+            http_request=http,
+            sleep=_no_sleep,
+        )
+
+
+def test_create_snapshot_without_epoch_omits_the_label() -> None:
+    """An empty epoch is allowed and must not produce an empty label.
+
+    An empty label value would still match a `nexus_epoch` selector,
+    which is a surprising way to make an unguarded snapshot look
+    guarded.
+    """
+    http = _Recorder(
+        {
+            "actions/create_image": {
+                "action": {"id": 7, "status": "success"},
+                "image": {"id": 99},
+            },
+            "/actions/7": {"action": {"id": 7, "status": "success"}},
+            "/images/99": {"image": _image(99, created="2026-08-05T21:00:00+00:00")},
+        },
+    )
+    create_snapshot(
+        42,
+        "tok",
+        domain_slug="example-com",
+        epoch="",
+        server_type="cx43",
+        timestamp="20260805T210000Z",
+        http_request=http,
+        sleep=_no_sleep,
+    )
+    _method, _url, payload = http.calls[0]
+    assert payload is not None
+    assert LABEL_EPOCH not in payload["labels"]
+    assert payload["labels"][LABEL_DOMAIN] == "example-com"
+
+
+def test_create_snapshot_raises_when_action_never_finishes() -> None:
+    """A stuck action must not be mistaken for a finished snapshot."""
+    http = _Recorder(
+        {
+            "actions/create_image": {
+                "action": {"id": 7, "status": "running"},
+                "image": {"id": 99},
+            },
+            "/actions/7": {"action": {"id": 7, "status": "running"}},
+        },
+    )
+    with pytest.raises(HetznerSnapshotError, match="still running after"):
+        create_snapshot(
+            42,
+            "tok",
+            domain_slug="example-com",
+            epoch=EPOCH_A,
+            server_type="cx43",
+            timestamp="20260805T210000Z",
+            http_request=http,
+            sleep=_no_sleep,
+            poll_attempts=2,
+        )
+
+
+def test_create_snapshot_raises_when_image_never_available() -> None:
+    """The action can succeed while the image is still 'creating'.
+
+    Returning here would hand the teardown an unusable image ID and let
+    it destroy the server anyway.
+    """
+    http = _Recorder(
+        {
+            "actions/create_image": {
+                "action": {"id": 7, "status": "success"},
+                "image": {"id": 99},
+            },
+            "/actions/7": {"action": {"id": 7, "status": "success"}},
+            "/images/99": {
+                "image": dict(_image(99, created="2026-08-05T21:00:00+00:00"), status="creating"),
+            },
+        },
+    )
+    with pytest.raises(HetznerSnapshotError, match="did not become 'available'"):
+        create_snapshot(
+            42,
+            "tok",
+            domain_slug="example-com",
+            epoch=EPOCH_A,
+            server_type="cx43",
+            timestamp="20260805T210000Z",
+            http_request=http,
+            sleep=_no_sleep,
+            poll_attempts=2,
+        )
+
+
+def test_create_snapshot_raises_on_available_but_unparseable_image() -> None:
+    http = _Recorder(
+        {
+            "actions/create_image": {
+                "action": {"id": 7, "status": "success"},
+                "image": {"id": 99},
+            },
+            "/actions/7": {"action": {"id": 7, "status": "success"}},
+            "/images/99": {"image": {"status": "available"}},
+        },
+    )
+    with pytest.raises(HetznerSnapshotError, match="unparseable"):
+        create_snapshot(
+            42,
+            "tok",
+            domain_slug="example-com",
+            epoch=EPOCH_A,
+            server_type="cx43",
+            timestamp="20260805T210000Z",
+            http_request=http,
+            sleep=_no_sleep,
+            poll_attempts=2,
+        )
+
+
+def test_create_snapshot_default_sleep_is_not_called_on_fast_path() -> None:
+    """Exercises the production `sleep=None` branch.
+
+    Safe because every poll succeeds on its first attempt, so the real
+    ``time.sleep`` is never reached — the test stays instant while
+    still covering the default-argument wiring.
+    """
+    http = _Recorder(
+        {
+            "actions/create_image": {
+                "action": {"id": 7, "status": "success"},
+                "image": {"id": 99},
+            },
+            "/actions/7": {"action": {"id": 7, "status": "success"}},
+            "/images/99": {"image": _image(99, created="2026-08-05T21:00:00+00:00")},
+        },
+    )
+    snap = create_snapshot(
+        42,
+        "tok",
+        domain_slug="example-com",
+        epoch=EPOCH_A,
+        server_type="cx43",
+        timestamp="20260805T210000Z",
+        http_request=http,
+    )
+    assert snap.image_id == 99
+
+
+def test_poweroff_default_sleep_is_not_called_when_already_off() -> None:
+    http = _Recorder(
+        {
+            "actions/shutdown": {"action": {"id": 1, "status": "success"}},
+            "/servers/42": {"server": {"id": 42, "status": "off"}},
+        },
+    )
+    poweroff_server(42, "tok", http_request=http)
+
+
+def test_snapshot_str_is_operator_readable() -> None:
+    snap = _snap(7, "2026-08-07T21:00:00+00:00")
+    assert str(snap) == "#7 snap-7 (160GB x86)"
+
+
+def test_create_snapshot_rejects_bad_slug() -> None:
+    with pytest.raises(HetznerSnapshotError, match="domain_slug"):
+        create_snapshot(
+            42,
+            "tok",
+            domain_slug="Example Com",
+            epoch=EPOCH_A,
+            server_type="cx43",
+            timestamp="20260805T210000Z",
+            http_request=_Recorder({}),
+            sleep=_no_sleep,
+        )
+
+
+# ---------------------------------------------------------------------------
+# delete_snapshot
+# ---------------------------------------------------------------------------
+
+
+def test_delete_snapshot_issues_delete() -> None:
+    http = _Recorder({"/images/99": None})
+    delete_snapshot(99, "tok", http_request=http)
+    assert http.calls == [("DELETE", "https://api.hetzner.cloud/v1/images/99", None)]
+
+
+# ---------------------------------------------------------------------------
+# label validation and restore constraints
+# ---------------------------------------------------------------------------
+
+
+def test_validate_label_value_accepts_truncated_fingerprint() -> None:
+    assert validate_label_value(EPOCH_A, field="epoch") == EPOCH_A
+
+
+def test_validate_label_value_rejects_full_sha256() -> None:
+    """64 hex chars exceed Hetzner's 63-char label limit.
+
+    This is exactly why tofu's credential_fingerprint output is
+    truncated to 32; the test pins the reason so nobody "fixes" the
+    truncation later.
+    """
+    with pytest.raises(HetznerSnapshotError, match="valid Hetzner label value"):
+        validate_label_value("a" * 64, field="epoch")
+
+
+@pytest.mark.parametrize("bad", ["-leading", "trailing-", "has space", "has/slash", ""])
+def test_validate_label_value_rejects_malformed(bad: str) -> None:
+    with pytest.raises(HetznerSnapshotError):
+        validate_label_value(bad, field="epoch")
+
+
+def test_can_restore_onto_requires_equal_or_larger_disk() -> None:
+    """Hetzner rejects a target disk smaller than the image's."""
+    snap = _snap(1, "2026-08-01T21:00:00+00:00")
+    assert can_restore_onto(snap, disk_gb=160, architecture="x86") is True
+    assert can_restore_onto(snap, disk_gb=240, architecture="x86") is True
+    assert can_restore_onto(snap, disk_gb=80, architecture="x86") is False
+
+
+def test_can_restore_onto_requires_matching_architecture() -> None:
+    snap = _snap(1, "2026-08-01T21:00:00+00:00")
+    assert can_restore_onto(snap, disk_gb=160, architecture="arm") is False
+
+
+def test_can_restore_onto_tolerates_unknown_architecture() -> None:
+    """An image without an architecture field must not be excluded.
+
+    Only the disk constraint is enforceable in that case; failing shut
+    would make a legitimate snapshot permanently unusable.
+    """
+    snap = Snapshot(
+        image_id=1,
+        description="d",
+        created="2026-08-01T21:00:00+00:00",
+        disk_gb=160,
+        architecture="",
+        epoch=EPOCH_A,
+        server_type="cx43",
+    )
+    assert can_restore_onto(snap, disk_gb=160, architecture="x86") is True

--- a/tests/unit/test_snapshot_cli.py
+++ b/tests/unit/test_snapshot_cli.py
@@ -1,0 +1,435 @@
+"""Tests for the `nexus-deploy snapshot-*` / `server-poweroff` handlers.
+
+The module functions are monkeypatched, so nothing here touches the
+network; what is under test is the CLI contract the workflows depend
+on:
+
+* **Exit codes.** ``snapshot-resolve`` is three-valued and the
+  workflow branches on it — 1 means "build fresh", 2 means "stop".
+  Collapsing those would either discard a good snapshot or hide an
+  outage.
+* **stdout is machine-readable and stdout-only.** The workflow evals
+  ``KEY=value`` lines; a stray human message on stdout would break it.
+* **Prune is dry-run by default.** Deleting a snapshot is
+  irreversible and may be the only copy of most stacks' data.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from nexus_deploy import __main__ as cli
+from nexus_deploy import hetzner_snapshot as _hsnap
+from nexus_deploy.hetzner_snapshot import HetznerSnapshotError, Snapshot
+
+EPOCH = "0123456789abcdef0123456789abcdef"
+
+
+def _snap(image_id: int = 99, created: str = "2026-08-05T21:00:00+00:00") -> Snapshot:
+    return Snapshot(
+        image_id=image_id,
+        description=f"nexus-example-com-{image_id}",
+        created=created,
+        disk_gb=160,
+        architecture="x86",
+        epoch=EPOCH,
+        server_type="cx43",
+    )
+
+
+@pytest.fixture(autouse=True)
+def _token(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HCLOUD_TOKEN", "tok")
+
+
+def _kv(capsys: pytest.CaptureFixture[str]) -> dict[str, str]:
+    """Parse the KEY=value lines a handler wrote to stdout."""
+    out = capsys.readouterr().out
+    pairs: dict[str, str] = {}
+    for line in out.splitlines():
+        assert "=" in line, f"non-machine-readable line on stdout: {line!r}"
+        key, _, value = line.partition("=")
+        pairs[key] = value
+    return pairs
+
+
+# ---------------------------------------------------------------------------
+# server-poweroff
+# ---------------------------------------------------------------------------
+
+
+def test_poweroff_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: dict[str, Any] = {}
+
+    def _fake(server_id: int, token: str) -> None:
+        seen["server_id"] = server_id
+        seen["token"] = token
+
+    monkeypatch.setattr(_hsnap, "poweroff_server", _fake)
+    assert cli._server_poweroff(["--server-id", "42"]) == 0
+    assert seen == {"server_id": 42, "token": "tok"}
+
+
+def test_poweroff_failure_is_rc2(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _fake(server_id: int, token: str) -> None:
+        raise HetznerSnapshotError("still running")
+
+    monkeypatch.setattr(_hsnap, "poweroff_server", _fake)
+    assert cli._server_poweroff(["--server-id", "42"]) == 2
+
+
+def test_poweroff_requires_server_id() -> None:
+    assert cli._server_poweroff([]) == 2
+
+
+def test_poweroff_rejects_non_integer_server_id() -> None:
+    assert cli._server_poweroff(["--server-id", "abc"]) == 2
+
+
+def test_poweroff_requires_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("HCLOUD_TOKEN", raising=False)
+    assert cli._server_poweroff(["--server-id", "42"]) == 2
+
+
+# ---------------------------------------------------------------------------
+# snapshot-create
+# ---------------------------------------------------------------------------
+
+
+def test_create_emits_machine_readable_coordinates(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(_hsnap, "count_snapshots", lambda _t: 3)
+    monkeypatch.setattr(_hsnap, "create_snapshot", lambda *a, **k: _snap())
+    rc = cli._snapshot_create(
+        [
+            "--server-id",
+            "42",
+            "--domain-slug",
+            "example-com",
+            "--timestamp",
+            "20260805T210000Z",
+            "--epoch",
+            EPOCH,
+            "--server-type",
+            "cx43",
+        ],
+    )
+    assert rc == 0
+    assert _kv(capsys) == {
+        "SNAPSHOT_IMAGE_ID": "99",
+        "SNAPSHOT_DISK_GB": "160",
+        "SNAPSHOT_ARCH": "x86",
+    }
+
+
+def test_create_passes_epoch_and_timestamp_through(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: dict[str, Any] = {}
+
+    def _fake(server_id: int, token: str, **kwargs: Any) -> Snapshot:
+        seen.update(kwargs)
+        seen["server_id"] = server_id
+        return _snap()
+
+    monkeypatch.setattr(_hsnap, "count_snapshots", lambda _t: 0)
+    monkeypatch.setattr(_hsnap, "create_snapshot", _fake)
+    cli._snapshot_create(
+        [
+            "--server-id",
+            "42",
+            "--domain-slug",
+            "example-com",
+            "--timestamp",
+            "20260805T210000Z",
+            "--epoch",
+            EPOCH,
+            "--server-type",
+            "cx43",
+        ],
+    )
+    assert seen["epoch"] == EPOCH
+    assert seen["timestamp"] == "20260805T210000Z"
+    assert seen["domain_slug"] == "example-com"
+    assert seen["server_type"] == "cx43"
+
+
+def test_create_warns_near_the_project_cap(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The cap is project-wide, so a sibling stack can block this one."""
+    monkeypatch.setattr(_hsnap, "count_snapshots", lambda _t: 29)
+    monkeypatch.setattr(_hsnap, "create_snapshot", lambda *a, **k: _snap())
+    cli._snapshot_create(
+        [
+            "--server-id",
+            "42",
+            "--domain-slug",
+            "example-com",
+            "--timestamp",
+            "20260805T210000Z",
+        ],
+    )
+    assert "snapshots exist project-wide" in capsys.readouterr().err
+
+
+def test_create_epoch_is_optional(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A stack predating credential_fingerprint must still snapshot."""
+    seen: dict[str, Any] = {}
+
+    def _fake(server_id: int, token: str, **kwargs: Any) -> Snapshot:
+        seen.update(kwargs)
+        return _snap()
+
+    monkeypatch.setattr(_hsnap, "count_snapshots", lambda _t: 0)
+    monkeypatch.setattr(_hsnap, "create_snapshot", _fake)
+    rc = cli._snapshot_create(
+        [
+            "--server-id",
+            "42",
+            "--domain-slug",
+            "example-com",
+            "--timestamp",
+            "20260805T210000Z",
+        ],
+    )
+    assert rc == 0
+    assert seen["epoch"] == ""
+
+
+def test_create_failure_is_rc2(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A failed create must not let the teardown proceed to destroy."""
+
+    def _fake(*_a: Any, **_k: Any) -> Snapshot:
+        raise HetznerSnapshotError("action failed")
+
+    monkeypatch.setattr(_hsnap, "count_snapshots", lambda _t: 0)
+    monkeypatch.setattr(_hsnap, "create_snapshot", _fake)
+    assert (
+        cli._snapshot_create(
+            [
+                "--server-id",
+                "42",
+                "--domain-slug",
+                "example-com",
+                "--timestamp",
+                "20260805T210000Z",
+            ],
+        )
+        == 2
+    )
+
+
+def test_create_requires_domain_slug() -> None:
+    assert cli._snapshot_create(["--server-id", "42", "--timestamp", "x"]) == 2
+
+
+def test_create_flag_without_value_is_rc2() -> None:
+    assert cli._snapshot_create(["--server-id"]) == 2
+
+
+# ---------------------------------------------------------------------------
+# snapshot-resolve — the three-valued contract
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_found_is_rc0(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(_hsnap, "resolve_latest", lambda *a, **k: _snap())
+    assert cli._snapshot_resolve(["--domain-slug", "example-com"]) == 0
+    assert _kv(capsys)["SNAPSHOT_IMAGE_ID"] == "99"
+
+
+def test_resolve_not_found_is_rc1_not_rc2(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No snapshot is a normal state, not a failure.
+
+    First-ever spin-up, pruned image, rotated epoch — all land here and
+    all must degrade to a fresh ubuntu-24.04 build. Returning 2 would
+    fail the workflow on a perfectly ordinary first deploy.
+    """
+    monkeypatch.setattr(_hsnap, "resolve_latest", lambda *a, **k: None)
+    assert cli._snapshot_resolve(["--domain-slug", "example-com"]) == 1
+
+
+def test_resolve_api_failure_is_rc2(monkeypatch: pytest.MonkeyPatch) -> None:
+    """ "Cannot tell" must not be treated as "there is none".
+
+    Rebuilding fresh on an API outage would discard a snapshot that
+    holds the only copy of most stacks' data.
+    """
+
+    def _fake(*_a: Any, **_k: Any) -> Snapshot | None:
+        raise HetznerSnapshotError("HTTP 503")
+
+    monkeypatch.setattr(_hsnap, "resolve_latest", _fake)
+    assert cli._snapshot_resolve(["--domain-slug", "example-com"]) == 2
+
+
+def test_resolve_forwards_expected_epoch(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: dict[str, Any] = {}
+
+    def _fake(token: str, **kwargs: Any) -> Snapshot:
+        seen.update(kwargs)
+        return _snap()
+
+    monkeypatch.setattr(_hsnap, "resolve_latest", _fake)
+    cli._snapshot_resolve(
+        ["--domain-slug", "example-com", "--expect-epoch", EPOCH],
+    )
+    assert seen["expect_epoch"] == EPOCH
+
+
+def test_resolve_without_epoch_passes_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: dict[str, Any] = {}
+
+    def _fake(token: str, **kwargs: Any) -> Snapshot:
+        seen.update(kwargs)
+        return _snap()
+
+    monkeypatch.setattr(_hsnap, "resolve_latest", _fake)
+    cli._snapshot_resolve(["--domain-slug", "example-com"])
+    assert seen["expect_epoch"] is None
+
+
+def test_resolve_requires_domain_slug() -> None:
+    assert cli._snapshot_resolve([]) == 2
+
+
+# ---------------------------------------------------------------------------
+# snapshot-prune
+# ---------------------------------------------------------------------------
+
+
+def test_prune_is_dry_run_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Without --apply nothing is deleted. Deletion is irreversible."""
+    deleted: list[int] = []
+    monkeypatch.setattr(_hsnap, "list_snapshots", lambda *a, **k: (_snap(1), _snap(2), _snap(3)))
+    monkeypatch.setattr(_hsnap, "select_prunable", lambda s, keep: (s[2],))
+    monkeypatch.setattr(
+        _hsnap,
+        "delete_snapshot",
+        lambda image_id, token: deleted.append(image_id),
+    )
+
+    assert cli._snapshot_prune(["--domain-slug", "example-com"]) == 0
+    assert deleted == []
+    err = capsys.readouterr().err
+    assert "would delete" in err
+    assert "--apply" in err
+
+
+def test_prune_apply_deletes(monkeypatch: pytest.MonkeyPatch) -> None:
+    deleted: list[int] = []
+    monkeypatch.setattr(_hsnap, "list_snapshots", lambda *a, **k: (_snap(1), _snap(2), _snap(3)))
+    monkeypatch.setattr(_hsnap, "select_prunable", lambda s, keep: (s[2],))
+    monkeypatch.setattr(
+        _hsnap,
+        "delete_snapshot",
+        lambda image_id, token: deleted.append(image_id),
+    )
+
+    assert cli._snapshot_prune(["--domain-slug", "example-com", "--apply"]) == 0
+    assert deleted == [3]
+
+
+def test_prune_forwards_keep(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: dict[str, Any] = {}
+
+    def _fake_select(snapshots: Any, keep: int) -> tuple[Snapshot, ...]:
+        seen["keep"] = keep
+        return ()
+
+    monkeypatch.setattr(_hsnap, "list_snapshots", lambda *a, **k: (_snap(1),))
+    monkeypatch.setattr(_hsnap, "select_prunable", _fake_select)
+    cli._snapshot_prune(["--domain-slug", "example-com", "--keep", "1"])
+    assert seen["keep"] == 1
+
+
+def test_prune_defaults_to_keep_two(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: dict[str, Any] = {}
+
+    def _fake_select(snapshots: Any, keep: int) -> tuple[Snapshot, ...]:
+        seen["keep"] = keep
+        return ()
+
+    monkeypatch.setattr(_hsnap, "list_snapshots", lambda *a, **k: (_snap(1),))
+    monkeypatch.setattr(_hsnap, "select_prunable", _fake_select)
+    cli._snapshot_prune(["--domain-slug", "example-com"])
+    assert seen["keep"] == 2
+
+
+def test_prune_nothing_to_do_is_rc0(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(_hsnap, "list_snapshots", lambda *a, **k: (_snap(1),))
+    monkeypatch.setattr(_hsnap, "select_prunable", lambda s, keep: ())
+    assert cli._snapshot_prune(["--domain-slug", "example-com"]) == 0
+
+
+def test_prune_delete_failure_is_rc2(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _fail(image_id: int, token: str) -> None:
+        raise HetznerSnapshotError("HTTP 409")
+
+    monkeypatch.setattr(_hsnap, "list_snapshots", lambda *a, **k: (_snap(1), _snap(2)))
+    monkeypatch.setattr(_hsnap, "select_prunable", lambda s, keep: (s[1],))
+    monkeypatch.setattr(_hsnap, "delete_snapshot", _fail)
+    assert cli._snapshot_prune(["--domain-slug", "example-com", "--apply"]) == 2
+
+
+def test_prune_list_failure_is_rc2(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _fail(*_a: Any, **_k: Any) -> tuple[Snapshot, ...]:
+        raise HetznerSnapshotError("HTTP 503")
+
+    monkeypatch.setattr(_hsnap, "list_snapshots", _fail)
+    assert cli._snapshot_prune(["--domain-slug", "example-com"]) == 2
+
+
+def test_prune_requires_domain_slug() -> None:
+    assert cli._snapshot_prune([]) == 2
+
+
+def test_prune_rejects_non_integer_keep() -> None:
+    assert cli._snapshot_prune(["--domain-slug", "example-com", "--keep", "many"]) == 2
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher wiring
+#
+# The tests above call the handlers directly, which does not prove the
+# subcommand names are actually routed. A typo in the dispatcher would
+# otherwise only surface in a workflow run.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("argv", "handler"),
+    [
+        (["server-poweroff", "--server-id", "1"], "_server_poweroff"),
+        (["snapshot-create", "--server-id", "1"], "_snapshot_create"),
+        (["snapshot-resolve", "--domain-slug", "x"], "_snapshot_resolve"),
+        (["snapshot-prune", "--domain-slug", "x"], "_snapshot_prune"),
+    ],
+)
+def test_dispatcher_routes_subcommand(
+    monkeypatch: pytest.MonkeyPatch,
+    argv: list[str],
+    handler: str,
+) -> None:
+    called: dict[str, list[str]] = {}
+
+    def _fake(args: list[str]) -> int:
+        called["args"] = args
+        return 0
+
+    monkeypatch.setattr(cli, handler, _fake)
+    monkeypatch.setattr("sys.argv", ["nexus-deploy", *argv])
+    assert cli.main() == 0
+    # The subcommand name itself must be stripped before the handler
+    # sees the flags.
+    assert called["args"] == argv[1:]

--- a/tofu/stack/main.tf
+++ b/tofu/stack/main.tf
@@ -606,51 +606,121 @@ resource "hcloud_server" "main" {
     managed_by  = "opentofu"
   }
 
+  # cloud-init runs on EVERY first boot of an instance — including a
+  # server created from a disk snapshot, because Hetzner assigns a new
+  # instance-id and cloud-init re-runs its PER_INSTANCE modules. The
+  # heavy provisioning below must therefore be guarded, or a
+  # snapshot-restored server would redo `apt-get upgrade` and the
+  # Docker install it already carries on disk.
+  #
+  # Two markers, deliberately on different filesystems:
+  #
+  #   /opt/docker-server/.image-provisioned  (disk, survives into a
+  #       snapshot)  — "this disk has been through the heavy path".
+  #   /run/nexus-setup-complete  (tmpfs, CANNOT survive into a
+  #       snapshot) — "this boot has finished provisioning".
+  #
+  # The tmpfs marker is what makes the readiness gate correct on a
+  # restored server. The old disk marker .setup-complete is still
+  # written on the heavy path so the existing spin-up.yml gate keeps
+  # working unchanged on a fresh server, but it is useless for a
+  # restore: it is already in the image, so a gate probing it would
+  # pass instantly — possibly before sshd and Docker are up.
   user_data = <<-EOT
     #!/bin/bash
     set -e
 
-    # Update system
-    apt-get update && apt-get upgrade -y
+    if [ ! -f /opt/docker-server/.image-provisioned ]; then
+      # ----- Heavy path: fresh Ubuntu image, provision from scratch -----
 
-    # Install Docker
-    curl -fsSL https://get.docker.com | sh
-    command -v docker >/dev/null 2>&1 || { echo "FATAL: Docker installation failed" >&2; exit 1; }
+      # Update system
+      apt-get update && apt-get upgrade -y
 
-    # Install security tools
-    apt-get install -y fail2ban unattended-upgrades jq
+      # Install Docker
+      curl -fsSL https://get.docker.com | sh
+      command -v docker >/dev/null 2>&1 || { echo "FATAL: Docker installation failed" >&2; exit 1; }
 
-    # Configure automatic security updates
-    cat > /etc/apt/apt.conf.d/20auto-upgrades << 'EOF'
-    APT::Periodic::Update-Package-Lists "1";
-    APT::Periodic::Unattended-Upgrade "1";
-    APT::Periodic::AutocleanInterval "7";
-    EOF
+      # Install security tools
+      apt-get install -y fail2ban unattended-upgrades jq
 
-    systemctl enable fail2ban unattended-upgrades
-    systemctl start fail2ban unattended-upgrades
+      # Configure automatic security updates.
+      # printf rather than a heredoc: a nested heredoc terminator must
+      # sit at column 0 after Terraform strips the common indentation,
+      # which silently breaks the moment this block is indented.
+      printf '%s\n' \
+        'APT::Periodic::Update-Package-Lists "1";' \
+        'APT::Periodic::Unattended-Upgrade "1";' \
+        'APT::Periodic::AutocleanInterval "7";' \
+        > /etc/apt/apt.conf.d/20auto-upgrades
 
-    # Detect architecture and install cloudflared
-    ARCH=$(dpkg --print-architecture)
-    if [ "$ARCH" = "arm64" ]; then
-      CLOUDFLARED_ARCH="arm64"
+      systemctl enable fail2ban unattended-upgrades
+      systemctl start fail2ban unattended-upgrades
+
+      # Detect architecture and install cloudflared
+      ARCH=$(dpkg --print-architecture)
+      if [ "$ARCH" = "arm64" ]; then
+        CLOUDFLARED_ARCH="arm64"
+      else
+        CLOUDFLARED_ARCH="amd64"
+      fi
+      curl -L --output cloudflared.deb "https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-$${CLOUDFLARED_ARCH}.deb"
+      dpkg -i cloudflared.deb
+      rm cloudflared.deb
+      command -v cloudflared >/dev/null 2>&1 || { echo "FATAL: cloudflared installation failed" >&2; exit 1; }
+
+      # Create app directories
+      mkdir -p /opt/docker-server/stacks
+
+      # Create Docker network
+      docker network create app-network || true
+
+      # This disk is now provisioned — future boots take the light path.
+      touch /opt/docker-server/.image-provisioned
+
+      # Legacy marker, kept so the existing spin-up.yml readiness gate
+      # is unchanged for fresh servers.
+      touch /opt/docker-server/.setup-complete
     else
-      CLOUDFLARED_ARCH="amd64"
+      # ----- Light path: restored from a snapshot, everything is here -----
+
+      # The target server type may have a larger disk than the one the
+      # snapshot was taken from. Hetzner only guarantees >= , so grow
+      # into whatever we got. Best-effort: a wrong device name or a
+      # missing growpart must not fail the boot.
+      growpart /dev/sda 1 || true
+      resize2fs /dev/sda1 || true
+
+      # Docker is installed and enabled on this disk, but do not assume
+      # systemd already got there.
+      systemctl is-active --quiet docker || systemctl start docker
+
+      # app-network is an external network every stack joins. It lives
+      # in Docker's state on disk, so it normally survives — recreate
+      # only if it somehow did not.
+      docker network inspect app-network >/dev/null 2>&1 || docker network create app-network
     fi
-    curl -L --output cloudflared.deb "https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-$${CLOUDFLARED_ARCH}.deb"
-    dpkg -i cloudflared.deb
-    rm cloudflared.deb
-    command -v cloudflared >/dev/null 2>&1 || { echo "FATAL: cloudflared installation failed" >&2; exit 1; }
 
-    # Create app directories
-    mkdir -p /opt/docker-server/stacks
-
-    # Create Docker network
-    docker network create app-network || true
-
-    # Signal completion
-    touch /opt/docker-server/.setup-complete
+    # Runs on BOTH paths, always last: the boot-scoped readiness signal.
+    touch /run/nexus-setup-complete
   EOT
+
+  # image / user_data / server_type / location are create-only.
+  #
+  # Without this, a snapshot-restored server is one legacy spin-up away
+  # from destruction: spin-up.yml hardcodes `server_image =
+  # "ubuntu-24.04"` and select-capacity rewrites server_type/location,
+  # so tofu would plan a REPLACEMENT of the live server and take every
+  # stack's data with it. image and user_data are ForceNew on
+  # hcloud_server, which makes that a silent data-loss path rather than
+  # a diff someone notices.
+  #
+  # This costs nothing operationally: the documented resize flow
+  # (docs/admin-guides/server-resize.md) is teardown -> set SERVER_TYPE
+  # -> spin-up, so the server is always created fresh with the new
+  # values rather than updated in place.
+  lifecycle {
+    ignore_changes = [image, user_data, server_type, location]
+  }
 }
 
 # =============================================================================

--- a/tofu/stack/main.tf
+++ b/tofu/stack/main.tf
@@ -618,7 +618,7 @@ resource "hcloud_server" "main" {
   #   /opt/docker-server/.image-provisioned  (disk, survives into a
   #       snapshot)  — "this disk has been through the heavy path".
   #   /run/nexus-setup-complete  (tmpfs, CANNOT survive into a
-  #       snapshot) — "this boot has finished provisioning".
+  #       snapshot) — "this boot is ready".
   #
   # The tmpfs marker is what makes the readiness gate correct on a
   # restored server. The old disk marker .setup-complete is still
@@ -626,6 +626,16 @@ resource "hcloud_server" "main" {
   # working unchanged on a fresh server, but it is useless for a
   # restore: it is already in the image, so a gate probing it would
   # pass instantly — possibly before sshd and Docker are up.
+  #
+  # The tmpfs marker is written by a systemd unit, NOT from this
+  # script. cloud-init's scripts-user module is PER_INSTANCE, so it
+  # does not run again on a plain reboot — a marker touched from here
+  # would be missing for the rest of the server's life after its first
+  # reboot, and a warm spin-up (server already running, the common
+  # case) would then hang on the gate for six minutes and fail.
+  # A unit ordered After=docker.service runs on every boot and lands
+  # the marker only once Docker is actually up, which makes it a
+  # stronger readiness signal than "cloud-init finished" as well.
   user_data = <<-EOT
     #!/bin/bash
     set -e
@@ -674,6 +684,30 @@ resource "hcloud_server" "main" {
       # Create Docker network
       docker network create app-network || true
 
+      # Boot-readiness unit. Installed once, runs on every boot —
+      # including reboots and snapshot restores, neither of which
+      # re-runs this script. Ordered after Docker so the marker means
+      # "ready", not just "booted".
+      printf '%s\n' \
+        '[Unit]' \
+        'Description=Nexus-Stack boot readiness marker' \
+        'After=docker.service' \
+        'Requires=docker.service' \
+        '' \
+        '[Service]' \
+        'Type=oneshot' \
+        'ExecStart=/bin/touch /run/nexus-setup-complete' \
+        'RemainAfterExit=yes' \
+        '' \
+        '[Install]' \
+        'WantedBy=multi-user.target' \
+        > /etc/systemd/system/nexus-ready.service
+      systemctl daemon-reload
+      # --now because multi-user.target has usually been reached by the
+      # time cloud-init gets here, so `enable` alone would not start it
+      # on this first boot.
+      systemctl enable --now nexus-ready.service
+
       # This disk is now provisioned — future boots take the light path.
       touch /opt/docker-server/.image-provisioned
 
@@ -698,10 +732,15 @@ resource "hcloud_server" "main" {
       # in Docker's state on disk, so it normally survives — recreate
       # only if it somehow did not.
       docker network inspect app-network >/dev/null 2>&1 || docker network create app-network
-    fi
 
-    # Runs on BOTH paths, always last: the boot-scoped readiness signal.
-    touch /run/nexus-setup-complete
+      # nexus-ready.service is enabled on this disk and systemd will
+      # already have run it during boot. Re-assert it anyway: it is
+      # ordered Requires=docker.service, so if Docker happened to be
+      # down earlier in this boot the unit failed and the marker never
+      # appeared — and we have just started Docker above. Starting an
+      # already-active RemainAfterExit oneshot is a no-op.
+      systemctl start nexus-ready.service
+    fi
   EOT
 
   # image / user_data / server_type / location are create-only.

--- a/tofu/stack/outputs.tf
+++ b/tofu/stack/outputs.tf
@@ -328,3 +328,47 @@ output "infisical_admin_password" {
 
 # persistent_volume_id output — REMOVED in RFC 0001 cutover.
 # Replaced by R2-backed snapshots (see tofu/control-plane/main.tf).
+
+# =============================================================================
+# Credential Epoch
+# =============================================================================
+
+# Identifies the generation of the generated-secret set, so a Hetzner
+# disk snapshot can be checked against the state that will be used to
+# talk to it.
+#
+# Why this is needed: a snapshot captures Postgres roles and app admin
+# accounts as they existed when it was taken. The snapshot-based
+# teardown keeps the random_* resources alive (it destroys only
+# hcloud_server.main), so credentials normally stay stable forever.
+# But the legacy teardown runs an untargeted `tofu destroy`, which
+# destroys all 81 random_* resources and regenerates every secret on
+# the next spin-up. Restoring a pre-rotation snapshot against
+# post-rotation state produces a stack that boots and then fails to
+# authenticate anywhere — a confusing, hard-to-diagnose half-failure.
+#
+# Teardown stamps this value onto the snapshot; spin-up compares before
+# restoring and falls back to a fresh build on mismatch.
+#
+# Safe to expose: it is a hash of hashes, never a secret, so it can be
+# read with `tofu output -raw`, stored as a Hetzner label and logged.
+#
+# Five canaries rather than all 81: every generated secret shares one
+# lifecycle — they are created together and destroyed together — so any
+# rotation moves all of them. Deliberately NOT derived from the
+# `secrets` output, which also carries pass-through values from GitHub
+# secrets (hetzner_s3_*, dockerhub_*, r2_data_*) that can legitimately
+# change without invalidating a snapshot.
+#
+# Truncated to 32 characters because Hetzner label values are limited
+# to 63 and a full sha256 hex digest is 64.
+output "credential_fingerprint" {
+  description = "Stable digest of the generated-secret set; a snapshot is only valid for a matching epoch"
+  value = substr(sha256(join("|", [
+    sha256(random_password.postgres.result),
+    sha256(random_password.gitea_db.result),
+    sha256(random_password.dify_db.result),
+    sha256(random_password.infisical_encryption_key.result),
+    sha256(random_password.gitea_admin.result),
+  ])), 0, 32)
+}

--- a/tofu/stack/outputs.tf
+++ b/tofu/stack/outputs.tf
@@ -362,8 +362,19 @@ output "infisical_admin_password" {
 #
 # Truncated to 32 characters because Hetzner label values are limited
 # to 63 and a full sha256 hex digest is 64.
+#
+# `sensitive = true` is required by OpenTofu, not by the value itself.
+# Sensitivity propagates syntactically: the inputs are
+# random_password.*.result, and tofu carries that taint through
+# sha256() and join() because it has no notion that a digest is
+# one-way. Without the marking, `tofu apply` fails with "Output refers
+# to sensitive values". The digest is not actually a secret — it is
+# stamped onto a Hetzner label and logged — and `tofu output -raw`
+# reads it fine, exactly as spin-up.yml already reads the equally
+# sensitive tunnel_token.
 output "credential_fingerprint" {
   description = "Stable digest of the generated-secret set; a snapshot is only valid for a matching epoch"
+  sensitive   = true
   value = substr(sha256(join("|", [
     sha256(random_password.postgres.result),
     sha256(random_password.gitea_db.result),


### PR DESCRIPTION
## Summary

Adds a second, opt-in teardown/spin-up lifecycle that takes a Hetzner disk snapshot before destroying the server, so the next spin-up restores from it instead of rebuilding from `ubuntu-24.04`.

This PR contains the **groundwork plus the teardown half**. The restore half (`spin-up-snapshot.yml`) follows in a separate PR — this one is merged first so `teardown-snapshot.yml` becomes dispatchable and the mechanism can be verified before anything depends on it.

**The existing `teardown.yml` and `spin-up.yml` are untouched.** Both paths keep working; nothing switches over until the Control Plane is pointed at the new workflows in a later PR.

## Why

Measured across real workflow runs (May 2026):

| Phase | Duration |
|---|---|
| Spin-up total | 3m49s – 9m47s |
| of which `Deploy stacks` | 99–465 s (~87%) |
| of which cloud-init gate (cold) | 42–123 s |
| Teardown total | ~2 min, unattended via the Worker at 21:00 |

Inside `Deploy stacks`, Docker image pulls are the single largest block — ~2.5 min at only 6 enabled stacks, up to ~6 min on larger sets. That work is pure repetition: the same images, pulled again onto a fresh disk.

**The bigger win is correctness, not speed.** The existing R2 persistence (`s3_persistence.py`) covers a hard-coded five-stack subset — Postgres dumps for gitea/dify/hedgedoc/planka plus filesystem trees for those and metabase. Every other stack's data is discarded on teardown; `standard_targets()` says so explicitly:

> Skipping this step means the stack's bind-mount under `/mnt/nexus-data/<stack>/` is purely ephemeral — present across container restarts on the same VM, gone the moment `tofu destroy` re-creates the host.

A disk snapshot captures everything on the root disk, so all ~76 stacks survive a teardown rather than 5. It also needs no per-stack maintenance, where the hard-coded list silently makes every new stack ephemeral until someone remembers to add it.

## Design

**Targeted destroy, not out-of-band deletion.**

```
tofu destroy -target=hcloud_server.main
```

This one choice is what makes a snapshot usable:

- All 81 `random_password` / `random_id` / `random_string` resources survive, so credentials stay stable. A snapshot captures Postgres roles and app admin accounts as they were; restoring it against regenerated credentials yields a stack that boots and then fails to authenticate anywhere.
- Tunnel, tunnel config, every DNS record and every Access app/policy survive, so the restored server's baked-in `cloudflared` config still matches.
- State stays truthful. Deleting the server out of band would leave `hcloud_server.main` in state and wedge the next teardown at the partial-state guard in `pipeline.py`.

The only resource destroyed with the server is `cloudflare_record.firewall_tcp`, which depends on its IPv4 address. That is deliberate — the address is about to be reassigned to another Hetzner customer, and an out-of-band delete would leave that unproxied A record live for the whole downtime window.

**Ordering is the safety property.** R2 logical snapshot (needs running containers) → power off, polled to `status=off` → create image, wait for `available` → mirror to D1 → *only then* destroy → prune, keep 2.

**Hetzner labels are the source of truth** for which snapshot belongs to which stack. The D1 rows are a mirror for the Control Plane UI. Labels cannot go stale relative to reality, survive a D1 loss, and make the whole thing multi-tenant-safe: two stacks in one Hetzner project never see each other's images.

## Two data-loss paths this closes

Both were found in design review before any code shipped, and both are the reason the tofu changes look larger than "add an output".

**1. `lifecycle.ignore_changes` on `hcloud_server.main`.** Without it, a snapshot-restored server is one legacy spin-up away from destruction: `spin-up.yml` hardcodes `server_image = "ubuntu-24.04"` and `select-capacity` rewrites `server_type`/`server_location`, so tofu would plan a **replacement** of the live server. `image` and `user_data` are ForceNew, which makes it a silent data-loss path rather than a diff someone notices.

**2. The credential-epoch guard.** The two teardowns must not be mixed. If the legacy `teardown.yml` runs after adoption, all 81 credentials rotate and every existing snapshot becomes poison. `credential_fingerprint` — a non-secret hash-of-hashes over five canary secrets — is stamped onto the snapshot as a label and compared on restore. A mismatch means "build fresh" rather than "restore something broken".

## Verification path

`teardown-snapshot.yml` takes a `skip_destroy` input that runs the whole snapshot sequence and then powers the server back on, destroying nothing. That is intended as the **first** run: it proves the mechanism against the real stack at the cost of one power cycle. The destructive form should not be used until it passes.

It also closes out the one check still open from the tofu groundwork: the boot-readiness marker has to survive a power cycle, which is exactly what `skip_destroy` exercises.

## Notable implementation details

- **`/run/nexus-setup-complete` is written by a systemd unit, not cloud-init.** `scripts-user` is PER_INSTANCE, so it does not re-run on a plain reboot while `/run` (tmpfs) is cleared — the marker would be missing for the rest of the server's life after its first reboot, and a warm spin-up (the common case) would hang on the gate for six minutes and then fail. A unit ordered `After=docker.service` runs on every boot and additionally means "Docker is up" rather than "cloud-init finished".
- **`user_data` is now idempotent**, guarded by `/opt/docker-server/.image-provisioned`, so a restored server does not redo `apt-get upgrade` and the Docker install it already carries. The legacy `.setup-complete` marker is still written on the heavy path, so the existing `spin-up.yml` gate is unchanged for fresh servers.
- **The nested apt-config heredoc became `printf`.** A heredoc terminator must sit at column 0 after Terraform strips the common indentation — wrapping the block in an `if` breaks it silently.
- **`credential_fingerprint` is marked `sensitive`** because OpenTofu propagates sensitivity syntactically through `sha256()`; the value itself is not a secret. `tofu output -raw` reads it, exactly as `spin-up.yml` already reads `tunnel_token`.
- **`select-capacity` gained `--min-disk-gb` / `--arch` filters.** Snapshots are architecture-locked and require a target disk ≥ the image's, while `DEFAULT_PREFERENCES` mixes 160/240/320 GB tiers with no notion of either. Defaults are an exact no-op, with regression tests pinning that.
- **`snapshot-resolve` is three-valued**: rc=0 found, rc=1 none usable (build fresh — a first-ever spin-up, a pruned image or a rotated epoch all land here), rc=2 lookup failed (stop). Collapsing 1 and 2 would mean rebuilding fresh during an API outage and discarding a snapshot that may hold the only copy of most stacks' data.
- **`snapshot-prune` is dry-run unless `--apply`.**

## Known constraints

- **30 snapshots per Hetzner account** (a default, raisable on request). At `keep=2` that caps a single project at ~15 stacks, which is a real limit for the Education fork's 26 tenants. `snapshot-create` pre-flights the count and warns near the cap; it fails loudly naming foreign snapshots rather than deleting them.
- **Disk-size ratchet.** A snapshot taken on a fallback tier permanently excludes smaller tiers on later restores. Mitigated by the `--min-disk-gb` filter; a fresh-mode cycle resets it.
- **Cross-network-zone restore is unverified.** Keep snapshot preferences within `eu-central`.
- **Pre-snapshot disk hygiene is deliberately deferred** — it only shrinks the billed image (charged on used space, worth cents) and would pull an SSH dependency into the critical path.

## Testing

Full suite **1663 passed**; `ruff`, `ruff format --check` and `mypy --strict` clean. `hetzner_capacity.py` at 100% coverage, `hetzner_snapshot.py` at 87% (only the real-network `_default_http_request` uncovered, matching how `hetzner_capacity._default_http_get` is treated). `tofu fmt -check`, `tofu validate` and `actionlint` clean.

Beyond the unit tests:

- The rendered `user_data` was extracted with Terraform's indentation-stripping and `$${}` unescaping reproduced, then checked with `bash -n` and `shellcheck`, and **both branches executed** against stubbed `apt`/`docker`/`systemctl`. The `systemctl` stub runs the generated unit's own `ExecStart` line, so a typo in the unit surfaces as a test failure. Fresh boot installs and runs it; snapshot restore re-asserts it; a reboot with cloud-init *not* running still produces the marker — the scenario that was broken.
- The `sensitive` error was reproduced and the fix verified against a standalone two-resource config with no backend or credentials, including that the digest is **stable across repeated applies** — a drifting fingerprint would invalidate every snapshot on each run.
- `initial-setup.yaml` ran green on this branch, so `tofu apply` accepts the `lifecycle` block and the new output, and cloud-init completes the heavy path.

## Not in this PR

`spin-up-snapshot.yml` (the restore half), the Control Plane wiring that makes the switch opt-in via D1 config keys, and docs. The Control Plane piece matters: `worker/src/index.js` hardcodes `teardown.yml` for the scheduled teardown, so until it is updated the scheduler keeps firing the legacy path.
