### PR TITLE
fix(examples): Quote values inlined into DuckDB SQL

### DIFF
--- a/examples/workspace-seeds/marimo/Getting_Started_DuckDB.py
+++ b/examples/workspace-seeds/marimo/Getting_Started_DuckDB.py
@@ -363,10 +363,20 @@ def _(mo):
 
           ```python
           import os
+
+          # DuckDB's SET takes no parameter placeholders — you cannot
+          # write SET s3_access_key_id = ? — so the values have to be
+          # inlined into the SQL text, which makes quoting your job.
+          # Doubling any apostrophe is the SQL-standard escape; without
+          # it a value containing one closes the literal early and the
+          # statement fails to parse.
+          def _lit(value):
+              return "'" + str(value).replace("'", "''") + "'"
+
           con.sql(f\"\"\"
-              SET s3_endpoint = '{os.environ["HETZNER_S3_ENDPOINT"].removeprefix("https://")}';
-              SET s3_access_key_id = '{os.environ["HETZNER_S3_ACCESS_KEY"]}';
-              SET s3_secret_access_key = '{os.environ["HETZNER_S3_SECRET_KEY"]}';
+              SET s3_endpoint = {_lit(os.environ["HETZNER_S3_ENDPOINT"].removeprefix("https://"))};
+              SET s3_access_key_id = {_lit(os.environ["HETZNER_S3_ACCESS_KEY"])};
+              SET s3_secret_access_key = {_lit(os.environ["HETZNER_S3_SECRET_KEY"])};
               SET s3_url_style = 'path';
           \"\"\")
           # then read with: SELECT * FROM read_parquet('s3://<bucket>/path/file.parquet')

--- a/examples/workspace-seeds/marimo/NYC_Taxi_Pipeline.py
+++ b/examples/workspace-seeds/marimo/NYC_Taxi_Pipeline.py
@@ -189,11 +189,22 @@ def _(months, os, s3_env_ok):
         # http(s):// itself based on s3_use_ssl). Strip it defensively
         # so users can paste a full URL into Infisical without
         # breaking things.
+        # DuckDB's SET statements take no parameter placeholders — you
+        # cannot write SET s3_access_key_id = ? — so these values have
+        # to be inlined into the SQL text. That makes quoting our job:
+        # an apostrophe inside a value would close the string literal
+        # early, and the statement then fails with a syntax error whose
+        # message can carry a fragment of the value into the notebook
+        # output. Doubling the apostrophe is the SQL-standard escape.
+        def _lit(value: object) -> str:
+            """Render a value as a safely quoted SQL string literal."""
+            return "'" + str(value).replace("'", "''") + "'"
+
         _endpoint = os.environ["HETZNER_S3_ENDPOINT"]
         _endpoint_host = _endpoint.replace("https://", "").replace("http://", "")
-        _con.execute(f"SET s3_endpoint = '{_endpoint_host}';")
-        _con.execute(f"SET s3_access_key_id = '{os.environ['HETZNER_S3_ACCESS_KEY']}';")
-        _con.execute(f"SET s3_secret_access_key = '{os.environ['HETZNER_S3_SECRET_KEY']}';")
+        _con.execute(f"SET s3_endpoint = {_lit(_endpoint_host)};")
+        _con.execute(f"SET s3_access_key_id = {_lit(os.environ['HETZNER_S3_ACCESS_KEY'])};")
+        _con.execute(f"SET s3_secret_access_key = {_lit(os.environ['HETZNER_S3_SECRET_KEY'])};")
         _con.execute("SET s3_url_style = 'path';")
         _con.execute("SET s3_use_ssl = true;")
 
@@ -211,8 +222,8 @@ def _(months, os, s3_env_ok):
                 f"yellow_tripdata_2025-{_month}.parquet"
             )
             _con.execute(
-                f"COPY (SELECT * FROM read_parquet('{_src}')) "
-                f"TO '{_dst}' (FORMAT PARQUET);"
+                f"COPY (SELECT * FROM read_parquet({_lit(_src)})) "
+                f"TO {_lit(_dst)} (FORMAT PARQUET);"
             )
             upload_results.append({"month": _month, "src": _src, "dst": _dst})
         _con.close()

--- a/examples/workspace-seeds/prefect/flows/nyc_green_taxi_pipeline.py
+++ b/examples/workspace-seeds/prefect/flows/nyc_green_taxi_pipeline.py
@@ -41,6 +41,20 @@ from prefect import flow, get_run_logger, task
 CLOUDFRONT = "https://d37ci6vzurychx.cloudfront.net/trip-data"
 
 
+def _lit(value: object) -> str:
+    """Render a value as a safely quoted SQL string literal.
+
+    DuckDB's SET statements take no parameter placeholders — you cannot
+    write ``SET s3_access_key_id = ?`` — so credentials and paths have
+    to be inlined into the SQL text. That makes quoting this code's job:
+    an apostrophe inside a value closes the string literal early, the
+    statement fails with a syntax error, and the error message can carry
+    a fragment of the value into the Prefect run log. Doubling the
+    apostrophe is the SQL-standard escape.
+    """
+    return "'" + str(value).replace("'", "''") + "'"
+
+
 @task(retries=2, retry_delay_seconds=10, log_prints=True)
 def download_month(month: str) -> bytes:
     """Pull one Green-Taxi month from NYC TLC's CloudFront and return raw parquet bytes.
@@ -111,15 +125,15 @@ def aggregate_stats(months: list[str]) -> dict:
     # and unions them. Sort for stability (deterministic earliest/
     # latest in the result).
     paths = ", ".join(
-        f"'s3://{bucket}/nexus-tutorials/NYC/green_tripdata_2025-{m}.parquet'"
+        _lit(f"s3://{bucket}/nexus-tutorials/NYC/green_tripdata_2025-{m}.parquet")
         for m in sorted(set(months))
     )
     sql = f"""
         INSTALL httpfs;
         LOAD httpfs;
-        SET s3_endpoint          = '{endpoint_host}';
-        SET s3_access_key_id     = '{os.environ["R2_ACCESS_KEY"]}';
-        SET s3_secret_access_key = '{os.environ["R2_SECRET_KEY"]}';
+        SET s3_endpoint          = {_lit(endpoint_host)};
+        SET s3_access_key_id     = {_lit(os.environ["R2_ACCESS_KEY"])};
+        SET s3_secret_access_key = {_lit(os.environ["R2_SECRET_KEY"])};
         SET s3_url_style         = 'path';
         SET s3_use_ssl           = true;
 


### PR DESCRIPTION
## The defect

Both seeded example flows built their DuckDB configuration with f-strings:

```python
_con.execute(f"SET s3_secret_access_key = '{os.environ['HETZNER_S3_SECRET_KEY']}';")
```

An apostrophe in any inlined value closes the string literal early. Verified against DuckDB, with a value of `abc'def'ghi`:

```
ParserException: Parser Error: syntax error at or near "def"
```

The flow aborts, and the error message can carry a fragment of the value into the notebook output or the Prefect run log.

## The fix

A small `_lit()` helper in each file that doubles apostrophes — the SQL-standard escape — applied to **every** inlined value. Not only the credentials: the endpoint host and the `s3://` paths built from the bucket name were equally exposed.

```python
def _lit(value: object) -> str:
    return "'" + str(value).replace("'", "''") + "'"
```

After the fix, DuckDB accepts the statement and `current_setting` returns the value unchanged.

## Why not parameterised queries

They are not expressible here. DuckDB's `SET` statements do not accept placeholders — `SET s3_access_key_id = ?` is not valid SQL. The values must be inlined, which makes quoting the caller's job.

Both helpers carry that explanation in their docstring. These files are teaching material seeded into every student's workspace, and a reader who knows the usual advice will otherwise wonder why the obvious fix was not used.

## Provenance

Found by a Sourcery security scan, reported as *"SQL injection from formatted SQL string"*.

That framing does not hold: the values come from platform-injected Infisical secrets, not from users, so there is no untrusted input altering query structure. The remediation it proposed — parameterised queries — is not expressible for `SET`, as above.

The defect it pointed at was nonetheless real, so it is fixed on its own terms rather than as reported. Of the nine findings in that scan, five were dependency advisories (handled in #655), three were false positives or a documented project decision, and this was the one with a genuine bug underneath a wrong diagnosis.

## Not done here

DuckDB's `CREATE SECRET` (0.10+) would avoid the whole class rather than escaping around it, and is arguably the better thing to teach. Left out deliberately: it changes the teaching content and raises the minimum DuckDB version for anyone running these seeds, which is a separate decision from fixing the bug.

## Verification

- Both files parse (`ast.parse`)
- Against real DuckDB: old form raises `ParserException`, new form succeeds and `current_setting('s3_access_key_id')` returns the input unchanged, apostrophes included
- Escaping checked on a benign value, a value with one apostrophe, and a statement-splitting attempt — the last is contained inside a single literal

## Documentation impact

None. No user-facing behaviour, service metadata, or setup step changes; the seeded files keep their filenames, so existing workspace repos are unaffected (the seed loop is create-only and skips files that already exist).

## Summary by Sourcery

Prevent seeded DuckDB examples from breaking on apostrophes in inlined configuration values by safely escaping all dynamic SQL literals.

Bug Fixes:
- Escape apostrophes in DuckDB configuration values and S3 paths so seeded example flows handle values containing quotes without SQL parse failures or leaking fragments into logs.

Enhancements:
- Apply consistent SQL string-literal quoting across the Marimo and Prefect DuckDB example flows, including endpoints, credentials, and generated object paths.