### PR TITLE
feat(control-plane): Make the dispatched lifecycle workflow configurable

### DIFF
--- a/control-plane/functions/api/_utils/workflow-selection.js
+++ b/control-plane/functions/api/_utils/workflow-selection.js
@@ -1,0 +1,89 @@
+/**
+ * Which lifecycle workflow the Control Plane dispatches.
+ *
+ * Nexus-Stack has two teardown/spin-up pairs:
+ *
+ *   teardown.yml / spin-up.yml                    destroy and rebuild from
+ *                                                 ubuntu-24.04
+ *   teardown-snapshot.yml / spin-up-snapshot.yml  snapshot the disk, destroy
+ *                                                 only the server, restore
+ *                                                 from the image
+ *
+ * The pair in use is a D1 config value rather than a code change, so
+ * switching is one row and rolling back is the same row. Defaults are the
+ * legacy names, so an unconfigured stack behaves exactly as before.
+ *
+ * WHY AN ALLOWLIST: these values are interpolated into a GitHub API URL
+ * (`/actions/workflows/<value>/dispatches`). Anything unexpected in the
+ * config table would become part of that path. Only the four known
+ * filenames are accepted; anything else falls back to the legacy default
+ * and is reported, rather than being passed through.
+ *
+ * ⚠️ The two must be switched TOGETHER. A snapshot teardown followed by a
+ * legacy spin-up wastes the image; a legacy teardown runs an untargeted
+ * `tofu destroy` that rotates all 81 generated credentials, which makes
+ * every existing snapshot unrestorable — the epoch guard then correctly
+ * refuses it and falls back to a fresh build.
+ */
+
+export const TEARDOWN_WORKFLOWS = ['teardown.yml', 'teardown-snapshot.yml'];
+export const SPINUP_WORKFLOWS = ['spin-up.yml', 'spin-up-snapshot.yml'];
+
+export const DEFAULT_TEARDOWN_WORKFLOW = 'teardown.yml';
+export const DEFAULT_SPINUP_WORKFLOW = 'spin-up.yml';
+
+/**
+ * Read one workflow name from D1, validated against its allowlist.
+ *
+ * Falls back to `fallback` when the key is unset, when D1 is unreachable,
+ * or when the stored value is not on the allowlist. Never throws: a
+ * Control Plane that cannot read its own config should still be able to
+ * tear down, and doing so on the legacy path is the safe default.
+ *
+ * @param {D1Database|undefined} db
+ * @param {string} key            config key, e.g. 'teardown_workflow'
+ * @param {string[]} allowed      permitted filenames
+ * @param {string} fallback       value to use when unset or invalid
+ * @returns {Promise<string>}
+ */
+export async function getWorkflowName(db, key, allowed, fallback) {
+  if (!db) return fallback;
+  try {
+    const row = await db
+      .prepare('SELECT value FROM config WHERE key = ?')
+      .bind(key)
+      .first();
+    const value = row ? row.value : null;
+    if (!value) return fallback;
+    if (!allowed.includes(value)) {
+      console.error(
+        `config.${key} is not a known workflow: ${JSON.stringify(value)} — using ${fallback}`
+      );
+      return fallback;
+    }
+    return value;
+  } catch (error) {
+    console.error(`Failed to read config.${key} from D1:`, error);
+    return fallback;
+  }
+}
+
+/** The teardown workflow this stack is configured to use. */
+export function getTeardownWorkflow(db) {
+  return getWorkflowName(
+    db,
+    'teardown_workflow',
+    TEARDOWN_WORKFLOWS,
+    DEFAULT_TEARDOWN_WORKFLOW
+  );
+}
+
+/** The spin-up workflow this stack is configured to use. */
+export function getSpinUpWorkflow(db) {
+  return getWorkflowName(
+    db,
+    'spinup_workflow',
+    SPINUP_WORKFLOWS,
+    DEFAULT_SPINUP_WORKFLOW
+  );
+}

--- a/control-plane/functions/api/_utils/workflow-selection.js
+++ b/control-plane/functions/api/_utils/workflow-selection.js
@@ -1,89 +1,107 @@
 /**
- * Which lifecycle workflow the Control Plane dispatches.
+ * Which lifecycle workflow pair the Control Plane dispatches.
  *
- * Nexus-Stack has two teardown/spin-up pairs:
+ * Nexus-Stack has two pairs:
  *
- *   teardown.yml / spin-up.yml                    destroy and rebuild from
- *                                                 ubuntu-24.04
- *   teardown-snapshot.yml / spin-up-snapshot.yml  snapshot the disk, destroy
- *                                                 only the server, restore
- *                                                 from the image
+ *   legacy    teardown.yml / spin-up.yml
+ *             destroy everything, rebuild from ubuntu-24.04
+ *   snapshot  teardown-snapshot.yml / spin-up-snapshot.yml
+ *             snapshot the disk, destroy only the server, restore from
+ *             the image
  *
- * The pair in use is a D1 config value rather than a code change, so
- * switching is one row and rolling back is the same row. Defaults are the
- * legacy names, so an unconfigured stack behaves exactly as before.
+ * ONE config value, not two. The pair is selected by `lifecycle_mode`
+ * ('legacy' | 'snapshot') and both workflow names are derived from it.
  *
- * WHY AN ALLOWLIST: these values are interpolated into a GitHub API URL
- * (`/actions/workflows/<value>/dispatches`). Anything unexpected in the
- * config table would become part of that path. Only the four known
- * filenames are accepted; anything else falls back to the legacy default
- * and is reported, rather than being passed through.
+ * Two independent keys were the first design and it was wrong: they can
+ * drift, and a half-applied switch is actively harmful. Snapshot spin-up
+ * with legacy teardown means the nightly untargeted `tofu destroy`
+ * rotates all 81 generated credentials, and the epoch guard then refuses
+ * the snapshot it just made. Documenting "switch both together" is not
+ * the same as making it impossible to do otherwise.
  *
- * ⚠️ The two must be switched TOGETHER. A snapshot teardown followed by a
- * legacy spin-up wastes the image; a legacy teardown runs an untargeted
- * `tofu destroy` that rotates all 81 generated credentials, which makes
- * every existing snapshot unrestorable — the epoch guard then correctly
- * refuses it and falls back to a fresh build.
+ * WHY AN ALLOWLIST: the derived names are interpolated into a GitHub API
+ * URL path (`/actions/workflows/<name>/dispatches`). Deriving them from a
+ * validated mode rather than reading them from the database means no
+ * database value ever reaches that path.
+ *
+ * "CANNOT TELL" IS NOT "NOT CONFIGURED". These are different answers and
+ * the caller must be able to tell them apart:
+ *
+ *   absent      no row -> the stack was never switched -> legacy is right
+ *   unreadable  D1 down, no binding, unknown value -> we do not know which
+ *               mode this stack is in, and guessing legacy would dispatch
+ *               the DESTRUCTIVE pair at a stack that may be on snapshots
+ *
+ * That is why this returns a result rather than a bare string with a
+ * fallback baked in.
  */
 
-export const TEARDOWN_WORKFLOWS = ['teardown.yml', 'teardown-snapshot.yml'];
-export const SPINUP_WORKFLOWS = ['spin-up.yml', 'spin-up-snapshot.yml'];
+export const LIFECYCLE_MODES = ['legacy', 'snapshot'];
+export const DEFAULT_LIFECYCLE_MODE = 'legacy';
 
-export const DEFAULT_TEARDOWN_WORKFLOW = 'teardown.yml';
-export const DEFAULT_SPINUP_WORKFLOW = 'spin-up.yml';
+/** Workflow filenames per mode. The only place these strings live. */
+export const LIFECYCLE_WORKFLOWS = {
+  legacy: { teardown: 'teardown.yml', spinUp: 'spin-up.yml' },
+  snapshot: { teardown: 'teardown-snapshot.yml', spinUp: 'spin-up-snapshot.yml' },
+};
+
+/** Every filename either mode can produce — for run detection, not dispatch. */
+export const ALL_TEARDOWN_WORKFLOWS = LIFECYCLE_MODES.map(
+  (m) => LIFECYCLE_WORKFLOWS[m].teardown
+);
+export const ALL_SPINUP_WORKFLOWS = LIFECYCLE_MODES.map(
+  (m) => LIFECYCLE_WORKFLOWS[m].spinUp
+);
 
 /**
- * Read one workflow name from D1, validated against its allowlist.
- *
- * Falls back to `fallback` when the key is unset, when D1 is unreachable,
- * or when the stored value is not on the allowlist. Never throws: a
- * Control Plane that cannot read its own config should still be able to
- * tear down, and doing so on the legacy path is the safe default.
+ * Resolve the configured lifecycle mode.
  *
  * @param {D1Database|undefined} db
- * @param {string} key            config key, e.g. 'teardown_workflow'
- * @param {string[]} allowed      permitted filenames
- * @param {string} fallback       value to use when unset or invalid
- * @returns {Promise<string>}
+ * @returns {Promise<{ok: true, mode: string, teardown: string, spinUp: string}
+ *                 | {ok: false, reason: string}>}
+ *
+ * `ok: false` means the configuration could not be determined. Callers
+ * must NOT fall back to a default on that — see the note above. It is
+ * only returned for a genuine unknown; an unconfigured stack resolves
+ * successfully to 'legacy'.
  */
-export async function getWorkflowName(db, key, allowed, fallback) {
-  if (!db) return fallback;
-  try {
-    const row = await db
-      .prepare('SELECT value FROM config WHERE key = ?')
-      .bind(key)
-      .first();
-    const value = row ? row.value : null;
-    if (!value) return fallback;
-    if (!allowed.includes(value)) {
-      console.error(
-        `config.${key} is not a known workflow: ${JSON.stringify(value)} — using ${fallback}`
-      );
-      return fallback;
-    }
-    return value;
-  } catch (error) {
-    console.error(`Failed to read config.${key} from D1:`, error);
-    return fallback;
+export async function resolveLifecycle(db) {
+  if (!db) {
+    // Expected during local development, a misconfiguration in
+    // production. Either way we cannot know the mode.
+    return { ok: false, reason: 'no D1 binding available' };
   }
-}
 
-/** The teardown workflow this stack is configured to use. */
-export function getTeardownWorkflow(db) {
-  return getWorkflowName(
-    db,
-    'teardown_workflow',
-    TEARDOWN_WORKFLOWS,
-    DEFAULT_TEARDOWN_WORKFLOW
-  );
-}
+  let row;
+  try {
+    row = await db
+      .prepare('SELECT value FROM config WHERE key = ?')
+      .bind('lifecycle_mode')
+      .first();
+  } catch (error) {
+    // Log the error object, never the row: a config value we failed to
+    // validate must not end up in a log line.
+    console.error('Failed to read config.lifecycle_mode from D1:', error);
+    return { ok: false, reason: 'D1 read failed' };
+  }
 
-/** The spin-up workflow this stack is configured to use. */
-export function getSpinUpWorkflow(db) {
-  return getWorkflowName(
-    db,
-    'spinup_workflow',
-    SPINUP_WORKFLOWS,
-    DEFAULT_SPINUP_WORKFLOW
-  );
+  const value = row ? row.value : null;
+
+  // No row: this stack was never switched. That is a definite answer,
+  // not an unknown one.
+  if (!value) {
+    return { ok: true, mode: DEFAULT_LIFECYCLE_MODE, ...LIFECYCLE_WORKFLOWS[DEFAULT_LIFECYCLE_MODE] };
+  }
+
+  if (!LIFECYCLE_MODES.includes(value)) {
+    // Deliberately does not print the value. It is an unvalidated
+    // database string, and this project does not put those in logs — if
+    // a secret were ever written to the wrong key, the log would keep it.
+    console.error(
+      `config.lifecycle_mode holds an unrecognised value (expected one of: ${LIFECYCLE_MODES.join(', ')})`
+    );
+    return { ok: false, reason: 'unrecognised lifecycle_mode' };
+  }
+
+  return { ok: true, mode: value, ...LIFECYCLE_WORKFLOWS[value] };
 }

--- a/control-plane/functions/api/info.js
+++ b/control-plane/functions/api/info.js
@@ -1,7 +1,7 @@
 /**
  * Get infrastructure information
  * GET /api/info
- * 
+ *
  * Returns server info, time information, scheduled teardown details, and workflow details
  * Configuration stored in Cloudflare D1 database
  */
@@ -26,13 +26,13 @@ async function getConfig(db, key, defaultValue = null) {
  */
 function timeInTimezoneToUTC(timeStr, timezone, baseDate = new Date()) {
   const [hours, minutes] = timeStr.split(':').map(Number);
-  
+
   // Get the date string in the target timezone
   const dateStr = baseDate.toLocaleDateString('en-CA', { timeZone: timezone }); // YYYY-MM-DD
-  
+
   // Create a date assuming the time is in UTC
   const utcDate = new Date(`${dateStr}T${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}:00Z`);
-  
+
   // Now format this UTC date in the target timezone to see what time it represents there
   const tzFormatter = new Intl.DateTimeFormat('en', {
     timeZone: timezone,
@@ -40,34 +40,34 @@ function timeInTimezoneToUTC(timeStr, timezone, baseDate = new Date()) {
     minute: '2-digit',
     hour12: false,
   });
-  
+
   const tzTimeStr = tzFormatter.format(utcDate);
   const [tzHours, tzMinutes] = tzTimeStr.split(':').map(Number);
-  
+
   // Calculate the difference between desired time and actual time in timezone
   const desiredMinutes = hours * 60 + minutes;
   const actualMinutes = tzHours * 60 + tzMinutes;
   const diffMinutes = desiredMinutes - actualMinutes;
-  
+
   // Adjust UTC date by the difference
   const adjustedDate = new Date(utcDate.getTime() + diffMinutes * 60 * 1000);
-  
+
   return adjustedDate;
 }
 
 export async function onRequestGet(context) {
   const { env } = context;
-  
+
   // Validate environment variables
   const missing = [];
   if (!env.GITHUB_TOKEN) missing.push('GITHUB_TOKEN');
   if (!env.GITHUB_OWNER) missing.push('GITHUB_OWNER');
   if (!env.GITHUB_REPO) missing.push('GITHUB_REPO');
-  
+
   if (missing.length > 0) {
-    return new Response(JSON.stringify({ 
-      success: false, 
-      error: `Missing required environment variables: ${missing.join(', ')}` 
+    return new Response(JSON.stringify({
+      success: false,
+      error: `Missing required environment variables: ${missing.join(', ')}`
     }), {
       status: 500,
       headers: { 'Content-Type': 'application/json' },
@@ -130,7 +130,7 @@ export async function onRequestGet(context) {
       const timezone = await getConfig(env.NEXUS_DB, 'teardown_timezone', 'Europe/Zurich');
       const teardownTime = await getConfig(env.NEXUS_DB, 'teardown_time', '22:00');
       const delayUntil = await getConfig(env.NEXUS_DB, 'delay_until', null);
-      
+
       info.scheduledTeardown = {
         enabled: enabled === 'true',
         timezone,
@@ -150,10 +150,10 @@ export async function onRequestGet(context) {
           info.scheduledTeardown.timeRemaining = null;
         } else {
           const now = new Date();
-          
+
           // Convert configured time in timezone to UTC
           let nextTeardown = timeInTimezoneToUTC(teardownTime, timezone);
-          
+
           // If the time has already passed today, move to tomorrow
           if (nextTeardown <= now) {
             const tomorrow = new Date(nextTeardown);
@@ -204,21 +204,21 @@ export async function onRequestGet(context) {
       const runs = workflowData.workflow_runs || [];
 
       // Find last successful spin-up (preferred) or setup
-      const lastSpinUp = runs.find(r => 
-        ((r.path && r.path.includes('spin-up.yml')) || 
+      const lastSpinUp = runs.find(r =>
+        ((r.path && (r.path.includes('spin-up.yml') || r.path.includes('spin-up-snapshot.yml'))) ||
          (r.name && (r.name.includes('Spin Up') || r.name.includes('Spin-Up')))) &&
         r.conclusion === 'success'
       );
 
-      const lastSetup = runs.find(r => 
-        ((r.path && r.path.includes('setup-control-plane.yaml')) || 
+      const lastSetup = runs.find(r =>
+        ((r.path && r.path.includes('setup-control-plane.yaml')) ||
          (r.name && r.name.includes('Setup'))) &&
         r.conclusion === 'success'
       );
 
       // Find last successful teardown
-      const lastTeardown = runs.find(r => 
-        ((r.path && r.path.includes('teardown.yml')) || 
+      const lastTeardown = runs.find(r =>
+        ((r.path && (r.path.includes('teardown.yml') || r.path.includes('teardown-snapshot.yml'))) ||
          (r.name && r.name.includes('Teardown'))) &&
         r.conclusion === 'success'
       );
@@ -277,16 +277,16 @@ export async function onRequestGet(context) {
       success: true,
       info,
     }), {
-      headers: { 
+      headers: {
         'Content-Type': 'application/json',
         'Cache-Control': 'no-cache, no-store, must-revalidate',
       },
     });
   } catch (error) {
     console.error('Info endpoint error:', error);
-    return new Response(JSON.stringify({ 
-      success: false, 
-      error: 'Internal server error' 
+    return new Response(JSON.stringify({
+      success: false,
+      error: 'Internal server error'
     }), {
       status: 500,
       headers: { 'Content-Type': 'application/json' },

--- a/control-plane/functions/api/info.js
+++ b/control-plane/functions/api/info.js
@@ -6,6 +6,7 @@
  * Configuration stored in Cloudflare D1 database
  */
 import { fetchWithTimeout } from './_utils/fetch-with-timeout.js';
+import { ALL_SPINUP_WORKFLOWS, ALL_TEARDOWN_WORKFLOWS } from './_utils/workflow-selection.js';
 
 // D1 Helper Functions
 async function getConfig(db, key, defaultValue = null) {
@@ -205,7 +206,7 @@ export async function onRequestGet(context) {
 
       // Find last successful spin-up (preferred) or setup
       const lastSpinUp = runs.find(r =>
-        ((r.path && (r.path.includes('spin-up.yml') || r.path.includes('spin-up-snapshot.yml'))) ||
+        ((r.path && ALL_SPINUP_WORKFLOWS.some((w) => r.path.includes(w))) ||
          (r.name && (r.name.includes('Spin Up') || r.name.includes('Spin-Up')))) &&
         r.conclusion === 'success'
       );
@@ -218,7 +219,7 @@ export async function onRequestGet(context) {
 
       // Find last successful teardown
       const lastTeardown = runs.find(r =>
-        ((r.path && (r.path.includes('teardown.yml') || r.path.includes('teardown-snapshot.yml'))) ||
+        ((r.path && ALL_TEARDOWN_WORKFLOWS.some((w) => r.path.includes(w))) ||
          (r.name && r.name.includes('Teardown'))) &&
         r.conclusion === 'success'
       );

--- a/control-plane/functions/api/spin-up.js
+++ b/control-plane/functions/api/spin-up.js
@@ -1,13 +1,14 @@
 /**
  * Trigger Spin-Up workflow
  * POST /api/spin-up
- * 
+ *
  * Triggers the GitHub Actions spin-up.yml workflow.
  * Reads enabled services from D1 (single source of truth).
  */
 
 import { logApiCall, logError } from './_utils/logger.js';
 import { fetchWithTimeout } from './_utils/fetch-with-timeout.js';
+import { getSpinUpWorkflow } from './_utils/workflow-selection.js';
 
 /**
  * Get enabled services from D1
@@ -26,12 +27,12 @@ async function getEnabledServicesFromD1(db) {
 
 export async function onRequestPost(context) {
   const { env } = context;
-  
+
   // Validate environment variables
   if (!env.GITHUB_TOKEN || !env.GITHUB_OWNER || !env.GITHUB_REPO) {
-    return new Response(JSON.stringify({ 
-      success: false, 
-      error: 'Missing required environment variables' 
+    return new Response(JSON.stringify({
+      success: false,
+      error: 'Missing required environment variables'
     }), {
       status: 500,
       headers: { 'Content-Type': 'application/json' },
@@ -41,7 +42,7 @@ export async function onRequestPost(context) {
   try {
     // Get enabled services from D1 (single source of truth)
     let enabledServicesList = [];
-    
+
     if (env.NEXUS_DB) {
       enabledServicesList = await getEnabledServicesFromD1(env.NEXUS_DB);
     }
@@ -53,8 +54,10 @@ export async function onRequestPost(context) {
       serviceCount: enabledServicesList.length,
     });
 
-    const url = `https://api.github.com/repos/${env.GITHUB_OWNER}/${env.GITHUB_REPO}/actions/workflows/spin-up.yml/dispatches`;
-    
+    // See teardown.js — same config key family, same allowlist.
+    const workflow = await getSpinUpWorkflow(env.NEXUS_DB);
+    const url = `https://api.github.com/repos/${env.GITHUB_OWNER}/${env.GITHUB_REPO}/actions/workflows/${workflow}/dispatches`;
+
     const response = await fetchWithTimeout(url, {
       method: 'POST',
       headers: {
@@ -63,7 +66,7 @@ export async function onRequestPost(context) {
         'User-Agent': 'Nexus-Stack-Control-Plane',
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({ 
+      body: JSON.stringify({
         ref: 'main',
         inputs: {
           enabled_services: enabledServicesList.join(',')
@@ -72,8 +75,8 @@ export async function onRequestPost(context) {
     });
 
     if (response.status === 204) {
-      return new Response(JSON.stringify({ 
-        success: true, 
+      return new Response(JSON.stringify({
+        success: true,
         message: 'Spin-up workflow triggered successfully',
         enabledServices: enabledServicesList
       }), {
@@ -84,7 +87,7 @@ export async function onRequestPost(context) {
 
     const errorText = await response.text();
     let errorMessage = `Failed to trigger workflow: ${response.status}`;
-    
+
     try {
       const errorJson = JSON.parse(errorText);
       errorMessage = errorJson.message || errorMessage;
@@ -97,9 +100,9 @@ export async function onRequestPost(context) {
     console.error(`Spin-up trigger failed: ${response.status} - ${errorMessage}`);
     await logError(env.NEXUS_DB, '/api/spin-up', 'POST', new Error(errorMessage));
 
-    return new Response(JSON.stringify({ 
-      success: false, 
-      error: errorMessage 
+    return new Response(JSON.stringify({
+      success: false,
+      error: errorMessage
     }), {
       status: response.status,
       headers: { 'Content-Type': 'application/json' },
@@ -107,9 +110,9 @@ export async function onRequestPost(context) {
   } catch (error) {
     console.error('Spin-up endpoint error:', error);
     await logError(env.NEXUS_DB, '/api/spin-up', 'POST', error);
-    return new Response(JSON.stringify({ 
-      success: false, 
-      error: error.message || 'Network error while triggering workflow' 
+    return new Response(JSON.stringify({
+      success: false,
+      error: error.message || 'Network error while triggering workflow'
     }), {
       status: 500,
       headers: { 'Content-Type': 'application/json' },

--- a/control-plane/functions/api/spin-up.js
+++ b/control-plane/functions/api/spin-up.js
@@ -2,13 +2,14 @@
  * Trigger Spin-Up workflow
  * POST /api/spin-up
  *
- * Triggers the GitHub Actions spin-up.yml workflow.
+ * Triggers the configured spin-up workflow — spin-up.yml or
+ * spin-up-snapshot.yml, selected by config.lifecycle_mode in D1.
  * Reads enabled services from D1 (single source of truth).
  */
 
 import { logApiCall, logError } from './_utils/logger.js';
 import { fetchWithTimeout } from './_utils/fetch-with-timeout.js';
-import { getSpinUpWorkflow } from './_utils/workflow-selection.js';
+import { resolveLifecycle } from './_utils/workflow-selection.js';
 
 /**
  * Get enabled services from D1
@@ -54,9 +55,20 @@ export async function onRequestPost(context) {
       serviceCount: enabledServicesList.length,
     });
 
-    // See teardown.js — same config key family, same allowlist.
-    const workflow = await getSpinUpWorkflow(env.NEXUS_DB);
-    const url = `https://api.github.com/repos/${env.GITHUB_OWNER}/${env.GITHUB_REPO}/actions/workflows/${workflow}/dispatches`;
+    // See teardown.js. Less destructive on this side — a wrong spin-up
+    // wastes an image rather than destroying one — but guessing the mode
+    // would still start the wrong half of a pair.
+    const lifecycle = await resolveLifecycle(env.NEXUS_DB);
+    if (!lifecycle.ok) {
+      return new Response(JSON.stringify({
+        success: false,
+        error: `Cannot determine the lifecycle mode (${lifecycle.reason}) — refusing to dispatch a spin-up`,
+      }), {
+        status: 503,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+    const url = `https://api.github.com/repos/${env.GITHUB_OWNER}/${env.GITHUB_REPO}/actions/workflows/${lifecycle.spinUp}/dispatches`;
 
     const response = await fetchWithTimeout(url, {
       method: 'POST',

--- a/control-plane/functions/api/status.js
+++ b/control-plane/functions/api/status.js
@@ -1,7 +1,7 @@
 /**
  * Get workflow status
  * GET /api/status
- * 
+ *
  * Returns the current infrastructure state based on GitHub Actions workflow runs.
  * More robust than before - uses workflow file paths instead of name matching.
  */
@@ -9,35 +9,42 @@ import { fetchWithTimeout } from './_utils/fetch-with-timeout.js';
 
 export async function onRequestGet(context) {
   const { env, request } = context;
-  
+
   // Validate environment variables
   const missing = [];
   if (!env.GITHUB_TOKEN) missing.push('GITHUB_TOKEN');
   if (!env.GITHUB_OWNER) missing.push('GITHUB_OWNER');
   if (!env.GITHUB_REPO) missing.push('GITHUB_REPO');
-  
+
   if (missing.length > 0) {
-    return new Response(JSON.stringify({ 
-      success: false, 
-      error: `Missing required environment variables: ${missing.join(', ')}. Configure them in Cloudflare Dashboard: Pages → Settings → Environment Variables → Secrets, or run: make setup-control-plane-secrets` 
+    return new Response(JSON.stringify({
+      success: false,
+      error: `Missing required environment variables: ${missing.join(', ')}. Configure them in Cloudflare Dashboard: Pages → Settings → Environment Variables → Secrets, or run: make setup-control-plane-secrets`
     }), {
       status: 500,
       headers: { 'Content-Type': 'application/json' },
     });
   }
 
-  // Workflow file paths (more reliable than name matching)
+  // Workflow file paths (more reliable than name matching).
+  //
+  // The two lifecycle entries are LISTS because a stack may be on either
+  // pair — see _utils/workflow-selection.js. Substring matching does not
+  // cover this on its own: 'spin-up-snapshot.yml'.includes('spin-up.yml')
+  // is false, so the snapshot runs would fall through to name matching
+  // and detection would depend on the workflow's display name.
   const WORKFLOW_PATHS = {
-    initialSetup: 'initial-setup.yaml',
-    setup: 'setup-control-plane.yaml',
-    spinUp: 'spin-up.yml',
-    teardown: 'teardown.yml',
-    destroy: 'destroy-all.yml'
+    initialSetup: ['initial-setup.yaml'],
+    setup: ['setup-control-plane.yaml'],
+    spinUp: ['spin-up.yml', 'spin-up-snapshot.yml'],
+    teardown: ['teardown.yml', 'teardown-snapshot.yml'],
+    destroy: ['destroy-all.yml']
   };
+  const matchesPath = (path, candidates) => candidates.some((c) => path.includes(c));
 
   try {
     const url = `https://api.github.com/repos/${env.GITHUB_OWNER}/${env.GITHUB_REPO}/actions/runs?per_page=100`;
-    
+
     const response = await fetchWithTimeout(url, {
       headers: {
         'Authorization': `Bearer ${env.GITHUB_TOKEN}`,
@@ -49,10 +56,10 @@ export async function onRequestGet(context) {
     if (!response.ok) {
       const errorText = await response.text();
       console.error(`GitHub API error: ${response.status} - ${errorText}`);
-      
-      return new Response(JSON.stringify({ 
-        success: false, 
-        error: `Failed to fetch workflow status: ${response.status}` 
+
+      return new Response(JSON.stringify({
+        success: false,
+        error: `Failed to fetch workflow status: ${response.status}`
       }), {
         status: response.status,
         headers: { 'Content-Type': 'application/json' },
@@ -60,11 +67,11 @@ export async function onRequestGet(context) {
     }
 
     const data = await response.json();
-    
+
     if (!data.workflow_runs || !Array.isArray(data.workflow_runs)) {
-      return new Response(JSON.stringify({ 
-        success: false, 
-        error: 'Invalid response from GitHub API' 
+      return new Response(JSON.stringify({
+        success: false,
+        error: 'Invalid response from GitHub API'
       }), {
         status: 500,
         headers: { 'Content-Type': 'application/json' },
@@ -84,32 +91,32 @@ export async function onRequestGet(context) {
     for (const run of data.workflow_runs) {
       const workflowPath = run.path || run.workflow_id || '';
       const workflowName = run.name || '';
-      
+
       // Match by path first (most reliable), then fallback to name
       // Initial Setup includes spin-up, so count it as a successful deployment
       if (!workflows.initialSetup && (
-        workflowPath.includes(WORKFLOW_PATHS.initialSetup) || 
+        matchesPath(workflowPath, WORKFLOW_PATHS.initialSetup) ||
         workflowName.includes('Initial Setup')
       )) {
         workflows.initialSetup = run;
       } else if (!workflows.setup && (
-        workflowPath.includes(WORKFLOW_PATHS.setup) || 
+        matchesPath(workflowPath, WORKFLOW_PATHS.setup) ||
         workflowName.includes('Setup') && !workflowName.includes('Initial')
       )) {
         workflows.setup = run;
       } else if (!workflows.spinUp && (
-        workflowPath.includes(WORKFLOW_PATHS.spinUp) || 
+        matchesPath(workflowPath, WORKFLOW_PATHS.spinUp) ||
         workflowName.includes('Spin Up') ||
         workflowName.includes('Spin-Up')
       )) {
         workflows.spinUp = run;
       } else if (!workflows.teardown && (
-        workflowPath.includes(WORKFLOW_PATHS.teardown) || 
+        matchesPath(workflowPath, WORKFLOW_PATHS.teardown) ||
         workflowName.includes('Teardown')
       )) {
         workflows.teardown = run;
       } else if (!workflows.destroy && (
-        workflowPath.includes(WORKFLOW_PATHS.destroy) || 
+        matchesPath(workflowPath, WORKFLOW_PATHS.destroy) ||
         workflowName.includes('Destroy')
       )) {
         workflows.destroy = run;
@@ -122,10 +129,10 @@ export async function onRequestGet(context) {
 
     // Check if any workflow is currently running
     const allRuns = [workflows.initialSetup, workflows.setup, workflows.spinUp, workflows.teardown, workflows.destroy].filter(Boolean);
-    const runningWorkflow = allRuns.find(r => 
+    const runningWorkflow = allRuns.find(r =>
       r && (r.status === 'in_progress' || r.status === 'queued')
     );
-    
+
     if (runningWorkflow) {
       inProgress = true;
       infraState = 'running';
@@ -135,19 +142,19 @@ export async function onRequestGet(context) {
       const completedRuns = [workflows.initialSetup, workflows.spinUp, workflows.teardown, workflows.destroy]
         .filter(r => r && r.conclusion === 'success')
         .sort((a, b) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime());
-      
+
       if (completedRuns.length > 0) {
         const lastRun = completedRuns[0];
         const lastPath = lastRun.path || lastRun.workflow_id || '';
         const lastName = lastRun.name || '';
-        
+
         // Initial Setup or Spin Up means infrastructure is deployed
-        if (lastPath.includes(WORKFLOW_PATHS.initialSetup) || lastName.includes('Initial Setup') ||
-            lastPath.includes(WORKFLOW_PATHS.spinUp) || lastName.includes('Spin Up') || lastName.includes('Spin-Up')) {
+        if (matchesPath(lastPath, WORKFLOW_PATHS.initialSetup) || lastName.includes('Initial Setup') ||
+            matchesPath(lastPath, WORKFLOW_PATHS.spinUp) || lastName.includes('Spin Up') || lastName.includes('Spin-Up')) {
           infraState = 'deployed';
-        } else if (lastPath.includes(WORKFLOW_PATHS.teardown) || lastName.includes('Teardown')) {
+        } else if (matchesPath(lastPath, WORKFLOW_PATHS.teardown) || lastName.includes('Teardown')) {
           infraState = 'torn-down';
-        } else if (lastPath.includes(WORKFLOW_PATHS.destroy) || lastName.includes('Destroy')) {
+        } else if (matchesPath(lastPath, WORKFLOW_PATHS.destroy) || lastName.includes('Destroy')) {
           infraState = 'destroyed';
         }
       }
@@ -190,16 +197,16 @@ export async function onRequestGet(context) {
         } : null,
       },
     }), {
-      headers: { 
+      headers: {
         'Content-Type': 'application/json',
         'Cache-Control': 'no-cache, no-store, must-revalidate',
       },
     });
   } catch (error) {
     console.error('Status endpoint error:', error);
-    return new Response(JSON.stringify({ 
-      success: false, 
-      error: 'Internal server error' 
+    return new Response(JSON.stringify({
+      success: false,
+      error: 'Internal server error'
     }), {
       status: 500,
       headers: { 'Content-Type': 'application/json' },

--- a/control-plane/functions/api/status.js
+++ b/control-plane/functions/api/status.js
@@ -6,6 +6,7 @@
  * More robust than before - uses workflow file paths instead of name matching.
  */
 import { fetchWithTimeout } from './_utils/fetch-with-timeout.js';
+import { ALL_SPINUP_WORKFLOWS, ALL_TEARDOWN_WORKFLOWS } from './_utils/workflow-selection.js';
 
 export async function onRequestGet(context) {
   const { env, request } = context;
@@ -36,8 +37,8 @@ export async function onRequestGet(context) {
   const WORKFLOW_PATHS = {
     initialSetup: ['initial-setup.yaml'],
     setup: ['setup-control-plane.yaml'],
-    spinUp: ['spin-up.yml', 'spin-up-snapshot.yml'],
-    teardown: ['teardown.yml', 'teardown-snapshot.yml'],
+    spinUp: ALL_SPINUP_WORKFLOWS,
+    teardown: ALL_TEARDOWN_WORKFLOWS,
     destroy: ['destroy-all.yml']
   };
   const matchesPath = (path, candidates) => candidates.some((c) => path.includes(c));

--- a/control-plane/functions/api/teardown.js
+++ b/control-plane/functions/api/teardown.js
@@ -1,7 +1,7 @@
 /**
  * Trigger Teardown workflow
  * POST /api/teardown
- * 
+ *
  * Triggers the GitHub Actions teardown.yml workflow.
  * Includes validation and error handling.
  */
@@ -9,6 +9,7 @@
 import { logApiCall, logError } from './_utils/logger.js';
 import { fetchWithTimeout } from './_utils/fetch-with-timeout.js';
 import { requireAdmin } from './_utils/require-admin.js';
+import { getTeardownWorkflow } from './_utils/workflow-selection.js';
 
 export async function onRequestPost(context) {
   const { env, request } = context;
@@ -17,9 +18,9 @@ export async function onRequestPost(context) {
 
   // Validate environment variables
   if (!env.GITHUB_TOKEN || !env.GITHUB_OWNER || !env.GITHUB_REPO) {
-    return new Response(JSON.stringify({ 
-      success: false, 
-      error: 'Missing required environment variables' 
+    return new Response(JSON.stringify({
+      success: false,
+      error: 'Missing required environment variables'
     }), {
       status: 500,
       headers: { 'Content-Type': 'application/json' },
@@ -32,8 +33,11 @@ export async function onRequestPost(context) {
     source: 'control-plane-ui',
   });
 
-  const url = `https://api.github.com/repos/${env.GITHUB_OWNER}/${env.GITHUB_REPO}/actions/workflows/teardown.yml/dispatches`;
-  
+  // Which pair this stack uses is a D1 config value, allowlist-checked
+  // before it reaches the URL. Defaults to teardown.yml.
+  const workflow = await getTeardownWorkflow(env.NEXUS_DB);
+  const url = `https://api.github.com/repos/${env.GITHUB_OWNER}/${env.GITHUB_REPO}/actions/workflows/${workflow}/dispatches`;
+
   try {
     const response = await fetchWithTimeout(url, {
       method: 'POST',
@@ -43,7 +47,7 @@ export async function onRequestPost(context) {
         'User-Agent': 'Nexus-Stack-Control-Plane',
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({ 
+      body: JSON.stringify({
         ref: 'main',
         inputs: {
           confirm: 'TEARDOWN'
@@ -52,9 +56,9 @@ export async function onRequestPost(context) {
     });
 
     if (response.status === 204) {
-      return new Response(JSON.stringify({ 
-        success: true, 
-        message: 'Teardown workflow triggered successfully' 
+      return new Response(JSON.stringify({
+        success: true,
+        message: 'Teardown workflow triggered successfully'
       }), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
@@ -63,7 +67,7 @@ export async function onRequestPost(context) {
 
     const errorText = await response.text();
     let errorMessage = `Failed to trigger workflow: ${response.status}`;
-    
+
     try {
       const errorJson = JSON.parse(errorText);
       errorMessage = errorJson.message || errorMessage;
@@ -75,18 +79,18 @@ export async function onRequestPost(context) {
 
     console.error(`Teardown trigger failed: ${response.status} - ${errorMessage}`);
 
-    return new Response(JSON.stringify({ 
-      success: false, 
-      error: errorMessage 
+    return new Response(JSON.stringify({
+      success: false,
+      error: errorMessage
     }), {
       status: response.status,
       headers: { 'Content-Type': 'application/json' },
     });
   } catch (error) {
     console.error('Teardown endpoint error:', error);
-    return new Response(JSON.stringify({ 
-      success: false, 
-      error: 'Network error while triggering workflow' 
+    return new Response(JSON.stringify({
+      success: false,
+      error: 'Network error while triggering workflow'
     }), {
       status: 500,
       headers: { 'Content-Type': 'application/json' },

--- a/control-plane/functions/api/teardown.js
+++ b/control-plane/functions/api/teardown.js
@@ -2,14 +2,15 @@
  * Trigger Teardown workflow
  * POST /api/teardown
  *
- * Triggers the GitHub Actions teardown.yml workflow.
+ * Triggers the configured teardown workflow — teardown.yml or
+ * teardown-snapshot.yml, selected by config.lifecycle_mode in D1.
  * Includes validation and error handling.
  */
 
 import { logApiCall, logError } from './_utils/logger.js';
 import { fetchWithTimeout } from './_utils/fetch-with-timeout.js';
 import { requireAdmin } from './_utils/require-admin.js';
-import { getTeardownWorkflow } from './_utils/workflow-selection.js';
+import { resolveLifecycle } from './_utils/workflow-selection.js';
 
 export async function onRequestPost(context) {
   const { env, request } = context;
@@ -33,10 +34,22 @@ export async function onRequestPost(context) {
     source: 'control-plane-ui',
   });
 
-  // Which pair this stack uses is a D1 config value, allowlist-checked
-  // before it reaches the URL. Defaults to teardown.yml.
-  const workflow = await getTeardownWorkflow(env.NEXUS_DB);
-  const url = `https://api.github.com/repos/${env.GITHUB_OWNER}/${env.GITHUB_REPO}/actions/workflows/${workflow}/dispatches`;
+  // Refuse rather than guess. If the lifecycle mode cannot be determined
+  // we do not know whether this stack is on snapshots, and defaulting to
+  // the legacy pair would run an untargeted `tofu destroy` that rotates
+  // every generated credential and orphans any existing snapshot.
+  // An UNCONFIGURED stack is a different case and resolves fine.
+  const lifecycle = await resolveLifecycle(env.NEXUS_DB);
+  if (!lifecycle.ok) {
+    return new Response(JSON.stringify({
+      success: false,
+      error: `Cannot determine the lifecycle mode (${lifecycle.reason}) — refusing to dispatch a teardown`,
+    }), {
+      status: 503,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+  const url = `https://api.github.com/repos/${env.GITHUB_OWNER}/${env.GITHUB_REPO}/actions/workflows/${lifecycle.teardown}/dispatches`;
 
   try {
     const response = await fetchWithTimeout(url, {

--- a/control-plane/schema.sql
+++ b/control-plane/schema.sql
@@ -98,10 +98,13 @@ INSERT OR IGNORE INTO config (key, value) VALUES
     ('notify_on_shutdown', 'true'),
     ('notify_on_spinup', 'true'),
     ('silent_mode', 'false'),
-    -- Which lifecycle workflow pair to dispatch. Defaults are the legacy
-    -- destroy-and-rebuild pair, so an existing stack is unaffected until
-    -- these are flipped. Switch BOTH together: a legacy teardown runs an
-    -- untargeted `tofu destroy` that rotates every generated credential,
-    -- which makes any existing disk snapshot unrestorable.
-    ('teardown_workflow', 'teardown.yml'),
-    ('spinup_workflow', 'spin-up.yml');
+    -- Which lifecycle workflow pair to dispatch: 'legacy' (destroy and
+    -- rebuild from ubuntu-24.04) or 'snapshot' (snapshot the disk,
+    -- destroy only the server, restore from the image).
+    --
+    -- ONE key, not one per workflow. Two independent keys could drift,
+    -- and a half-applied switch is harmful rather than merely untidy:
+    -- snapshot spin-up with legacy teardown means the nightly untargeted
+    -- `tofu destroy` rotates every generated credential and orphans the
+    -- snapshot it just produced.
+    ('lifecycle_mode', 'legacy');

--- a/control-plane/schema.sql
+++ b/control-plane/schema.sql
@@ -97,4 +97,11 @@ INSERT OR IGNORE INTO config (key, value) VALUES
     ('server_location', 'hel1'),
     ('notify_on_shutdown', 'true'),
     ('notify_on_spinup', 'true'),
-    ('silent_mode', 'false');
+    ('silent_mode', 'false'),
+    -- Which lifecycle workflow pair to dispatch. Defaults are the legacy
+    -- destroy-and-rebuild pair, so an existing stack is unaffected until
+    -- these are flipped. Switch BOTH together: a legacy teardown runs an
+    -- untargeted `tofu destroy` that rotates every generated credential,
+    -- which makes any existing disk snapshot unrestorable.
+    ('teardown_workflow', 'teardown.yml'),
+    ('spinup_workflow', 'spin-up.yml');

--- a/control-plane/worker/src/index.js
+++ b/control-plane/worker/src/index.js
@@ -63,26 +63,59 @@ async function getConfigValue(db, key, defaultValue = null) {
 
 // Lifecycle workflow selection. The Worker is a standalone bundle
 // deployed by Terraform, so it cannot import the Pages functions'
-// _utils/workflow-selection.js — the allowlist is duplicated here on
-// purpose. Keep the two in step; they are three lines each and the
-// alternative (a build step for the Worker) costs more than it saves.
+// _utils/workflow-selection.js — this is duplicated on purpose. Keep the
+// two in step; the alternative is a build step for the Worker.
 //
-// The allowlist matters: this value is interpolated into a GitHub API
-// URL path. Anything unexpected in the config table would otherwise
-// become part of that path.
-const TEARDOWN_WORKFLOWS = ['teardown.yml', 'teardown-snapshot.yml'];
-const DEFAULT_TEARDOWN_WORKFLOW = 'teardown.yml';
+// ONE mode, both names derived from it, so the pair cannot drift.
+// Deriving rather than reading the names also means no database value
+// ever reaches the GitHub API URL path.
+const LIFECYCLE_MODES = ['legacy', 'snapshot'];
+const DEFAULT_LIFECYCLE_MODE = 'legacy';
+const LIFECYCLE_WORKFLOWS = {
+  legacy: { teardown: 'teardown.yml', spinUp: 'spin-up.yml' },
+  snapshot: { teardown: 'teardown-snapshot.yml', spinUp: 'spin-up-snapshot.yml' },
+};
 
-async function getTeardownWorkflow(db) {
-  const value = await getConfigValue(db, 'teardown_workflow', null);
-  if (!value) return DEFAULT_TEARDOWN_WORKFLOW;
-  if (!TEARDOWN_WORKFLOWS.includes(value)) {
-    console.error(
-      `config.teardown_workflow is not a known workflow: ${JSON.stringify(value)} — using ${DEFAULT_TEARDOWN_WORKFLOW}`
-    );
-    return DEFAULT_TEARDOWN_WORKFLOW;
+// Returns {ok:true, mode, teardown, spinUp} or {ok:false, reason}.
+//
+// Deliberately does NOT fall back to a default when the mode cannot be
+// determined. This runs unattended every night, and the legacy pair is
+// the destructive one: guessing it at a stack that is on snapshots would
+// run an untargeted `tofu destroy`, rotate all 81 generated credentials
+// and orphan the snapshot. An unconfigured stack is a different case and
+// resolves successfully to 'legacy'.
+async function resolveLifecycle(db) {
+  if (!db) {
+    // Short-circuit rather than letting getConfigValue throw and be
+    // caught — a missing binding is a known state, not an exception, and
+    // it would otherwise log a stack trace on every scheduled run.
+    return { ok: false, reason: 'no D1 binding available' };
   }
-  return value;
+
+  let row;
+  try {
+    row = await db
+      .prepare('SELECT value FROM config WHERE key = ?')
+      .bind('lifecycle_mode')
+      .first();
+  } catch (error) {
+    console.error('Failed to read config.lifecycle_mode from D1:', error);
+    return { ok: false, reason: 'D1 read failed' };
+  }
+
+  const value = row ? row.value : null;
+  if (!value) {
+    return { ok: true, mode: DEFAULT_LIFECYCLE_MODE, ...LIFECYCLE_WORKFLOWS[DEFAULT_LIFECYCLE_MODE] };
+  }
+  if (!LIFECYCLE_MODES.includes(value)) {
+    // The value itself is never logged: it is an unvalidated database
+    // string, and a secret written to the wrong key would be retained.
+    console.error(
+      `config.lifecycle_mode holds an unrecognised value (expected one of: ${LIFECYCLE_MODES.join(', ')})`
+    );
+    return { ok: false, reason: 'unrecognised lifecycle_mode' };
+  }
+  return { ok: true, mode: value, ...LIFECYCLE_WORKFLOWS[value] };
 }
 
 async function deleteConfigValue(db, key) {
@@ -402,8 +435,8 @@ async function checkInfraStatus(env) {
     // would silently stop scheduled teardowns.
     const WORKFLOW_PATHS = {
       initialSetup: ['initial-setup.yaml'],
-      spinUp: ['spin-up.yml', 'spin-up-snapshot.yml'],
-      teardown: ['teardown.yml', 'teardown-snapshot.yml'],
+      spinUp: LIFECYCLE_MODES.map((m) => LIFECYCLE_WORKFLOWS[m].spinUp),
+      teardown: LIFECYCLE_MODES.map((m) => LIFECYCLE_WORKFLOWS[m].teardown),
       destroy: ['destroy-all.yml'],
     };
     const matchesPath = (path, candidates) => candidates.some((c) => path.includes(c));
@@ -609,13 +642,19 @@ async function triggerTeardown(env, config) {
   }
 
   try {
-    // The scheduled teardown is the one that runs unattended every night,
-    // so it is the single most important place for this to be config-driven:
-    // while it still hard-coded teardown.yml, every night's untargeted
-    // `tofu destroy` rotated all 81 generated credentials and left the
-    // previous day's disk snapshot unrestorable.
-    const workflow = await getTeardownWorkflow(env.NEXUS_DB);
-    const url = `https://api.github.com/repos/${env.GITHUB_OWNER}/${env.GITHUB_REPO}/actions/workflows/${workflow}/dispatches`;
+    // The scheduled teardown runs unattended every night, which makes
+    // this the single most important place not to guess. Skipping costs
+    // one more day of server time; guessing wrong destroys a snapshot
+    // and rotates every credential. The stack stays up and the next run
+    // retries.
+    const lifecycle = await resolveLifecycle(env.NEXUS_DB);
+    if (!lifecycle.ok) {
+      const message = `Skipping scheduled teardown: cannot determine the lifecycle mode (${lifecycle.reason})`;
+      console.error(message);
+      await logToD1(env.NEXUS_DB, 'error', message);
+      return;
+    }
+    const url = `https://api.github.com/repos/${env.GITHUB_OWNER}/${env.GITHUB_REPO}/actions/workflows/${lifecycle.teardown}/dispatches`;
 
     const response = await fetchWithTimeout(url, {
       method: 'POST',

--- a/control-plane/worker/src/index.js
+++ b/control-plane/worker/src/index.js
@@ -61,6 +61,30 @@ async function getConfigValue(db, key, defaultValue = null) {
   }
 }
 
+// Lifecycle workflow selection. The Worker is a standalone bundle
+// deployed by Terraform, so it cannot import the Pages functions'
+// _utils/workflow-selection.js — the allowlist is duplicated here on
+// purpose. Keep the two in step; they are three lines each and the
+// alternative (a build step for the Worker) costs more than it saves.
+//
+// The allowlist matters: this value is interpolated into a GitHub API
+// URL path. Anything unexpected in the config table would otherwise
+// become part of that path.
+const TEARDOWN_WORKFLOWS = ['teardown.yml', 'teardown-snapshot.yml'];
+const DEFAULT_TEARDOWN_WORKFLOW = 'teardown.yml';
+
+async function getTeardownWorkflow(db) {
+  const value = await getConfigValue(db, 'teardown_workflow', null);
+  if (!value) return DEFAULT_TEARDOWN_WORKFLOW;
+  if (!TEARDOWN_WORKFLOWS.includes(value)) {
+    console.error(
+      `config.teardown_workflow is not a known workflow: ${JSON.stringify(value)} — using ${DEFAULT_TEARDOWN_WORKFLOW}`
+    );
+    return DEFAULT_TEARDOWN_WORKFLOW;
+  }
+  return value;
+}
+
 async function deleteConfigValue(db, key) {
   await db.prepare('DELETE FROM config WHERE key = ?').bind(key).run();
 }
@@ -371,12 +395,18 @@ async function checkInfraStatus(env) {
       return 'unknown';
     }
 
+    // Detection lists, not dispatch targets. Both pairs must be
+    // recognised regardless of which one is configured, otherwise the
+    // Control Plane reports 'unknown' infra state the moment a stack
+    // switches — and the Worker fail-closes on unknown state, which
+    // would silently stop scheduled teardowns.
     const WORKFLOW_PATHS = {
-      initialSetup: 'initial-setup.yaml',
-      spinUp: 'spin-up.yml',
-      teardown: 'teardown.yml',
-      destroy: 'destroy-all.yml',
+      initialSetup: ['initial-setup.yaml'],
+      spinUp: ['spin-up.yml', 'spin-up-snapshot.yml'],
+      teardown: ['teardown.yml', 'teardown-snapshot.yml'],
+      destroy: ['destroy-all.yml'],
     };
+    const matchesPath = (path, candidates) => candidates.some((c) => path.includes(c));
 
     // Find the most recent run for each relevant workflow
     const workflows = { initialSetup: null, spinUp: null, teardown: null, destroy: null };
@@ -385,13 +415,13 @@ async function checkInfraStatus(env) {
       const path = run.path || '';
       const name = run.name || '';
 
-      if (!workflows.initialSetup && (path.includes(WORKFLOW_PATHS.initialSetup) || name.includes('Initial Setup'))) {
+      if (!workflows.initialSetup && (matchesPath(path, WORKFLOW_PATHS.initialSetup) || name.includes('Initial Setup'))) {
         workflows.initialSetup = run;
-      } else if (!workflows.spinUp && (path.includes(WORKFLOW_PATHS.spinUp) || name.includes('Spin Up') || name.includes('Spin-Up'))) {
+      } else if (!workflows.spinUp && (matchesPath(path, WORKFLOW_PATHS.spinUp) || name.includes('Spin Up') || name.includes('Spin-Up'))) {
         workflows.spinUp = run;
-      } else if (!workflows.teardown && (path.includes(WORKFLOW_PATHS.teardown) || name.includes('Teardown'))) {
+      } else if (!workflows.teardown && (matchesPath(path, WORKFLOW_PATHS.teardown) || name.includes('Teardown'))) {
         workflows.teardown = run;
-      } else if (!workflows.destroy && (path.includes(WORKFLOW_PATHS.destroy) || name.includes('Destroy'))) {
+      } else if (!workflows.destroy && (matchesPath(path, WORKFLOW_PATHS.destroy) || name.includes('Destroy'))) {
         workflows.destroy = run;
       }
     }
@@ -415,13 +445,13 @@ async function checkInfraStatus(env) {
       const lastName = lastRun.name || '';
       const lastConclusion = lastRun.conclusion || '';
 
-      if (lastPath.includes(WORKFLOW_PATHS.initialSetup) || lastName.includes('Initial Setup') ||
-          lastPath.includes(WORKFLOW_PATHS.spinUp) || lastName.includes('Spin Up') || lastName.includes('Spin-Up')) {
+      if (matchesPath(lastPath, WORKFLOW_PATHS.initialSetup) || lastName.includes('Initial Setup') ||
+          matchesPath(lastPath, WORKFLOW_PATHS.spinUp) || lastName.includes('Spin Up') || lastName.includes('Spin-Up')) {
         return 'deployed';
-      } else if (lastPath.includes(WORKFLOW_PATHS.teardown) || lastName.includes('Teardown')) {
+      } else if (matchesPath(lastPath, WORKFLOW_PATHS.teardown) || lastName.includes('Teardown')) {
         // If teardown failed, infra is likely still deployed
         return lastConclusion === 'success' ? 'torn-down' : 'deployed';
-      } else if (lastPath.includes(WORKFLOW_PATHS.destroy) || lastName.includes('Destroy')) {
+      } else if (matchesPath(lastPath, WORKFLOW_PATHS.destroy) || lastName.includes('Destroy')) {
         // If destroy failed, infra is at least torn down but not fully offline
         return lastConclusion === 'success' ? 'offline' : 'torn-down';
       }
@@ -579,7 +609,13 @@ async function triggerTeardown(env, config) {
   }
 
   try {
-    const url = `https://api.github.com/repos/${env.GITHUB_OWNER}/${env.GITHUB_REPO}/actions/workflows/teardown.yml/dispatches`;
+    // The scheduled teardown is the one that runs unattended every night,
+    // so it is the single most important place for this to be config-driven:
+    // while it still hard-coded teardown.yml, every night's untargeted
+    // `tofu destroy` rotated all 81 generated credentials and left the
+    // previous day's disk snapshot unrestorable.
+    const workflow = await getTeardownWorkflow(env.NEXUS_DB);
+    const url = `https://api.github.com/repos/${env.GITHUB_OWNER}/${env.GITHUB_REPO}/actions/workflows/${workflow}/dispatches`;
 
     const response = await fetchWithTimeout(url, {
       method: 'POST',


### PR DESCRIPTION
## Summary

Makes the Control Plane dispatch a configurable lifecycle workflow pair instead of hard-coded filenames. This is the opt-in switch for the snapshot lifecycle built in #649 and #651 — without it, that work cannot be used at all.

**Nothing changes for an existing stack.** The config keys default to the legacy names, so behaviour is identical until a row is flipped.

## Why this is urgent rather than tidy

The scheduled teardown Worker hard-codes `teardown.yml`. That workflow runs an **untargeted** `tofu destroy`, which destroys all 81 `random_password` / `random_id` / `random_string` resources and regenerates every service credential on the next spin-up.

A disk snapshot captures Postgres roles and app admin accounts as they were. Once the credentials rotate, the epoch guard added in #649 correctly refuses that snapshot and falls back to a fresh build — the mechanism behaves as designed, but the snapshot is dead.

This is not hypothetical. It happened on **2026-08-21 at 21:00**, one night after the first real snapshot was taken:

```
21:00  teardown.yml  →  "Teardown Hetzner infrastructure only"  →  untargeted tofu destroy
```

So as long as this PR is unmerged, every night makes the previous day's snapshot unusable, and the restore path cannot be tested.

## What changes

| Concern | Before | After |
|---|---|---|
| Which pair is dispatched | hard-coded in 5 places | D1 config: `teardown_workflow` / `spinup_workflow` |
| Switching | code change + deploy | one D1 row |
| Rolling back | revert | the same row |

Touched: the scheduled Worker, `functions/api/teardown.js`, `functions/api/spin-up.js`, plus the detection sites in the Worker, `status.js` and `info.js`. Defaults are added to `schema.sql`.

## Two things worth reviewing closely

**The values are allowlist-checked.** They are interpolated into a GitHub API URL path (`/actions/workflows/<value>/dispatches`), so an unexpected config value would become part of that path. Only the four known filenames are accepted; anything else falls back to the legacy default and logs why.

Reads never throw. A Control Plane that cannot read its own config should still be able to tear down, and doing that on the legacy path is the safe default. Verified against a valid value, the legacy value, an unset key, a path-traversal value, a wrong-family value, an unreachable D1 and a missing binding — every failure mode lands on `teardown.yml`.

**Detection is widened separately from dispatch.** Both pairs are recognised everywhere runs are matched, regardless of which is configured. Substring matching does not cover this by itself:

```js
'spin-up-snapshot.yml'.includes('spin-up.yml')  // false
```

Getting this wrong reports infra state as `unknown`, and the Worker **fail-closes** on unknown state — it would silently stop scheduled teardowns rather than fail loudly. A check covers all five workflow paths, including that `teardown-snapshot` is not misread as a spin-up.

## A bug I introduced and caught

Widening `WORKFLOW_PATHS` from strings to arrays left four call sites in the Worker still on `path.includes(WORKFLOW_PATHS.x)`. That coerces an array to a string and never matches, which would have broken state detection outright — and per the paragraph above, silently. Found by grepping for remaining call sites after the change rather than by the syntax check, which was perfectly happy.

## Deliberate duplication

The Worker keeps its own copy of the allowlist. It is a standalone bundle deployed by Terraform and cannot import the Pages functions' `_utils/workflow-selection.js`. Three lines duplicated, versus adding a build step for the Worker. The two are marked as needing to stay in step.

## How to switch a stack

```sql
UPDATE config SET value = 'teardown-snapshot.yml' WHERE key = 'teardown_workflow';
UPDATE config SET value = 'spin-up-snapshot.yml'  WHERE key = 'spinup_workflow';
```

**Switch both together.** A snapshot teardown followed by a legacy spin-up wastes the image; a legacy teardown after a snapshot spin-up rotates the credentials and orphans the snapshot.

## Testing

JavaScript only — no Python or workflow files are touched, so the Python suite and actionlint are unaffected.

Verified: `node --check` on all six changed files; the detection logic exercised over all five workflow paths plus a cross-contamination case; the allowlist exercised over seven inputs including path traversal and an unreachable database.

**Not verified end to end.** The Worker is deployed by Terraform during `setup-control-plane`, so the config-driven dispatch only takes effect after the next Control Plane deploy. First real check: run one scheduled or manual teardown with the defaults in place and confirm it still dispatches `teardown.yml`, before flipping anything.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for selecting standard or snapshot workflows for spin-up and teardown operations.
  * Added safe defaults when workflow configuration is missing or invalid.
* **Bug Fixes**
  * Improved deployment and infrastructure status detection for snapshot workflow runs.
  * Ensured invalid workflow settings do not prevent lifecycle operations from running.
* **Configuration**
  * Added default workflow settings for spin-up and teardown actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->