### PR TITLE
docs: Document the snapshot lifecycle

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,19 +50,20 @@ Nexus-Stack is an **open-source infrastructure-as-code project** that provides o
 Nexus-Stack/
 ├── Makefile                    # Main entry point - all commands here
 ├── README.md                   # User documentation
-├── AGENTS.md                   # Agent instructions (this file)
+├── CLAUDE.md                   # Agent instructions (this file)
+├── AGENTS.md                   # Deprecated stub, points at CLAUDE.md
 ├── services.yaml               # Service metadata (subdomain, port, description, image)
 ├── .github/
 │   ├── actions/               # Composite actions shared by the workflows
 │   │   ├── nexus-bootstrap/    # OpenTofu + uv + cloudflared + SSH key + R2 creds
-│   │   └── nexus-config-tfvars/# Generates tofu/stack/config.tfvars
+│   │   └── nexus-config-tfvars/ # Generates tofu/stack/config.tfvars
 │   └── workflows/             # GitHub Actions workflows
 │       ├── initial-setup.yaml  # Initial setup (triggers Control Plane + Spin Up)
 │       ├── setup-control-plane.yaml # Setup Control Plane only
 │       ├── spin-up.yml         # Spin-up workflow (re-deploy after teardown)
 │       ├── teardown.yml        # Teardown workflow (stops infrastructure)
-│       ├── spin-up-snapshot.yml# Spin-up restoring from a Hetzner disk snapshot
-│       ├── teardown-snapshot.yml# Teardown that snapshots the disk first
+│       ├── spin-up-snapshot.yml # Spin-up restoring from a Hetzner disk snapshot
+│       ├── teardown-snapshot.yml # Teardown that snapshots the disk first
 │       ├── destroy-all.yml     # Destroy workflow (full cleanup)
 │       └── release.yml         # Release workflow
 ├── tofu/                       # OpenTofu/Terraform configuration
@@ -111,7 +112,7 @@ Nexus-Stack/
     │   ├── ssh-access.md       # SSH via Cloudflare Tunnel
     │   ├── snapshot-lifecycle.md # Disk-snapshot teardown/spin-up: switching + rollback
     │   ├── troubleshooting.md  # Common operational issues
-    │   └── docs-website-sync.md# How these docs sync to nexus-stack.ch
+    │   └── docs-website-sync.md # How these docs sync to nexus-stack.ch
     ├── stacks/                 # Per-service documentation (one .md per service)
     └── tutorials/              # Tutorials and walkthroughs
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,11 +53,16 @@ Nexus-Stack/
 ├── AGENTS.md                   # Agent instructions (this file)
 ├── services.yaml               # Service metadata (subdomain, port, description, image)
 ├── .github/
+│   ├── actions/               # Composite actions shared by the workflows
+│   │   ├── nexus-bootstrap/    # OpenTofu + uv + cloudflared + SSH key + R2 creds
+│   │   └── nexus-config-tfvars/# Generates tofu/stack/config.tfvars
 │   └── workflows/             # GitHub Actions workflows
 │       ├── initial-setup.yaml  # Initial setup (triggers Control Plane + Spin Up)
 │       ├── setup-control-plane.yaml # Setup Control Plane only
 │       ├── spin-up.yml         # Spin-up workflow (re-deploy after teardown)
 │       ├── teardown.yml        # Teardown workflow (stops infrastructure)
+│       ├── spin-up-snapshot.yml# Spin-up restoring from a Hetzner disk snapshot
+│       ├── teardown-snapshot.yml# Teardown that snapshots the disk first
 │       ├── destroy-all.yml     # Destroy workflow (full cleanup)
 │       └── release.yml         # Release workflow
 ├── tofu/                       # OpenTofu/Terraform configuration
@@ -104,6 +109,7 @@ Nexus-Stack/
     │   ├── setup-guide.md      # Initial infrastructure setup
     │   ├── debugging.md        # Log inspection, systemd, Docker
     │   ├── ssh-access.md       # SSH via Cloudflare Tunnel
+    │   ├── snapshot-lifecycle.md # Disk-snapshot teardown/spin-up: switching + rollback
     │   ├── troubleshooting.md  # Common operational issues
     │   └── docs-website-sync.md# How these docs sync to nexus-stack.ch
     ├── stacks/                 # Per-service documentation (one .md per service)
@@ -119,6 +125,22 @@ gh workflow run spin-up.yml         # Re-deploy after teardown
 gh workflow run teardown.yml        # Stop infrastructure
 gh workflow run destroy-all.yml -f confirm=DESTROY  # Full cleanup
 ```
+
+**Two lifecycles.** `spin-up.yml` / `teardown.yml` destroy and rebuild from
+`ubuntu-24.04`. `spin-up-snapshot.yml` / `teardown-snapshot.yml` take a Hetzner
+disk snapshot and restore from it — faster, and the only path that preserves
+data for stacks outside the five the R2 layer covers.
+
+Which pair a stack uses is the D1 config value `lifecycle_mode`
+(`legacy` | `snapshot`), read by the Control Plane. **Never dispatch the two
+pairs at the same stack interchangeably**: the legacy teardown runs an
+untargeted `tofu destroy` that regenerates all 81 service credentials, and the
+epoch guard then correctly refuses any existing snapshot. That is why it is one
+config key rather than one per workflow.
+
+See [docs/admin-guides/snapshot-lifecycle.md](docs/admin-guides/snapshot-lifecycle.md)
+for switching and rollback, and `docs/proposals/0002-hetzner-disk-snapshots.md`
+for the design.
 
 **Debugging Tools (local, requires SSH):**
 ```bash

--- a/docs/admin-guides/snapshot-lifecycle.md
+++ b/docs/admin-guides/snapshot-lifecycle.md
@@ -1,0 +1,166 @@
+---
+title: "Snapshot Lifecycle"
+description: "Restore the server from a Hetzner disk snapshot instead of rebuilding it, and how to get back if that goes wrong"
+order: 6
+---
+
+# Snapshot Lifecycle
+
+Nexus-Stack has two teardown/spin-up pairs. This guide covers the second one, when to use it, and — more importantly — how to get out of it.
+
+| Mode | Teardown | Spin-up | What happens |
+|---|---|---|---|
+| `legacy` | `teardown.yml` | `spin-up.yml` | Destroy everything, rebuild from `ubuntu-24.04` |
+| `snapshot` | `teardown-snapshot.yml` | `spin-up-snapshot.yml` | Snapshot the disk, destroy only the server, restore from the image |
+
+**The default is `legacy`.** Nothing changes until you switch.
+
+---
+
+## Why you might want it
+
+Two reasons, and the second is the stronger one.
+
+**Speed.** Measured on real runs in August 2026, same service set:
+
+| | cold (rebuild) | warm | difference |
+|---|---|---|---|
+| cloud-init gate | 78 s | 14 s | −64 s |
+| `Deploy stacks` | 257 s | 148 s | −109 s |
+
+A restore skips both: cloud-init takes a light path, and the Docker images are already on the disk. Roughly **3 minutes on a small service set**, scaling with the number of images. The cost lands on the teardown (~2 min → ~2.5 min), which runs unattended at 21:00.
+
+**Data coverage.** The R2 persistence layer covers a hard-coded five-stack subset — Postgres dumps for gitea, dify, hedgedoc and planka, plus filesystem trees for those and metabase. Everything else is discarded on teardown. `s3_restore.standard_targets()` says so directly:
+
+> Skipping this step means the stack's bind-mount under `/mnt/nexus-data/<stack>/` is purely ephemeral — present across container restarts on the same VM, gone the moment `tofu destroy` re-creates the host.
+
+A disk snapshot captures the whole root disk, so **all ~76 stacks** survive a teardown rather than five. It also needs no per-stack maintenance, where the hard-coded list silently makes every new stack ephemeral until someone remembers to extend it.
+
+---
+
+## Switching a stack
+
+Two steps, in this order.
+
+### 1. Deploy the Control Plane
+
+The scheduled-teardown Worker is deployed by Terraform. A Worker that predates this feature does not know the `lifecycle_mode` key at all, so the config change would have no effect on the nightly run.
+
+```bash
+gh workflow run setup-control-plane.yaml
+```
+
+### 2. Flip the mode
+
+```bash
+npx wrangler@4 d1 execute nexus-<your-domain-with-dashes>-db --remote \
+  --command "UPDATE config SET value = 'snapshot' WHERE key = 'lifecycle_mode'"
+```
+
+Valid values are `legacy` and `snapshot`. Anything else is refused — see [When the mode cannot be determined](#when-the-mode-cannot-be-determined).
+
+**One key controls both workflows on purpose.** An earlier design had one key per workflow and it was wrong: a half-applied switch means snapshot spin-up with legacy teardown, and the legacy teardown runs an untargeted `tofu destroy` that regenerates every service credential — which orphans the snapshot it just produced.
+
+### 3. Verify before relying on it
+
+`teardown-snapshot.yml` takes a `skip_destroy` input that runs the whole sequence and then powers the server back on, destroying nothing:
+
+```bash
+gh workflow run teardown-snapshot.yml -f confirm=TEARDOWN -f skip_destroy=true
+```
+
+Cost: one power cycle. Check afterwards that the image appears in the Hetzner console with the `nexus_role`, `nexus_domain` and `nexus_epoch` labels, and that the stack came back up.
+
+---
+
+## Switching back
+
+```bash
+npx wrangler@4 d1 execute nexus-<domain>-db --remote \
+  --command "UPDATE config SET value = 'legacy' WHERE key = 'lifecycle_mode'"
+```
+
+That is the whole rollback. The legacy workflows were never modified and do not depend on anything the snapshot path added.
+
+For a single run rather than a permanent switch, `spin-up-snapshot.yml` takes `force_fresh=true`, which ignores any snapshot and builds from `ubuntu-24.04`.
+
+---
+
+## What can go wrong
+
+### The snapshot is refused and the stack rebuilds fresh
+
+This is the **designed** behaviour, not a fault. A snapshot is only used when it is genuinely usable. It is skipped when:
+
+- there is none yet (first spin-up after switching)
+- it was pruned
+- its credential epoch no longer matches
+- its architecture or disk size cannot be satisfied by any available server type
+
+In every case the spin-up falls back to a normal `ubuntu-24.04` build **with R2 restore enabled**, so the five R2-covered stacks keep their data. The other stacks come back empty — the same as the legacy path has always behaved.
+
+The workflow log names the reason.
+
+### The credential epoch stopped matching
+
+Symptom: every spin-up rebuilds fresh, and the log says the snapshot was rejected on epoch.
+
+Cause: the legacy `teardown.yml` ran at some point. Its untargeted `tofu destroy` destroys all 81 `random_password` / `random_id` / `random_string` resources, so every service credential is regenerated on the next spin-up. A snapshot taken before that holds Postgres roles and admin accounts with the old passwords; restoring it would produce a stack that boots and then authenticates nowhere.
+
+The guard exists precisely to prevent that, so this is the mechanism working. The snapshot is dead, though — take a fresh one on the next teardown.
+
+**Do not mix the two teardowns on one stack.** That is what `lifecycle_mode` being a single key is for.
+
+### The restore cannot find a server type
+
+Symptom: `select-capacity` reports that every preference was excluded, and the spin-up stops.
+
+Cause: a Hetzner snapshot is architecture-locked and requires a target disk **at least as large** as the source server's. `DEFAULT_PREFERENCES` mixes disk sizes across tiers, so a snapshot taken on a large tier excludes the smaller ones.
+
+This is a one-way ratchet: restore a 160 GB snapshot onto a 240 GB server and the *next* snapshot is 240 GB, permanently excluding 160 GB types.
+
+Fixes, in order of preference:
+
+1. Widen `SERVER_PREFERENCES` to include types that can host it
+2. Run once with `force_fresh=true` to rebuild from the base image, which resets the ratchet
+
+Do not trust the tier comments in `hetzner_capacity.py` for disk sizes — they were wrong once already. `fetch_server_types` reads the real values from the API at runtime.
+
+### The snapshot limit is reached
+
+Hetzner allows **30 snapshots across all projects** by default. Retention keeps 2 per stack, so a single project supports roughly 15 stacks before this bites. `snapshot-create` counts before creating and warns near the cap; it fails loudly naming foreign snapshots rather than deleting anything it does not own.
+
+Ask Hetzner support to raise the limit, or reduce retention.
+
+### When the mode cannot be determined
+
+If D1 is unreachable, the binding is missing, or `lifecycle_mode` holds an unrecognised value, **nothing is dispatched**:
+
+- the scheduled Worker skips that night's teardown and logs why
+- the Control Plane API returns `503`
+
+This is deliberate. "Cannot tell" is not "not configured": guessing would fall back to the legacy pair, which is the *destructive* one, and running it at a stack that is on snapshots would rotate every credential and orphan the snapshot. Skipping costs one more day of server time; guessing wrong costs the snapshot.
+
+An **unconfigured** stack — no row at all — is a different case and resolves to `legacy` without complaint.
+
+---
+
+## Costs
+
+Hetzner bills snapshots on **used** space, not the disk size, at roughly EUR 0.011–0.014 per GB per month. At two retained snapshots that is on the order of EUR 1–2 per month — small against the server, not zero.
+
+Note the two figures are different and easy to confuse:
+
+- `disk_size` — the source server's whole disk. Decides which types can host the image.
+- `image_size` — compressed used space. What you pay for.
+
+Both are reported by `snapshot-create` and `snapshot-resolve`.
+
+---
+
+## Related
+
+- [Server Resize](./server-resize.md) — changing server type; interacts with the disk ratchet above
+- [SSH Access](./ssh-access.md) — needed for the verification steps
+- [Troubleshooting](./troubleshooting.md) — general operational issues
+- `docs/proposals/0002-hetzner-disk-snapshots.md` — the design and why it looks like this

--- a/docs/admin-guides/snapshot-lifecycle.md
+++ b/docs/admin-guides/snapshot-lifecycle.md
@@ -40,7 +40,7 @@ A disk snapshot captures the whole root disk, so **all ~76 stacks** survive a te
 
 ## Switching a stack
 
-Two steps, in this order.
+Three steps, in this order. The third is not optional for a first switch — it is the only thing that proves the mechanism works before you rely on it.
 
 ### 1. Deploy the Control Plane
 
@@ -53,9 +53,13 @@ gh workflow run setup-control-plane.yaml
 ### 2. Flip the mode
 
 ```bash
-npx wrangler@4 d1 execute nexus-<your-domain-with-dashes>-db --remote \
+npx wrangler@4 d1 execute nexus-<domain-slug>-db --remote \
   --command "UPDATE config SET value = 'snapshot' WHERE key = 'lifecycle_mode'"
 ```
+
+`<domain-slug>` is your domain with dots replaced by hyphens — for
+`nexus-stack.ch` the database is `nexus-nexus-stack-ch-db`. Same convention as
+the R2 buckets described in [Setup Guide](./setup-guide.md).
 
 Valid values are `legacy` and `snapshot`. Anything else is refused — see [When the mode cannot be determined](#when-the-mode-cannot-be-determined).
 
@@ -76,7 +80,7 @@ Cost: one power cycle. Check afterwards that the image appears in the Hetzner co
 ## Switching back
 
 ```bash
-npx wrangler@4 d1 execute nexus-<domain>-db --remote \
+npx wrangler@4 d1 execute nexus-<domain-slug>-db --remote \
   --command "UPDATE config SET value = 'legacy' WHERE key = 'lifecycle_mode'"
 ```
 

--- a/docs/proposals/0002-hetzner-disk-snapshots.md
+++ b/docs/proposals/0002-hetzner-disk-snapshots.md
@@ -1,0 +1,159 @@
+# RFC 0002 — Hetzner Disk Snapshots as a Second Lifecycle
+
+**Status:** implemented (#649, #651, #653), not yet exercised end to end
+**Supersedes:** nothing. Complements [RFC 0001](./0001-s3-persistence.md).
+
+## tl;dr
+
+Add a second teardown/spin-up pair that takes a Hetzner disk snapshot before destroying the server and restores from it on the next spin-up, selected per stack by a single D1 config value. The existing pair is untouched and remains the default.
+
+The headline is speed, but the stronger argument is coverage: RFC 0001's R2 layer protects five stacks by name; a disk snapshot protects all of them.
+
+## Motivation
+
+### What the current cycle repeats
+
+Every teardown destroys the whole stack; every spin-up rebuilds it from `ubuntu-24.04`. Most of that rebuild is work already done: patching Ubuntu, installing Docker, and pulling the same container images.
+
+Measured across real workflow runs (May–August 2026):
+
+| Phase | Duration | Share |
+|---|---|---|
+| Spin-up total | 3m49s – 9m47s | |
+| of which `Deploy stacks` | 99–465 s | ~87% |
+| of which cloud-init gate (cold) | 42–123 s | |
+| of which `Apply infrastructure` | 9–21 s | |
+| Teardown total | ~2 min | |
+
+Within `Deploy stacks`, Docker image pulls are the single largest block. A cold/warm comparison of the same service set isolates it:
+
+| | cold | warm | delta |
+|---|---|---|---|
+| cloud-init gate | 78 s | 14 s | −64 s |
+| `Deploy stacks` | 257 s | 148 s | −109 s |
+
+A restore skips both.
+
+### The part that is not about speed
+
+RFC 0001 moved persistence to R2 and, in doing so, made the covered set explicit and finite. `s3_restore.standard_targets()` lists Postgres dumps for gitea, dify, hedgedoc and planka, plus filesystem trees for those and metabase. Its own docstring states the consequence for everything else:
+
+> Skipping this step means the stack's bind-mount under `/mnt/nexus-data/<stack>/` is purely ephemeral — present across container restarts on the same VM, gone the moment `tofu destroy` re-creates the host.
+
+That is five stacks out of roughly seventy-six. A disk snapshot captures the whole root disk, which after RFC 0001's volume removal holds both the bind mounts and the Docker named volumes. It also requires no per-stack registration, so a new stack is protected by default rather than silently ephemeral until someone extends a list.
+
+### What this is NOT
+
+- **Not a replacement for RFC 0001.** R2 remains, runs first on every snapshot teardown, and is the recovery path whenever a snapshot is unavailable, epoch-mismatched or architecture-incompatible. It is also logically consistent (`pg_dump`) where a disk image is not, and portable where a snapshot is vendor- and architecture-locked.
+- **Not the default.** Stacks stay on the legacy pair until switched.
+- **Not a backup.** Retention is two generations and the images live in the same Hetzner project as the server.
+
+## Design
+
+### Targeted destroy, not out-of-band deletion
+
+```
+tofu destroy -target=hcloud_server.main
+```
+
+The original sketch was to delete the server outside OpenTofu. Targeted destroy is better on three counts:
+
+1. **Credentials survive.** All 81 `random_password` / `random_id` / `random_string` resources stay in state, so service credentials remain stable. A snapshot captures Postgres roles and app admin accounts as they were; restoring it against regenerated credentials produces a stack that boots and then authenticates nowhere.
+2. **So does everything else that is free to keep.** Tunnel, tunnel config, every DNS record, every Access application and policy. The restored server's baked-in `cloudflared` config still matches, so that work is skipped too.
+3. **State stays truthful.** An out-of-band delete leaves `hcloud_server.main` in state, where the partial-state guard in `pipeline.py` would then try to SSH to a server that no longer exists.
+
+The one resource destroyed alongside the server is `cloudflare_record.firewall_tcp`, which depends on its IPv4 address. That is desirable rather than incidental: the address is about to be reassigned to another Hetzner customer, and an out-of-band delete would leave that unproxied A record live for the whole downtime window.
+
+### Ordering is the safety property
+
+1. R2 logical snapshot — first, while containers still run, since it needs `docker exec … pg_dump`
+2. Power off, polled to `status=off` — Hetzner recommends it, and the graceful stop is what makes the captured Postgres directories trustworthy
+3. `create_image`, waited to `available` — the action reaching `success` means the copy finished; only `available` means it can create a server
+4. Mirror metadata to D1
+5. **Only then** destroy
+6. Prune older generations, keep 2 — after the new one is available, never before
+
+### One config value, not two
+
+`lifecycle_mode` is `legacy` or `snapshot`, and both workflow filenames are derived from it.
+
+The first implementation used one key per workflow. That allows drift, and a half-applied switch is harmful rather than untidy: snapshot spin-up with legacy teardown means the nightly untargeted destroy rotates every credential and orphans the snapshot it just made. Documenting "switch both together" is not the same as making the other case impossible.
+
+Deriving the names rather than storing them also removes an injection surface: no database value reaches the GitHub API URL path.
+
+### "Cannot tell" is not "there is none"
+
+This rule appears in four places across the implementation, and it is the one most worth remembering:
+
+| Situation | Answer | Action |
+|---|---|---|
+| No snapshot exists | definite | build fresh |
+| Epoch mismatch | definite | build fresh |
+| No `lifecycle_mode` row | definite | `legacy` |
+| Snapshot lookup failed | **unknown** | stop |
+| `tofu init` failed | **unknown** | stop |
+| D1 unreadable | **unknown** | dispatch nothing |
+
+The asymmetry matters because the fallbacks are not neutral. Building fresh during an API outage discards a snapshot that may hold the only copy of most stacks' data. Defaulting to `legacy` when the mode is unknown dispatches the *destructive* pair at a stack that may be on snapshots.
+
+### Boot readiness
+
+`user_data` is guarded by `/opt/docker-server/.image-provisioned` so a restored server does not repeat `apt-get upgrade` and the Docker install it already carries.
+
+Readiness is signalled by `/run/nexus-setup-complete`, written by a small systemd unit ordered `After=docker.service`. Two properties matter:
+
+- `/run` is tmpfs, so it is structurally impossible to capture in a disk image. The old marker `/opt/docker-server/.setup-complete` lives on the disk and is therefore *inside* every snapshot — a gate probing it would pass instantly, possibly before sshd and Docker were up.
+- A systemd unit runs on **every** boot. cloud-init's `scripts-user` is PER_INSTANCE and does not re-run on a plain reboot, so a marker touched from `user_data` would be missing for the rest of the server's life after its first reboot — which breaks the warm spin-up, the common case.
+
+The gate itself is unified rather than branched:
+
+```bash
+test -f /run/nexus-setup-complete \
+  || { test -f /opt/docker-server/.setup-complete && systemctl is-active --quiet docker; }
+```
+
+This is monotonically safer for the legacy path: it accepts everything the old gate accepted, plus requires Docker to be up. It can only wait longer, never pass earlier.
+
+### `lifecycle.ignore_changes` on the server
+
+```hcl
+lifecycle {
+  ignore_changes = [image, user_data, server_type, location]
+}
+```
+
+Load-bearing, not tidiness. Without it a snapshot-restored server is one legacy spin-up away from destruction: `spin-up.yml` supplies `ubuntu-24.04` and `select-capacity` rewrites `server_type`/`server_location`, so OpenTofu would plan a **replacement** of the live server. `image` and `user_data` are ForceNew, which makes it a silent data-loss path rather than a diff someone notices.
+
+It costs nothing operationally: the documented resize flow is teardown → set `SERVER_TYPE` → spin-up, so the server is always created fresh with the new values.
+
+## Known limits
+
+**30 snapshots per Hetzner account**, a raisable default. At two retained generations that caps a single project at roughly 15 stacks — a real constraint for the Education fork's 26 tenants, and the main reason this is opt-in per stack rather than a global switch.
+
+**Disk-size ratchet.** A snapshot requires a target disk at least as large as its source. Restoring onto a larger tier makes the next snapshot larger, permanently excluding the smaller ones. Mitigated by the `--min-disk-gb` / `--arch` filters in capacity selection; reset by one `force_fresh` cycle.
+
+**Architecture lock.** x86 snapshots restore only onto x86. Relevant if the project ever reverts to ARM, and a reason the R2 layer stays.
+
+**Cross-network-zone restore is unverified.** Keep snapshot preferences within one zone.
+
+**Nothing has run end to end.** `skip_destroy=true` proved snapshot creation against the live stack on 2026-08-21 (72 s: 28 s power-off, 44 s create-and-available). The restore half has never executed. Five review rounds found eight genuine defects in this path before it ran once — the first real restore remains the test that matters.
+
+## Code map
+
+| Area | Where |
+|---|---|
+| Hetzner snapshot API | `src/nexus_deploy/hetzner_snapshot.py` |
+| CLI subcommands | `src/nexus_deploy/__main__.py` (`server-poweroff`, `snapshot-create`, `snapshot-resolve`, `snapshot-prune`) |
+| Restore constraints | `src/nexus_deploy/hetzner_capacity.py` (`fetch_server_types`, `filter_specs`) |
+| Server + credential epoch | `tofu/stack/main.tf`, `tofu/stack/outputs.tf` |
+| Workflows | `.github/workflows/teardown-snapshot.yml`, `spin-up-snapshot.yml` |
+| Shared workflow steps | `.github/actions/nexus-bootstrap`, `.github/actions/nexus-config-tfvars` |
+| Mode selection | `control-plane/functions/api/_utils/workflow-selection.js`, `control-plane/worker/src/index.js` |
+
+Operator instructions live in [Snapshot Lifecycle](../admin-guides/snapshot-lifecycle.md).
+
+## Open questions
+
+1. Which server types actually satisfy the current snapshot's disk requirement? Needs one `/v1/server_types` query; determines whether the ratchet costs money.
+2. Should pre-snapshot disk hygiene (`docker image prune`, `journalctl --vacuum`) be added? Deferred as a cost optimisation worth cents against an SSH dependency in the critical path.
+3. Should `teardown.yml` and `destroy-all.yml` move onto the composite actions? Deliberately not done yet — a bug in a shared action would take every path down at once, so the actions are being proven on the newer workflows first.


### PR DESCRIPTION
## Summary

Documents the snapshot lifecycle shipped in #649, #651 and #653.

Those three PRs went in without touching docs, which `CLAUDE.md` explicitly forbids:

> Every PR must be checked for documentation impact. […] Update affected docs in the same PR. Never leave docs out of sync.

Before this, `docs/` and `CLAUDE.md` mentioned the second lifecycle **zero times**. This is the correction, not new functionality — no code changes.

## Three pieces, three readers

### `docs/admin-guides/snapshot-lifecycle.md` — the operator runbook

The one that matters first, since the cycle runs for real tomorrow. It leads with **switching and rolling back** rather than with how it works, and spends most of its length on what goes wrong:

- why a snapshot gets refused — usually the mechanism working, not a fault
- what a stopped credential epoch means, and that the two teardowns must not be mixed
- the disk-size ratchet, and the two ways out of it
- the 30-snapshot cap
- why **nothing is dispatched** when the lifecycle mode cannot be determined, and why that is preferable to guessing

It also warns against trusting the tier comments in `hetzner_capacity.py` for disk sizes — those were wrong once already, which is how the ratchet was discovered.

### `docs/proposals/0002-hetzner-disk-snapshots.md` — the design

In RFC 0001's format and cross-linked with it, since the two are complements rather than alternatives. Records the reasoning that otherwise lives only in commit messages:

- why targeted destroy rather than deleting the server out of band
- why the ordering *is* the safety property
- why one config key instead of one per workflow
- why the readiness marker lives on tmpfs and is written by systemd rather than cloud-init
- why `lifecycle.ignore_changes` is load-bearing rather than tidiness

It carries the measurements as evidence rather than assertion — the cold/warm comparison that isolates image pulls, and the 72 s snapshot timing from the `skip_destroy` run on 2026-08-21.

And it states plainly what has **not** been verified: snapshot creation is proven against the live stack; the restore half has never executed. Five review rounds found eight genuine defects in that path before it ran once. That belongs in the record, not only in our heads.

### `CLAUDE.md`

Structure tree gained the two workflows, the `.github/actions/` directory and the new guide. The Key Commands section gained the rule an agent actually needs:

> **Never dispatch the two pairs at the same stack interchangeably**: the legacy teardown runs an untargeted `tofu destroy` that regenerates all 81 service credentials, and the epoch guard then correctly refuses any existing snapshot.

## Conventions

Checked rather than assumed, because both of these have bitten this repo before (#450, #454):

- frontmatter matches the other admin guides; `order: 6` was free
- every relative link carries its `.md` extension and resolves — verified programmatically, since extension-less links render fine on GitHub and 404 on the website
- no HTML `<img>` tags
- no index file needs updating; the site orders admin guides from frontmatter

## Open questions recorded rather than lost

The RFC closes with three, so they do not evaporate:

1. Which server types actually satisfy the current snapshot's disk requirement — one API query, determines whether the ratchet costs money
2. Whether pre-snapshot disk hygiene is worth an SSH dependency in the critical path
3. Whether `teardown.yml` and `destroy-all.yml` should move onto the composite actions, deliberately deferred until those are proven

## Summary by Sourcery

Document the Hetzner disk-snapshot lifecycle and clarify how agents and operators should use it alongside the legacy lifecycle.

Enhancements:
- Document the operator procedures, safeguards, limitations, and rollback paths for the Hetzner disk-snapshot lifecycle.
- Record the snapshot lifecycle design, rationale, measurements, verification status, and open questions in a new RFC.
- Update the agent project structure and command guidance to describe the two lifecycle workflow pairs and prevent mixing them.

Documentation:
- Add an administrator guide covering snapshot lifecycle switching, rollback, failure modes, costs, and operational verification.
- Add RFC 0002 documenting the Hetzner disk-snapshot lifecycle and its relationship to R2 persistence.