### PR TITLE
feat(ci): Add snapshot-based spin-up and share workflow steps via composite actions

### DIFF
--- a/.github/actions/nexus-bootstrap/action.yml
+++ b/.github/actions/nexus-bootstrap/action.yml
@@ -1,0 +1,157 @@
+name: Nexus bootstrap
+description: >-
+  Install the toolchain every infrastructure workflow needs (OpenTofu, uv +
+  nexus_deploy runtime deps, cloudflared), install the persistent SSH key,
+  and write tofu/.r2-credentials + tofu/backend.hcl.
+
+# =============================================================================
+# Why this exists
+#
+# spin-up.yml, teardown.yml, teardown-snapshot.yml and destroy-all.yml each
+# carried their own copy of the same ~100 lines. That is not merely untidy:
+# the block pins action versions and handles the SSH key and R2 credentials,
+# so a version bump or a fix has to be repeated in every copy, and a copy
+# that gets missed fails at deploy time rather than at review time.
+#
+# Secrets deliberately arrive as explicit inputs. A composite action cannot
+# read the `secrets` context, and that constraint is worth having: the
+# contract is visible at the call site instead of being ambient.
+#
+# Scope is the *stable* part only. Anything that differs between workflows —
+# config.tfvars generation, capacity selection, readiness gating, the deploy
+# itself — stays in the workflow where it can be read in context.
+# =============================================================================
+
+inputs:
+  domain:
+    description: Stack domain, used to derive the R2 state bucket name.
+    required: true
+  cloudflare_account_id:
+    description: Cloudflare account ID, used for the R2 S3 endpoint.
+    required: true
+  r2_access_key_id:
+    description: R2 access key for the OpenTofu state backend.
+    required: true
+  r2_secret_access_key:
+    description: R2 secret key for the OpenTofu state backend.
+    required: true
+  ssh_private_key:
+    description: >-
+      The PERSISTENT private key that is already in the server's
+      authorized_keys. Steps that only call provider APIs do not need it,
+      but anything that SSHes to the live server does.
+    required: false
+    default: ''
+  ssh_public_key:
+    description: Public key; derived from the private key when omitted.
+    required: false
+    default: ''
+  require_ssh_key:
+    description: >-
+      Fail fast when no private key was supplied. Set this on workflows that
+      genuinely SSH (snapshot, deploy) so the failure names the cause instead
+      of surfacing later as a connection timeout.
+    required: false
+    default: 'false'
+  tofu_version:
+    description: OpenTofu version.
+    required: false
+    default: '1.10.0'
+  uv_version:
+    description: uv version. Keep in step with python-tests.yml.
+    required: false
+    default: '0.11.7'
+
+runs:
+  using: composite
+  steps:
+    - name: Install OpenTofu
+      uses: opentofu/setup-opentofu@v2
+      with:
+        tofu_version: ${{ inputs.tofu_version }}
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v3
+      with:
+        version: ${{ inputs.uv_version }}
+        enable-cache: true
+
+    - name: Sync nexus_deploy runtime deps
+      # --no-dev: ruff/mypy/pytest are not needed at deploy time.
+      shell: bash
+      run: uv sync --frozen --no-dev
+
+    - name: Install cloudflared
+      # Needed wherever SSH goes over Cloudflare Access, i.e. anything
+      # calling nexus_deploy.setup.configure_ssh.
+      shell: bash
+      run: |
+        curl -fsSL https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64 -o cloudflared
+        chmod +x cloudflared
+        sudo mv cloudflared /usr/local/bin/
+
+    - name: Install SSH key
+      shell: bash
+      env:
+        SSH_PRIVATE_KEY: ${{ inputs.ssh_private_key }}
+        SSH_PUBLIC_KEY: ${{ inputs.ssh_public_key }}
+        REQUIRE_SSH_KEY: ${{ inputs.require_ssh_key }}
+      run: |
+        mkdir -p ~/.ssh
+        chmod 700 ~/.ssh
+        umask 077
+
+        if [ -z "$SSH_PRIVATE_KEY" ]; then
+          if [ "$REQUIRE_SSH_KEY" = "true" ]; then
+            echo "❌ No SSH private key supplied, but this workflow needs SSH access"
+            echo "   to the live server. Run 'Initial Setup' to bootstrap the key"
+            echo "   pair, or set the SSH_PRIVATE_KEY secret."
+            exit 1
+          fi
+          echo "ℹ️  No SSH private key supplied — skipping (provider-API only)"
+          exit 0
+        fi
+
+        # Passed via env rather than interpolated into the heredoc: an
+        # expression starting at column 0 breaks the Actions YAML parser,
+        # and the indent-then-strip workaround mangles keys whose own
+        # content is indented.
+        printf '%s\n' "$SSH_PRIVATE_KEY" | sed 's/^[[:space:]]*//' > ~/.ssh/id_ed25519
+        chmod 600 ~/.ssh/id_ed25519
+
+        if [ -n "$SSH_PUBLIC_KEY" ]; then
+          printf '%s\n' "$SSH_PUBLIC_KEY" > ~/.ssh/id_ed25519.pub
+        else
+          ssh-keygen -y -f ~/.ssh/id_ed25519 > ~/.ssh/id_ed25519.pub
+        fi
+        chmod 644 ~/.ssh/id_ed25519.pub
+        echo "✅ SSH key installed"
+
+    - name: Create R2 credentials and backend config
+      shell: bash
+      env:
+        R2_ACCESS_KEY_ID: ${{ inputs.r2_access_key_id }}
+        R2_SECRET_ACCESS_KEY: ${{ inputs.r2_secret_access_key }}
+        CLOUDFLARE_ACCOUNT_ID: ${{ inputs.cloudflare_account_id }}
+        DOMAIN: ${{ inputs.domain }}
+      run: |
+        mkdir -p tofu
+
+        # Trim whitespace — a trailing newline in a secret produces an
+        # opaque S3 auth failure rather than an obvious one.
+        ACCESS_KEY=$(printf '%s' "$R2_ACCESS_KEY_ID" | tr -d '[:space:]')
+        SECRET_KEY=$(printf '%s' "$R2_SECRET_ACCESS_KEY" | tr -d '[:space:]')
+        BUCKET_NAME="$(printf '%s' "$DOMAIN" | tr '.' '-')-terraform-state"
+        echo "📦 Using bucket: $BUCKET_NAME"
+
+        {
+          echo "R2_ACCESS_KEY_ID=\"$ACCESS_KEY\""
+          echo "R2_SECRET_ACCESS_KEY=\"$SECRET_KEY\""
+        } > tofu/.r2-credentials
+
+        {
+          echo "endpoints = {"
+          echo "  s3 = \"https://${CLOUDFLARE_ACCOUNT_ID}.r2.cloudflarestorage.com\""
+          echo "}"
+          echo "bucket = \"$BUCKET_NAME\""
+        } > tofu/backend.hcl

--- a/.github/actions/nexus-config-tfvars/action.yml
+++ b/.github/actions/nexus-config-tfvars/action.yml
@@ -100,9 +100,18 @@ runs:
         SERVER_IMAGE: ${{ inputs.server_image }}
       shell: bash
       run: |
-        # Either a Hetzner image name (ubuntu-24.04, debian-12) or a
-        # numeric snapshot image id. Nothing else is legitimate.
-        if ! printf '%s' "$SERVER_IMAGE" | grep -qE '^[a-z0-9][a-z0-9.-]{0,62}$'; then
+        # Exactly two legitimate shapes, and the alternation says so
+        # rather than approximating it:
+        #   - an image name, which always starts with a letter
+        #     (ubuntu-24.04, debian-12, rocky-9)
+        #   - a numeric snapshot id, which is digits only (422646995)
+        #
+        # A single character class would also admit things like `123abc`,
+        # which is neither. That is not a security hole — quotes,
+        # newlines and spaces are excluded either way, which is what this
+        # step exists for — but it would let a typo through to fail as an
+        # opaque `tofu apply` image error instead of by name here.
+        if ! printf '%s' "$SERVER_IMAGE" | grep -qE '^([a-z][a-z0-9.-]{0,62}|[0-9]{1,19})$'; then
           echo "❌ server_image is not a valid Hetzner image reference: '$SERVER_IMAGE'"
           echo "   Expected an image name (e.g. ubuntu-24.04) or a numeric"
           echo "   snapshot id. Refusing to write it into config.tfvars."

--- a/.github/actions/nexus-config-tfvars/action.yml
+++ b/.github/actions/nexus-config-tfvars/action.yml
@@ -156,7 +156,10 @@ runs:
         # list when the env var isn't set — fully backward-compatible.
 
         # Get Hetzner Object Storage config from control-plane output
-        cd tofu/control-plane
+        # || exit: a failed cd would leave `tofu output` running in the
+        # wrong directory, quietly writing empty S3 coordinates into
+        # config.tfvars instead of failing.
+        cd tofu/control-plane || exit 1
         source ../.r2-credentials
         export AWS_ACCESS_KEY_ID="$R2_ACCESS_KEY_ID"
         export AWS_SECRET_ACCESS_KEY="$R2_SECRET_ACCESS_KEY"
@@ -197,14 +200,31 @@ runs:
           echo "📋 Reading services from D1 database..."
           # Get enabled services from D1
           D1_DATABASE_NAME="nexus-${DOMAIN//./-}-db"
-          ENABLED_SERVICES=$(npx wrangler@4 d1 execute "$D1_DATABASE_NAME" --remote --json \
-            --command "SELECT name FROM services WHERE enabled = 1" 2>/dev/null \
-            | jq -r '.[0].results | map(.name) | join(",")' 2>/dev/null || echo "")
+          # A failed query must NOT look like an empty result. `|| echo ""`
+          # would turn a D1 outage into "no services enabled", and the
+          # deploy would then regenerate the tunnel ingress and DNS for
+          # core services only — silently making every other service
+          # unreachable. CLAUDE.md names this exact pattern as forbidden
+          # for critical operations. Zero rows is legitimate; a failed
+          # query is not.
+          if ! D1_SERVICES_JSON=$(npx wrangler@4 d1 execute "$D1_DATABASE_NAME" --remote --json \
+            --command "SELECT name FROM services WHERE enabled = 1"); then
+            echo "❌ Could not read the enabled services from D1."
+            echo "   Refusing to continue: an unreadable service list is not an"
+            echo "   empty one, and deploying as though it were would take every"
+            echo "   non-core service offline."
+            exit 1
+          fi
+          if ! ENABLED_SERVICES=$(printf '%s' "$D1_SERVICES_JSON" \
+            | jq -er '.[0].results | map(.name) | join(",")'); then
+            echo "❌ Unexpected shape in the D1 services response — aborting"
+            exit 1
+          fi
 
           if [ -n "$ENABLED_SERVICES" ]; then
             echo "📋 Enabled services from D1: $ENABLED_SERVICES"
           else
-            echo "📋 No services in D1 yet - core services will be enabled by default"
+            echo "📋 D1 returned zero enabled services - core services will be enabled by default"
           fi
         fi
 
@@ -223,14 +243,27 @@ runs:
 
         # Read enabled firewall rules from D1
         echo "🔥 Reading firewall rules from D1..."
-        FIREWALL_RULES=$(npx wrangler@4 d1 execute "$D1_DATABASE_NAME" --remote --json \
-          --command "SELECT service_name, port, source_ips, dns_record FROM firewall_rules WHERE enabled = 1" 2>/dev/null \
-          | jq -r '.[0].results // [] | map("\(.service_name):\(.port):\(.source_ips // ""):\(.dns_record // "")") | join(";")' 2>/dev/null || echo "")
+        # Same reasoning as the service query, with a sharper edge: a
+        # swallowed failure here yields an empty rule set, which reads as
+        # a deliberate "Zero Entry mode" and closes every port that was
+        # meant to be open.
+        if ! D1_FIREWALL_JSON=$(npx wrangler@4 d1 execute "$D1_DATABASE_NAME" --remote --json \
+          --command "SELECT service_name, port, source_ips, dns_record FROM firewall_rules WHERE enabled = 1"); then
+          echo "❌ Could not read the firewall rules from D1."
+          echo "   Refusing to continue: this would be indistinguishable from"
+          echo "   'no rules enabled' and would close every intended port."
+          exit 1
+        fi
+        if ! FIREWALL_RULES=$(printf '%s' "$D1_FIREWALL_JSON" \
+          | jq -er '.[0].results // [] | map("\(.service_name):\(.port):\(.source_ips // ""):\(.dns_record // "")") | join(";")'); then
+          echo "❌ Unexpected shape in the D1 firewall response — aborting"
+          exit 1
+        fi
 
         if [ -n "$FIREWALL_RULES" ]; then
           echo "🔥 Enabled firewall rules: $FIREWALL_RULES"
         else
-          echo "🔥 No firewall rules enabled (Zero Entry mode)"
+          echo "🔥 D1 returned zero enabled firewall rules (Zero Entry mode)"
         fi
 
         # Generate services and firewall config from services.yaml

--- a/.github/actions/nexus-config-tfvars/action.yml
+++ b/.github/actions/nexus-config-tfvars/action.yml
@@ -172,7 +172,22 @@ runs:
         source ../.r2-credentials
         export AWS_ACCESS_KEY_ID="$R2_ACCESS_KEY_ID"
         export AWS_SECRET_ACCESS_KEY="$R2_SECRET_ACCESS_KEY"
-        tofu init -backend-config=../backend.hcl >/dev/null 2>&1 || true
+        # A failed init is NOT the same as "Object Storage not configured".
+        # Both used to look identical: init errors were discarded, every
+        # `tofu output` then fell back to an empty string, and the deploy
+        # continued having written empty bucket names into config.tfvars —
+        # reported as the perfectly normal "LakeFS will need manual setup".
+        #
+        # Absent outputs on a working backend stay legitimate (the buckets
+        # are optional). A backend that will not initialise is not, and
+        # CLAUDE.md requires that to fail loudly.
+        if ! tofu init -backend-config=../backend.hcl; then
+          echo "❌ Could not initialise the control-plane OpenTofu backend."
+          echo "   Refusing to continue: the Hetzner Object Storage coordinates"
+          echo "   would silently be written empty, which is indistinguishable"
+          echo "   from a stack that simply has no object storage."
+          exit 1
+        fi
         HETZNER_S3_SERVER=$(tofu output -raw hetzner_s3_server 2>/dev/null || echo "${{ inputs.hetzner_object_storage_server || format('{0}.your-objectstorage.com', inputs.hetzner_s3_location || 'fsn1') }}")
         HETZNER_S3_REGION=$(tofu output -raw hetzner_s3_region 2>/dev/null || echo "${{ inputs.hetzner_s3_location || 'fsn1' }}")
         HETZNER_S3_BUCKET=$(tofu output -raw hetzner_s3_bucket 2>/dev/null || echo "")

--- a/.github/actions/nexus-config-tfvars/action.yml
+++ b/.github/actions/nexus-config-tfvars/action.yml
@@ -1,0 +1,214 @@
+name: Nexus config.tfvars
+description: >-
+  Generate tofu/stack/config.tfvars — stack settings, Hetzner Object Storage
+  coordinates from the control-plane state, the enabled-service list from D1,
+  and the firewall rules.
+
+# =============================================================================
+# Shared by spin-up.yml and spin-up-snapshot.yml. The two differ in exactly
+# one value — `server_image` — so duplicating this 120-line block would mean
+# maintaining the D1 reads, the firewall sync and the Hetzner S3 lookup twice
+# and having them drift.
+#
+# `server_image` defaults to ubuntu-24.04, which is what the legacy path
+# passes. That keeps snapshot awareness OUT of spin-up.yml entirely: it
+# supplies a default like it always did, and only the snapshot workflow ever
+# passes an image id. The fallback path therefore stays independent of the
+# snapshot mechanism.
+#
+# Secrets and repository variables arrive as explicit inputs. A composite
+# action cannot read the `secrets` context at all, and rather than assume
+# `vars` is available, both are threaded through the same way — which also
+# makes the contract visible at the call site.
+# =============================================================================
+
+inputs:
+  server_image:
+    description: >-
+      Hetzner image to build from — `ubuntu-24.04` for a normal build, or a
+      numeric snapshot image id to restore from.
+    required: false
+    default: 'ubuntu-24.04'
+  enabled_services:
+    description: Comma-separated service list; read from D1 when empty.
+    required: false
+    default: ''
+  server_type:
+    description: Repo variable SERVER_TYPE.
+    required: false
+    default: ''
+  server_location:
+    description: Repo variable SERVER_LOCATION.
+    required: false
+    default: ''
+  hetzner_s3_location:
+    description: Repo variable HETZNER_S3_LOCATION.
+    required: false
+    default: ''
+  domain:
+    description: Stack domain.
+    required: true
+  cloudflare_api_token:
+    description: Cloudflare API token (D1 reads, firewall sync).
+    required: true
+  cloudflare_account_id:
+    description: Cloudflare account ID.
+    required: true
+  tf_var_admin_email:
+    description: Admin email for Cloudflare Access.
+    required: false
+    default: ''
+  tf_var_user_email:
+    description: User email for Cloudflare Access.
+    required: false
+    default: ''
+  tf_var_guest_emails:
+    description: Guest emails for Cloudflare Access.
+    required: false
+    default: ''
+  subdomain_separator:
+    description: "'.' (default) or '-' for flat-subdomain tenants."
+    required: false
+    default: ''
+  dockerhub_username:
+    description: Optional Docker Hub user, to raise the pull rate limit.
+    required: false
+    default: ''
+  dockerhub_token:
+    description: Optional Docker Hub token.
+    required: false
+    default: ''
+  hetzner_object_storage_server:
+    description: Fallback Hetzner S3 endpoint when the control-plane output is absent.
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: Generate config.tfvars
+      env:
+        CLOUDFLARE_API_TOKEN: ${{ inputs.cloudflare_api_token }}
+        CLOUDFLARE_ACCOUNT_ID: ${{ inputs.cloudflare_account_id }}
+        DOMAIN: ${{ inputs.domain }}
+      shell: bash
+      run: |
+        # Stack config (emails from secrets)
+        cat > tofu/stack/config.tfvars << EOF
+        server_type     = "${{ inputs.server_type || 'cx43' }}"
+        server_location = "${{ inputs.server_location || 'hel1' }}"
+        server_image    = "${{ inputs.server_image }}"
+
+        ssh_public_key_path  = "~/.ssh/id_ed25519.pub"
+        ssh_private_key_path = "~/.ssh/id_ed25519"
+
+        domain               = "${{ inputs.domain }}"
+        admin_email          = "${{ inputs.tf_var_admin_email }}"
+        user_email           = "${{ inputs.tf_var_user_email }}"
+        guest_emails         = "${{ inputs.tf_var_guest_emails }}"
+        subdomain_separator  = "${{ inputs.subdomain_separator || '.' }}"
+        github_owner         = "${{ github.repository_owner }}"
+        github_repo          = "${{ github.event.repository.name }}"
+        EOF
+        sed -i 's/^          //' tofu/stack/config.tfvars
+
+        # Add Docker Hub credentials if provided (optional)
+        if [ -n "${{ inputs.dockerhub_username }}" ] && [ -n "${{ inputs.dockerhub_token }}" ]; then
+          cat >> tofu/stack/config.tfvars << EOF
+        dockerhub_username = "${{ inputs.dockerhub_username }}"
+        dockerhub_token    = "${{ inputs.dockerhub_token }}"
+        EOF
+          sed -i 's/^          //' tofu/stack/config.tfvars
+        fi
+
+        # Issue #536: SERVER_PREFERENCES is NOT written into config.tfvars
+        # here. The select-capacity step below already reads it directly
+        # from the env (highest priority in its source-resolution order),
+        # and tfvars-injecting a workflow variable would be unsafe — a
+        # value containing ``"`` or ``\n`` could break the heredoc and
+        # silently inject extra tfvars keys. The legacy server_type /
+        # server_location lines (above) are used as a 1-element preference
+        # list when the env var isn't set — fully backward-compatible.
+
+        # Get Hetzner Object Storage config from control-plane output
+        cd tofu/control-plane
+        source ../.r2-credentials
+        export AWS_ACCESS_KEY_ID="$R2_ACCESS_KEY_ID"
+        export AWS_SECRET_ACCESS_KEY="$R2_SECRET_ACCESS_KEY"
+        tofu init -backend-config=../backend.hcl >/dev/null 2>&1 || true
+        HETZNER_S3_SERVER=$(tofu output -raw hetzner_s3_server 2>/dev/null || echo "${{ inputs.hetzner_object_storage_server || format('{0}.your-objectstorage.com', inputs.hetzner_s3_location || 'fsn1') }}")
+        HETZNER_S3_REGION=$(tofu output -raw hetzner_s3_region 2>/dev/null || echo "${{ inputs.hetzner_s3_location || 'fsn1' }}")
+        HETZNER_S3_BUCKET=$(tofu output -raw hetzner_s3_bucket 2>/dev/null || echo "")
+        HETZNER_S3_BUCKET_GENERAL=$(tofu output -raw hetzner_s3_bucket_general 2>/dev/null || echo "")
+        HETZNER_S3_BUCKET_PGDUCKLAKE=$(tofu output -raw hetzner_s3_bucket_pgducklake 2>/dev/null || echo "")
+        # RFC 0001 cutover: persistent_volume_id is gone — Hetzner
+        # volumes are no longer used; persistence lives in R2.
+        cd ../..
+
+        # Add Hetzner Object Storage config to stack
+        cat >> tofu/stack/config.tfvars << EOF
+        hetzner_object_storage_server = "$HETZNER_S3_SERVER"
+        hetzner_object_storage_region = "$HETZNER_S3_REGION"
+        hetzner_s3_bucket             = "$HETZNER_S3_BUCKET"
+        hetzner_s3_bucket_general     = "$HETZNER_S3_BUCKET_GENERAL"
+        hetzner_s3_bucket_pgducklake  = "$HETZNER_S3_BUCKET_PGDUCKLAKE"
+        EOF
+        sed -i 's/^          //' tofu/stack/config.tfvars
+
+        if [ -n "$HETZNER_S3_BUCKET" ]; then
+          echo "📦 Hetzner Object Storage configured (bucket: $HETZNER_S3_BUCKET)"
+        else
+          echo "⚠️  Hetzner Object Storage not configured (LakeFS will need manual setup)"
+        fi
+
+        # Generate services config from D1 (single source of truth)
+        # If enabled_services input is provided (from Control Plane), use it
+        # Otherwise, read from D1 database
+        ENABLED_SERVICES="${{ inputs.enabled_services }}"
+
+        if [ -n "$ENABLED_SERVICES" ]; then
+          echo "📋 Using services from Control Plane: $ENABLED_SERVICES"
+        else
+          echo "📋 Reading services from D1 database..."
+          # Get enabled services from D1
+          D1_DATABASE_NAME="nexus-${DOMAIN//./-}-db"
+          ENABLED_SERVICES=$(npx wrangler@4 d1 execute "$D1_DATABASE_NAME" --remote --json \
+            --command "SELECT name FROM services WHERE enabled = 1" 2>/dev/null \
+            | jq -r '.[0].results | map(.name) | join(",")' 2>/dev/null || echo "")
+
+          if [ -n "$ENABLED_SERVICES" ]; then
+            echo "📋 Enabled services from D1: $ENABLED_SERVICES"
+          else
+            echo "📋 No services in D1 yet - core services will be enabled by default"
+          fi
+        fi
+
+        # Sync firewall rules from services.yaml to D1 BEFORE reading them
+        # This ensures dns_record and label changes are applied before Tofu reads them
+        D1_DATABASE_NAME="nexus-${DOMAIN//./-}-db"
+        echo "🔥 Syncing firewall rules from services.yaml to D1..."
+        chmod +x .github/scripts/sync-firewall-rules.sh
+        if ! CLOUDFLARE_API_TOKEN="${{ inputs.cloudflare_api_token }}" \
+          CLOUDFLARE_ACCOUNT_ID="${{ inputs.cloudflare_account_id }}" \
+          DOMAIN="${{ inputs.domain }}" \
+          bash .github/scripts/sync-firewall-rules.sh; then
+          echo "❌ Firewall rule sync failed — aborting to avoid stale firewall metadata"
+          exit 1
+        fi
+
+        # Read enabled firewall rules from D1
+        echo "🔥 Reading firewall rules from D1..."
+        FIREWALL_RULES=$(npx wrangler@4 d1 execute "$D1_DATABASE_NAME" --remote --json \
+          --command "SELECT service_name, port, source_ips, dns_record FROM firewall_rules WHERE enabled = 1" 2>/dev/null \
+          | jq -r '.[0].results // [] | map("\(.service_name):\(.port):\(.source_ips // ""):\(.dns_record // "")") | join(";")' 2>/dev/null || echo "")
+
+        if [ -n "$FIREWALL_RULES" ]; then
+          echo "🔥 Enabled firewall rules: $FIREWALL_RULES"
+        else
+          echo "🔥 No firewall rules enabled (Zero Entry mode)"
+        fi
+
+        # Generate services and firewall config from services.yaml
+        # Use shared script to avoid code duplication
+        chmod +x .github/scripts/generate-services-tfvars.py
+        ENABLED_SERVICES="$ENABLED_SERVICES" FIREWALL_RULES="$FIREWALL_RULES" python3 .github/scripts/generate-services-tfvars.py

--- a/.github/actions/nexus-config-tfvars/action.yml
+++ b/.github/actions/nexus-config-tfvars/action.yml
@@ -86,18 +86,43 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Validate server_image
+      # server_image reaches an HCL heredoc, and spin-up.yml exposes it as
+      # a free-text workflow_dispatch input. A value containing a quote
+      # would close the HCL string and let arbitrary tfvars keys be
+      # injected — the same reasoning the SERVER_PREFERENCES comment in
+      # spin-up.yml already spells out for that variable.
+      #
+      # Passed via env rather than interpolated into the condition, so a
+      # value containing quotes or newlines cannot break the script that
+      # is checking it.
+      env:
+        SERVER_IMAGE: ${{ inputs.server_image }}
+      shell: bash
+      run: |
+        # Either a Hetzner image name (ubuntu-24.04, debian-12) or a
+        # numeric snapshot image id. Nothing else is legitimate.
+        if ! printf '%s' "$SERVER_IMAGE" | grep -qE '^[a-z0-9][a-z0-9.-]{0,62}$'; then
+          echo "❌ server_image is not a valid Hetzner image reference: '$SERVER_IMAGE'"
+          echo "   Expected an image name (e.g. ubuntu-24.04) or a numeric"
+          echo "   snapshot id. Refusing to write it into config.tfvars."
+          exit 1
+        fi
+        echo "✅ server_image validated: $SERVER_IMAGE"
+
     - name: Generate config.tfvars
       env:
         CLOUDFLARE_API_TOKEN: ${{ inputs.cloudflare_api_token }}
         CLOUDFLARE_ACCOUNT_ID: ${{ inputs.cloudflare_account_id }}
         DOMAIN: ${{ inputs.domain }}
+        SERVER_IMAGE: ${{ inputs.server_image }}
       shell: bash
       run: |
         # Stack config (emails from secrets)
         cat > tofu/stack/config.tfvars << EOF
         server_type     = "${{ inputs.server_type || 'cx43' }}"
         server_location = "${{ inputs.server_location || 'hel1' }}"
-        server_image    = "${{ inputs.server_image }}"
+        server_image    = "${SERVER_IMAGE}"
 
         ssh_public_key_path  = "~/.ssh/id_ed25519.pub"
         ssh_private_key_path = "~/.ssh/id_ed25519"

--- a/.github/workflows/spin-up-snapshot.yml
+++ b/.github/workflows/spin-up-snapshot.yml
@@ -115,11 +115,16 @@ jobs:
           source ../.r2-credentials
           export AWS_ACCESS_KEY_ID="$R2_ACCESS_KEY_ID"
           export AWS_SECRET_ACCESS_KEY="$R2_SECRET_ACCESS_KEY"
-          if ! tofu init -backend-config=../backend.hcl -input=false >/dev/null 2>&1; then
-            echo "⚠️  Could not initialise tofu state — building fresh"
-            cd ../..
-            fresh
-            exit 0
+          if ! tofu init -backend-config=../backend.hcl -input=false; then
+            echo "❌ Could not initialise the OpenTofu backend."
+            echo "   Stopping rather than building fresh. Without state there is"
+            echo "   no credential epoch to check, so a fresh build would enable"
+            echo "   R2 restore and put data from the LAST teardown on top of a"
+            echo "   perfectly good newer snapshot — a silent one-cycle"
+            echo "   regression. Same rule as a failed snapshot lookup below:"
+            echo "   'cannot tell' is not 'there is none'."
+            echo "   Fix the backend, or pass force_fresh=true deliberately."
+            exit 1
           fi
 
           # The epoch guard. If the legacy teardown.yml ran in between, all

--- a/.github/workflows/spin-up-snapshot.yml
+++ b/.github/workflows/spin-up-snapshot.yml
@@ -1,0 +1,204 @@
+name: Spin Up Nexus-Stack (Snapshot)
+
+# =============================================================================
+# Snapshot-based spin-up — the counterpart to teardown-snapshot.yml.
+#
+# Resolves the newest usable Hetzner disk snapshot for this stack and hands
+# it to spin-up.yml as `server_image`. Everything after that is the ordinary
+# spin-up: same apply, same readiness gate, same pipeline, same post-steps.
+#
+# It is deliberately an orchestrator rather than a copy. spin-up.yml carries
+# ~420 lines of post-deploy work (D1 writes, Cloudflare secrets, Control
+# Plane redeploy, state sync, mail) that is identical on both paths.
+# Duplicating it would drift, and drift here fails silently: the copy rots
+# unnoticed until someone needs a restore — which is exactly when data is on
+# the line. A shared implementation fails loudly on the next run instead.
+#
+# spin-up.yml gains no snapshot logic from this. It takes four optional,
+# defaulted inputs; passing none reproduces its previous behaviour exactly.
+#
+# FALLBACK IS THE NORMAL CASE, NOT AN ERROR PATH.
+# A first-ever spin-up, a pruned snapshot, a rotated credential epoch and an
+# arch/disk mismatch all resolve to "build fresh". Only a failed *lookup*
+# stops the workflow — "cannot tell" is not "there is none", and rebuilding
+# fresh during an API outage would discard a snapshot that may hold the only
+# copy of most stacks' data.
+# =============================================================================
+
+on:
+  workflow_dispatch:
+    inputs:
+      enabled_services:
+        description: 'Comma-separated list of services to enable (empty = use D1 state)'
+        required: false
+        default: ''
+        type: string
+      silent_mode:
+        description: 'Suppress all automated emails for this run'
+        required: false
+        default: false
+        type: boolean
+      force_fresh:
+        description: 'Ignore any snapshot and build from ubuntu-24.04. Use this to escape a bad snapshot, or to move to a new base image.'
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: infrastructure
+  cancel-in-progress: false
+
+jobs:
+  resolve:
+    name: Resolve snapshot
+    runs-on: ubuntu-latest
+    outputs:
+      server_image: ${{ steps.resolve.outputs.server_image }}
+      min_disk_gb: ${{ steps.resolve.outputs.min_disk_gb }}
+      arch: ${{ steps.resolve.outputs.arch }}
+      s3_persistence: ${{ steps.resolve.outputs.s3_persistence }}
+      mode: ${{ steps.resolve.outputs.mode }}
+    env:
+      TF_VAR_cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      TF_VAR_cloudflare_account_id: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      TF_VAR_cloudflare_zone_id: ${{ secrets.CLOUDFLARE_ZONE_ID }}
+      TF_VAR_hcloud_token: ${{ secrets.HCLOUD_TOKEN }}
+      TF_VAR_domain: ${{ secrets.DOMAIN }}
+      TF_VAR_github_owner: ${{ github.repository_owner }}
+      TF_VAR_github_repo: ${{ github.event.repository.name }}
+      HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Bootstrap toolchain and credentials
+        # No SSH key needed: this job only talks to the Hetzner and R2
+        # APIs. require_ssh_key stays false so a stack without the secret
+        # can still resolve and fall back.
+        uses: ./.github/actions/nexus-bootstrap
+        with:
+          domain: ${{ secrets.DOMAIN }}
+          cloudflare_account_id: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          r2_access_key_id: ${{ secrets.R2_ACCESS_KEY_ID }}
+          r2_secret_access_key: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+      - name: Resolve the newest usable snapshot
+        id: resolve
+        env:
+          DOMAIN: ${{ secrets.DOMAIN }}
+        run: |
+          set +e
+
+          fresh() {
+            {
+              echo "mode=fresh"
+              echo "server_image=ubuntu-24.04"
+              echo "min_disk_gb="
+              echo "arch="
+              # R2 restore is the entire recovery story when no snapshot
+              # is used, so it must be on.
+              echo "s3_persistence=true"
+            } >> "$GITHUB_OUTPUT"
+          }
+
+          if [ "${{ github.event.inputs.force_fresh }}" = "true" ]; then
+            echo "🔄 force_fresh requested — building from ubuntu-24.04"
+            fresh
+            exit 0
+          fi
+
+          cd tofu/stack
+          source ../.r2-credentials
+          export AWS_ACCESS_KEY_ID="$R2_ACCESS_KEY_ID"
+          export AWS_SECRET_ACCESS_KEY="$R2_SECRET_ACCESS_KEY"
+          if ! tofu init -backend-config=../backend.hcl -input=false >/dev/null 2>&1; then
+            echo "⚠️  Could not initialise tofu state — building fresh"
+            cd ../..
+            fresh
+            exit 0
+          fi
+
+          # The epoch guard. If the legacy teardown.yml ran in between, all
+          # 81 generated credentials were rotated and any older snapshot
+          # holds Postgres roles and admin accounts that no longer match
+          # the state this deploy will use — a stack that boots and then
+          # authenticates nowhere. An absent output (a stack predating the
+          # fingerprint) simply means no epoch is expected.
+          EPOCH=$(tofu output -raw credential_fingerprint 2>/dev/null || echo "")
+          if [ -n "$EPOCH" ]; then
+            echo "::add-mask::$EPOCH"
+            EXPECT="--expect-epoch $EPOCH"
+          else
+            echo "ℹ️  No credential_fingerprint in state — resolving without an epoch check"
+            EXPECT=""
+          fi
+          cd ../..
+
+          DOMAIN_SLUG=$(echo "$DOMAIN" | tr '.' '-')
+
+          # shellcheck disable=SC2086
+          uv run --quiet --project "$GITHUB_WORKSPACE" \
+            python -m nexus_deploy snapshot-resolve \
+              --domain-slug "$DOMAIN_SLUG" $EXPECT > /tmp/resolve.out
+          RC=$?
+
+          cat /tmp/resolve.out
+
+          if [ "$RC" = "2" ]; then
+            echo "❌ Snapshot lookup failed (auth, network or schema)."
+            echo "   Stopping rather than building fresh: 'cannot tell' is not"
+            echo "   'there is none', and a fresh build would discard a snapshot"
+            echo "   that may hold the only copy of most stacks' data."
+            echo "   Re-run once the API is reachable, or use force_fresh=true."
+            exit 1
+          fi
+
+          if [ "$RC" != "0" ]; then
+            echo "🔄 No usable snapshot — building fresh"
+            fresh
+            exit 0
+          fi
+
+          # Parse as data, never `source`: these values originate from
+          # Hetzner API fields and sourcing would execute them as shell.
+          read_kv() {
+            grep -m1 "^$1=" /tmp/resolve.out | cut -d= -f2- | tr -dc 'A-Za-z0-9_.-'
+          }
+          IMAGE_ID=$(read_kv SNAPSHOT_IMAGE_ID)
+          DISK_GB=$(read_kv SNAPSHOT_DISK_GB)
+          ARCH=$(read_kv SNAPSHOT_ARCH)
+
+          if [ -z "$IMAGE_ID" ] || [ -z "$DISK_GB" ]; then
+            echo "⚠️  Resolver returned no usable coordinates — building fresh"
+            fresh
+            exit 0
+          fi
+
+          echo "📸 Restoring from snapshot #$IMAGE_ID (needs a disk >= ${DISK_GB}GB, $ARCH)"
+          {
+            echo "mode=snapshot"
+            echo "server_image=$IMAGE_ID"
+            echo "min_disk_gb=$DISK_GB"
+            echo "arch=$ARCH"
+            # Critical: the snapshot's data is NEWER than the last R2
+            # snapshot, so restoring R2 on top would silently revert the
+            # stack by one teardown cycle.
+            echo "s3_persistence=false"
+          } >> "$GITHUB_OUTPUT"
+
+  spin-up:
+    name: Spin Up
+    needs: resolve
+    uses: ./.github/workflows/spin-up.yml
+    secrets: inherit
+    with:
+      enabled_services: ${{ inputs.enabled_services }}
+      silent_mode: ${{ inputs.silent_mode }}
+      server_image: ${{ needs.resolve.outputs.server_image }}
+      min_disk_gb: ${{ needs.resolve.outputs.min_disk_gb }}
+      arch: ${{ needs.resolve.outputs.arch }}
+      s3_persistence: ${{ needs.resolve.outputs.s3_persistence }}

--- a/.github/workflows/spin-up.yml
+++ b/.github/workflows/spin-up.yml
@@ -13,6 +13,26 @@ on:
         required: false
         default: false
         type: boolean
+      server_image:
+        description: 'Hetzner image to build from. Empty = ubuntu-24.04. A numeric image id restores from that snapshot.'
+        required: false
+        default: ''
+        type: string
+      min_disk_gb:
+        description: 'Constrain capacity selection to server types with at least this disk, in GB. Required when restoring a snapshot.'
+        required: false
+        default: ''
+        type: string
+      arch:
+        description: 'Constrain capacity selection to this architecture. Required when restoring a snapshot.'
+        required: false
+        default: ''
+        type: string
+      s3_persistence:
+        description: 'Override NEXUS_S3_PERSISTENCE. Set to false when restoring a snapshot, whose data is newer than R2.'
+        required: false
+        default: ''
+        type: string
   workflow_call:
     inputs:
       enabled_services:
@@ -52,6 +72,26 @@ on:
       ssh_private_key:
         description: 'SSH Private Key (from setup-control-plane, for initial setup)'
         required: false
+        type: string
+      server_image:
+        description: 'Hetzner image to build from. Empty = ubuntu-24.04. A numeric image id restores from that snapshot.'
+        required: false
+        default: ''
+        type: string
+      min_disk_gb:
+        description: 'Constrain capacity selection to server types with at least this disk, in GB. Required when restoring a snapshot.'
+        required: false
+        default: ''
+        type: string
+      arch:
+        description: 'Constrain capacity selection to this architecture. Required when restoring a snapshot.'
+        required: false
+        default: ''
+        type: string
+      s3_persistence:
+        description: 'Override NEXUS_S3_PERSISTENCE. Set to false when restoring a snapshot, whose data is newer than R2.'
+        required: false
+        default: ''
         type: string
 
 permissions:
@@ -294,6 +334,9 @@ jobs:
         # default here, so this workflow carries no snapshot awareness.
         uses: ./.github/actions/nexus-config-tfvars
         with:
+          # Empty on the normal path — the action defaults to
+          # ubuntu-24.04. Only spin-up-snapshot.yml ever passes an id.
+          server_image: ${{ inputs.server_image || 'ubuntu-24.04' }}
           enabled_services: ${{ inputs.enabled_services }}
           server_type: ${{ vars.SERVER_TYPE }}
           server_location: ${{ vars.SERVER_LOCATION }}
@@ -328,9 +371,24 @@ jobs:
           HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}
           SERVER_PREFERENCES: ${{ vars.SERVER_PREFERENCES }}
         run: |
+          # A snapshot is architecture-locked and needs a target disk at
+          # least as large as the image's, so the snapshot path narrows
+          # the preference walk. Both empty on the normal path, where
+          # the flags are omitted and behaviour is unchanged.
+          EXTRA=""
+          if [ -n "${{ inputs.min_disk_gb }}" ]; then
+            EXTRA="$EXTRA --min-disk-gb ${{ inputs.min_disk_gb }}"
+          fi
+          if [ -n "${{ inputs.arch }}" ]; then
+            EXTRA="$EXTRA --arch ${{ inputs.arch }}"
+          fi
+
+          # EXTRA is built from the two validated values above and must
+          # word-split into separate flags, so it is deliberately unquoted.
+          # shellcheck disable=SC2086
           uv run --quiet --project "$GITHUB_WORKSPACE" \
             python -m nexus_deploy select-capacity \
-              --tfvars tofu/stack/config.tfvars
+              --tfvars tofu/stack/config.tfvars $EXTRA
 
       - name: Initialize OpenTofu
         run: |
@@ -411,8 +469,8 @@ jobs:
           # a kernel update.
           for i in {1..72}; do
             if ssh -o StrictHostKeyChecking=no -o ConnectTimeout=5 -o BatchMode=yes \
-              root@"$SERVER_IP" "test -f /opt/docker-server/.setup-complete" 2>/dev/null; then
-              echo "✅ SSH ready + cloud-init complete (attempt $i)"
+              root@"$SERVER_IP" "test -f /run/nexus-setup-complete || { test -f /opt/docker-server/.setup-complete && systemctl is-active --quiet docker; }" 2>/dev/null; then
+              echo "✅ SSH ready + host provisioned (attempt $i)"
               break
             fi
             if [ $i -eq 72 ]; then
@@ -540,7 +598,11 @@ jobs:
           # (e.g. for an experiment), set the secret EXPLICITLY to a
           # non-"true" value like "false"; just unsetting it leaves
           # the default on.
-          NEXUS_S3_PERSISTENCE: ${{ secrets.NEXUS_S3_PERSISTENCE || 'true' }}
+          # Snapshot restores pass 'false': the disk already holds data
+          # newer than R2, and restoring on top would silently revert the
+          # stack by one cycle. Empty everywhere else, so the secret (and
+          # its 'true' default) still decides.
+          NEXUS_S3_PERSISTENCE: ${{ inputs.s3_persistence || secrets.NEXUS_S3_PERSISTENCE || 'true' }}
           # R2 persistence-bucket coords. ALL derived from already-
           # existing secrets — no new operator-set secret needed:
           #   - endpoint   = https://<CF account>.r2.cloudflarestorage.com

--- a/.github/workflows/spin-up.yml
+++ b/.github/workflows/spin-up.yml
@@ -370,21 +370,38 @@ jobs:
         env:
           HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}
           SERVER_PREFERENCES: ${{ vars.SERVER_PREFERENCES }}
+          MIN_DISK_GB: ${{ inputs.min_disk_gb }}
+          ARCH: ${{ inputs.arch }}
         run: |
           # A snapshot is architecture-locked and needs a target disk at
           # least as large as the image's, so the snapshot path narrows
           # the preference walk. Both empty on the normal path, where
           # the flags are omitted and behaviour is unchanged.
+          #
+          # Read from env, never interpolated into the script: these are
+          # workflow inputs, so a value containing quotes or newlines
+          # would otherwise break the script constructing the argv. The
+          # regexes then constrain them to what the CLI can accept —
+          # a bad value fails here by name rather than as an argparse
+          # error three steps later.
           EXTRA=""
-          if [ -n "${{ inputs.min_disk_gb }}" ]; then
-            EXTRA="$EXTRA --min-disk-gb ${{ inputs.min_disk_gb }}"
+          if [ -n "$MIN_DISK_GB" ]; then
+            if ! printf '%s' "$MIN_DISK_GB" | grep -qE '^[0-9]{1,5}$'; then
+              echo "❌ min_disk_gb must be a plain integer, got '$MIN_DISK_GB'"
+              exit 1
+            fi
+            EXTRA="$EXTRA --min-disk-gb $MIN_DISK_GB"
           fi
-          if [ -n "${{ inputs.arch }}" ]; then
-            EXTRA="$EXTRA --arch ${{ inputs.arch }}"
+          if [ -n "$ARCH" ]; then
+            if ! printf '%s' "$ARCH" | grep -qE '^[a-z0-9]{1,16}$'; then
+              echo "❌ arch must be lowercase alphanumeric, got '$ARCH'"
+              exit 1
+            fi
+            EXTRA="$EXTRA --arch $ARCH"
           fi
 
-          # EXTRA is built from the two validated values above and must
-          # word-split into separate flags, so it is deliberately unquoted.
+          # EXTRA now holds only regex-checked tokens and must word-split
+          # into separate flags, so it is deliberately unquoted.
           # shellcheck disable=SC2086
           uv run --quiet --project "$GITHUB_WORKSPACE" \
             python -m nexus_deploy select-capacity \

--- a/.github/workflows/spin-up.yml
+++ b/.github/workflows/spin-up.yml
@@ -289,130 +289,25 @@ jobs:
           echo "✅ R2 credentials file created"
 
       - name: Generate config.tfvars
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          DOMAIN: ${{ secrets.DOMAIN }}
-        run: |
-          # Stack config (emails from secrets)
-          cat > tofu/stack/config.tfvars << EOF
-          server_type     = "${{ vars.SERVER_TYPE || 'cx43' }}"
-          server_location = "${{ vars.SERVER_LOCATION || 'hel1' }}"
-          server_image    = "ubuntu-24.04"
-
-          ssh_public_key_path  = "~/.ssh/id_ed25519.pub"
-          ssh_private_key_path = "~/.ssh/id_ed25519"
-
-          domain               = "${{ secrets.DOMAIN }}"
-          admin_email          = "${{ secrets.TF_VAR_admin_email }}"
-          user_email           = "${{ secrets.TF_VAR_user_email }}"
-          guest_emails         = "${{ secrets.TF_VAR_guest_emails }}"
-          subdomain_separator  = "${{ secrets.SUBDOMAIN_SEPARATOR || '.' }}"
-          github_owner         = "${{ github.repository_owner }}"
-          github_repo          = "${{ github.event.repository.name }}"
-          EOF
-          sed -i 's/^          //' tofu/stack/config.tfvars
-
-          # Add Docker Hub credentials if provided (optional)
-          if [ -n "${{ secrets.DOCKERHUB_USERNAME }}" ] && [ -n "${{ secrets.DOCKERHUB_TOKEN }}" ]; then
-            cat >> tofu/stack/config.tfvars << EOF
-          dockerhub_username = "${{ secrets.DOCKERHUB_USERNAME }}"
-          dockerhub_token    = "${{ secrets.DOCKERHUB_TOKEN }}"
-          EOF
-            sed -i 's/^          //' tofu/stack/config.tfvars
-          fi
-
-          # Issue #536: SERVER_PREFERENCES is NOT written into config.tfvars
-          # here. The select-capacity step below already reads it directly
-          # from the env (highest priority in its source-resolution order),
-          # and tfvars-injecting a workflow variable would be unsafe — a
-          # value containing ``"`` or ``\n`` could break the heredoc and
-          # silently inject extra tfvars keys. The legacy server_type /
-          # server_location lines (above) are used as a 1-element preference
-          # list when the env var isn't set — fully backward-compatible.
-
-          # Get Hetzner Object Storage config from control-plane output
-          cd tofu/control-plane
-          source ../.r2-credentials
-          export AWS_ACCESS_KEY_ID="$R2_ACCESS_KEY_ID"
-          export AWS_SECRET_ACCESS_KEY="$R2_SECRET_ACCESS_KEY"
-          tofu init -backend-config=../backend.hcl >/dev/null 2>&1 || true
-          HETZNER_S3_SERVER=$(tofu output -raw hetzner_s3_server 2>/dev/null || echo "${{ secrets.HETZNER_OBJECT_STORAGE_SERVER || format('{0}.your-objectstorage.com', vars.HETZNER_S3_LOCATION || 'fsn1') }}")
-          HETZNER_S3_REGION=$(tofu output -raw hetzner_s3_region 2>/dev/null || echo "${{ vars.HETZNER_S3_LOCATION || 'fsn1' }}")
-          HETZNER_S3_BUCKET=$(tofu output -raw hetzner_s3_bucket 2>/dev/null || echo "")
-          HETZNER_S3_BUCKET_GENERAL=$(tofu output -raw hetzner_s3_bucket_general 2>/dev/null || echo "")
-          HETZNER_S3_BUCKET_PGDUCKLAKE=$(tofu output -raw hetzner_s3_bucket_pgducklake 2>/dev/null || echo "")
-          # RFC 0001 cutover: persistent_volume_id is gone — Hetzner
-          # volumes are no longer used; persistence lives in R2.
-          cd ../..
-
-          # Add Hetzner Object Storage config to stack
-          cat >> tofu/stack/config.tfvars << EOF
-          hetzner_object_storage_server = "$HETZNER_S3_SERVER"
-          hetzner_object_storage_region = "$HETZNER_S3_REGION"
-          hetzner_s3_bucket             = "$HETZNER_S3_BUCKET"
-          hetzner_s3_bucket_general     = "$HETZNER_S3_BUCKET_GENERAL"
-          hetzner_s3_bucket_pgducklake  = "$HETZNER_S3_BUCKET_PGDUCKLAKE"
-          EOF
-          sed -i 's/^          //' tofu/stack/config.tfvars
-
-          if [ -n "$HETZNER_S3_BUCKET" ]; then
-            echo "📦 Hetzner Object Storage configured (bucket: $HETZNER_S3_BUCKET)"
-          else
-            echo "⚠️  Hetzner Object Storage not configured (LakeFS will need manual setup)"
-          fi
-
-          # Generate services config from D1 (single source of truth)
-          # If enabled_services input is provided (from Control Plane), use it
-          # Otherwise, read from D1 database
-          ENABLED_SERVICES="${{ inputs.enabled_services }}"
-
-          if [ -n "$ENABLED_SERVICES" ]; then
-            echo "📋 Using services from Control Plane: $ENABLED_SERVICES"
-          else
-            echo "📋 Reading services from D1 database..."
-            # Get enabled services from D1
-            D1_DATABASE_NAME="nexus-${DOMAIN//./-}-db"
-            ENABLED_SERVICES=$(npx wrangler@4 d1 execute "$D1_DATABASE_NAME" --remote --json \
-              --command "SELECT name FROM services WHERE enabled = 1" 2>/dev/null \
-              | jq -r '.[0].results | map(.name) | join(",")' 2>/dev/null || echo "")
-
-            if [ -n "$ENABLED_SERVICES" ]; then
-              echo "📋 Enabled services from D1: $ENABLED_SERVICES"
-            else
-              echo "📋 No services in D1 yet - core services will be enabled by default"
-            fi
-          fi
-
-          # Sync firewall rules from services.yaml to D1 BEFORE reading them
-          # This ensures dns_record and label changes are applied before Tofu reads them
-          D1_DATABASE_NAME="nexus-${DOMAIN//./-}-db"
-          echo "🔥 Syncing firewall rules from services.yaml to D1..."
-          chmod +x .github/scripts/sync-firewall-rules.sh
-          if ! CLOUDFLARE_API_TOKEN="${{ secrets.CLOUDFLARE_API_TOKEN }}" \
-            CLOUDFLARE_ACCOUNT_ID="${{ secrets.CLOUDFLARE_ACCOUNT_ID }}" \
-            DOMAIN="${{ secrets.DOMAIN }}" \
-            bash .github/scripts/sync-firewall-rules.sh; then
-            echo "❌ Firewall rule sync failed — aborting to avoid stale firewall metadata"
-            exit 1
-          fi
-
-          # Read enabled firewall rules from D1
-          echo "🔥 Reading firewall rules from D1..."
-          FIREWALL_RULES=$(npx wrangler@4 d1 execute "$D1_DATABASE_NAME" --remote --json \
-            --command "SELECT service_name, port, source_ips, dns_record FROM firewall_rules WHERE enabled = 1" 2>/dev/null \
-            | jq -r '.[0].results // [] | map("\(.service_name):\(.port):\(.source_ips // ""):\(.dns_record // "")") | join(";")' 2>/dev/null || echo "")
-
-          if [ -n "$FIREWALL_RULES" ]; then
-            echo "🔥 Enabled firewall rules: $FIREWALL_RULES"
-          else
-            echo "🔥 No firewall rules enabled (Zero Entry mode)"
-          fi
-
-          # Generate services and firewall config from services.yaml
-          # Use shared script to avoid code duplication
-          chmod +x .github/scripts/generate-services-tfvars.py
-          ENABLED_SERVICES="$ENABLED_SERVICES" FIREWALL_RULES="$FIREWALL_RULES" python3 .github/scripts/generate-services-tfvars.py
+        # Shared with spin-up-snapshot.yml — see
+        # .github/actions/nexus-config-tfvars. server_image is left at its
+        # default here, so this workflow carries no snapshot awareness.
+        uses: ./.github/actions/nexus-config-tfvars
+        with:
+          enabled_services: ${{ inputs.enabled_services }}
+          server_type: ${{ vars.SERVER_TYPE }}
+          server_location: ${{ vars.SERVER_LOCATION }}
+          hetzner_s3_location: ${{ vars.HETZNER_S3_LOCATION }}
+          domain: ${{ secrets.DOMAIN }}
+          cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          cloudflare_account_id: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          tf_var_admin_email: ${{ secrets.TF_VAR_admin_email }}
+          tf_var_user_email: ${{ secrets.TF_VAR_user_email }}
+          tf_var_guest_emails: ${{ secrets.TF_VAR_guest_emails }}
+          subdomain_separator: ${{ secrets.SUBDOMAIN_SEPARATOR }}
+          dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}
+          dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}
+          hetzner_object_storage_server: ${{ secrets.HETZNER_OBJECT_STORAGE_SERVER }}
 
       - name: Select Hetzner capacity
         # Issue #536: Hetzner sells out of specific server-type /

--- a/.github/workflows/spin-up.yml
+++ b/.github/workflows/spin-up.yml
@@ -330,8 +330,15 @@ jobs:
 
       - name: Generate config.tfvars
         # Shared with spin-up-snapshot.yml — see
-        # .github/actions/nexus-config-tfvars. server_image is left at its
-        # default here, so this workflow carries no snapshot awareness.
+        # .github/actions/nexus-config-tfvars.
+        #
+        # The `|| 'ubuntu-24.04'` is load-bearing, not decoration: the
+        # action's own `default:` only applies when a key is ABSENT, and
+        # `with:` always sends this one. An unset workflow input would
+        # otherwise arrive as an empty string and fail the image
+        # validation. This workflow still carries no snapshot awareness —
+        # it names the base image and nothing else; only
+        # spin-up-snapshot.yml ever supplies a snapshot id.
         uses: ./.github/actions/nexus-config-tfvars
         with:
           # Empty on the normal path — the action defaults to

--- a/.github/workflows/teardown-snapshot.yml
+++ b/.github/workflows/teardown-snapshot.yml
@@ -109,77 +109,21 @@ jobs:
             .github/scripts/log-to-d1.sh warn "Snapshot teardown workflow started"
           fi
 
-      - name: Install OpenTofu
-        uses: opentofu/setup-opentofu@v2
+      - name: Bootstrap toolchain and credentials
+        # Shared with the other infrastructure workflows — see
+        # .github/actions/nexus-bootstrap. require_ssh_key because the
+        # pre-destroy R2 snapshot really SSHes into the live server
+        # (docker exec pg_dump + rclone sync); a missing key must fail
+        # here by name rather than later as a connection timeout.
+        uses: ./.github/actions/nexus-bootstrap
         with:
-          tofu_version: 1.10.0
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v3
-        with:
-          version: "0.11.7"
-          enable-cache: true
-
-      - name: Sync nexus_deploy runtime deps
-        run: uv sync --frozen --no-dev
-
-      - name: Install cloudflared
-        # Needed by nexus_deploy.pipeline.run_snapshot, which SSHes to
-        # the live server over Cloudflare Access for the R2 snapshot.
-        run: |
-          curl -fsSL https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64 -o cloudflared
-          chmod +x cloudflared
-          sudo mv cloudflared /usr/local/bin/
-
-      - name: Install SSH key from GitHub Secrets
-        # The R2 snapshot step needs real SSH into the live server
-        # (docker exec pg_dump + rclone sync), so this must be the
-        # PERSISTENT key that is already in the server's
-        # authorized_keys — not a freshly generated one.
-        run: |
-          mkdir -p ~/.ssh
-          chmod 700 ~/.ssh
-          umask 077
-          if [ -z "${{ secrets.SSH_PRIVATE_KEY }}" ]; then
-            echo "❌ SSH_PRIVATE_KEY secret not set — the pre-snapshot R2 step needs SSH access to the live server."
-            echo "   Run 'Initial Setup' first to bootstrap the key pair, or set SSH_PRIVATE_KEY manually."
-            exit 1
-          fi
-          # Expression placeholders must NOT start at column 0 or the
-          # Actions YAML parser breaks; strip the indent afterwards.
-          sed 's/^[[:space:]]*//' > ~/.ssh/id_ed25519 <<'EOF_PRIVATE_KEY'
-          ${{ secrets.SSH_PRIVATE_KEY }}
-          EOF_PRIVATE_KEY
-          chmod 600 ~/.ssh/id_ed25519
-          if [ -n "${{ secrets.SSH_PUBLIC_KEY }}" ]; then
-            echo "${{ secrets.SSH_PUBLIC_KEY }}" > ~/.ssh/id_ed25519.pub
-          else
-            ssh-keygen -y -f ~/.ssh/id_ed25519 > ~/.ssh/id_ed25519.pub
-          fi
-          chmod 644 ~/.ssh/id_ed25519.pub
-          echo "✅ SSH key installed from secrets"
-
-      - name: Create R2 credentials from secrets
-        run: |
-          mkdir -p tofu
-          R2_ACCESS_KEY_ID=$(echo -n "${{ secrets.R2_ACCESS_KEY_ID }}" | tr -d '[:space:]')
-          R2_SECRET_ACCESS_KEY=$(echo -n "${{ secrets.R2_SECRET_ACCESS_KEY }}" | tr -d '[:space:]')
-          BUCKET_NAME=$(echo "${{ secrets.DOMAIN }}" | tr '.' '-')-terraform-state
-          echo "📦 Using bucket: $BUCKET_NAME"
-
-          cat > tofu/.r2-credentials << EOF
-          R2_ACCESS_KEY_ID="${R2_ACCESS_KEY_ID}"
-          R2_SECRET_ACCESS_KEY="${R2_SECRET_ACCESS_KEY}"
-          EOF
-          sed -i 's/^          //' tofu/.r2-credentials
-
-          cat > tofu/backend.hcl << EOF
-          endpoints = {
-            s3 = "https://${{ secrets.CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com"
-          }
-          bucket = "${BUCKET_NAME}"
-          EOF
-          sed -i 's/^          //' tofu/backend.hcl
+          domain: ${{ secrets.DOMAIN }}
+          cloudflare_account_id: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          r2_access_key_id: ${{ secrets.R2_ACCESS_KEY_ID }}
+          r2_secret_access_key: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          ssh_private_key: ${{ secrets.SSH_PRIVATE_KEY }}
+          ssh_public_key: ${{ secrets.SSH_PUBLIC_KEY }}
+          require_ssh_key: 'true'
 
       - name: Generate config.tfvars
         env:

--- a/src/nexus_deploy/__main__.py
+++ b/src/nexus_deploy/__main__.py
@@ -2951,6 +2951,7 @@ def _snapshot_create(args: list[str]) -> int:
     print(f"SNAPSHOT_IMAGE_ID={snapshot.image_id}")
     print(f"SNAPSHOT_DISK_GB={snapshot.disk_gb}")
     print(f"SNAPSHOT_ARCH={snapshot.architecture}")
+    print(f"SNAPSHOT_IMAGE_GB={snapshot.image_gb:.2f}")
     return 0
 
 
@@ -3002,6 +3003,7 @@ def _snapshot_resolve(args: list[str]) -> int:
     print(f"SNAPSHOT_IMAGE_ID={snapshot.image_id}")
     print(f"SNAPSHOT_DISK_GB={snapshot.disk_gb}")
     print(f"SNAPSHOT_ARCH={snapshot.architecture}")
+    print(f"SNAPSHOT_IMAGE_GB={snapshot.image_gb:.2f}")
     return 0
 
 

--- a/src/nexus_deploy/__main__.py
+++ b/src/nexus_deploy/__main__.py
@@ -2634,6 +2634,8 @@ def _select_capacity(args: list[str]) -> int:
     """
     # Crude arg-parse — keeps us out of argparse for one-flag handlers.
     tfvars_path: Path | None = None
+    min_disk_gb = 0
+    arch: str | None = None
     i = 0
     while i < len(args):
         if args[i] == "--tfvars":
@@ -2648,6 +2650,31 @@ def _select_capacity(args: list[str]) -> int:
                 )
                 return 2
             tfvars_path = Path(args[i + 1])
+            i += 2
+            continue
+        # Snapshot-restore constraints. A Hetzner snapshot is
+        # architecture-locked and needs a target disk at least as large
+        # as the image's, so the snapshot spin-up narrows the preference
+        # walk. Omitted on the normal path, where behaviour is unchanged.
+        if args[i] == "--min-disk-gb":
+            if i + 1 >= len(args):
+                print("select-capacity: --min-disk-gb requires a value", file=sys.stderr)
+                return 2
+            try:
+                min_disk_gb = int(args[i + 1])
+            except ValueError:
+                print(
+                    f"select-capacity: --min-disk-gb must be an integer, got {args[i + 1]!r}",
+                    file=sys.stderr,
+                )
+                return 2
+            i += 2
+            continue
+        if args[i] == "--arch":
+            if i + 1 >= len(args):
+                print("select-capacity: --arch requires a value", file=sys.stderr)
+                return 2
+            arch = args[i + 1]
             i += 2
             continue
         print(f"select-capacity: unknown arg {args[i]!r}", file=sys.stderr)
@@ -2731,8 +2758,43 @@ def _select_capacity(args: list[str]) -> int:
         print(f"select-capacity: Hetzner API failure: {exc}", file=sys.stderr)
         return 2
 
+    # Snapshot-restore constraints, when given. Applied BEFORE the
+    # availability walk so a type that could never host the image is
+    # never selected — the failure would otherwise only surface as an
+    # opaque `tofu apply` error.
+    excluded: dict[_hetzner.ServerSpec, str] = {}
+    if min_disk_gb > 0 or arch is not None:
+        try:
+            types = _hetzner.fetch_server_types(token)
+        except _hetzner.HetznerCapacityError as exc:
+            print(f"select-capacity: Hetzner API failure: {exc}", file=sys.stderr)
+            return 2
+        preferences, excluded = _hetzner.filter_specs(
+            preferences,
+            types,
+            min_disk_gb=min_disk_gb,
+            arch=arch,
+        )
+        constraint = []
+        if min_disk_gb > 0:
+            constraint.append(f"disk >= {min_disk_gb}GB")
+        if arch is not None:
+            constraint.append(f"arch {arch}")
+        sys.stderr.write(
+            f"select-capacity: restore constraints ({', '.join(constraint)}) "
+            f"excluded {len(excluded)} of {len(preferences) + len(excluded)} preferences\n",
+        )
+        if not preferences:
+            sys.stderr.write(
+                "✗ select-capacity: every preference was excluded by the restore "
+                "constraints — no server type can host this snapshot. Widen "
+                "SERVER_PREFERENCES, or spin up with force_fresh=true to rebuild "
+                "from the base image.\n",
+            )
+            return 2
+
     selected = _hetzner.select(preferences, availability)
-    status_lines = _hetzner.render_status_lines(preferences, availability, selected)
+    status_lines = _hetzner.render_status_lines(preferences, availability, selected, excluded)
 
     if selected is None:
         # PR #537 R7 #1: distinguish "every preference has an unknown

--- a/src/nexus_deploy/__main__.py
+++ b/src/nexus_deploy/__main__.py
@@ -2668,6 +2668,18 @@ def _select_capacity(args: list[str]) -> int:
                     file=sys.stderr,
                 )
                 return 2
+            # 0 and negatives must be refused, not tolerated: the filter
+            # below is gated on `> 0`, so they would silently disable the
+            # disk check rather than apply it. That is reachable — a
+            # snapshot whose disk_size is missing parses as 0 and reaches
+            # here through SNAPSHOT_DISK_GB, and the restore would then
+            # pick a target that cannot host the image.
+            if min_disk_gb <= 0:
+                print(
+                    f"select-capacity: --min-disk-gb must be greater than zero, got {min_disk_gb}",
+                    file=sys.stderr,
+                )
+                return 2
             i += 2
             continue
         if args[i] == "--arch":
@@ -2755,7 +2767,13 @@ def _select_capacity(args: list[str]) -> int:
     try:
         availability = _hetzner.fetch_availability(token)
     except _hetzner.HetznerCapacityError as exc:
-        print(f"select-capacity: Hetzner API failure: {exc}", file=sys.stderr)
+        # Type only, never str(exc): the message embeds the response body,
+        # which is upstream text we do not control. Per CLAUDE.md and the
+        # src/nexus_deploy path instructions.
+        print(
+            f"select-capacity: Hetzner API failure ({type(exc).__name__})",
+            file=sys.stderr,
+        )
         return 2
 
     # Snapshot-restore constraints, when given. Applied BEFORE the
@@ -2774,7 +2792,10 @@ def _select_capacity(args: list[str]) -> int:
         try:
             types = _hetzner.fetch_server_types(token)
         except _hetzner.HetznerCapacityError as exc:
-            print(f"select-capacity: Hetzner API failure: {exc}", file=sys.stderr)
+            print(
+                f"select-capacity: Hetzner API failure ({type(exc).__name__})",
+                file=sys.stderr,
+            )
             return 2
         preferences, excluded = _hetzner.filter_specs(
             preferences,

--- a/src/nexus_deploy/__main__.py
+++ b/src/nexus_deploy/__main__.py
@@ -2971,7 +2971,7 @@ def _server_poweroff(args: list[str]) -> int:
     try:
         _hsnap.poweroff_server(server_id, token)
     except _hsnap.HetznerSnapshotError as exc:
-        print(f"server-poweroff: {exc}", file=sys.stderr)
+        print(f"server-poweroff: Hetzner API failure ({type(exc).__name__})", file=sys.stderr)
         return 2
     sys.stderr.write(f"✓ server-poweroff: server {server_id} is off\n")
     return 0
@@ -3019,7 +3019,10 @@ def _snapshot_create(args: list[str]) -> int:
     try:
         total = _hsnap.count_snapshots(token)
     except _hsnap.HetznerSnapshotError as exc:
-        print(f"snapshot-create: could not count existing snapshots: {exc}", file=sys.stderr)
+        print(
+            f"snapshot-create: could not count existing snapshots ({type(exc).__name__})",
+            file=sys.stderr,
+        )
         return 2
     if total >= _hsnap.DEFAULT_SNAPSHOT_LIMIT - 2:
         sys.stderr.write(
@@ -3039,7 +3042,7 @@ def _snapshot_create(args: list[str]) -> int:
             timestamp=timestamp,
         )
     except _hsnap.HetznerSnapshotError as exc:
-        print(f"snapshot-create: {exc}", file=sys.stderr)
+        print(f"snapshot-create: Hetzner API failure ({type(exc).__name__})", file=sys.stderr)
         return 2
 
     sys.stderr.write(f"✓ snapshot-create: {snapshot}\n")
@@ -3083,7 +3086,7 @@ def _snapshot_resolve(args: list[str]) -> int:
             expect_epoch=expect_epoch or None,
         )
     except _hsnap.HetznerSnapshotError as exc:
-        print(f"snapshot-resolve: {exc}", file=sys.stderr)
+        print(f"snapshot-resolve: Hetzner API failure ({type(exc).__name__})", file=sys.stderr)
         return 2
 
     if snapshot is None:
@@ -3130,7 +3133,7 @@ def _snapshot_prune(args: list[str]) -> int:
         snapshots = _hsnap.list_snapshots(token, domain_slug=domain_slug)
         prunable = _hsnap.select_prunable(snapshots, keep=keep)
     except _hsnap.HetznerSnapshotError as exc:
-        print(f"snapshot-prune: {exc}", file=sys.stderr)
+        print(f"snapshot-prune: Hetzner API failure ({type(exc).__name__})", file=sys.stderr)
         return 2
 
     if not prunable:
@@ -3147,7 +3150,10 @@ def _snapshot_prune(args: list[str]) -> int:
         try:
             _hsnap.delete_snapshot(snapshot.image_id, token)
         except _hsnap.HetznerSnapshotError as exc:
-            print(f"snapshot-prune: failed to delete {snapshot}: {exc}", file=sys.stderr)
+            print(
+                f"snapshot-prune: failed to delete {snapshot} ({type(exc).__name__})",
+                file=sys.stderr,
+            )
             return 2
         sys.stderr.write(f"✓ snapshot-prune: deleted {snapshot}\n")
 

--- a/src/nexus_deploy/__main__.py
+++ b/src/nexus_deploy/__main__.py
@@ -2762,7 +2762,14 @@ def _select_capacity(args: list[str]) -> int:
     # availability walk so a type that could never host the image is
     # never selected — the failure would otherwise only surface as an
     # opaque `tofu apply` error.
+    #
+    # ``all_preferences`` keeps the UNFILTERED list for the status block.
+    # render_status_lines iterates what it is given, so handing it the
+    # filtered tuple would silently drop every excluded entry and the ⊘
+    # marker could never appear — which is exactly the information an
+    # operator needs when a restore cannot find a host.
     excluded: dict[_hetzner.ServerSpec, str] = {}
+    all_preferences = preferences
     if min_disk_gb > 0 or arch is not None:
         try:
             types = _hetzner.fetch_server_types(token)
@@ -2782,7 +2789,7 @@ def _select_capacity(args: list[str]) -> int:
             constraint.append(f"arch {arch}")
         sys.stderr.write(
             f"select-capacity: restore constraints ({', '.join(constraint)}) "
-            f"excluded {len(excluded)} of {len(preferences) + len(excluded)} preferences\n",
+            f"excluded {len(excluded)} of {len(all_preferences)} preferences\n",
         )
         if not preferences:
             sys.stderr.write(
@@ -2794,7 +2801,12 @@ def _select_capacity(args: list[str]) -> int:
             return 2
 
     selected = _hetzner.select(preferences, availability)
-    status_lines = _hetzner.render_status_lines(preferences, availability, selected, excluded)
+    status_lines = _hetzner.render_status_lines(
+        all_preferences,
+        availability,
+        selected,
+        excluded,
+    )
 
     if selected is None:
         # PR #537 R7 #1: distinguish "every preference has an unknown

--- a/src/nexus_deploy/hetzner_capacity.py
+++ b/src/nexus_deploy/hetzner_capacity.py
@@ -58,21 +58,28 @@ _DEFAULT_TIMEOUT = 30.0
 # shared-only (no dedicated, no ARM), five type-tiers in cost order,
 # three EU regions per tier.
 #
-#   Tier 1: cx43 (Intel shared, 8 vCPU / 16 GB / 160 GB, project
-#           default since 2026-05). The cheapest box that still fits
-#           the 40+ Docker stacks workload.
-#   Tier 2: cx53 (Intel shared, 16 vCPU / 32 GB / 320 GB). One step
-#           up if cx43 is dry across all three EU regions — keeps
-#           Intel + shared, just gives more headroom.
-#   Tier 3: cpx42 (AMD shared, 8 vCPU / 16 GB / 240 GB). Same
-#           8/16 class as cx43, different silicon → independent
-#           stock pool. linux/amd64 images run on Intel and AMD
-#           without distinction (per CLAUDE.md).
-#   Tier 4: cpx52 (AMD shared, 16 vCPU / 32 GB / 360 GB). AMD
-#           equivalent of cx53.
-#   Tier 5: cpx62 (AMD shared, 32 vCPU / 64 GB / 720 GB). Last
-#           resort when nothing else has stock — generously oversized
-#           but keeps the spin-up unblocked.
+#   Tier 1: cx43 (Intel shared, project default since 2026-05). The
+#           cheapest box that still fits the 40+ Docker stacks workload.
+#   Tier 2: cx53 (Intel shared). One step up if cx43 is dry across all
+#           three EU regions — keeps Intel + shared, just gives more
+#           headroom.
+#   Tier 3: cpx42 (AMD shared). Same class as cx43, different silicon
+#           → independent stock pool. linux/amd64 images run on Intel
+#           and AMD without distinction (per CLAUDE.md).
+#   Tier 4: cpx52 (AMD shared). AMD equivalent of cx53.
+#   Tier 5: cpx62 (AMD shared). Last resort when nothing else has
+#           stock — generously oversized but keeps the spin-up
+#           unblocked.
+#
+# ⚠️ Deliberately no vCPU/RAM/disk figures here any more. This list
+# previously carried them and they were WRONG: cpx42 was documented as
+# 240 GB, and the first real disk snapshot taken off a cpx42 reported
+# 320 GB. Hetzner revises specs, a comment cannot track that, and a
+# stale number here is not cosmetic — the snapshot restore path filters
+# server types by disk size, so believing the comment would exclude
+# valid targets or admit impossible ones. :func:`fetch_server_types`
+# reads the real values from ``/v1/server_types`` at runtime; that is
+# the only source to trust.
 #
 # Region order hel1 → fsn1 → nbg1 within every tier — matches the
 # historical project default ``server_location = "hel1"`` from

--- a/src/nexus_deploy/hetzner_snapshot.py
+++ b/src/nexus_deploy/hetzner_snapshot.py
@@ -101,10 +101,20 @@ class HetznerSnapshotError(Exception):
 class Snapshot:
     """A Hetzner snapshot image plus what we need to judge it.
 
-    ``disk_gb`` is the image's ``disk_size``: the **minimum** disk a
-    target server type must have to restore this image. It is not the
-    billed figure — that is ``image_size``, which reflects used space
-    only and is typically far smaller.
+    Two sizes, and conflating them is a costly mistake in both
+    directions:
+
+    ``disk_gb`` is the image's ``disk_size`` — the **minimum** disk a
+    target server type must have to restore this image. It equals the
+    source server's disk, not its used space, so it is what decides
+    which server types remain reachable. Verified in practice: the
+    first real snapshot of this stack came off a cpx42 and reported
+    320 GB.
+
+    ``image_gb`` is ``image_size`` — the compressed used space, and the
+    figure Hetzner actually bills (~EUR 0.011-0.014/GB/month). Usually
+    a small fraction of ``disk_gb``. Reported so the cost of a
+    retention policy is visible rather than guessed at.
 
     ``epoch`` is the credential fingerprint that was current when the
     snapshot was taken. A snapshot whose epoch no longer matches the
@@ -129,6 +139,7 @@ class Snapshot:
     epoch: str
     server_type: str
     status: str = ""
+    image_gb: float = 0.0
 
     @property
     def is_available(self) -> bool:
@@ -136,7 +147,12 @@ class Snapshot:
         return self.status == "available"
 
     def __str__(self) -> str:
-        return f"#{self.image_id} {self.description} ({self.disk_gb}GB {self.architecture})"
+        # Both sizes on purpose: disk_gb is the restore constraint,
+        # image_gb is what shows up on the invoice.
+        return (
+            f"#{self.image_id} {self.description} "
+            f"(disk {self.disk_gb}GB, billed {self.image_gb:.1f}GB, {self.architecture})"
+        )
 
 
 def _default_http_request(
@@ -245,6 +261,12 @@ def _parse_snapshot(image: dict[str, Any]) -> Snapshot | None:
     # both int and float across API versions.
     disk_gb = int(disk) if isinstance(disk, (int, float)) else 0
 
+    # image_size is the billed figure and is genuinely fractional
+    # (e.g. 12.5), so it must not be truncated to int the way disk_size
+    # is. It is also absent while an image is still `creating`.
+    billed = image.get("image_size")
+    image_gb = float(billed) if isinstance(billed, (int, float)) else 0.0
+
     arch = image.get("architecture")
     description = image.get("description")
     created = image.get("created")
@@ -258,6 +280,7 @@ def _parse_snapshot(image: dict[str, Any]) -> Snapshot | None:
         epoch=str(labels.get(LABEL_EPOCH, "")),
         server_type=str(labels.get(LABEL_SERVER_TYPE, "")),
         status=str(image.get("status", "")),
+        image_gb=image_gb,
     )
 
 

--- a/tests/unit/test_hetzner_snapshot.py
+++ b/tests/unit/test_hetzner_snapshot.py
@@ -677,11 +677,6 @@ def test_poweroff_default_sleep_is_not_called_when_already_off() -> None:
     poweroff_server(42, "tok", http_request=http)
 
 
-def test_snapshot_str_is_operator_readable() -> None:
-    snap = _snap(7, "2026-08-07T21:00:00+00:00")
-    assert str(snap) == "#7 snap-7 (160GB x86)"
-
-
 def test_create_snapshot_rejects_bad_slug() -> None:
     with pytest.raises(HetznerSnapshotError, match="domain_slug"):
         create_snapshot(
@@ -1078,3 +1073,43 @@ def test_create_snapshot_allows_empty_server_type() -> None:
     _method, _url, payload = http.calls[0]
     assert payload is not None
     assert LABEL_SERVER_TYPE not in payload["labels"]
+
+
+def test_parse_carries_billed_image_size() -> None:
+    """image_size is the billed figure and is fractional.
+
+    Truncating it the way disk_size is truncated would misreport cost;
+    conflating it with disk_size would misreport the restore constraint.
+    """
+    http = _Recorder(
+        {"/images": {"images": [_image(1, created="2026-08-01T21:00:00+00:00")]}},
+    )
+    snaps = list_snapshots("tok", domain_slug="example-com", http_request=http)
+    assert snaps[0].image_gb == 12.5
+    assert snaps[0].disk_gb == 160
+
+
+def test_parse_tolerates_missing_image_size() -> None:
+    """Absent while an image is still `creating`."""
+    payload = _image(1, created="2026-08-01T21:00:00+00:00", status="creating")
+    del payload["image_size"]
+    http = _Recorder({"/images": {"images": [payload]}})
+    snaps = list_snapshots("tok", domain_slug="example-com", http_request=http)
+    assert snaps[0].image_gb == 0.0
+
+
+def test_str_reports_both_sizes() -> None:
+    """The two numbers answer different questions — which server types
+    can host this, and what does keeping it cost."""
+    snap = Snapshot(
+        image_id=7,
+        description="snap-7",
+        created="2026-08-07T21:00:00+00:00",
+        disk_gb=320,
+        architecture="x86",
+        epoch=EPOCH_A,
+        server_type="cpx42",
+        status="available",
+        image_gb=12.5,
+    )
+    assert str(snap) == "#7 snap-7 (disk 320GB, billed 12.5GB, x86)"

--- a/tests/unit/test_select_capacity_cli.py
+++ b/tests/unit/test_select_capacity_cli.py
@@ -396,7 +396,19 @@ def test_select_capacity_aborts_on_api_error(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     """HetznerCapacityError (HTTP 401, network error, schema drift)
-    propagates to rc=2 with the original message."""
+    propagates to rc=2, reported by TYPE rather than by message.
+
+    This assertion was inverted in PR #651: it previously required the
+    exception text to appear. That contradicted the project rule
+    (CLAUDE.md, and the src/nexus_deploy path instructions) that error
+    logs carry `type(exc).__name__` and never `str(exc)`, because
+    exception messages embed upstream response bodies.
+
+    The trade-off is real and worth naming: HetznerCapacityError covers
+    auth, network, timeout and schema drift alike, so the log no longer
+    distinguishes them. The rule prefers that over the chance of a
+    credential reaching a public build log.
+    """
     monkeypatch.setenv("HCLOUD_TOKEN", "t")
 
     def _raise(_token: str, http_get: object = None) -> dict[str, set[str]]:
@@ -407,7 +419,8 @@ def test_select_capacity_aborts_on_api_error(
     assert rc == 2
     err = capsys.readouterr().err
     assert "Hetzner API failure" in err
-    assert "HTTP 401" in err
+    assert "HetznerCapacityError" in err
+    assert "HTTP 401" not in err
 
 
 def test_select_capacity_aborts_on_invalid_preferences(
@@ -669,3 +682,46 @@ def test_excluded_preferences_appear_in_the_status_block(
     assert "disk 160GB < 320GB required" in err
     # And the count must describe the original list, not the survivors.
     assert "excluded 1 of 2 preferences" in err
+
+
+@pytest.mark.parametrize("value", ["0", "-1"])
+def test_min_disk_gb_rejects_non_positive(
+    tfvars_with_legacy_pair: Path,
+    value: str,
+) -> None:
+    """Zero and negatives must be refused, not tolerated.
+
+    The filter is gated on `min_disk_gb > 0`, so accepting these would
+    silently disable the disk check instead of applying it. It is
+    reachable: a snapshot whose `disk_size` is missing parses as 0 and
+    reaches the CLI through SNAPSHOT_DISK_GB, and the restore would then
+    pick a target that cannot host the image.
+    """
+    rc = _select_capacity(["--tfvars", str(tfvars_with_legacy_pair), "--min-disk-gb", value])
+    assert rc == 2
+
+
+def test_api_failure_does_not_log_exception_text(
+    tfvars_with_legacy_pair: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Only the exception type reaches stderr.
+
+    HetznerCapacityError messages embed the upstream response body, which
+    is text we do not control. Per CLAUDE.md and the src/nexus_deploy
+    path instructions, error logs carry `type(exc).__name__`, never
+    `str(exc)`.
+    """
+    monkeypatch.setenv("HCLOUD_TOKEN", "t")
+
+    def _raise(*_a: object, **_k: object) -> dict[str, set[str]]:
+        raise _hetzner.HetznerCapacityError("HTTP 401 for https://api — token=SUPERSECRET")
+
+    monkeypatch.setattr(_hetzner, "fetch_availability", _raise)
+
+    assert _select_capacity(["--tfvars", str(tfvars_with_legacy_pair)]) == 2
+    out = capsys.readouterr()
+    combined = out.err + out.out
+    assert "HetznerCapacityError" in combined
+    assert "SUPERSECRET" not in combined

--- a/tests/unit/test_select_capacity_cli.py
+++ b/tests/unit/test_select_capacity_cli.py
@@ -725,3 +725,35 @@ def test_api_failure_does_not_log_exception_text(
     combined = out.err + out.out
     assert "HetznerCapacityError" in combined
     assert "SUPERSECRET" not in combined
+
+
+def test_server_types_failure_does_not_log_exception_text(
+    tfvars_with_legacy_pair: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The second API call needs the same guarantee as the first.
+
+    The `str(exc)` fix covered fetch_availability; fetch_server_types is
+    only reached on the snapshot path and had no test of its own. It is
+    the more exposed of the two, since it is the call the restore
+    constraints depend on.
+    """
+    monkeypatch.setenv("HCLOUD_TOKEN", "t")
+    monkeypatch.setenv("SERVER_PREFERENCES", "cx43:hel1")
+    monkeypatch.setattr(
+        _hetzner, "fetch_availability", lambda _t, http_get=None: {"hel1": {"cx43"}}
+    )
+
+    def _raise(*_a: object, **_k: object) -> dict[str, object]:
+        raise _hetzner.HetznerCapacityError("HTTP 401 for https://api — token=SUPERSECRET")
+
+    monkeypatch.setattr(_hetzner, "fetch_server_types", _raise)
+
+    rc = _select_capacity(["--tfvars", str(tfvars_with_legacy_pair), "--min-disk-gb", "320"])
+    assert rc == 2
+    out = capsys.readouterr()
+    combined = out.err + out.out
+    assert "HetznerCapacityError" in combined
+    assert "SUPERSECRET" not in combined
+    assert "HTTP 401" not in combined

--- a/tests/unit/test_select_capacity_cli.py
+++ b/tests/unit/test_select_capacity_cli.py
@@ -636,3 +636,36 @@ def test_constraint_flag_without_value_is_rc2(
 ) -> None:
     rc = _select_capacity(["--tfvars", str(tfvars_with_legacy_pair), flag])
     assert rc == 2
+
+
+def test_excluded_preferences_appear_in_the_status_block(
+    tfvars_with_legacy_pair: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The status block must show WHY a tier was skipped.
+
+    render_status_lines iterates whatever list it is handed, so passing
+    it the post-filter tuple silently drops every excluded entry and the
+    ⊘ marker can never appear — leaving an operator debugging a failed
+    restore with no indication that disk size was the reason. This is the
+    integration the module-level render test cannot cover, because that
+    one passes the excluded spec in directly.
+    """
+    monkeypatch.setenv("HCLOUD_TOKEN", "t")
+    monkeypatch.setenv("SERVER_PREFERENCES", "cx43:hel1, cx53:hel1")
+    monkeypatch.setattr(
+        _hetzner,
+        "fetch_availability",
+        lambda _t, http_get=None: {"hel1": {"cx43", "cx53"}},
+    )
+    monkeypatch.setattr(_hetzner, "fetch_server_types", lambda _t, http_get=None: _TYPES)
+
+    assert _select_capacity(["--tfvars", str(tfvars_with_legacy_pair), "--min-disk-gb", "320"]) == 0
+
+    err = capsys.readouterr().err
+    assert "⊘" in err
+    assert "cx43:hel1" in err
+    assert "disk 160GB < 320GB required" in err
+    # And the count must describe the original list, not the survivors.
+    assert "excluded 1 of 2 preferences" in err

--- a/tests/unit/test_select_capacity_cli.py
+++ b/tests/unit/test_select_capacity_cli.py
@@ -523,3 +523,116 @@ def test_select_capacity_appends_keys_when_absent(
     # Original lines preserved.
     assert 'domain = "example.com"' in rewritten
     assert 'server_preferences = "cx43:fsn1, ccx33:nbg1"' in rewritten
+
+
+# ---------------------------------------------------------------------------
+# Restore constraints: --min-disk-gb / --arch  (PR #651 review)
+#
+# These flags existed as module functions with full coverage while the CLI
+# rejected them outright with "unknown arg". Every snapshot restore would
+# have failed at the capacity step. The module tests could not catch it
+# because they call filter_specs directly; only a CLI-level test does.
+# ---------------------------------------------------------------------------
+
+
+_TYPES = {
+    "cx43": _hetzner.ServerTypeInfo(name="cx43", disk_gb=160, architecture="x86"),
+    "cx53": _hetzner.ServerTypeInfo(name="cx53", disk_gb=320, architecture="x86"),
+    "cax31": _hetzner.ServerTypeInfo(name="cax31", disk_gb=160, architecture="arm"),
+}
+
+
+def test_min_disk_gb_flag_is_accepted(
+    tfvars_with_legacy_pair: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The regression guard: this used to exit 2 with 'unknown arg'."""
+    monkeypatch.setenv("HCLOUD_TOKEN", "t")
+    monkeypatch.setenv("SERVER_PREFERENCES", "cx43:hel1, cx53:hel1")
+    monkeypatch.setattr(
+        _hetzner,
+        "fetch_availability",
+        lambda _t, http_get=None: {"hel1": {"cx43", "cx53"}},
+    )
+    monkeypatch.setattr(_hetzner, "fetch_server_types", lambda _t, http_get=None: _TYPES)
+
+    rc = _select_capacity(["--tfvars", str(tfvars_with_legacy_pair), "--min-disk-gb", "320"])
+    assert rc == 0
+    # cx43 has a 160GB disk and cannot host a 320GB image, so the walk
+    # must skip it even though it is first and in stock.
+    assert 'server_type     = "cx53"' in tfvars_with_legacy_pair.read_text()
+
+
+def test_arch_flag_excludes_mismatched_architecture(
+    tfvars_with_legacy_pair: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("HCLOUD_TOKEN", "t")
+    monkeypatch.setenv("SERVER_PREFERENCES", "cax31:hel1, cx43:hel1")
+    monkeypatch.setattr(
+        _hetzner,
+        "fetch_availability",
+        lambda _t, http_get=None: {"hel1": {"cax31", "cx43"}},
+    )
+    monkeypatch.setattr(_hetzner, "fetch_server_types", lambda _t, http_get=None: _TYPES)
+
+    rc = _select_capacity(["--tfvars", str(tfvars_with_legacy_pair), "--arch", "x86"])
+    assert rc == 0
+    assert 'server_type     = "cx43"' in tfvars_with_legacy_pair.read_text()
+
+
+def test_all_preferences_excluded_is_rc2(
+    tfvars_with_legacy_pair: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """No type can host the image: fail with an actionable message rather
+    than letting `tofu apply` surface it as an opaque image error."""
+    monkeypatch.setenv("HCLOUD_TOKEN", "t")
+    monkeypatch.setenv("SERVER_PREFERENCES", "cx43:hel1")
+    monkeypatch.setattr(
+        _hetzner, "fetch_availability", lambda _t, http_get=None: {"hel1": {"cx43"}}
+    )
+    monkeypatch.setattr(_hetzner, "fetch_server_types", lambda _t, http_get=None: _TYPES)
+
+    rc = _select_capacity(["--tfvars", str(tfvars_with_legacy_pair), "--min-disk-gb", "999"])
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "every preference was excluded" in err
+    assert "force_fresh" in err
+
+
+def test_constraint_flags_are_optional(
+    tfvars_with_legacy_pair: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without them, fetch_server_types must not even be called — the
+    legacy path stays a single API round-trip."""
+    called = {"n": 0}
+
+    def _boom(*_a: object, **_k: object) -> dict[str, object]:
+        called["n"] += 1
+        return {}
+
+    monkeypatch.setenv("HCLOUD_TOKEN", "t")
+    monkeypatch.setattr(
+        _hetzner, "fetch_availability", lambda _t, http_get=None: {"hel1": {"cx43"}}
+    )
+    monkeypatch.setattr(_hetzner, "fetch_server_types", _boom)
+
+    assert _select_capacity(["--tfvars", str(tfvars_with_legacy_pair)]) == 0
+    assert called["n"] == 0
+
+
+def test_min_disk_gb_rejects_non_integer(tfvars_with_legacy_pair: Path) -> None:
+    rc = _select_capacity(["--tfvars", str(tfvars_with_legacy_pair), "--min-disk-gb", "lots"])
+    assert rc == 2
+
+
+@pytest.mark.parametrize("flag", ["--min-disk-gb", "--arch"])
+def test_constraint_flag_without_value_is_rc2(
+    tfvars_with_legacy_pair: Path,
+    flag: str,
+) -> None:
+    rc = _select_capacity(["--tfvars", str(tfvars_with_legacy_pair), flag])
+    assert rc == 2

--- a/tests/unit/test_snapshot_cli.py
+++ b/tests/unit/test_snapshot_cli.py
@@ -438,3 +438,52 @@ def test_dispatcher_routes_subcommand(
     # The subcommand name itself must be stripped before the handler
     # sees the flags.
     assert called["args"] == argv[1:]
+
+
+# ---------------------------------------------------------------------------
+# Error logging (PR #651 review)
+#
+# HetznerSnapshotError messages embed up to 400 characters of the upstream
+# HTTP response body (see _default_http_request), so they must never be
+# printed verbatim. Our own _FlagError messages are a different case: they
+# are text we wrote, and they are the diagnostic — "--server-id is
+# required" has to stay readable.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("handler", "argv", "patch_target"),
+    [
+        ("_server_poweroff", ["--server-id", "42"], "poweroff_server"),
+        ("_snapshot_resolve", ["--domain-slug", "example-com"], "resolve_latest"),
+        ("_snapshot_prune", ["--domain-slug", "example-com"], "list_snapshots"),
+    ],
+)
+def test_api_errors_are_logged_by_type_only(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    handler: str,
+    argv: list[str],
+    patch_target: str,
+) -> None:
+    def _raise(*_a: Any, **_k: Any) -> Any:
+        raise HetznerSnapshotError("HTTP 403 body={'token': 'SUPERSECRET'}")
+
+    monkeypatch.setattr(_hsnap, patch_target, _raise)
+    assert getattr(cli, handler)(argv) == 2
+
+    out = capsys.readouterr()
+    combined = out.err + out.out
+    assert "HetznerSnapshotError" in combined
+    assert "SUPERSECRET" not in combined
+    assert "HTTP 403" not in combined
+
+
+def test_flag_errors_keep_their_message(capsys: pytest.CaptureFixture[str]) -> None:
+    """Our own messages are the diagnostic and must survive.
+
+    Redacting these too would turn every misuse into an unhelpful
+    "_FlagError" with no indication of which flag was wrong.
+    """
+    assert cli._snapshot_create(["--server-id", "42"]) == 2
+    assert "--domain-slug is required" in capsys.readouterr().err

--- a/tests/unit/test_snapshot_cli.py
+++ b/tests/unit/test_snapshot_cli.py
@@ -36,6 +36,8 @@ def _snap(image_id: int = 99, created: str = "2026-08-05T21:00:00+00:00") -> Sna
         architecture="x86",
         epoch=EPOCH,
         server_type="cx43",
+        status="available",
+        image_gb=12.5,
     )
 
 
@@ -123,6 +125,9 @@ def test_create_emits_machine_readable_coordinates(
         "SNAPSHOT_IMAGE_ID": "99",
         "SNAPSHOT_DISK_GB": "160",
         "SNAPSHOT_ARCH": "x86",
+        # The billed size, so a retention policy's cost is visible in
+        # the workflow log rather than guessed at.
+        "SNAPSHOT_IMAGE_GB": "12.50",
     }
 
 


### PR DESCRIPTION
## Summary

Closes the snapshot lifecycle opened in #649. That PR produced the image; this one consumes it.

Also extracts the workflow steps that were being duplicated — including duplication #649 itself introduced — into composite actions.

**`teardown.yml`, `destroy-all.yml` and `spin-up.yml`'s behaviour are unchanged.** `spin-up.yml` gains four optional, defaulted inputs; passing none reproduces exactly what it did before.

## What the first real snapshot told us

#649 was verified against the live stack with `skip_destroy=true`. It worked, and it produced numbers that were previously guesses:

| | |
|---|---|
| Disk snapshot | **72 s** (power-off 28 s + create/available 44 s) |
| R2 logical snapshot | 42 s |
| Teardown total | ~2 min → ~2.5 min |
| Prune | correctly scoped — found exactly this stack's one image |

And a comparison of the same service set, cold against warm:

| | cold (fresh build) | warm | delta |
|---|---|---|---|
| cloud-init gate | 78 s | 14 s | **−64 s** |
| `Deploy stacks` | 257 s | 148 s | **−109 s** |

A restore hits both: cloud-init takes the light path, and the images are already on the disk. **~3 minutes on a small service set**, scaling with image count. The cost lands on the teardown, which runs unattended at 21:00.

It also surfaced a bug: `DEFAULT_PREFERENCES` documented cpx42 as "240 GB"; the snapshot taken from a cpx42 reported **320 GB**. Not cosmetic — the restore path filters server types by disk size, so a stale figure would exclude valid targets or admit impossible ones. The numbers are removed rather than corrected: Hetzner revises specs, a comment cannot track that, and `fetch_server_types` already reads the real values at runtime.

## Design: orchestrator, not a copy

`spin-up-snapshot.yml` is **204 lines**. It resolves the newest usable snapshot and hands it to `spin-up.yml` as `server_image`; everything after is the ordinary spin-up.

A standalone workflow would have duplicated ~1400 lines — `spin-up.yml` alone carries ~420 lines of post-deploy work (D1 writes, Cloudflare secrets, Control Plane redeploy, state sync, mail) identical on both paths.

The choice was made on stability grounds. Duplication and sharing fail differently:

- **drift** is silent. The copy rots when someone edits `spin-up.yml` and forgets it, and that surfaces the first time a restore is needed — precisely when data is on the line.
- **shared code** fails loudly. A mistake breaks the next spin-up visibly, against a proven history to revert to.

Loud beats silent when the silent case lands in disaster recovery.

## Composite actions

| Action | Contents |
|---|---|
| `nexus-bootstrap` | OpenTofu + uv + deps + cloudflared, SSH key from secrets, `tofu/.r2-credentials` + `backend.hcl` |
| `nexus-config-tfvars` | the whole `config.tfvars` generation: stack settings, Hetzner Object Storage coordinates from control-plane state, enabled services from D1, firewall sync and rules |

`teardown.yml` and `teardown-snapshot.yml` already carried the same ~100-line preamble twice — #649 wrote the second copy. This PR would have added a third, plus a second copy of the 126-line `config.tfvars` block whose D1 reads, firewall sync and S3 lookup are the least pleasant thing in the repo to keep in sync. The block differs between the two spin-up paths in exactly one value.

That value, `server_image`, is an input defaulting to `ubuntu-24.04`. **`spin-up.yml` passes nothing and stays free of snapshot awareness** — only the snapshot workflow supplies an id. The fallback therefore does not depend on the snapshot mechanism, which was the property worth protecting.

Secrets and repository variables are explicit inputs: a composite action cannot read the `secrets` context at all, and rather than assume `vars` is available, both go the same way — which also makes the contract visible at the call site.

`teardown.yml` and `destroy-all.yml` are deliberately **not** migrated yet. A bug in a shared action would take every path down at once, so the actions get proven on the newer workflows first.

## The readiness gate

Unified rather than branched:

```bash
test -f /run/nexus-setup-complete \
  || { test -f /opt/docker-server/.setup-complete && systemctl is-active --quiet docker; }
```

This is **monotonically safer for the existing path**. Today's gate accepts `.setup-complete` alone; the new one additionally requires Docker to be up, so it can only ever wait longer, never pass earlier.

It simultaneously fixes the premature-pass that made the old gate wrong for restores — `.setup-complete` is already inside the image — without a conditional, and therefore without snapshot awareness leaking into `spin-up.yml`.

## Fallback is the normal case, not an error path

A first-ever spin-up, a pruned snapshot, a rotated credential epoch and an arch/disk mismatch all resolve to a fresh `ubuntu-24.04` build with S3 restore enabled.

**Only a failed lookup stops the workflow.** "Cannot tell" is not "there is none": building fresh during an API outage would discard a snapshot that may hold the only copy of most stacks' data. `force_fresh=true` is the manual escape from a bad snapshot, or the route to a new base image (see #650).

`s3_persistence=false` on a restore is load-bearing: the disk already holds data **newer** than the last R2 snapshot, so restoring R2 on top would silently revert the stack by one teardown cycle.

## Review fixes carried over from #649

Copilot found four issues there, all confirmed against the code, two worse than reported:

- `source`ing the CLI output executed an unvalidated Hetzner API field as shell, in a workflow holding every deploy secret. Both resolvers now parse as data.
- `resolve_latest` could pick a `creating` image; `select_prunable` had the same blind spot in both directions — a `creating` image occupied a keep slot and could be handed to `delete_snapshot`. Root cause worth remembering: the code trusted "newest by `created`" as a proxy for "usable". Sort order was already defended against; usability was not.

## Testing

Full Python suite **1681 passed**; `ruff`, `ruff format --check`, `mypy --strict` clean. `hetzner_snapshot.py` and `hetzner_capacity.py` both at 100% statement and branch coverage.

Workflow validation was done by parity rather than by "it's clean": **actionlint findings per workflow are identical to `main`** — `spin-up.yml` still has exactly its two pre-existing SC2086 infos in the tunnel-install step, `teardown.yml` 0, `destroy-all.yml` 0, `initial-setup.yaml` 1, `setup-control-plane.yaml` 19. Both new workflows are clean, and every composite `run` block passes shellcheck.

The extracted `config.tfvars` step was proven content-identical to the block it replaces: 105 normalised lines on both sides, differing only where secrets were renamed to inputs.

## What has NOT been verified

Nothing here has run end to end. New `workflow_dispatch` files are only dispatchable from the default branch, so the restore path can only be exercised after merge. First run after merging:

```bash
gh workflow run teardown-snapshot.yml -f confirm=TEARDOWN   # destructive, produces the image
gh workflow run spin-up-snapshot.yml                        # restores from it
```

Watch for: no `must be replaced` in the apply (this is also the first real test of the `lifecycle.ignore_changes` guard from #649, which the warm spin-up could not exercise because there was no divergence to ignore), the readiness gate passing on `/run`, `Deploy stacks` well under the 148 s warm baseline because no images are pulled, and the stack's data intact.

Rollback is `force_fresh=true`, or simply using the untouched `spin-up.yml`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added snapshot-aware deployment workflows with automatic snapshot selection or fresh-build fallback.
  - Added controls for server image, minimum disk size, architecture, and storage restoration.
  - Added shared automation for deployment setup, credentials, and infrastructure configuration.

- **Bug Fixes**
  - Improved snapshot capacity filtering and reporting.
  - Snapshot details now distinguish required disk capacity from billed image size.
  - Added validation for incompatible capacity requirements and invalid inputs.
  - Improved failure handling for configuration and infrastructure lookups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->