### PR TITLE
fix(tofu): Run cloud-init apt non-interactively

### DIFF
--- a/tofu/stack/main.tf
+++ b/tofu/stack/main.tf
@@ -640,11 +640,33 @@ resource "hcloud_server" "main" {
     #!/bin/bash
     set -e
 
+    # Non-interactive apt for everything below. `-y` only answers apt's
+    # own yes/no prompts; a package whose debconf question is priority
+    # medium or higher still opens an ncurses dialog and then blocks
+    # FOREVER, because a cloud-init boot has no tty to answer it.
+    #
+    # That is not a slow boot the readiness gate can wait out — it is a
+    # permanent hang, and no timeout is large enough. Observed on
+    # 2026-08-24: keyboard-configuration 1.226ubuntu1.1 asked for the
+    # keyboard layout, every cold spin-up stalled, and the 6-minute gate
+    # failed the workflow with "cloud-init did not complete".
+    #
+    # This had worked for months purely because no upgraded package
+    # happened to ask anything. That is luck, not a property.
+    export DEBIAN_FRONTEND=noninteractive
+    # needrestart ships enabled on 24.04 and prompts about restarting
+    # services after a library upgrade. `a` applies automatically.
+    export NEEDRESTART_MODE=a
+
     if [ ! -f /opt/docker-server/.image-provisioned ]; then
       # ----- Heavy path: fresh Ubuntu image, provision from scratch -----
 
-      # Update system
-      apt-get update && apt-get upgrade -y
+      # Update system.
+      # --force-confold keeps the existing config file when a package
+      # ships a changed one. Without it dpkg asks which to keep — the
+      # same class of hang as the debconf dialog above.
+      apt-get update
+      apt-get upgrade -y -o Dpkg::Options::=--force-confold
 
       # Install Docker
       curl -fsSL https://get.docker.com | sh


### PR DESCRIPTION
## Symptom

Every cold spin-up fails with:

```
❌ cloud-init did not complete after 6 minutes
```

The readiness gate was not too short. The boot was hung, and no timeout would have been long enough.

## Root cause

`apt-get upgrade -y` answers apt's own yes/no prompts. It does **not** suppress debconf, so a package whose configuration question is priority medium or higher opens an ncurses dialog and waits for input that a cloud-init boot has no tty to provide.

Captured verbatim from the diagnostic the gate printed on failure:

```
Setting up keyboard-configuration (1.226ubuntu1.1) ...
Package configuration
┌──────────────────┤ Configuring keyboard-configuration ├──────────────────┐
│ The layout of keyboards varies per country, with some countries having   │
│ multiple common layouts. Please select the country of origin for the     │
│ keyboard of this computer.                                               │
│ Country of origin for the keyboard:
```

## Timeline

The gap between the defect and its first symptom is the interesting part:

| Date | Event |
|---|---|
| 2026-01-09 | `apt-get update && apt-get upgrade -y` lands in `user_data` (38c3516). `DEBIAN_FRONTEND` has **never** appeared anywhere in this repo |
| 2026-08-20 21:29 UTC | Ubuntu publishes `keyboard-configuration 1.226ubuntu1.1` to `noble-updates` |
| 2026-08-21 13:57 | Last successful spin-up — its log shows **0 apt unpacks**, so it took the light path on a warm server and never reached apt |
| 2026-08-24 11:58 | First genuinely cold build since the package landed. 19 packages in the upgrade set; one of them asks a question. Hangs |

So the defect is seven months old and worked only because no upgraded package happened to ask anything. That is luck, not a property — and the same luck can run out again on any future Ubuntu update.

## The fix

```bash
export DEBIAN_FRONTEND=noninteractive
export NEEDRESTART_MODE=a

apt-get update
apt-get upgrade -y -o Dpkg::Options::=--force-confold
```

Three parts, each closing a different variant of the same hang:

- **`DEBIAN_FRONTEND=noninteractive`** — the actual fix. Exported for the whole script rather than prefixed to one command, so the later `apt-get install -y fail2ban unattended-upgrades jq` is covered too.
- **`NEEDRESTART_MODE=a`** — `needrestart` ships enabled on 24.04 and prompts about restarting services after a library upgrade. `a` applies automatically.
- **`--force-confold`** — keeps the existing config file when a package ships a changed one. Without it dpkg asks which to keep, which is the same class of hang from a different source.

## Recovery for a stack already holding a hung server

`hcloud_server.main` carries `lifecycle.ignore_changes = [image, user_data, server_type, location]`, so this change does **not** recreate an existing server. That block is load-bearing for the snapshot lifecycle and should not be weakened for this.

A stack with a hung server therefore needs a teardown before the next spin-up:

```bash
gh workflow run teardown.yml
gh workflow run spin-up.yml
```

## Verification

`tofu validate` passes; `tofu fmt` clean.

**Not verified against a real boot** — that requires a cold spin-up, which is the thing currently broken. The change is the standard remedy for this failure mode and the diagnostic identifies the mechanism unambiguously, but the proof is the next cold build completing.

## Follow-up worth considering, not in this PR

The failure took seven months to surface and nothing in CI would have caught it. Two directions:

1. A periodic cold-build smoke test, so an Ubuntu update that breaks provisioning is found by a scheduled run rather than by a course starting.
2. The snapshot lifecycle sidesteps this entirely on the warm path — a restored server never runs the heavy path. That is an argument for finishing its verification, not a substitute for this fix: the fresh-build fallback stays reachable by design.

## Summary by Sourcery

Ensure fresh Ubuntu server provisioning completes reliably by running apt package operations non-interactively.

Bug Fixes:
- Prevent cloud-init provisioning from hanging on interactive apt, debconf, needrestart, or dpkg configuration prompts.

Enhancements:
- Apply non-interactive package configuration consistently across system upgrades and package installation, while preserving existing package configuration files.