### PR TITLE
fix(ci): Delete Hetzner disk snapshots on destroy-all

### DIFF
--- a/.github/workflows/destroy-all.yml
+++ b/.github/workflows/destroy-all.yml
@@ -59,11 +59,20 @@ jobs:
       TF_VAR_r2_data_access_key: ${{ secrets.R2_DATA_ACCESS_KEY_ID || secrets.R2_ACCESS_KEY_ID }}
       TF_VAR_r2_data_secret_key: ${{ secrets.R2_DATA_SECRET_ACCESS_KEY || secrets.R2_SECRET_ACCESS_KEY }}
       TF_VAR_r2_data_bucket: ${{ secrets.R2_DATA_BUCKET }}
+      # Workflow inputs reach bash as env vars, never as ${{ }} inside a
+      # `run:` block. A template expansion is substituted BEFORE bash
+      # parses the script, so a dispatch value carrying shell syntax would
+      # execute inside a job that holds the Hetzner and Cloudflare provider
+      # credentials. Referencing "$CONFIRM" / "$DELETE_DATA" makes the
+      # value data instead of code. Step-level `if:` conditions are a
+      # different case and stay as expressions — they never reach a shell.
+      CONFIRM: ${{ github.event.inputs.confirm }}
+      DELETE_DATA: ${{ github.event.inputs.delete_data }}
 
     steps:
       - name: Validate confirmation
         run: |
-          if [ "${{ github.event.inputs.confirm }}" != "DESTROY" ]; then
+          if [ "$CONFIRM" != "DESTROY" ]; then
             echo "❌ Destruction cancelled. You must type 'DESTROY' (uppercase) to confirm."
             exit 1
           fi
@@ -430,10 +439,20 @@ jobs:
         run: |
           set -euo pipefail
           DOMAIN_SLUG=$(echo "$DOMAIN" | tr '.' '-')
-          PURGE="uv run --quiet --project \"\$GITHUB_WORKSPACE\" \\
-            python -m nexus_deploy snapshot-purge --domain-slug $DOMAIN_SLUG --apply"
+          # Printed for humans to copy, so no --project
+          # "$GITHUB_WORKSPACE": that variable exists only on the runner and
+          # would expand to an empty path on a normal machine, failing before
+          # snapshot-purge ever runs. From a repo checkout, plain `uv run`
+          # resolves the project itself. Matches the command in
+          # docs/admin-guides/snapshot-lifecycle.md.
+          PURGE="uv run python -m nexus_deploy snapshot-purge \\
+            --domain-slug $DOMAIN_SLUG --apply"
 
-          if [ "${{ github.event.inputs.delete_data }}" = "DESTROY" ]; then
+          # ${VAR:-} because this step runs under `set -u` and the input
+          # is optional. Actions does set a declared env var to "" when the
+          # expression is empty, but an unbound-variable abort in the last
+          # step of the most destructive workflow is not worth the bet.
+          if [ "${DELETE_DATA:-}" = "DESTROY" ]; then
             echo "🔥 delete_data=DESTROY — deleting Hetzner disk snapshots"
             if ! uv run --quiet --project "$GITHUB_WORKSPACE" \
               python -m nexus_deploy snapshot-purge \
@@ -444,7 +463,10 @@ jobs:
               echo "     HCLOUD_TOKEN=<token> $PURGE"
               exit 1
             fi
-            echo "✅ Hetzner disk snapshots deleted"
+            # Not "all deleted": purge exits 0 having skipped any image
+            # still in `creating`, which the API cannot delete. It names
+            # those individually above.
+            echo "✅ snapshot-purge finished — see above for any image it could not delete"
           else
             # Dry run: report what survives so it cannot be forgotten.
             # Deliberately non-fatal — the infrastructure is already
@@ -479,11 +501,13 @@ jobs:
           echo "   - Cloudflare Access policies"
           echo "   - Control Plane (Pages + Worker + D1)"
           echo "   - Hetzner Object Storage buckets (LakeFS, General)"
-          if [ "${{ github.event.inputs.delete_data }}" = "DESTROY" ]; then
+          if [ "$DELETE_DATA" = "DESTROY" ]; then
             echo "   - R2 persistence bucket (snapshots) — wiped via delete_data=DESTROY"
             echo "   - R2 datalake bucket — wiped via delete_data=DESTROY"
             echo "   - R2 tofu state bucket — wiped via delete_data=DESTROY"
-            echo "   - Hetzner disk snapshots — deleted via delete_data=DESTROY"
+            echo "   - Hetzner disk snapshots — purged via delete_data=DESTROY"
+            echo "     (an image still in 'creating' cannot be deleted via the"
+            echo "      API; the step above names any that were left)"
           else
             echo ""
             echo "   Preserved (reused on next initial-setup):"

--- a/.github/workflows/destroy-all.yml
+++ b/.github/workflows/destroy-all.yml
@@ -8,14 +8,20 @@ on:
         required: true
         type: string
       delete_data:
-        # Opt-in extra step that wipes the R2 buckets after tofu
-        # destroy: persistence (snapshots), data (datalake), and
-        # state (tofu state) buckets. Without this, those buckets
-        # survive destroy-all so a later initial-setup + spin-up
-        # reattaches to existing snapshot history (RFC 0001 decision
-        # #6). Setting this to "DESTROY" turns destroy-all into a
-        # true one-shot wipe.
-        description: 'Type "DESTROY" to ALSO wipe R2 buckets (snapshots + data + tofu state). Leave empty to preserve them.'
+        # Opt-in extra steps that wipe what tofu destroy cannot reach:
+        # the R2 buckets — persistence (snapshots), data (datalake) and
+        # state (tofu state) — plus the Hetzner disk snapshots from
+        # teardown-snapshot.yml, which survive `tofu destroy` by design
+        # because they live outside Tofu state.
+        #
+        # Without this, all of it survives destroy-all: a later
+        # initial-setup + spin-up reattaches to the existing R2
+        # snapshot history (RFC 0001 decision #6). The Hetzner images
+        # are a different case — they survive but cannot be restored
+        # from, since the destroy rotates the credential epoch (see the
+        # "Handle Hetzner disk snapshots" step). Setting this to
+        # "DESTROY" turns destroy-all into a true one-shot wipe.
+        description: 'Type "DESTROY" to ALSO wipe R2 buckets (snapshots + data + tofu state) and Hetzner disk snapshots. Leave empty to preserve them.'
         required: false
         type: string
         default: ''
@@ -70,6 +76,19 @@ jobs:
         uses: opentofu/setup-opentofu@v2
         with:
           tofu_version: 1.10.0
+
+      - name: Install uv
+        # Needed by the Hetzner snapshot cleanup at the end of this
+        # workflow. Version kept in step with .github/actions/
+        # nexus-bootstrap and python-tests.yml.
+        uses: astral-sh/setup-uv@v3
+        with:
+          version: '0.11.7'
+          enable-cache: true
+
+      - name: Sync nexus_deploy runtime deps
+        # --no-dev: ruff/mypy/pytest are not needed here.
+        run: uv sync --frozen --no-dev
 
       - name: Generate SSH key for OpenTofu
         run: |
@@ -383,6 +402,73 @@ jobs:
           done
           echo "✅ All R2 buckets wiped"
 
+      - name: Handle Hetzner disk snapshots
+        # Hetzner disk snapshots live OUTSIDE Tofu state on purpose: a
+        # Tofu-managed snapshot would be destroyed by the very
+        # `tofu destroy` it exists to survive. The consequence is that
+        # nothing above this step removes them.
+        #
+        # Leaving one behind is worse than untidy. The stack destroy
+        # above took all 81 random_* resources with it, so the next
+        # initial-setup mints a fresh credential epoch and the epoch
+        # guard in spin-up-snapshot.yml will refuse the old image for
+        # good. It is unrestorable, it keeps billing, and it occupies
+        # one of the 30 per-account snapshot slots — the binding
+        # constraint for multi-tenant projects long before the cost is.
+        #
+        # WHY THIS IS OPT-IN, like the R2 buckets: a snapshot is data.
+        # Even with the automated restore path closed by the epoch
+        # guard, an operator who ran destroy-all by mistake can still
+        # attach the image to a scratch server and read files off it by
+        # hand. Deleting it by default would remove the last recovery
+        # net from the most destructive workflow in the repo. So the
+        # default lists them and prints the command; delete_data=DESTROY
+        # deletes them.
+        env:
+          HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}
+          DOMAIN: ${{ secrets.DOMAIN }}
+        run: |
+          set -euo pipefail
+          DOMAIN_SLUG=$(echo "$DOMAIN" | tr '.' '-')
+          PURGE="uv run --quiet --project \"\$GITHUB_WORKSPACE\" \\
+            python -m nexus_deploy snapshot-purge --domain-slug $DOMAIN_SLUG --apply"
+
+          if [ "${{ github.event.inputs.delete_data }}" = "DESTROY" ]; then
+            echo "🔥 delete_data=DESTROY — deleting Hetzner disk snapshots"
+            if ! uv run --quiet --project "$GITHUB_WORKSPACE" \
+              python -m nexus_deploy snapshot-purge \
+                --domain-slug "$DOMAIN_SLUG" --apply; then
+              echo "❌ ERROR: Failed to delete one or more Hetzner snapshots"
+              echo "   They are still billing and still occupy account snapshot slots."
+              echo "   Retry manually:"
+              echo "     HCLOUD_TOKEN=<token> $PURGE"
+              exit 1
+            fi
+            echo "✅ Hetzner disk snapshots deleted"
+          else
+            # Dry run: report what survives so it cannot be forgotten.
+            # Deliberately non-fatal — the infrastructure is already
+            # gone at this point, and failing the run over a listing
+            # would turn a successful destroy red for no actionable
+            # reason. The failure is announced rather than swallowed.
+            echo "📸 Hetzner disk snapshots preserved (delete_data was not DESTROY):"
+            if ! uv run --quiet --project "$GITHUB_WORKSPACE" \
+              python -m nexus_deploy snapshot-purge \
+                --domain-slug "$DOMAIN_SLUG"; then
+              echo "   ⚠️  Could not list snapshots (API or token problem)."
+              echo "      Check the Hetzner console manually — any image left"
+              echo "      behind keeps billing and holds an account slot."
+            fi
+            echo ""
+            echo "   These can no longer be restored from: the destroy above"
+            echo "   rotated every generated credential, so the epoch guard"
+            echo "   will reject them. They remain only as a manual recovery"
+            echo "   path (attach to a scratch server and copy files off)."
+            echo ""
+            echo "   To delete them: re-run with delete_data=DESTROY, or run"
+            echo "     HCLOUD_TOKEN=<token> $PURGE"
+          fi
+
       - name: Confirm destruction
         run: |
           echo ""
@@ -397,12 +483,16 @@ jobs:
             echo "   - R2 persistence bucket (snapshots) — wiped via delete_data=DESTROY"
             echo "   - R2 datalake bucket — wiped via delete_data=DESTROY"
             echo "   - R2 tofu state bucket — wiped via delete_data=DESTROY"
+            echo "   - Hetzner disk snapshots — deleted via delete_data=DESTROY"
           else
             echo ""
             echo "   Preserved (reused on next initial-setup):"
             echo "   - R2 state bucket and credentials"
             echo "   - R2 datalake bucket and credentials"
             echo "   - R2 persistence bucket (snapshots)"
+            echo ""
+            echo "   Preserved but NOT reusable — see the step above:"
+            echo "   - Hetzner disk snapshots (credential epoch rotated)"
             echo ""
             echo "   To wipe these too, re-run with delete_data=DESTROY."
           fi

--- a/docs/admin-guides/snapshot-lifecycle.md
+++ b/docs/admin-guides/snapshot-lifecycle.md
@@ -90,6 +90,35 @@ For a single run rather than a permanent switch, `spin-up-snapshot.yml` takes `f
 
 ---
 
+## Destroying a stack for good
+
+`destroy-all.yml` does **not** delete the Hetzner disk snapshots by default, and the reason is worth understanding before you decide.
+
+A snapshot lives outside OpenTofu state on purpose — a Tofu-managed one would be destroyed by the very `tofu destroy` it exists to survive. So `destroy-all` cannot reach it as a side effect, and a leftover image keeps billing and keeps holding one of the 30 per-account slots.
+
+It is also **unrestorable** at that point. The destroy takes all 81 `random_*` resources with it, so the next initial-setup mints a fresh credential epoch and the [epoch guard](#the-credential-epoch-stopped-matching) rejects the old image permanently.
+
+Unrestorable is not the same as worthless, which is why the default keeps it: you can still attach the image to a scratch server and copy files off it by hand. That is the last recovery path after an accidental `destroy-all`, so removing it automatically would be the wrong default for the most destructive workflow in the repo.
+
+The workflow therefore lists what survives and prints the command to remove it. To delete the snapshots in the same run, use the same opt-in that wipes the R2 buckets:
+
+```bash
+gh workflow run destroy-all.yml -f confirm=DESTROY -f delete_data=DESTROY
+```
+
+To delete them later, or from a machine:
+
+```bash
+HCLOUD_TOKEN=<token> uv run python -m nexus_deploy snapshot-purge \
+  --domain-slug <domain-slug> --apply
+```
+
+`snapshot-purge` is label-scoped to one stack, so it can never reach another tenant's images, and it is a dry run until `--apply`. It is a separate command from `snapshot-prune` rather than `--keep 0`: prune refuses `keep < 1` so a retention pass can never leave a stack with nothing to restore from, and that guard is worth keeping absolute.
+
+An image still in `creating` state cannot be deleted through the API. Purge names it and moves on — remove it from the Hetzner console once the create settles.
+
+---
+
 ## What can go wrong
 
 ### The snapshot is refused and the stack rebuilds fresh

--- a/docs/proposals/0002-hetzner-disk-snapshots.md
+++ b/docs/proposals/0002-hetzner-disk-snapshots.md
@@ -134,6 +134,8 @@ It costs nothing operationally: the documented resize flow is teardown → set `
 
 **Architecture lock.** x86 snapshots restore only onto x86. Relevant if the project ever reverts to ARM, and a reason the R2 layer stays.
 
+**Living outside Tofu state cuts both ways.** It is what lets a snapshot survive the `tofu destroy` in its own teardown, and equally what stops `destroy-all.yml` from removing it as a side effect. Handled by an explicit `snapshot-purge` step under the existing `delete_data=DESTROY` opt-in; the default lists what survives rather than deleting it, because an unrestorable image is still readable by hand and is the last recovery path after an accidental destroy-all.
+
 **Cross-network-zone restore is unverified.** Keep snapshot preferences within one zone.
 
 **Nothing has run end to end.** `skip_destroy=true` proved snapshot creation against the live stack on 2026-08-21 (72 s: 28 s power-off, 44 s create-and-available). The restore half has never executed. Five review rounds found eight genuine defects in this path before it ran once — the first real restore remains the test that matters.

--- a/src/nexus_deploy/__main__.py
+++ b/src/nexus_deploy/__main__.py
@@ -3162,6 +3162,83 @@ def _snapshot_prune(args: list[str]) -> int:
     return 0
 
 
+def _snapshot_purge(args: list[str]) -> int:
+    """`nexus-deploy snapshot-purge --domain-slug S [--apply]`.
+
+    Deletes EVERY snapshot of one stack. Label-scoped exactly like
+    ``snapshot-prune``, so it can never reach another tenant's images.
+
+    Deliberately a separate command rather than ``snapshot-prune
+    --keep 0``. ``select_prunable`` refuses ``keep < 1`` so a retention
+    pass can never leave a stack with nothing to restore from, and that
+    guard is worth keeping absolute. Purge has the opposite intent —
+    the stack itself is going away — and says so in its name rather
+    than by passing a value the other command exists to reject.
+
+    Written for ``destroy-all.yml``. A Hetzner snapshot survives ``tofu
+    destroy`` by design, which is precisely what makes it dead weight
+    after a full teardown: the destroy takes all 81 ``random_*``
+    resources with it, so the next initial-setup mints a new credential
+    epoch and the epoch guard will refuse the old image forever. It
+    keeps costing money and keeps occupying one of the 30 per-account
+    snapshot slots.
+
+    Images that are not ``available`` (an interrupted create) cannot be
+    deleted through the API. They are reported individually rather than
+    silently skipped — an orphan nobody knows about is the whole
+    problem this command exists to solve — but they do not fail the
+    run, since there is no action the caller could take to fix it in
+    the moment.
+
+    Exit codes: 0 done (or nothing to do), 2 on API failure.
+    """
+    try:
+        domain_slug = _required_flag(args, "domain-slug")
+        token = _snapshot_token()
+    except _FlagError as exc:
+        print(f"snapshot-purge: {exc}", file=sys.stderr)
+        return 2
+    apply_changes = "--apply" in args
+
+    try:
+        snapshots = _hsnap.list_snapshots(token, domain_slug=domain_slug)
+    except _hsnap.HetznerSnapshotError as exc:
+        print(
+            f"snapshot-purge: Hetzner API failure ({type(exc).__name__})",
+            file=sys.stderr,
+        )
+        return 2
+
+    if not snapshots:
+        sys.stderr.write(f"snapshot-purge: no snapshots for {domain_slug} — nothing to do\n")
+        return 0
+
+    for snapshot in snapshots:
+        if not snapshot.is_available:
+            sys.stderr.write(
+                f"⚠ snapshot-purge: #{snapshot.image_id} is '{snapshot.status}', "
+                f"not 'available' — the API cannot delete it. Remove it from the "
+                f"Hetzner console once the create settles.\n"
+            )
+            continue
+        if not apply_changes:
+            sys.stderr.write(f"snapshot-purge: would delete {snapshot}\n")
+            continue
+        try:
+            _hsnap.delete_snapshot(snapshot.image_id, token)
+        except _hsnap.HetznerSnapshotError as exc:
+            print(
+                f"snapshot-purge: failed to delete {snapshot} ({type(exc).__name__})",
+                file=sys.stderr,
+            )
+            return 2
+        sys.stderr.write(f"✓ snapshot-purge: deleted {snapshot}\n")
+
+    if not apply_changes:
+        sys.stderr.write("snapshot-purge: dry run — pass --apply to delete\n")
+    return 0
+
+
 def _run_pipeline(args: list[str]) -> int:
     """`nexus-deploy run-pipeline`.
 
@@ -3781,6 +3858,8 @@ def main() -> int:
         return _snapshot_resolve(args[1:])
     if args[:1] == ["snapshot-prune"]:
         return _snapshot_prune(args[1:])
+    if args[:1] == ["snapshot-purge"]:
+        return _snapshot_purge(args[1:])
     if args[:1] == ["run-pipeline"]:
         return _run_pipeline(args[1:])
     if args[:1] == ["s3-snapshot"]:
@@ -3830,6 +3909,8 @@ def main() -> int:
         "(newest restorable snapshot; rc=0 found, rc=1 none — build fresh, rc=2 lookup failed), "
         "snapshot-prune --domain-slug SLUG [--keep 2] [--apply] "
         "(drop all but the newest N; dry-run unless --apply), "
+        "snapshot-purge --domain-slug SLUG [--apply] "
+        "(delete EVERY snapshot of one stack, for destroy-all; dry-run unless --apply), "
         "run-pipeline (top-level deploy entry; reads tofu state + "
         "config.tfvars; optional env: SSH_PRIVATE_KEY_CONTENT, "
         "GH_MIRROR_TOKEN, GH_MIRROR_REPOS, DOCKERHUB_USER, DOCKERHUB_TOKEN, "

--- a/src/nexus_deploy/__main__.py
+++ b/src/nexus_deploy/__main__.py
@@ -2922,6 +2922,48 @@ def _flag(args: list[str], name: str) -> str | None:
     return None
 
 
+def _known_args_only(
+    args: list[str],
+    *,
+    valued: tuple[str, ...] = (),
+    boolean: tuple[str, ...] = (),
+) -> None:
+    """Reject any argument the handler does not understand.
+
+    :func:`_flag` scans for the flags it wants and ignores everything
+    else. That is tolerable for a handler whose worst case is an option
+    going unread; it is not tolerable for a destructive one, where it
+    fails quietly in both directions:
+
+    * ``snapshot-purge --domain-slug X --apply --keep 2`` silently
+      ignores the ``--keep`` borrowed from ``snapshot-prune`` and
+      deletes every snapshot, when the operator asked to retain two.
+    * ``snapshot-purge --domain-slug X --aply`` silently downgrades a
+      real purge to a dry run that exits 0, so ``destroy-all`` reports
+      success while the images it was meant to remove survive.
+
+    Hand-rolled to match ``secret-sync`` rather than pulling in argparse
+    for three flags. A value is consumed positionally, so a value that
+    happens to look like a flag behaves exactly as :func:`_flag` would.
+    """
+    seen: set[str] = set()
+    i = 0
+    while i < len(args):
+        token = args[i]
+        name = token[2:] if token.startswith("--") else None
+        if name is None or (name not in valued and name not in boolean):
+            raise _FlagError(f"unknown argument {token!r}")
+        if name in seen:
+            raise _FlagError(f"--{name} given more than once")
+        seen.add(name)
+        if name in valued:
+            if i + 1 >= len(args):
+                raise _FlagError(f"--{name} requires a value")
+            i += 2
+        else:
+            i += 1
+
+
 def _required_flag(args: list[str], name: str) -> str:
     value = _flag(args, name)
     if value is None:
@@ -3193,6 +3235,10 @@ def _snapshot_purge(args: list[str]) -> int:
     Exit codes: 0 done (or nothing to do), 2 on API failure.
     """
     try:
+        # Strict, unlike the other snapshot handlers: this one deletes,
+        # and both ways of getting the arguments wrong are silent. See
+        # _known_args_only for the two concrete cases.
+        _known_args_only(args, valued=("domain-slug",), boolean=("apply",))
         domain_slug = _required_flag(args, "domain-slug")
         token = _snapshot_token()
     except _FlagError as exc:

--- a/src/nexus_deploy/__main__.py
+++ b/src/nexus_deploy/__main__.py
@@ -2922,29 +2922,38 @@ def _flag(args: list[str], name: str) -> str | None:
     return None
 
 
-def _known_args_only(
+def _validated_flags(
     args: list[str],
     *,
     valued: tuple[str, ...] = (),
     boolean: tuple[str, ...] = (),
-) -> None:
-    """Reject any argument the handler does not understand.
+) -> set[str]:
+    """Validate an arg list strictly; report which flags were given.
 
     :func:`_flag` scans for the flags it wants and ignores everything
     else. That is tolerable for a handler whose worst case is an option
     going unread; it is not tolerable for a destructive one, where it
-    fails quietly in both directions:
+    fails quietly in three ways, all of them wrong:
 
-    * ``snapshot-purge --domain-slug X --apply --keep 2`` silently
-      ignores the ``--keep`` borrowed from ``snapshot-prune`` and
-      deletes every snapshot, when the operator asked to retain two.
-    * ``snapshot-purge --domain-slug X --aply`` silently downgrades a
-      real purge to a dry run that exits 0, so ``destroy-all`` reports
-      success while the images it was meant to remove survive.
+    * ``--domain-slug X --apply --keep 2`` — ``--keep`` is a
+      ``snapshot-prune`` option. Ignored, and purge does not retain, so
+      an operator reaching for the flag they know from the sibling
+      command deletes every snapshot when they asked to keep two.
+    * ``--domain-slug X --aply`` — a typo. Ignored, so a real purge
+      downgrades to a dry run that exits 0 while the images survive.
+    * ``--domain-slug --apply`` — the slug is missing, so ``--apply``
+      is taken as its value. The destructive path then runs against a
+      slug matching nothing and exits 0 having deleted none of the real
+      snapshots, reporting success.
+
+    Hence: a value may not itself look like a flag, and the return value
+    reports which names appeared **as flags**. Callers must use that
+    rather than ``"--x" in args`` — a membership test cannot tell a flag
+    from a value that happens to spell one, which is the third failure
+    above.
 
     Hand-rolled to match ``secret-sync`` rather than pulling in argparse
-    for three flags. A value is consumed positionally, so a value that
-    happens to look like a flag behaves exactly as :func:`_flag` would.
+    for three flags.
     """
     seen: set[str] = set()
     i = 0
@@ -2959,9 +2968,13 @@ def _known_args_only(
         if name in valued:
             if i + 1 >= len(args):
                 raise _FlagError(f"--{name} requires a value")
+            value = args[i + 1]
+            if value.startswith("--"):
+                raise _FlagError(f"--{name} requires a value, got flag {value!r}")
             i += 2
         else:
             i += 1
+    return seen
 
 
 def _required_flag(args: list[str], name: str) -> str:
@@ -3236,15 +3249,17 @@ def _snapshot_purge(args: list[str]) -> int:
     """
     try:
         # Strict, unlike the other snapshot handlers: this one deletes,
-        # and both ways of getting the arguments wrong are silent. See
-        # _known_args_only for the two concrete cases.
-        _known_args_only(args, valued=("domain-slug",), boolean=("apply",))
+        # and every way of getting the arguments wrong is silent. See
+        # _validated_flags for the three concrete cases.
+        present = _validated_flags(args, valued=("domain-slug",), boolean=("apply",))
         domain_slug = _required_flag(args, "domain-slug")
         token = _snapshot_token()
     except _FlagError as exc:
         print(f"snapshot-purge: {exc}", file=sys.stderr)
         return 2
-    apply_changes = "--apply" in args
+    # From the validated parse, NOT `"--apply" in args`: the latter
+    # cannot tell a flag from a value that spells one.
+    apply_changes = "apply" in present
 
     try:
         snapshots = _hsnap.list_snapshots(token, domain_slug=domain_slug)

--- a/tests/unit/test_snapshot_cli.py
+++ b/tests/unit/test_snapshot_cli.py
@@ -618,3 +618,86 @@ def test_purge_aborts_when_a_delete_fails(monkeypatch: pytest.MonkeyPatch) -> No
 def test_purge_requires_domain_slug(capsys: pytest.CaptureFixture[str]) -> None:
     assert cli._snapshot_purge([]) == 2
     assert "--domain-slug is required" in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# snapshot-purge argument validation
+#
+# Strict, unlike the other snapshot handlers, because this one deletes and
+# both ways of getting the arguments wrong are SILENT:
+#
+#   --keep 2   borrowed from snapshot-prune, ignored -> deletes everything
+#              when the operator asked to retain two
+#   --aply     a typo, ignored -> a real purge silently downgrades to a
+#              dry run that exits 0, so destroy-all reports success while
+#              the images it was meant to remove survive
+#
+# The two failures point in opposite directions, which is why neither
+# default (accept-and-ignore) is defensible here.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("argv", "expected"),
+    [
+        (["--domain-slug", "example-com", "--apply", "--keep", "2"], "unknown argument '--keep'"),
+        (["--domain-slug", "example-com", "--aply"], "unknown argument '--aply'"),
+        (["--domain-slug", "example-com", "extra"], "unknown argument 'extra'"),
+        (["--domain-slug", "example-com", "--apply", "--apply"], "--apply given more than once"),
+        (["--domain-slug"], "--domain-slug requires a value"),
+    ],
+)
+def test_purge_rejects_bad_arguments(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    argv: list[str],
+    expected: str,
+) -> None:
+    """rc=2 and, critically, nothing is deleted."""
+    deleted: list[int] = []
+    monkeypatch.setattr(_hsnap, "list_snapshots", lambda *a, **k: (_snap(1), _snap(2), _snap(3)))
+    monkeypatch.setattr(
+        _hsnap,
+        "delete_snapshot",
+        lambda image_id, token: deleted.append(image_id),
+    )
+
+    assert cli._snapshot_purge(argv) == 2
+    assert deleted == []
+    assert expected in capsys.readouterr().err
+
+
+def test_purge_rejects_keep_before_deleting_anything(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The regression this validation exists for, stated on its own.
+
+    `snapshot-purge --domain-slug X --apply --keep 2` used to delete
+    every snapshot: --keep is a snapshot-prune option, it was ignored,
+    and purge does not retain. An operator reaching for the flag they
+    know from the sibling command got the opposite of what they asked
+    for, irreversibly.
+    """
+    deleted: list[int] = []
+    monkeypatch.setattr(_hsnap, "list_snapshots", lambda *a, **k: (_snap(1), _snap(2), _snap(3)))
+    monkeypatch.setattr(
+        _hsnap,
+        "delete_snapshot",
+        lambda image_id, token: deleted.append(image_id),
+    )
+
+    rc = cli._snapshot_purge(["--domain-slug", "example-com", "--apply", "--keep", "2"])
+    assert rc == 2
+    assert deleted == []
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["--domain-slug", "example-com"],
+        ["--domain-slug", "example-com", "--apply"],
+        ["--apply", "--domain-slug", "example-com"],
+    ],
+)
+def test_purge_accepts_every_valid_form(monkeypatch: pytest.MonkeyPatch, argv: list[str]) -> None:
+    """Validation must not reject what the workflow actually sends."""
+    monkeypatch.setattr(_hsnap, "list_snapshots", lambda *a, **k: ())
+    assert cli._snapshot_purge(argv) == 0

--- a/tests/unit/test_snapshot_cli.py
+++ b/tests/unit/test_snapshot_cli.py
@@ -645,6 +645,14 @@ def test_purge_requires_domain_slug(capsys: pytest.CaptureFixture[str]) -> None:
         (["--domain-slug", "example-com", "extra"], "unknown argument 'extra'"),
         (["--domain-slug", "example-com", "--apply", "--apply"], "--apply given more than once"),
         (["--domain-slug"], "--domain-slug requires a value"),
+        # The slug is missing and --apply is swallowed as its value.
+        # Without the flag-shaped-value check this reached the
+        # DESTRUCTIVE path with domain_slug="--apply", matched no
+        # snapshots, and exited 0 — reporting success while every real
+        # snapshot survived. Same silent-no-op class the strict parsing
+        # exists to remove.
+        (["--domain-slug", "--apply"], "requires a value, got flag '--apply'"),
+        (["--apply", "--domain-slug"], "--domain-slug requires a value"),
     ],
 )
 def test_purge_rejects_bad_arguments(
@@ -701,3 +709,24 @@ def test_purge_accepts_every_valid_form(monkeypatch: pytest.MonkeyPatch, argv: l
     """Validation must not reject what the workflow actually sends."""
     monkeypatch.setattr(_hsnap, "list_snapshots", lambda *a, **k: ())
     assert cli._snapshot_purge(argv) == 0
+
+
+def test_purge_apply_is_read_from_the_parse_not_from_argv() -> None:
+    """`"--apply" in args` cannot tell a flag from a value spelling one.
+
+    `--domain-slug --apply` puts the literal string "--apply" in argv as
+    a VALUE. A membership test sees it and switches on the destructive
+    path. The handler therefore reads the validated parse instead, and
+    this asserts the underlying helper reports flags only.
+    """
+    assert cli._validated_flags(
+        ["--domain-slug", "example-com"],
+        valued=("domain-slug",),
+        boolean=("apply",),
+    ) == {"domain-slug"}
+
+    assert cli._validated_flags(
+        ["--domain-slug", "example-com", "--apply"],
+        valued=("domain-slug",),
+        boolean=("apply",),
+    ) == {"domain-slug", "apply"}

--- a/tests/unit/test_snapshot_cli.py
+++ b/tests/unit/test_snapshot_cli.py
@@ -457,6 +457,7 @@ def test_dispatcher_routes_subcommand(
         ("_server_poweroff", ["--server-id", "42"], "poweroff_server"),
         ("_snapshot_resolve", ["--domain-slug", "example-com"], "resolve_latest"),
         ("_snapshot_prune", ["--domain-slug", "example-com"], "list_snapshots"),
+        ("_snapshot_purge", ["--domain-slug", "example-com"], "list_snapshots"),
     ],
 )
 def test_api_errors_are_logged_by_type_only(
@@ -486,4 +487,134 @@ def test_flag_errors_keep_their_message(capsys: pytest.CaptureFixture[str]) -> N
     "_FlagError" with no indication of which flag was wrong.
     """
     assert cli._snapshot_create(["--server-id", "42"]) == 2
+    assert "--domain-slug is required" in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# snapshot-purge — destroy-all's cleanup
+#
+# A Hetzner snapshot survives `tofu destroy` by design, so destroy-all
+# leaves one behind unless something deletes it explicitly. What makes
+# that worse than a stray euro: the destroy takes all 81 random_*
+# resources with it, the next initial-setup mints a new credential
+# epoch, and the epoch guard then refuses the old image forever. It is
+# unusable AND it occupies one of the 30 per-account snapshot slots.
+# ---------------------------------------------------------------------------
+
+
+def test_purge_is_dry_run_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Same guarantee as prune: deletion is irreversible, so opt in."""
+    deleted: list[int] = []
+    monkeypatch.setattr(_hsnap, "list_snapshots", lambda *a, **k: (_snap(1), _snap(2)))
+    monkeypatch.setattr(
+        _hsnap,
+        "delete_snapshot",
+        lambda image_id, token: deleted.append(image_id),
+    )
+
+    assert cli._snapshot_purge(["--domain-slug", "example-com"]) == 0
+    assert deleted == []
+    err = capsys.readouterr().err
+    assert "would delete" in err
+    assert "--apply" in err
+
+
+def test_purge_apply_deletes_every_snapshot(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The point of the command: nothing is kept back.
+
+    This is what separates it from prune, whose `select_prunable`
+    refuses `keep < 1` precisely so a retention pass can never empty a
+    stack out.
+    """
+    deleted: list[int] = []
+    monkeypatch.setattr(_hsnap, "list_snapshots", lambda *a, **k: (_snap(1), _snap(2), _snap(3)))
+    monkeypatch.setattr(
+        _hsnap,
+        "delete_snapshot",
+        lambda image_id, token: deleted.append(image_id),
+    )
+
+    assert cli._snapshot_purge(["--domain-slug", "example-com", "--apply"]) == 0
+    assert deleted == [1, 2, 3]
+
+
+def test_purge_is_scoped_to_the_domain(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Never a project-wide wipe — other tenants share the account.
+
+    The 30-snapshot limit is per account, so a multi-tenant project has
+    other stacks' images sitting right next to these ones.
+    """
+    seen: dict[str, Any] = {}
+
+    def _fake_list(_token: str, *, domain_slug: str) -> tuple[Snapshot, ...]:
+        seen["domain_slug"] = domain_slug
+        return ()
+
+    monkeypatch.setattr(_hsnap, "list_snapshots", _fake_list)
+    assert cli._snapshot_purge(["--domain-slug", "example-com", "--apply"]) == 0
+    assert seen["domain_slug"] == "example-com"
+
+
+def test_purge_on_empty_listing_is_a_success(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A stack that never took a snapshot must not fail destroy-all."""
+    monkeypatch.setattr(_hsnap, "list_snapshots", lambda *a, **k: ())
+    assert cli._snapshot_purge(["--domain-slug", "example-com", "--apply"]) == 0
+    assert "nothing to do" in capsys.readouterr().err
+
+
+def test_purge_reports_images_it_cannot_delete(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A `creating` image is skipped loudly, not silently.
+
+    The API cannot delete one mid-creation. Staying quiet would leave
+    exactly the orphan this command exists to prevent — and nobody
+    would know to go looking for it.
+    """
+    stuck = Snapshot(
+        image_id=7,
+        description="nexus-example-com-7",
+        created="2026-08-05T21:00:00+00:00",
+        disk_gb=160,
+        architecture="x86",
+        epoch=EPOCH,
+        server_type="cx43",
+        status="creating",
+        image_gb=0.0,
+    )
+    deleted: list[int] = []
+    monkeypatch.setattr(_hsnap, "list_snapshots", lambda *a, **k: (_snap(1), stuck))
+    monkeypatch.setattr(
+        _hsnap,
+        "delete_snapshot",
+        lambda image_id, token: deleted.append(image_id),
+    )
+
+    assert cli._snapshot_purge(["--domain-slug", "example-com", "--apply"]) == 0
+    assert deleted == [1]
+    err = capsys.readouterr().err
+    assert "#7" in err
+    assert "creating" in err
+
+
+def test_purge_aborts_when_a_delete_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    """rc=2 so destroy-all reports failure instead of a false all-clear."""
+    monkeypatch.setattr(_hsnap, "list_snapshots", lambda *a, **k: (_snap(1), _snap(2)))
+
+    def _raise(image_id: int, token: str) -> None:
+        raise HetznerSnapshotError("HTTP 409")
+
+    monkeypatch.setattr(_hsnap, "delete_snapshot", _raise)
+    assert cli._snapshot_purge(["--domain-slug", "example-com", "--apply"]) == 2
+
+
+def test_purge_requires_domain_slug(capsys: pytest.CaptureFixture[str]) -> None:
+    assert cli._snapshot_purge([]) == 2
     assert "--domain-slug is required" in capsys.readouterr().err


### PR DESCRIPTION
## The gap

`destroy-all.yml` left every Hetzner disk snapshot behind. All eleven mentions of "snapshot" in that workflow referred to the R2 persistence layer from RFC 0001; there was no call against the Hetzner image API anywhere in it.

This is a direct consequence of a deliberate design decision, which is why it was easy to miss. A snapshot lives **outside** OpenTofu state on purpose — a Tofu-managed snapshot would be destroyed by the very `tofu destroy` it exists to survive (RFC 0002). The same property that makes teardown work stops `destroy-all` from cleaning up as a side effect.

## Why it matters more than the cost

The leftover image is **unrestorable**. The untargeted destroy takes all 81 `random_*` resources with it, so the next initial-setup mints a fresh credential epoch and the epoch guard in `spin-up-snapshot.yml` rejects the old image permanently.

So it is not a spare copy. It is an object that:

- keeps billing (~EUR 0.011–0.014 per GB per month on used space),
- holds one of the **30 per-account snapshot slots**, and
- can never be used by the automated restore path again.

The slot limit is the part that actually bites. At two retained generations it caps a project at roughly 15 stacks, so for the Education fork's 26 tenants an orphan per destroyed stack is a real constraint, not an accounting rounding error.

## New CLI command

`nexus-deploy snapshot-purge --domain-slug S [--apply]`

- **Label-scoped** exactly like `snapshot-prune` (`nexus_role` AND `nexus_domain`), so it can never reach another tenant's images — relevant precisely because the slot limit is per account and other stacks' images sit right next to these.
- **A separate command, not `snapshot-prune --keep 0`.** `select_prunable` refuses `keep < 1` so a retention pass can never leave a stack with nothing to restore from. That guard is worth keeping absolute, and purge has the opposite intent — the stack itself is going away — so it says so in its name rather than by passing the value the other command exists to reject.
- **Dry run until `--apply`.**
- Images stuck in `creating` cannot be deleted through the API. They are **named individually** rather than skipped silently: an orphan nobody knows about is the entire problem this command exists to solve. They do not fail the run, since there is no action the caller could take in the moment.

## Why deletion is opt-in

Wired into `destroy-all.yml` under the existing `delete_data=DESTROY` gate — the same one that wipes the R2 buckets, and for the same reason: a snapshot is data.

Unrestorable is not the same as worthless. With the automated path closed by the epoch guard, an operator who ran `destroy-all` by mistake can still attach the image to a scratch server and copy files off it by hand. That is the last recovery net after the most destructive workflow in the repo, so deleting it by default would be the wrong call.

The default therefore **lists** what survives, explains that it cannot be restored from, and prints the exact command — so it cannot be quietly forgotten either.

Failure handling differs by branch on purpose: on the `DESTROY` path a failed delete exits 1, because a silent orphan is exactly what this fixes. On the listing path an API failure warns loudly but does not fail the run — the infrastructure is already gone by then, and turning a successful destroy red over a listing helps nobody.

## Changes

| File | What |
|---|---|
| `src/nexus_deploy/__main__.py` | `_snapshot_purge` handler, dispatch entry, help text |
| `tests/unit/test_snapshot_cli.py` | 7 new tests + purge added to the secret-redaction parametrisation |
| `.github/workflows/destroy-all.yml` | uv setup, `Handle Hetzner disk snapshots` step, updated input description and summary |
| `docs/admin-guides/snapshot-lifecycle.md` | new "Destroying a stack for good" section |
| `docs/proposals/0002-hetzner-disk-snapshots.md` | known-limits note |

## Verification

- `uv run pytest` — 1705 passed
- `uv run ruff check` / `ruff format --check` / `uv run mypy src/` — clean
- `destroy-all.yml` parses; 14 steps in the expected order
- CLI smoke: missing `--domain-slug` exits 2 with a readable message; the command appears in the help listing

Not exercised against live infrastructure — `destroy-all` is not a workflow to test speculatively. The API surface it uses (`list_snapshots`, `delete_snapshot`) is the same one `snapshot-prune` already exercises in production.

## Follow-up, deliberately not in this PR

`teardown.yml` and `destroy-all.yml` still carry their own toolchain preamble rather than using `.github/actions/nexus-bootstrap`. This PR adds a minimal uv setup to `destroy-all.yml` instead of adopting the composite action, keeping to the sequencing decided in RFC 0002: prove the shared actions on the newer workflows first, since a bug in one would take every path down at once.

## Summary by Sourcery

Handle Hetzner disk snapshots during full stack destruction while keeping irreversible cleanup explicitly opt-in.

New Features:
- Add a label-scoped `snapshot-purge` CLI command that lists snapshots by default and deletes all available snapshots only with `--apply`.

Bug Fixes:
- Ensure `destroy-all.yml` handles Hetzner disk snapshots that survive OpenTofu destruction, preventing unrecoverable and billing-consuming orphaned images.
- Prevent unsafe purge invocations by rejecting unknown, duplicate, or malformed arguments before any deletion occurs.

Enhancements:
- Preserve snapshots by default as a manual recovery path while clearly reporting their status and cleanup instructions.
- Handle snapshots still being created by reporting them individually without failing the overall purge.

Build:
- Install and synchronize the production uv dependencies in `destroy-all.yml` for snapshot cleanup.

Documentation:
- Document permanent stack destruction, snapshot cleanup behavior, and the new purge command.
- Record the lifecycle trade-off of keeping disk snapshots outside OpenTofu state and cleaning them explicitly.

Tests:
- Add coverage for purge dry runs, deletion, tenant scoping, empty results, in-progress images, API failures, and strict argument validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `snapshot-purge` command to safely review snapshots by default and delete domain-scoped snapshots with `--apply`.
  * Added clear handling for unavailable or still-creating snapshots without interrupting cleanup.
  * Added optional snapshot cleanup when permanently destroying a deployment, while preserving snapshots by default.

* **Documentation**
  * Documented snapshot retention, recovery options, deletion behavior, manual recovery, and limitations after credential changes.
  * Clarified dry-run behavior and snapshot handling during deployment destruction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->