### PR TITLE
feat(control-plane): Let the stack owner choose the lifecycle

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -13,6 +13,9 @@
 #   1. reviews.profile: assertive → chill
 #   2. reviews.tools.languagetool.enabled: true → false
 #   3. reviews.auto_review.drafts: true → false
+#
+# request_changes_workflow was turned off for a different reason — see
+# the note at that key. It is about the verdict, not the volume.
 
 language: en
 
@@ -29,7 +32,19 @@ knowledge_base:
 
 reviews:
   profile: assertive             # flag more granular findings, not just high-confidence
-  request_changes_workflow: true # set "Changes requested" status when issues found
+  # Comment, never block. CodeRabbit's findings on this repo are worth
+  # having — it caught three real defects in #667 alone — but its
+  # "Changes requested" verdict does not clear itself: it posts follow-up
+  # reviews as COMMENTED and never converts to APPROVED, so every PR ends
+  # with a manual dismissal even after it has agreed in-thread that every
+  # finding is resolved. Observed on #656, #665 and #667; resolving all
+  # threads did not release it either.
+  #
+  # The findings are unchanged by this. What goes away is a gate that
+  # only ever opened by hand. Sourcery and Copilot already review without
+  # blocking, and branch protection is the right place for a hard gate if
+  # one is wanted.
+  request_changes_workflow: false
   high_level_summary: true       # PR-level summary at the top
   poem: false                    # disable the closing rhyme — pure noise
   review_status: true            # show review state in the PR

--- a/.github/workflows/cleanup-orphaned-resources.yml
+++ b/.github/workflows/cleanup-orphaned-resources.yml
@@ -1,4 +1,4 @@
-name: Cleanup Orphaned Resources
+name: "Ops: Cleanup Orphaned Resources"
 
 on:
   workflow_dispatch:
@@ -15,7 +15,7 @@ jobs:
       TF_VAR_cloudflare_account_id: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
       TF_VAR_cloudflare_zone_id: ${{ secrets.CLOUDFLARE_ZONE_ID }}
       TF_VAR_domain: ${{ secrets.DOMAIN }}
-    
+
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -30,24 +30,24 @@ jobs:
           DOMAIN="${{ secrets.DOMAIN }}"
           RESOURCE_PREFIX="nexus-${DOMAIN//./-}"
           D1_DATABASE_NAME="${RESOURCE_PREFIX}-db"
-          
+
           # Get all D1 databases
           D1_DATABASES_RESPONSE=$(curl -s \
             "https://api.cloudflare.com/client/v4/accounts/${{ secrets.CLOUDFLARE_ACCOUNT_ID }}/d1/database" \
             -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" \
             -H "Content-Type: application/json")
-          
+
           D1_DATABASE_ID=$(echo "$D1_DATABASES_RESPONSE" | jq -r ".result[] | select(.name == \"$D1_DATABASE_NAME\") | .uuid" 2>/dev/null || echo "")
-          
+
           if [ -n "$D1_DATABASE_ID" ] && [ "$D1_DATABASE_ID" != "null" ]; then
             echo "  Found D1 Database ID: $D1_DATABASE_ID"
-            
+
             # Delete the database
             D1_DELETE_RESPONSE=$(curl -s -X DELETE \
               "https://api.cloudflare.com/client/v4/accounts/${{ secrets.CLOUDFLARE_ACCOUNT_ID }}/d1/database/$D1_DATABASE_ID" \
               -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" \
               -H "Content-Type: application/json")
-            
+
             if echo "$D1_DELETE_RESPONSE" | grep -q '"success":true'; then
               echo "✅ D1 Database deleted"
             else
@@ -62,24 +62,24 @@ jobs:
         run: |
           echo "🔍 Finding Access Application..."
           ACCESS_APP_DOMAIN="control.${{ secrets.DOMAIN }}"
-          
+
           # Get all Access applications for the zone
           ACCESS_APPS_RESPONSE=$(curl -s \
             "https://api.cloudflare.com/client/v4/zones/${{ secrets.CLOUDFLARE_ZONE_ID }}/access/apps" \
             -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" \
             -H "Content-Type: application/json")
-          
+
           ACCESS_APP_ID=$(echo "$ACCESS_APPS_RESPONSE" | jq -r ".result[] | select(.domain == \"$ACCESS_APP_DOMAIN\") | .id" 2>/dev/null || echo "")
-          
+
           if [ -n "$ACCESS_APP_ID" ] && [ "$ACCESS_APP_ID" != "null" ]; then
             echo "  Found Access Application ID: $ACCESS_APP_ID"
-            
+
             # Delete the Access Application
             ACCESS_DELETE_RESPONSE=$(curl -s -X DELETE \
               "https://api.cloudflare.com/client/v4/zones/${{ secrets.CLOUDFLARE_ZONE_ID }}/access/apps/$ACCESS_APP_ID" \
               -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" \
               -H "Content-Type: application/json")
-            
+
             if echo "$ACCESS_DELETE_RESPONSE" | grep -q '"success":true'; then
               echo "✅ Access Application deleted"
             else

--- a/.github/workflows/destroy-all.yml
+++ b/.github/workflows/destroy-all.yml
@@ -1,4 +1,4 @@
-name: Destroy All Infrastructure
+name: ⚠️ Destroy All Infrastructure
 
 on:
   workflow_dispatch:

--- a/.github/workflows/initial-setup.yaml
+++ b/.github/workflows/initial-setup.yaml
@@ -1,4 +1,4 @@
-name: Initial Setup
+name: "Setup: First-Time Deploy"
 
 on:
   workflow_dispatch:
@@ -92,7 +92,7 @@ jobs:
           echo "✅ D1 updated with initial service selection"
 
   spin-up:
-    name: Spin Up Nexus-Stack
+    name: Spin Up
     needs: [setup-control-plane, configure-initial-services]
     if: ${{ always() && needs.setup-control-plane.result == 'success' && needs.configure-initial-services.result != 'failure' }}
     uses: ./.github/workflows/spin-up.yml

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -10,7 +10,7 @@
 # during pure docs/stack PRs.
 # =============================================================================
 
-name: Python Tests
+name: "CI: Python Tests"
 
 on:
   pull_request:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,4 +1,4 @@
-name: Release Please
+name: "CI: Release Please"
 
 on:
   push:

--- a/.github/workflows/setup-control-plane.yaml
+++ b/.github/workflows/setup-control-plane.yaml
@@ -1,4 +1,4 @@
-name: Setup Nexus Control Plane
+name: "Setup: Control Plane"
 
 on:
   workflow_dispatch:
@@ -36,7 +36,7 @@ concurrency:
 
 jobs:
   deploy:
-    name: Setup Nexus Control Plane
+    name: Setup Control Plane
     runs-on: ubuntu-latest
     outputs:
       r2_access_key_id: ${{ steps.r2_credentials.outputs.r2_access_key_id }}
@@ -1370,4 +1370,4 @@ jobs:
           echo "ℹ️  Next steps:"
           echo "   1. Use the Control Plane to manage your infrastructure"
           echo "   2. Run 'Spin Up' workflow to deploy the Hetzner server and services"
-          echo "   3. Or trigger it manually: Actions → Spin Up Nexus-Stack → Run workflow"
+          echo "   3. Or trigger it manually: Actions → 'Lifecycle: Spin Up (Rebuild)' → Run workflow"

--- a/.github/workflows/spin-up-snapshot.yml
+++ b/.github/workflows/spin-up-snapshot.yml
@@ -1,4 +1,4 @@
-name: Spin Up Nexus-Stack (Snapshot)
+name: "Lifecycle: Spin Up (Snapshot)"
 
 # =============================================================================
 # Snapshot-based spin-up — the counterpart to teardown-snapshot.yml.

--- a/.github/workflows/spin-up.yml
+++ b/.github/workflows/spin-up.yml
@@ -1,4 +1,4 @@
-name: Spin Up Nexus-Stack
+name: "Lifecycle: Spin Up (Rebuild)"
 
 on:
   workflow_dispatch:
@@ -102,7 +102,7 @@ permissions:
 
 jobs:
   spin-up:
-    name: Spin Up Nexus-Stack
+    name: Spin Up
     runs-on: ubuntu-latest
     env:
       TF_VAR_cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/sync-docs-site.yml
+++ b/.github/workflows/sync-docs-site.yml
@@ -15,7 +15,7 @@
 # 3. Set WEBSITE_SYNC_ENABLED repo variable to "true"
 # =============================================================================
 
-name: Sync docs to website
+name: "Docs: Sync to Website"
 
 on:
   push:

--- a/.github/workflows/teardown-snapshot.yml
+++ b/.github/workflows/teardown-snapshot.yml
@@ -1,4 +1,4 @@
-name: Teardown Nexus-Stack (Snapshot)
+name: "Lifecycle: Teardown (Snapshot)"
 
 # =============================================================================
 # Snapshot-based teardown — the counterpart to spin-up-snapshot.yml.

--- a/.github/workflows/teardown.yml
+++ b/.github/workflows/teardown.yml
@@ -1,4 +1,4 @@
-name: Teardown Nexus-Stack
+name: "Lifecycle: Teardown (Rebuild)"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/toggle-silent-mode.yml
+++ b/.github/workflows/toggle-silent-mode.yml
@@ -1,4 +1,4 @@
-name: Toggle Silent Mode
+name: "Ops: Toggle Silent Mode"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/validate-workflows.yaml
+++ b/.github/workflows/validate-workflows.yaml
@@ -1,4 +1,4 @@
-name: Validate Workflows
+name: "CI: Validate Workflows"
 
 on:
   push:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,11 +133,12 @@ disk snapshot and restore from it — faster, and the only path that preserves
 data for stacks outside the five the R2 layer covers.
 
 Which pair a stack uses is the D1 config value `lifecycle_mode`
-(`legacy` | `snapshot`), read by the Control Plane. In the Actions UI the two
-pairs appear as **Lifecycle: … (Rebuild)** and **Lifecycle: … (Snapshot)** —
-the config value stayed `legacy` because it is a stored identifier, but the
-pair is a permanent fallback rather than something deprecated, so the workflow
-names describe what it does. **Never dispatch the two pairs at the same stack
+(`rebuild` | `snapshot`), read by the Control Plane and settable from its
+Settings page. In the Actions UI the pairs appear as **Lifecycle: …
+(Rebuild)** and **Lifecycle: … (Snapshot)**. The value was originally
+`legacy`; it was renamed because the pair is a permanent fallback rather than
+something deprecated, and `schema.sql` migrates existing rows on every
+Control Plane deploy. **Never dispatch the two pairs at the same stack
 interchangeably**: the rebuild teardown runs an
 untargeted `tofu destroy` that regenerates all 81 service credentials, and the
 epoch guard then correctly refuses any existing snapshot. That is why it is one

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,8 +133,12 @@ disk snapshot and restore from it — faster, and the only path that preserves
 data for stacks outside the five the R2 layer covers.
 
 Which pair a stack uses is the D1 config value `lifecycle_mode`
-(`legacy` | `snapshot`), read by the Control Plane. **Never dispatch the two
-pairs at the same stack interchangeably**: the legacy teardown runs an
+(`legacy` | `snapshot`), read by the Control Plane. In the Actions UI the two
+pairs appear as **Lifecycle: … (Rebuild)** and **Lifecycle: … (Snapshot)** —
+the config value stayed `legacy` because it is a stored identifier, but the
+pair is a permanent fallback rather than something deprecated, so the workflow
+names describe what it does. **Never dispatch the two pairs at the same stack
+interchangeably**: the rebuild teardown runs an
 untargeted `tofu destroy` that regenerates all 81 service credentials, and the
 epoch guard then correctly refuses any existing snapshot. That is why it is one
 config key rather than one per workflow.

--- a/control-plane/functions/api/_utils/require-same-origin.js
+++ b/control-plane/functions/api/_utils/require-same-origin.js
@@ -1,0 +1,59 @@
+// CSRF guard for state-changing endpoints.
+//
+// Cloudflare Access authenticates the caller, but authentication is not
+// the same as intent. Access identity travels in a cookie, so a browser
+// that is logged in sends it on *any* request to this origin — including
+// one triggered by a page the operator did not write. The endpoint then
+// sees a valid admin and does as it is told.
+//
+// TWO CHECKS, because either alone leaves a gap:
+//
+// 1. Content-Type must be JSON. A cross-site HTML form can only send
+//    urlencoded, multipart, or text/plain — it cannot set
+//    application/json without a CORS preflight the browser will refuse.
+//    This matters more than it looks: `request.json()` does not care
+//    what the Content-Type says, so a form with enctype="text/plain"
+//    and a carefully named field produces a body that parses as valid
+//    JSON. Requiring the header closes that door.
+//
+// 2. Origin, when present, must match. Browsers attach Origin to every
+//    cross-origin request and to same-origin POSTs. A mismatch is a
+//    cross-site submission and nothing else.
+//
+// A MISSING Origin is allowed on purpose: curl, the CLI and any
+// server-to-server caller send none, and those are legitimate. They also
+// cannot be driven by a victim's browser, which is the whole threat
+// here. The Content-Type check still applies to them.
+const deny = (reason) =>
+  new Response(JSON.stringify({ success: false, error: reason }), {
+    status: 403,
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+/**
+ * Returns a 403 Response to return immediately, or null when the request
+ * may proceed. Mirrors requireAdmin's shape so handlers read the same:
+ *
+ *   const blocked = requireSameOrigin(request);
+ *   if (blocked) return blocked;
+ */
+export function requireSameOrigin(request) {
+  const contentType = (request.headers.get('Content-Type') || '').toLowerCase();
+  if (!contentType.includes('application/json')) {
+    return deny('Content-Type must be application/json');
+  }
+
+  const origin = request.headers.get('Origin');
+  if (!origin) return null;
+
+  let expected;
+  try {
+    expected = new URL(request.url).origin;
+  } catch {
+    // An unparseable request URL should never happen. Fail closed rather
+    // than guess, since the only caller is a state-changing endpoint.
+    return deny('Could not determine the request origin');
+  }
+
+  return origin === expected ? null : deny('Cross-origin request refused');
+}

--- a/control-plane/functions/api/_utils/workflow-selection.js
+++ b/control-plane/functions/api/_utils/workflow-selection.js
@@ -101,15 +101,18 @@ export async function resolveLifecycle(db) {
     return { ok: false, reason: 'D1 read failed' };
   }
 
-  const value = row ? row.value : null;
-
-  // No row: this stack was never switched. That is a definite answer,
-  // not an unknown one.
-  if (!value) {
+  // `!row`, NOT `!row.value`. Absent and empty are different answers and
+  // this module exists to keep them apart: no row means the stack was
+  // never switched, which is definite and resolves to the default. An
+  // empty string is a stored value that is invalid, and must fall
+  // through to the refusal below — treating it as unconfigured would
+  // dispatch the DESTRUCTIVE pair at a stack that may be on snapshots,
+  // which is the exact failure the rest of this file guards against.
+  if (!row) {
     return { ok: true, mode: DEFAULT_LIFECYCLE_MODE, ...LIFECYCLE_WORKFLOWS[DEFAULT_LIFECYCLE_MODE] };
   }
 
-  const mode = canonicalMode(value);
+  const mode = canonicalMode(row.value);
   if (!LIFECYCLE_MODES.includes(mode)) {
     // Deliberately does not print the value. It is an unvalidated
     // database string, and this project does not put those in logs — if

--- a/control-plane/functions/api/_utils/workflow-selection.js
+++ b/control-plane/functions/api/_utils/workflow-selection.js
@@ -3,18 +3,18 @@
  *
  * Nexus-Stack has two pairs:
  *
- *   legacy    teardown.yml / spin-up.yml
+ *   rebuild   teardown.yml / spin-up.yml
  *             destroy everything, rebuild from ubuntu-24.04
  *   snapshot  teardown-snapshot.yml / spin-up-snapshot.yml
  *             snapshot the disk, destroy only the server, restore from
  *             the image
  *
  * ONE config value, not two. The pair is selected by `lifecycle_mode`
- * ('legacy' | 'snapshot') and both workflow names are derived from it.
+ * ('rebuild' | 'snapshot') and both workflow names are derived from it.
  *
  * Two independent keys were the first design and it was wrong: they can
  * drift, and a half-applied switch is actively harmful. Snapshot spin-up
- * with legacy teardown means the nightly untargeted `tofu destroy`
+ * with rebuild teardown means the nightly untargeted `tofu destroy`
  * rotates all 81 generated credentials, and the epoch guard then refuses
  * the snapshot it just made. Documenting "switch both together" is not
  * the same as making it impossible to do otherwise.
@@ -27,23 +27,39 @@
  * "CANNOT TELL" IS NOT "NOT CONFIGURED". These are different answers and
  * the caller must be able to tell them apart:
  *
- *   absent      no row -> the stack was never switched -> legacy is right
+ *   absent      no row -> the stack was never switched -> the default is right
  *   unreadable  D1 down, no binding, unknown value -> we do not know which
- *               mode this stack is in, and guessing legacy would dispatch
+ *               mode this stack is in, and guessing rebuild would dispatch
  *               the DESTRUCTIVE pair at a stack that may be on snapshots
  *
  * That is why this returns a result rather than a bare string with a
  * fallback baked in.
  */
 
-export const LIFECYCLE_MODES = ['legacy', 'snapshot'];
-export const DEFAULT_LIFECYCLE_MODE = 'legacy';
-
 /** Workflow filenames per mode. The only place these strings live. */
 export const LIFECYCLE_WORKFLOWS = {
-  legacy: { teardown: 'teardown.yml', spinUp: 'spin-up.yml' },
+  rebuild: { teardown: 'teardown.yml', spinUp: 'spin-up.yml' },
   snapshot: { teardown: 'teardown-snapshot.yml', spinUp: 'spin-up-snapshot.yml' },
 };
+
+export const LIFECYCLE_MODES = Object.keys(LIFECYCLE_WORKFLOWS);
+export const DEFAULT_LIFECYCLE_MODE = 'rebuild';
+
+/**
+ * Normalise a submitted or stored mode for comparison.
+ *
+ * Trims and lowercases only — there is deliberately no alias table.
+ * `legacy` was the original name for `rebuild` and is migrated in
+ * `schema.sql`, which runs on every setup-control-plane deploy AFTER
+ * the Worker is updated. New code therefore never meets an old value,
+ * and an alias would only keep a name nobody should use alive.
+ *
+ * Returns the input lowercased when unrecognised, so the caller can
+ * reject it rather than having it silently coerced to a default.
+ */
+export function canonicalMode(value) {
+  return String(value ?? '').trim().toLowerCase();
+}
 
 /** Every filename either mode can produce — for run detection, not dispatch. */
 export const ALL_TEARDOWN_WORKFLOWS = LIFECYCLE_MODES.map(
@@ -63,7 +79,7 @@ export const ALL_SPINUP_WORKFLOWS = LIFECYCLE_MODES.map(
  * `ok: false` means the configuration could not be determined. Callers
  * must NOT fall back to a default on that — see the note above. It is
  * only returned for a genuine unknown; an unconfigured stack resolves
- * successfully to 'legacy'.
+ * successfully to the default.
  */
 export async function resolveLifecycle(db) {
   if (!db) {
@@ -93,7 +109,8 @@ export async function resolveLifecycle(db) {
     return { ok: true, mode: DEFAULT_LIFECYCLE_MODE, ...LIFECYCLE_WORKFLOWS[DEFAULT_LIFECYCLE_MODE] };
   }
 
-  if (!LIFECYCLE_MODES.includes(value)) {
+  const mode = canonicalMode(value);
+  if (!LIFECYCLE_MODES.includes(mode)) {
     // Deliberately does not print the value. It is an unvalidated
     // database string, and this project does not put those in logs — if
     // a secret were ever written to the wrong key, the log would keep it.
@@ -103,5 +120,5 @@ export async function resolveLifecycle(db) {
     return { ok: false, reason: 'unrecognised lifecycle_mode' };
   }
 
-  return { ok: true, mode: value, ...LIFECYCLE_WORKFLOWS[value] };
+  return { ok: true, mode, ...LIFECYCLE_WORKFLOWS[mode] };
 }

--- a/control-plane/functions/api/lifecycle.js
+++ b/control-plane/functions/api/lifecycle.js
@@ -67,9 +67,12 @@ async function readMode(db) {
     .prepare('SELECT value FROM config WHERE key = ?')
     .bind('lifecycle_mode')
     .first();
-  // An absent row is a definite answer, not an unknown: the stack was
-  // never switched, so the default applies.
-  if (!row || !row.value) return DEFAULT_LIFECYCLE_MODE;
+  // An absent row is a definite answer: the stack was never switched, so
+  // the default applies. An empty string is NOT that — it is a stored
+  // value that happens to be invalid, and it must come back as itself so
+  // the caller reports `recognised: false` instead of showing a mode the
+  // stack is not actually on.
+  if (!row) return DEFAULT_LIFECYCLE_MODE;
   return canonicalMode(row.value);
 }
 

--- a/control-plane/functions/api/lifecycle.js
+++ b/control-plane/functions/api/lifecycle.js
@@ -58,7 +58,7 @@ const MODE_INFO = {
     summary: 'Snapshot the disk, restore from it on the next spin-up.',
     keeps: 'Everything on the server, across all stacks.',
     loses: 'Nothing, as long as a usable snapshot exists.',
-    images: 'Frozen at the snapshot — refresh them explicitly when you want newer ones.',
+    images: 'Frozen at the snapshot, so they age. Switching to Rebuild for one cycle is currently the only way to pull newer ones.',
   },
 };
 

--- a/control-plane/functions/api/lifecycle.js
+++ b/control-plane/functions/api/lifecycle.js
@@ -87,7 +87,7 @@ async function logChange(db, level, message, metadata) {
 }
 
 export async function onRequestGet(context) {
-  const { env } = context;
+  const { env, request } = context;
   if (!env.NEXUS_DB) {
     return json({ success: false, error: 'D1 database not configured' }, 500);
   }
@@ -95,8 +95,15 @@ export async function onRequestGet(context) {
   try {
     const mode = await readMode(env.NEXUS_DB);
     const known = LIFECYCLE_MODES.includes(mode);
+    // Reuse the guard rather than re-implementing the comparison, so the
+    // answer the UI renders and the answer POST enforces cannot drift.
+    // Reported so the page can present the setting as read-only instead
+    // of offering a control that returns 403 on click — a student on the
+    // Access whitelist reaches this endpoint like anyone else.
+    const canEdit = requireAdmin(env, request) === null;
     return json({
       success: true,
+      canEdit,
       // `null` rather than the raw string when unrecognised: the stored
       // value is unvalidated input and does not belong in a response
       // body any more than it belongs in a log line.

--- a/control-plane/functions/api/lifecycle.js
+++ b/control-plane/functions/api/lifecycle.js
@@ -113,7 +113,17 @@ export async function onRequestGet(context) {
     // Reported so the page can present the setting as read-only instead
     // of offering a control that returns 403 on click — a student on the
     // Access whitelist reaches this endpoint like anyone else.
-    const canEdit = requireAdmin(env, request) === null;
+    //
+    // requireAdmin refuses for two different reasons and they must not
+    // collapse into one flag. 403 means "you are not the admin", which
+    // is an ordinary state and the whole point of canEdit. 500 means
+    // ADMIN_EMAIL is unset — nobody can change the setting and the stack
+    // is misconfigured. Reporting that as canEdit:false would show every
+    // caller a read-only page and hide the actual problem, so the denial
+    // is returned as-is and the operator sees it.
+    const denial = requireAdmin(env, request);
+    if (denial && denial.status !== 403) return denial;
+    const canEdit = denial === null;
     return json({
       success: true,
       canEdit,

--- a/control-plane/functions/api/lifecycle.js
+++ b/control-plane/functions/api/lifecycle.js
@@ -1,0 +1,181 @@
+// Read and change which teardown/spin-up pair this stack uses.
+//
+// Nexus-Stack has two lifecycles and they are a genuine choice, not a
+// migration with an old and a new side:
+//
+//   rebuild   Destroy everything, rebuild from ubuntu-24.04 on the next
+//             spin-up. Fresh OS and freshly pulled images every time, so
+//             nothing drifts and `:latest` stacks stay current. Costs a
+//             few minutes per spin-up, and anything not covered by the
+//             R2 persistence layer is gone — that layer protects Gitea,
+//             Dify, HedgeDoc, Planka and Metabase by name, so a stack's
+//             own Postgres tables, Grafana dashboards, Kestra run
+//             history and uncommitted notebooks are not included.
+//
+//   snapshot  Snapshot the disk before destroying the server, restore
+//             from that image on the next spin-up. Every stack's state
+//             survives, not only the five, and the boot skips apt and
+//             the Docker install. In exchange the images age: a `:latest`
+//             stack keeps whatever was pulled when the snapshot line
+//             began.
+//
+// Which one is right depends on how the stack is used, which is why it
+// is a setting rather than a decision baked into the code.
+//
+// WRITES ARE ADMIN-ONLY. Switching is not reversible in effect: moving
+// from snapshot to rebuild means the next teardown runs an untargeted
+// `tofu destroy` that rotates all 81 generated credentials, after which
+// the epoch guard permanently refuses every existing snapshot. Reading
+// is open to any Access-authenticated caller so the UI can show the
+// current state without an admin session.
+import { getAccessUserEmail } from './_utils/cf-access-email.js';
+import { requireAdmin } from './_utils/require-admin.js';
+import {
+  LIFECYCLE_MODES,
+  LIFECYCLE_WORKFLOWS,
+  DEFAULT_LIFECYCLE_MODE,
+  canonicalMode,
+} from './_utils/workflow-selection.js';
+
+const json = (body, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+// Shown in the UI. Kept here rather than in workflow-selection.js so the
+// Worker's duplicate of that module stays free of presentation strings.
+const MODE_INFO = {
+  rebuild: {
+    label: 'Rebuild',
+    summary: 'Destroy and rebuild from a clean Ubuntu image every time.',
+    keeps: 'Only what the R2 layer backs up: Gitea, Dify, HedgeDoc, Planka, Metabase.',
+    loses: 'Everything else — your own Postgres tables, Grafana dashboards, Kestra run history, uncommitted notebooks.',
+    images: 'Always freshly pulled, so `:latest` stacks stay current.',
+  },
+  snapshot: {
+    label: 'Snapshot',
+    summary: 'Snapshot the disk, restore from it on the next spin-up.',
+    keeps: 'Everything on the server, across all stacks.',
+    loses: 'Nothing, as long as a usable snapshot exists.',
+    images: 'Frozen at the snapshot — refresh them explicitly when you want newer ones.',
+  },
+};
+
+async function readMode(db) {
+  const row = await db
+    .prepare('SELECT value FROM config WHERE key = ?')
+    .bind('lifecycle_mode')
+    .first();
+  // An absent row is a definite answer, not an unknown: the stack was
+  // never switched, so the default applies.
+  if (!row || !row.value) return DEFAULT_LIFECYCLE_MODE;
+  return canonicalMode(row.value);
+}
+
+async function logChange(db, level, message, metadata) {
+  // Best-effort: a failed audit write must not fail the request that
+  // already succeeded, or the caller retries and switches twice.
+  try {
+    await db
+      .prepare('INSERT INTO logs (source, level, message, metadata) VALUES (?, ?, ?, ?)')
+      .bind('lifecycle', level, message, metadata ? JSON.stringify(metadata) : null)
+      .run();
+  } catch {
+    /* ignore */
+  }
+}
+
+export async function onRequestGet(context) {
+  const { env } = context;
+  if (!env.NEXUS_DB) {
+    return json({ success: false, error: 'D1 database not configured' }, 500);
+  }
+
+  try {
+    const mode = await readMode(env.NEXUS_DB);
+    const known = LIFECYCLE_MODES.includes(mode);
+    return json({
+      success: true,
+      // `null` rather than the raw string when unrecognised: the stored
+      // value is unvalidated input and does not belong in a response
+      // body any more than it belongs in a log line.
+      mode: known ? mode : null,
+      recognised: known,
+      workflows: known ? LIFECYCLE_WORKFLOWS[mode] : null,
+      modes: LIFECYCLE_MODES.map((m) => ({
+        value: m,
+        ...MODE_INFO[m],
+        workflows: LIFECYCLE_WORKFLOWS[m],
+      })),
+    });
+  } catch (error) {
+    console.error('lifecycle: failed to read config.lifecycle_mode:', error);
+    return json({ success: false, error: 'Could not read the lifecycle mode' }, 500);
+  }
+}
+
+export async function onRequestPost(context) {
+  const { env, request } = context;
+  const denial = requireAdmin(env, request);
+  if (denial) return denial;
+
+  if (!env.NEXUS_DB) {
+    return json({ success: false, error: 'D1 database not configured' }, 500);
+  }
+
+  let body;
+  try {
+    body = await request.json();
+  } catch {
+    return json({ success: false, error: 'Request body must be JSON' }, 400);
+  }
+
+  const requested = canonicalMode(body?.mode);
+  if (!LIFECYCLE_MODES.includes(requested)) {
+    // Echoes the accepted values, never the rejected one.
+    return json(
+      { success: false, error: `mode must be one of: ${LIFECYCLE_MODES.join(', ')}` },
+      400,
+    );
+  }
+
+  try {
+    const previous = await readMode(env.NEXUS_DB);
+    if (previous === requested) {
+      return json({ success: true, mode: requested, changed: false });
+    }
+
+    await env.NEXUS_DB.prepare(
+      `INSERT INTO config (key, value, updated_at)
+       VALUES ('lifecycle_mode', ?, datetime('now'))
+       ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = datetime('now')`,
+    )
+      .bind(requested)
+      .run();
+
+    const userEmail = getAccessUserEmail(request) || 'unknown';
+    await logChange(env.NEXUS_DB, 'info', `Lifecycle mode changed to ${requested}`, {
+      from: previous,
+      to: requested,
+      by: userEmail,
+    });
+
+    return json({
+      success: true,
+      mode: requested,
+      changed: true,
+      previous,
+      workflows: LIFECYCLE_WORKFLOWS[requested],
+      // Surfaced so the UI can warn rather than the operator finding out
+      // at the next teardown.
+      warning:
+        requested === 'rebuild'
+          ? 'Switching to Rebuild rotates every generated credential on the next teardown. Existing snapshots will be refused from then on and cannot be restored.'
+          : null,
+    });
+  } catch (error) {
+    console.error('lifecycle: failed to write config.lifecycle_mode:', error);
+    return json({ success: false, error: 'Could not save the lifecycle mode' }, 500);
+  }
+}

--- a/control-plane/functions/api/lifecycle.js
+++ b/control-plane/functions/api/lifecycle.js
@@ -73,16 +73,26 @@ async function readMode(db) {
   return canonicalMode(row.value);
 }
 
+// Returns true when the audit row landed, false when it did not.
+//
+// Deliberately does NOT throw. By the time this runs the config write has
+// already committed, so failing the response would tell the caller the
+// change did not happen when it did — and their retry would switch
+// again. But the failure is not swallowed either: it is logged to the
+// Worker console and reported to the caller as `auditLogged: false`, so
+// a lifecycle change without an audit trail is visible rather than
+// silent. That is the part that matters for a setting whose next
+// teardown can rotate every credential on the stack.
 async function logChange(db, level, message, metadata) {
-  // Best-effort: a failed audit write must not fail the request that
-  // already succeeded, or the caller retries and switches twice.
   try {
     await db
       .prepare('INSERT INTO logs (source, level, message, metadata) VALUES (?, ?, ?, ?)')
       .bind('lifecycle', level, message, metadata ? JSON.stringify(metadata) : null)
       .run();
-  } catch {
-    /* ignore */
+    return true;
+  } catch (error) {
+    console.error('lifecycle: config was changed but the audit row failed:', error);
+    return false;
   }
 }
 
@@ -148,7 +158,14 @@ export async function onRequestPost(context) {
   }
 
   try {
-    const previous = await readMode(env.NEXUS_DB);
+    const stored = await readMode(env.NEXUS_DB);
+    // Only report a previous value we recognise. `stored` comes straight
+    // from a database row, and this file already refuses to put an
+    // unvalidated one in a log line or a response body — `previous` goes
+    // into BOTH, so it gets the same treatment. If someone ever writes a
+    // secret to this key, it must not be echoed back or persisted into
+    // the audit record.
+    const previous = LIFECYCLE_MODES.includes(stored) ? stored : null;
     if (previous === requested) {
       return json({ success: true, mode: requested, changed: false });
     }
@@ -162,17 +179,19 @@ export async function onRequestPost(context) {
       .run();
 
     const userEmail = getAccessUserEmail(request) || 'unknown';
-    await logChange(env.NEXUS_DB, 'info', `Lifecycle mode changed to ${requested}`, {
-      from: previous,
-      to: requested,
-      by: userEmail,
-    });
+    const auditLogged = await logChange(
+      env.NEXUS_DB,
+      'info',
+      `Lifecycle mode changed to ${requested}`,
+      { from: previous, to: requested, by: userEmail },
+    );
 
     return json({
       success: true,
       mode: requested,
       changed: true,
       previous,
+      auditLogged,
       workflows: LIFECYCLE_WORKFLOWS[requested],
       // Surfaced so the UI can warn rather than the operator finding out
       // at the next teardown.

--- a/control-plane/functions/api/lifecycle.js
+++ b/control-plane/functions/api/lifecycle.js
@@ -28,7 +28,6 @@
 // the epoch guard permanently refuses every existing snapshot. Reading
 // is open to any Access-authenticated caller so the UI can show the
 // current state without an admin session.
-import { getAccessUserEmail } from './_utils/cf-access-email.js';
 import { requireAdmin } from './_utils/require-admin.js';
 import { requireSameOrigin } from './_utils/require-same-origin.js';
 import {
@@ -186,12 +185,20 @@ export async function onRequestPost(context) {
       .bind(requested)
       .run();
 
-    const userEmail = getAccessUserEmail(request) || 'unknown';
+    // No caller email in the metadata. `requireAdmin` above allows
+    // exactly one identity through, so recording *who* adds no
+    // information — but /api/logs has no admin guard and the Monitoring
+    // page renders metadata verbatim, so it would put the admin address
+    // in front of every Access-authenticated user on the stack.
+    //
+    // Different from the extension log in scheduled-teardown.js, which
+    // does keep the address: extensions are counted per user, so there
+    // the identity is the whole point.
     const auditLogged = await logChange(
       env.NEXUS_DB,
       'info',
       `Lifecycle mode changed to ${requested}`,
-      { from: previous, to: requested, by: userEmail },
+      { from: previous, to: requested },
     );
 
     return json({

--- a/control-plane/functions/api/lifecycle.js
+++ b/control-plane/functions/api/lifecycle.js
@@ -30,6 +30,7 @@
 // current state without an admin session.
 import { getAccessUserEmail } from './_utils/cf-access-email.js';
 import { requireAdmin } from './_utils/require-admin.js';
+import { requireSameOrigin } from './_utils/require-same-origin.js';
 import {
   LIFECYCLE_MODES,
   LIFECYCLE_WORKFLOWS,
@@ -137,6 +138,10 @@ export async function onRequestGet(context) {
 
 export async function onRequestPost(context) {
   const { env, request } = context;
+  // Origin before identity: a cross-site submission carries a perfectly
+  // valid Access session, so authenticating it first proves nothing.
+  const crossSite = requireSameOrigin(request);
+  if (crossSite) return crossSite;
   const denial = requireAdmin(env, request);
   if (denial) return denial;
 

--- a/control-plane/functions/api/teardown.js
+++ b/control-plane/functions/api/teardown.js
@@ -36,7 +36,7 @@ export async function onRequestPost(context) {
 
   // Refuse rather than guess. If the lifecycle mode cannot be determined
   // we do not know whether this stack is on snapshots, and defaulting to
-  // the legacy pair would run an untargeted `tofu destroy` that rotates
+  // the rebuild pair would run an untargeted `tofu destroy` that rotates
   // every generated credential and orphans any existing snapshot.
   // An UNCONFIGURED stack is a different case and resolves fine.
   const lifecycle = await resolveLifecycle(env.NEXUS_DB);

--- a/control-plane/schema.sql
+++ b/control-plane/schema.sql
@@ -98,13 +98,39 @@ INSERT OR IGNORE INTO config (key, value) VALUES
     ('notify_on_shutdown', 'true'),
     ('notify_on_spinup', 'true'),
     ('silent_mode', 'false'),
-    -- Which lifecycle workflow pair to dispatch: 'legacy' (destroy and
+    -- Which lifecycle workflow pair to dispatch: 'rebuild' (destroy and
     -- rebuild from ubuntu-24.04) or 'snapshot' (snapshot the disk,
     -- destroy only the server, restore from the image).
     --
     -- ONE key, not one per workflow. Two independent keys could drift,
     -- and a half-applied switch is harmful rather than merely untidy:
-    -- snapshot spin-up with legacy teardown means the nightly untargeted
+    -- snapshot spin-up with rebuild teardown means the nightly untargeted
     -- `tofu destroy` rotates every generated credential and orphans the
     -- snapshot it just produced.
-    ('lifecycle_mode', 'legacy');
+    ('lifecycle_mode', 'rebuild');
+
+-- ---------------------------------------------------------------------------
+-- Migration: 'legacy' -> 'rebuild'
+--
+-- 'legacy' was the original name for this pair and described it wrongly:
+-- it is not deprecated. It is the permanent fallback whenever a snapshot
+-- is unusable, the only option across an architecture change, and
+-- spin-up.yml is the shared engine the snapshot spin-up itself calls via
+-- workflow_call. The name is now 'rebuild', which says what it does.
+--
+-- No alias is kept in code, deliberately: an alias keeps a name alive
+-- that nobody should use. This file is applied on every
+-- setup-control-plane run, so every stack is migrated the next time its
+-- Control Plane is deployed.
+--
+-- ORDERING, and the one rough edge: the Worker is deployed before this
+-- runs, so the scheduled teardown never sees a value it cannot read. The
+-- Pages Functions are deployed AFTER, so between this statement and that
+-- step the API is briefly serving code that does not know 'rebuild' and
+-- will answer 503. That window is minutes long, only during a deliberate
+-- deploy, and it fails closed rather than dispatching the wrong pair.
+--
+-- Idempotent: after the first run no row matches.
+UPDATE config
+   SET value = 'rebuild', updated_at = datetime('now')
+ WHERE key = 'lifecycle_mode' AND value = 'legacy';

--- a/control-plane/src/pages/settings.astro
+++ b/control-plane/src/pages/settings.astro
@@ -392,7 +392,16 @@ import Layout from '../layouts/Layout.astro';
     try {
       const response = await fetch(API_URL + '/api/lifecycle', { credentials: 'same-origin' });
       const data = await response.json();
-      if (!data.success) throw new Error(data.error || 'failed');
+      if (!data.success) {
+        // Tag the error so the catch can tell an API message apart from
+        // a network or parse failure. The backend returns a specific 500
+        // when ADMIN_EMAIL is unset so the operator can see the
+        // misconfiguration — throwing that away here would undo the
+        // point of returning it.
+        const apiError = new Error(data.error || 'failed');
+        apiError.apiMessage = data.error || null;
+        throw apiError;
+      }
       lifecycleModes = data.modes || [];
 
       const active = lifecycleModes.find((m) => m.value === data.mode);
@@ -427,7 +436,7 @@ import Layout from '../layouts/Layout.astro';
         line4.textContent = 'Only the stack administrator can change this.';
         info.appendChild(line4);
       }
-    } catch {
+    } catch (error) {
       // Clear the state as well as showing the error. Without this the
       // toggle keeps whatever the last successful load set, so the page
       // would show a definite-looking mode next to a message saying it
@@ -436,7 +445,15 @@ import Layout from '../layouts/Layout.astro';
       toggle.classList.remove('active');
       toggle.classList.add('disabled');
       toggle.title = 'Lifecycle mode unavailable';
-      info.textContent = 'Could not load the lifecycle mode.';
+      // Show the server's own message when there is one — "Server
+      // misconfigured: ADMIN_EMAIL is not set" is actionable in a way
+      // that "could not load" is not. A network or parse failure has no
+      // apiMessage and falls back to the generic text, since the
+      // browser's own wording ("Failed to fetch") explains nothing.
+      // textContent, so the message cannot carry markup either way.
+      info.textContent = error && error.apiMessage
+        ? 'Could not load the lifecycle mode: ' + error.apiMessage
+        : 'Could not load the lifecycle mode.';
     }
   }
 

--- a/control-plane/src/pages/settings.astro
+++ b/control-plane/src/pages/settings.astro
@@ -428,8 +428,15 @@ import Layout from '../layouts/Layout.astro';
         info.appendChild(line4);
       }
     } catch {
-      info.textContent = 'Could not load the lifecycle mode.';
+      // Clear the state as well as showing the error. Without this the
+      // toggle keeps whatever the last successful load set, so the page
+      // would show a definite-looking mode next to a message saying it
+      // could not be read — worse than showing nothing.
+      lifecycleModes = [];
+      toggle.classList.remove('active');
       toggle.classList.add('disabled');
+      toggle.title = 'Lifecycle mode unavailable';
+      info.textContent = 'Could not load the lifecycle mode.';
     }
   }
 

--- a/control-plane/src/pages/settings.astro
+++ b/control-plane/src/pages/settings.astro
@@ -50,13 +50,13 @@ import Layout from '../layouts/Layout.astro';
   <!-- Lifecycle -->
   <div class="panel">
     <h2>Lifecycle</h2>
-    <div class="setting-info" style="margin-bottom: 0.9rem;">
-      How this stack is torn down at night and brought back the next day.
-      Both options stop the server, so both save the same amount of money —
-      they differ in what survives and how long the spin-up takes.
+    <div class="setting-row">
+      <div>
+        <div class="setting-label">Snapshot Lifecycle</div>
+        <div class="setting-info" id="lifecycle-info">Loading...</div>
+      </div>
+      <div class="toggle-switch disabled" id="toggle-lifecycle"></div>
     </div>
-    <div id="lifecycle-options"><div class="setting-info">Loading...</div></div>
-    <div class="setting-info" id="lifecycle-current" style="margin-top: 0.8rem;"></div>
   </div>
 
   <!-- Email Notifications -->
@@ -375,75 +375,70 @@ import Layout from '../layouts/Layout.astro';
   // ---------------------------------------------------------------------
   // Lifecycle mode
   //
-  // Rendered from the API rather than hardcoded here, so the wording and
-  // the list of modes live next to the code that acts on them. Values are
-  // server-side constants, but everything is still written with
-  // textContent — this page has had innerHTML findings before and a
-  // radio label is not worth a second one.
+  // Two modes, so a toggle: off = Rebuild, on = Snapshot. The info line
+  // always names the ACTIVE mode and what it means, so the current
+  // setting is readable even when the control is greyed out.
+  //
+  // Greyed out for everyone but the admin. The API enforces this anyway
+  // (POST answers 403); disabling the control means a student sees which
+  // mode the stack is on without being offered a switch that fails.
   // ---------------------------------------------------------------------
+  let lifecycleModes = [];
+
   async function loadLifecycle() {
-    const box = document.getElementById('lifecycle-options');
-    const current = document.getElementById('lifecycle-current');
-    if (!box) return;
+    const toggle = document.getElementById('toggle-lifecycle');
+    const info = document.getElementById('lifecycle-info');
+    if (!toggle || !info) return;
     try {
       const response = await fetch(API_URL + '/api/lifecycle', { credentials: 'same-origin' });
       const data = await response.json();
       if (!data.success) throw new Error(data.error || 'failed');
+      lifecycleModes = data.modes || [];
 
-      box.textContent = '';
-      (data.modes || []).forEach((m) => {
-        const row = document.createElement('label');
-        row.className = 'setting-row';
-        row.style.cursor = 'pointer';
-        row.style.alignItems = 'flex-start';
+      const active = lifecycleModes.find((m) => m.value === data.mode);
+      toggle.classList.toggle('active', data.mode === 'snapshot');
 
-        const text = document.createElement('div');
-        const label = document.createElement('div');
-        label.className = 'setting-label';
-        label.textContent = m.label + (m.value === data.mode ? ' — active' : '');
-        const info = document.createElement('div');
-        info.className = 'setting-info';
-        info.textContent = m.summary;
-        const detail = document.createElement('div');
-        detail.className = 'setting-info';
-        detail.style.marginTop = '0.25rem';
-        detail.textContent = 'Keeps: ' + m.keeps + ' \u2014 Images: ' + m.images;
-        text.appendChild(label);
-        text.appendChild(info);
-        text.appendChild(detail);
+      if (data.canEdit) {
+        toggle.classList.remove('disabled');
+        toggle.title = 'Switch between Rebuild and Snapshot';
+      } else {
+        toggle.classList.add('disabled');
+        toggle.title = 'Only the stack administrator can change the lifecycle';
+      }
 
-        const radio = document.createElement('input');
-        radio.type = 'radio';
-        radio.name = 'lifecycle-mode';
-        radio.value = m.value;
-        radio.checked = m.value === data.mode;
-        radio.addEventListener('change', () => {
-          if (radio.checked) saveLifecycle(m.value, m.label);
-        });
+      // textContent throughout: this page has had innerHTML findings.
+      info.textContent = '';
+      const line1 = document.createElement('div');
+      line1.textContent = data.recognised
+        ? 'Active: ' + (active ? active.label : data.mode) + ' \u2014 ' + (active ? active.summary : '')
+        : 'The stored mode is not recognised \u2014 nothing will be dispatched until it is set.';
+      info.appendChild(line1);
 
-        row.appendChild(text);
-        row.appendChild(radio);
-        box.appendChild(row);
-      });
-
-      if (current) {
-        current.textContent = data.recognised
-          ? 'Dispatches ' + data.workflows.teardown + ' and ' + data.workflows.spinUp + '.'
-          : 'The stored mode is not recognised — nothing will be dispatched until it is set.';
+      if (active) {
+        const line2 = document.createElement('div');
+        line2.textContent = 'Keeps: ' + active.keeps;
+        info.appendChild(line2);
+        const line3 = document.createElement('div');
+        line3.textContent = 'Images: ' + active.images;
+        info.appendChild(line3);
+      }
+      if (!data.canEdit) {
+        const line4 = document.createElement('div');
+        line4.textContent = 'Only the stack administrator can change this.';
+        info.appendChild(line4);
       }
     } catch {
-      box.textContent = '';
-      const err = document.createElement('div');
-      err.className = 'setting-info';
-      err.textContent = 'Could not load the lifecycle mode.';
-      box.appendChild(err);
+      info.textContent = 'Could not load the lifecycle mode.';
+      toggle.classList.add('disabled');
     }
   }
 
-  async function saveLifecycle(mode, label) {
-    // Rebuild is the destructive direction: the next teardown rotates
-    // every generated credential, after which existing snapshots are
-    // refused for good. Worth one confirmation.
+  async function saveLifecycle(mode) {
+    const entry = lifecycleModes.find((m) => m.value === mode);
+    const label = entry ? entry.label : mode;
+    // Rebuild is the direction that cannot be undone: the next teardown
+    // rotates every generated credential, after which existing snapshots
+    // are refused for good.
     if (mode === 'rebuild') {
       const ok = confirm(
         'Switch to Rebuild?\n\n' +
@@ -470,6 +465,13 @@ import Layout from '../layouts/Layout.astro';
     }
     loadLifecycle();
   }
+
+  document.getElementById('toggle-lifecycle')?.addEventListener('click', function () {
+    // .disabled sets pointer-events:none, so this cannot fire while
+    // greyed out — the guard is belt and braces.
+    if (this.classList.contains('disabled')) return;
+    saveLifecycle(this.classList.contains('active') ? 'rebuild' : 'snapshot');
+  });
 
   fetchInfo();
   loadScheduledTeardownConfig();

--- a/control-plane/src/pages/settings.astro
+++ b/control-plane/src/pages/settings.astro
@@ -47,6 +47,18 @@ import Layout from '../layouts/Layout.astro';
     <button class="btn-warning" id="btn-delay-teardown" disabled style="margin-top: 0.8rem;">Delay Teardown</button>
   </div>
 
+  <!-- Lifecycle -->
+  <div class="panel">
+    <h2>Lifecycle</h2>
+    <div class="setting-info" style="margin-bottom: 0.9rem;">
+      How this stack is torn down at night and brought back the next day.
+      Both options stop the server, so both save the same amount of money —
+      they differ in what survives and how long the spin-up takes.
+    </div>
+    <div id="lifecycle-options"><div class="setting-info">Loading...</div></div>
+    <div class="setting-info" id="lifecycle-current" style="margin-top: 0.8rem;"></div>
+  </div>
+
   <!-- Email Notifications -->
   <div class="panel">
     <h2>Email Notifications</h2>
@@ -360,8 +372,108 @@ import Layout from '../layouts/Layout.astro';
     }
   }
 
+  // ---------------------------------------------------------------------
+  // Lifecycle mode
+  //
+  // Rendered from the API rather than hardcoded here, so the wording and
+  // the list of modes live next to the code that acts on them. Values are
+  // server-side constants, but everything is still written with
+  // textContent — this page has had innerHTML findings before and a
+  // radio label is not worth a second one.
+  // ---------------------------------------------------------------------
+  async function loadLifecycle() {
+    const box = document.getElementById('lifecycle-options');
+    const current = document.getElementById('lifecycle-current');
+    if (!box) return;
+    try {
+      const response = await fetch(API_URL + '/api/lifecycle', { credentials: 'same-origin' });
+      const data = await response.json();
+      if (!data.success) throw new Error(data.error || 'failed');
+
+      box.textContent = '';
+      (data.modes || []).forEach((m) => {
+        const row = document.createElement('label');
+        row.className = 'setting-row';
+        row.style.cursor = 'pointer';
+        row.style.alignItems = 'flex-start';
+
+        const text = document.createElement('div');
+        const label = document.createElement('div');
+        label.className = 'setting-label';
+        label.textContent = m.label + (m.value === data.mode ? ' — active' : '');
+        const info = document.createElement('div');
+        info.className = 'setting-info';
+        info.textContent = m.summary;
+        const detail = document.createElement('div');
+        detail.className = 'setting-info';
+        detail.style.marginTop = '0.25rem';
+        detail.textContent = 'Keeps: ' + m.keeps + ' \u2014 Images: ' + m.images;
+        text.appendChild(label);
+        text.appendChild(info);
+        text.appendChild(detail);
+
+        const radio = document.createElement('input');
+        radio.type = 'radio';
+        radio.name = 'lifecycle-mode';
+        radio.value = m.value;
+        radio.checked = m.value === data.mode;
+        radio.addEventListener('change', () => {
+          if (radio.checked) saveLifecycle(m.value, m.label);
+        });
+
+        row.appendChild(text);
+        row.appendChild(radio);
+        box.appendChild(row);
+      });
+
+      if (current) {
+        current.textContent = data.recognised
+          ? 'Dispatches ' + data.workflows.teardown + ' and ' + data.workflows.spinUp + '.'
+          : 'The stored mode is not recognised — nothing will be dispatched until it is set.';
+      }
+    } catch {
+      box.textContent = '';
+      const err = document.createElement('div');
+      err.className = 'setting-info';
+      err.textContent = 'Could not load the lifecycle mode.';
+      box.appendChild(err);
+    }
+  }
+
+  async function saveLifecycle(mode, label) {
+    // Rebuild is the destructive direction: the next teardown rotates
+    // every generated credential, after which existing snapshots are
+    // refused for good. Worth one confirmation.
+    if (mode === 'rebuild') {
+      const ok = confirm(
+        'Switch to Rebuild?\n\n' +
+        'The next teardown will destroy everything and rotate all generated ' +
+        'credentials. Existing snapshots can no longer be restored after that, ' +
+        'and only the stacks covered by the R2 backup keep their data.'
+      );
+      if (!ok) { loadLifecycle(); return; }
+    }
+    try {
+      const response = await fetch(API_URL + '/api/lifecycle', {
+        method: 'POST', credentials: 'same-origin',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ mode }),
+      });
+      const data = await response.json();
+      if (data.success) {
+        showToast(data.changed ? 'Lifecycle set to ' + label : 'Already using ' + label);
+      } else {
+        showToast(data.error || 'Failed to update', 'error');
+      }
+    } catch {
+      showToast('Failed to update the lifecycle mode', 'error');
+    }
+    loadLifecycle();
+  }
+
   fetchInfo();
   loadScheduledTeardownConfig();
+  loadLifecycle();
   loadEmailSettings();
   loadHistory();
 </script>

--- a/control-plane/src/pages/settings.astro
+++ b/control-plane/src/pages/settings.astro
@@ -52,7 +52,7 @@ import Layout from '../layouts/Layout.astro';
     <h2>Lifecycle</h2>
     <div class="setting-row">
       <div>
-        <div class="setting-label">Snapshot Lifecycle</div>
+        <div class="setting-label">Lifecycle mode</div>
         <div class="setting-info" id="lifecycle-info">Loading...</div>
       </div>
       <div class="toggle-switch disabled" id="toggle-lifecycle"></div>

--- a/control-plane/worker/src/index.js
+++ b/control-plane/worker/src/index.js
@@ -69,21 +69,27 @@ async function getConfigValue(db, key, defaultValue = null) {
 // ONE mode, both names derived from it, so the pair cannot drift.
 // Deriving rather than reading the names also means no database value
 // ever reaches the GitHub API URL path.
-const LIFECYCLE_MODES = ['legacy', 'snapshot'];
-const DEFAULT_LIFECYCLE_MODE = 'legacy';
 const LIFECYCLE_WORKFLOWS = {
-  legacy: { teardown: 'teardown.yml', spinUp: 'spin-up.yml' },
+  rebuild: { teardown: 'teardown.yml', spinUp: 'spin-up.yml' },
   snapshot: { teardown: 'teardown-snapshot.yml', spinUp: 'spin-up-snapshot.yml' },
 };
+const LIFECYCLE_MODES = Object.keys(LIFECYCLE_WORKFLOWS);
+const DEFAULT_LIFECYCLE_MODE = 'rebuild';
+// No alias table: `legacy` was the original name for `rebuild` and is
+// migrated in schema.sql, which runs on every setup-control-plane
+// deploy AFTER this Worker is updated.
+function canonicalMode(value) {
+  return String(value ?? '').trim().toLowerCase();
+}
 
 // Returns {ok:true, mode, teardown, spinUp} or {ok:false, reason}.
 //
 // Deliberately does NOT fall back to a default when the mode cannot be
-// determined. This runs unattended every night, and the legacy pair is
+// determined. This runs unattended every night, and the rebuild pair is
 // the destructive one: guessing it at a stack that is on snapshots would
 // run an untargeted `tofu destroy`, rotate all 81 generated credentials
 // and orphan the snapshot. An unconfigured stack is a different case and
-// resolves successfully to 'legacy'.
+// resolves successfully to the default.
 async function resolveLifecycle(db) {
   if (!db) {
     // Short-circuit rather than letting getConfigValue throw and be
@@ -107,7 +113,8 @@ async function resolveLifecycle(db) {
   if (!value) {
     return { ok: true, mode: DEFAULT_LIFECYCLE_MODE, ...LIFECYCLE_WORKFLOWS[DEFAULT_LIFECYCLE_MODE] };
   }
-  if (!LIFECYCLE_MODES.includes(value)) {
+  const mode = canonicalMode(value);
+  if (!LIFECYCLE_MODES.includes(mode)) {
     // The value itself is never logged: it is an unvalidated database
     // string, and a secret written to the wrong key would be retained.
     console.error(
@@ -115,7 +122,7 @@ async function resolveLifecycle(db) {
     );
     return { ok: false, reason: 'unrecognised lifecycle_mode' };
   }
-  return { ok: true, mode: value, ...LIFECYCLE_WORKFLOWS[value] };
+  return { ok: true, mode, ...LIFECYCLE_WORKFLOWS[mode] };
 }
 
 async function deleteConfigValue(db, key) {

--- a/control-plane/worker/src/index.js
+++ b/control-plane/worker/src/index.js
@@ -109,11 +109,13 @@ async function resolveLifecycle(db) {
     return { ok: false, reason: 'D1 read failed' };
   }
 
-  const value = row ? row.value : null;
-  if (!value) {
+  // `!row`, NOT `!row.value` — see the Pages copy of this function.
+  // An empty stored string is invalid, not unconfigured, and must reach
+  // the refusal below rather than defaulting to the destructive pair.
+  if (!row) {
     return { ok: true, mode: DEFAULT_LIFECYCLE_MODE, ...LIFECYCLE_WORKFLOWS[DEFAULT_LIFECYCLE_MODE] };
   }
-  const mode = canonicalMode(value);
+  const mode = canonicalMode(row.value);
   if (!LIFECYCLE_MODES.includes(mode)) {
     // The value itself is never logged: it is an unvalidated database
     // string, and a secret written to the wrong key would be retained.

--- a/docs/admin-guides/snapshot-lifecycle.md
+++ b/docs/admin-guides/snapshot-lifecycle.md
@@ -8,22 +8,20 @@ order: 6
 
 Nexus-Stack has two teardown/spin-up pairs. This guide covers the second one, when to use it, and — more importantly — how to get out of it.
 
-| Config value | Shown in Actions as | Files | What happens |
+| Mode | Shown in Actions as | Files | What happens |
 |---|---|---|---|
-| `legacy` | **Lifecycle: Teardown (Rebuild)**<br>**Lifecycle: Spin Up (Rebuild)** | `teardown.yml`<br>`spin-up.yml` | Destroy everything, rebuild from `ubuntu-24.04` |
+| `rebuild` | **Lifecycle: Teardown (Rebuild)**<br>**Lifecycle: Spin Up (Rebuild)** | `teardown.yml`<br>`spin-up.yml` | Destroy everything, rebuild from `ubuntu-24.04` |
 | `snapshot` | **Lifecycle: Teardown (Snapshot)**<br>**Lifecycle: Spin Up (Snapshot)** | `teardown-snapshot.yml`<br>`spin-up-snapshot.yml` | Snapshot the disk, destroy only the server, restore from the image |
 
-**The default is `legacy`.** Nothing changes until you switch.
+**The default is `rebuild`.** Nothing changes until you switch.
 
-> **On the two names for one thing.** The config value is `legacy`; the
-> workflows are called **Rebuild**. The mismatch is deliberate. `legacy`
-> is the stored identifier and renaming it would break every stack whose
-> D1 row already holds it. But the word is a poor description: this pair
-> is not deprecated and is not going away. It is the permanent fallback
-> whenever a snapshot is unusable, it is the only option on an
-> architecture switch, and `spin-up.yml` is the shared engine that the
-> snapshot spin-up itself calls. "Rebuild" says what the pair does;
-> `legacy` says only what it is called in the database.
+> The mode was called `legacy` until it was renamed here. The word
+> described the pair wrongly: it is not deprecated and is not going away.
+> It is the permanent fallback whenever a snapshot is unusable, the only
+> option across an architecture change, and `spin-up.yml` is the shared
+> engine that the snapshot spin-up itself calls. Existing stacks are
+> migrated by `schema.sql` on the next Control Plane deploy; no alias is
+> kept in code.
 
 **Never mix the pairs at one stack.** Both halves carry their lifecycle's
 name so this is visible at the moment you click. Running the Rebuild
@@ -67,6 +65,17 @@ gh workflow run setup-control-plane.yaml
 
 ### 2. Flip the mode
 
+**Control Plane → Settings → Lifecycle.** Pick Rebuild or Snapshot; the change
+takes effect on the next teardown. The page states what each option keeps and
+what it does to your images, and switching *to* Rebuild asks for confirmation
+because it is the direction that cannot be undone — see
+[Switching back](#switching-back).
+
+Writing the setting requires the admin identity (`ADMIN_EMAIL`). Reading it
+does not, so anyone with Access can see which mode a stack is on.
+
+If the Control Plane is unavailable, the same row can be set directly:
+
 ```bash
 npx wrangler@4 d1 execute nexus-<domain-slug>-db --remote \
   --command "UPDATE config SET value = 'snapshot' WHERE key = 'lifecycle_mode'"
@@ -76,7 +85,7 @@ npx wrangler@4 d1 execute nexus-<domain-slug>-db --remote \
 `nexus-stack.ch` the database is `nexus-nexus-stack-ch-db`. Same convention as
 the R2 buckets described in [Setup Guide](./setup-guide.md).
 
-Valid values are `legacy` and `snapshot`. Anything else is refused — see [When the mode cannot be determined](#when-the-mode-cannot-be-determined).
+Valid values are `rebuild` and `snapshot`. Anything else is refused — see [When the mode cannot be determined](#when-the-mode-cannot-be-determined).
 
 **One key controls both workflows on purpose.** An earlier design had one key per workflow and it was wrong: a half-applied switch means snapshot spin-up with rebuild teardown, and the rebuild teardown runs an untargeted `tofu destroy` that regenerates every service credential — which orphans the snapshot it just produced.
 
@@ -94,12 +103,17 @@ Cost: one power cycle. Check afterwards that the image appears in the Hetzner co
 
 ## Switching back
 
+**Control Plane → Settings → Lifecycle → Rebuild**, or directly:
+
 ```bash
 npx wrangler@4 d1 execute nexus-<domain-slug>-db --remote \
-  --command "UPDATE config SET value = 'legacy' WHERE key = 'lifecycle_mode'"
+  --command "UPDATE config SET value = 'rebuild' WHERE key = 'lifecycle_mode'"
 ```
 
-That is the whole rollback. The rebuild workflows were never modified and do not depend on anything the snapshot path added.
+That is the whole rollback — with one caveat the UI warns about: the next
+Rebuild teardown rotates every generated credential, so **every existing
+snapshot becomes unrestorable from that moment on**. Going back is cheap;
+going back and then forward again means starting the snapshot line over. The rebuild workflows were never modified and do not depend on anything the snapshot path added.
 
 For a single run rather than a permanent switch, `spin-up-snapshot.yml` takes `force_fresh=true`, which ignores any snapshot and builds from `ubuntu-24.04`.
 
@@ -221,7 +235,7 @@ If D1 is unreachable, the binding is missing, or `lifecycle_mode` holds an unrec
 
 This is deliberate. "Cannot tell" is not "not configured": guessing would fall back to the rebuild pair, which is the *destructive* one, and running it at a stack that is on snapshots would rotate every credential and orphan the snapshot. Skipping costs one more day of server time; guessing wrong costs the snapshot.
 
-An **unconfigured** stack — no row at all — is a different case and resolves to `legacy` without complaint.
+An **unconfigured** stack — no row at all — is a different case and resolves to `rebuild` without complaint.
 
 ---
 

--- a/docs/admin-guides/snapshot-lifecycle.md
+++ b/docs/admin-guides/snapshot-lifecycle.md
@@ -8,12 +8,27 @@ order: 6
 
 Nexus-Stack has two teardown/spin-up pairs. This guide covers the second one, when to use it, and — more importantly — how to get out of it.
 
-| Mode | Teardown | Spin-up | What happens |
+| Config value | Shown in Actions as | Files | What happens |
 |---|---|---|---|
-| `legacy` | `teardown.yml` | `spin-up.yml` | Destroy everything, rebuild from `ubuntu-24.04` |
-| `snapshot` | `teardown-snapshot.yml` | `spin-up-snapshot.yml` | Snapshot the disk, destroy only the server, restore from the image |
+| `legacy` | **Lifecycle: Teardown (Rebuild)**<br>**Lifecycle: Spin Up (Rebuild)** | `teardown.yml`<br>`spin-up.yml` | Destroy everything, rebuild from `ubuntu-24.04` |
+| `snapshot` | **Lifecycle: Teardown (Snapshot)**<br>**Lifecycle: Spin Up (Snapshot)** | `teardown-snapshot.yml`<br>`spin-up-snapshot.yml` | Snapshot the disk, destroy only the server, restore from the image |
 
 **The default is `legacy`.** Nothing changes until you switch.
+
+> **On the two names for one thing.** The config value is `legacy`; the
+> workflows are called **Rebuild**. The mismatch is deliberate. `legacy`
+> is the stored identifier and renaming it would break every stack whose
+> D1 row already holds it. But the word is a poor description: this pair
+> is not deprecated and is not going away. It is the permanent fallback
+> whenever a snapshot is unusable, it is the only option on an
+> architecture switch, and `spin-up.yml` is the shared engine that the
+> snapshot spin-up itself calls. "Rebuild" says what the pair does;
+> `legacy` says only what it is called in the database.
+
+**Never mix the pairs at one stack.** Both halves carry their lifecycle's
+name so this is visible at the moment you click. Running the Rebuild
+teardown against a stack on snapshots rotates all 81 credentials, after
+which the epoch guard correctly refuses the snapshot it just made.
 
 ---
 
@@ -63,7 +78,7 @@ the R2 buckets described in [Setup Guide](./setup-guide.md).
 
 Valid values are `legacy` and `snapshot`. Anything else is refused — see [When the mode cannot be determined](#when-the-mode-cannot-be-determined).
 
-**One key controls both workflows on purpose.** An earlier design had one key per workflow and it was wrong: a half-applied switch means snapshot spin-up with legacy teardown, and the legacy teardown runs an untargeted `tofu destroy` that regenerates every service credential — which orphans the snapshot it just produced.
+**One key controls both workflows on purpose.** An earlier design had one key per workflow and it was wrong: a half-applied switch means snapshot spin-up with rebuild teardown, and the rebuild teardown runs an untargeted `tofu destroy` that regenerates every service credential — which orphans the snapshot it just produced.
 
 ### 3. Verify before relying on it
 
@@ -84,7 +99,7 @@ npx wrangler@4 d1 execute nexus-<domain-slug>-db --remote \
   --command "UPDATE config SET value = 'legacy' WHERE key = 'lifecycle_mode'"
 ```
 
-That is the whole rollback. The legacy workflows were never modified and do not depend on anything the snapshot path added.
+That is the whole rollback. The rebuild workflows were never modified and do not depend on anything the snapshot path added.
 
 For a single run rather than a permanent switch, `spin-up-snapshot.yml` takes `force_fresh=true`, which ignores any snapshot and builds from `ubuntu-24.04`.
 
@@ -130,7 +145,7 @@ This is the **designed** behaviour, not a fault. A snapshot is only used when it
 - its credential epoch no longer matches
 - its architecture or disk size cannot be satisfied by any available server type
 
-In every case the spin-up falls back to a normal `ubuntu-24.04` build **with R2 restore enabled**, so the five R2-covered stacks keep their data. The other stacks come back empty — the same as the legacy path has always behaved.
+In every case the spin-up falls back to a normal `ubuntu-24.04` build **with R2 restore enabled**, so the five R2-covered stacks keep their data. The other stacks come back empty — the same as the rebuild path has always behaved.
 
 The workflow log names the reason.
 
@@ -138,7 +153,7 @@ The workflow log names the reason.
 
 Symptom: every spin-up rebuilds fresh, and the log says the snapshot was rejected on epoch.
 
-Cause: the legacy `teardown.yml` ran at some point. Its untargeted `tofu destroy` destroys all 81 `random_password` / `random_id` / `random_string` resources, so every service credential is regenerated on the next spin-up. A snapshot taken before that holds Postgres roles and admin accounts with the old passwords; restoring it would produce a stack that boots and then authenticates nowhere.
+Cause: the Rebuild teardown (`teardown.yml`) ran at some point. Its untargeted `tofu destroy` destroys all 81 `random_password` / `random_id` / `random_string` resources, so every service credential is regenerated on the next spin-up. A snapshot taken before that holds Postgres roles and admin accounts with the old passwords; restoring it would produce a stack that boots and then authenticates nowhere.
 
 The guard exists precisely to prevent that, so this is the mechanism working. The snapshot is dead, though — take a fresh one on the next teardown.
 
@@ -204,7 +219,7 @@ If D1 is unreachable, the binding is missing, or `lifecycle_mode` holds an unrec
 - the scheduled Worker skips that night's teardown and logs why
 - the Control Plane API returns `503`
 
-This is deliberate. "Cannot tell" is not "not configured": guessing would fall back to the legacy pair, which is the *destructive* one, and running it at a stack that is on snapshots would rotate every credential and orphan the snapshot. Skipping costs one more day of server time; guessing wrong costs the snapshot.
+This is deliberate. "Cannot tell" is not "not configured": guessing would fall back to the rebuild pair, which is the *destructive* one, and running it at a stack that is on snapshots would rotate every credential and orphan the snapshot. Skipping costs one more day of server time; guessing wrong costs the snapshot.
 
 An **unconfigured** stack — no row at all — is a different case and resolves to `legacy` without complaint.
 

--- a/docs/proposals/0002-hetzner-disk-snapshots.md
+++ b/docs/proposals/0002-hetzner-disk-snapshots.md
@@ -45,7 +45,7 @@ That is five stacks out of roughly seventy-six. A disk snapshot captures the who
 ### What this is NOT
 
 - **Not a replacement for RFC 0001.** R2 remains, runs first on every snapshot teardown, and is the recovery path whenever a snapshot is unavailable, epoch-mismatched or architecture-incompatible. It is also logically consistent (`pg_dump`) where a disk image is not, and portable where a snapshot is vendor- and architecture-locked.
-- **Not the default.** Stacks stay on the legacy pair until switched.
+- **Not the default.** Stacks stay on the rebuild pair (config value `legacy`) until switched.
 - **Not a backup.** Retention is two generations and the images live in the same Hetzner project as the server.
 
 ## Design

--- a/docs/proposals/0002-hetzner-disk-snapshots.md
+++ b/docs/proposals/0002-hetzner-disk-snapshots.md
@@ -45,7 +45,7 @@ That is five stacks out of roughly seventy-six. A disk snapshot captures the who
 ### What this is NOT
 
 - **Not a replacement for RFC 0001.** R2 remains, runs first on every snapshot teardown, and is the recovery path whenever a snapshot is unavailable, epoch-mismatched or architecture-incompatible. It is also logically consistent (`pg_dump`) where a disk image is not, and portable where a snapshot is vendor- and architecture-locked.
-- **Not the default.** Stacks stay on the rebuild pair (config value `legacy`) until switched.
+- **Not the default.** Stacks stay on the rebuild pair until switched.
 - **Not a backup.** Retention is two generations and the images live in the same Hetzner project as the server.
 
 ## Design
@@ -75,9 +75,9 @@ The one resource destroyed alongside the server is `cloudflare_record.firewall_t
 
 ### One config value, not two
 
-`lifecycle_mode` is `legacy` or `snapshot`, and both workflow filenames are derived from it.
+`lifecycle_mode` is `rebuild` or `snapshot`, and both workflow filenames are derived from it. It was originally `legacy`, renamed because the pair is a permanent fallback rather than something deprecated; `schema.sql` migrates existing rows.
 
-The first implementation used one key per workflow. That allows drift, and a half-applied switch is harmful rather than untidy: snapshot spin-up with legacy teardown means the nightly untargeted destroy rotates every credential and orphans the snapshot it just made. Documenting "switch both together" is not the same as making the other case impossible.
+The first implementation used one key per workflow. That allows drift, and a half-applied switch is harmful rather than untidy: snapshot spin-up with rebuild teardown means the nightly untargeted destroy rotates every credential and orphans the snapshot it just made. Documenting "switch both together" is not the same as making the other case impossible.
 
 Deriving the names rather than storing them also removes an injection surface: no database value reaches the GitHub API URL path.
 
@@ -89,12 +89,12 @@ This rule appears in four places across the implementation, and it is the one mo
 |---|---|---|
 | No snapshot exists | definite | build fresh |
 | Epoch mismatch | definite | build fresh |
-| No `lifecycle_mode` row | definite | `legacy` |
+| No `lifecycle_mode` row | definite | `rebuild` |
 | Snapshot lookup failed | **unknown** | stop |
 | `tofu init` failed | **unknown** | stop |
 | D1 unreadable | **unknown** | dispatch nothing |
 
-The asymmetry matters because the fallbacks are not neutral. Building fresh during an API outage discards a snapshot that may hold the only copy of most stacks' data. Defaulting to `legacy` when the mode is unknown dispatches the *destructive* pair at a stack that may be on snapshots.
+The asymmetry matters because the fallbacks are not neutral. Building fresh during an API outage discards a snapshot that may hold the only copy of most stacks' data. Defaulting to `rebuild` when the mode is unknown dispatches the *destructive* pair at a stack that may be on snapshots.
 
 ### Boot readiness
 
@@ -112,7 +112,7 @@ test -f /run/nexus-setup-complete \
   || { test -f /opt/docker-server/.setup-complete && systemctl is-active --quiet docker; }
 ```
 
-This is monotonically safer for the legacy path: it accepts everything the old gate accepted, plus requires Docker to be up. It can only wait longer, never pass earlier.
+This is monotonically safer for the rebuild path: it accepts everything the old gate accepted, plus requires Docker to be up. It can only wait longer, never pass earlier.
 
 ### `lifecycle.ignore_changes` on the server
 
@@ -122,7 +122,7 @@ lifecycle {
 }
 ```
 
-Load-bearing, not tidiness. Without it a snapshot-restored server is one legacy spin-up away from destruction: `spin-up.yml` supplies `ubuntu-24.04` and `select-capacity` rewrites `server_type`/`server_location`, so OpenTofu would plan a **replacement** of the live server. `image` and `user_data` are ForceNew, which makes it a silent data-loss path rather than a diff someone notices.
+Load-bearing, not tidiness. Without it a snapshot-restored server is one rebuild spin-up away from destruction: `spin-up.yml` supplies `ubuntu-24.04` and `select-capacity` rewrites `server_type`/`server_location`, so OpenTofu would plan a **replacement** of the live server. `image` and `user_data` are ForceNew, which makes it a silent data-loss path rather than a diff someone notices.
 
 It costs nothing operationally: the documented resize flow is teardown → set `SERVER_TYPE` → spin-up, so the server is always created fresh with the new values.
 

--- a/docs/user-guides/control-plane.md
+++ b/docs/user-guides/control-plane.md
@@ -41,7 +41,7 @@ The top nav has seven sections:
 | [Monitoring](./monitoring.md) | Inspect workflow logs, config, and runtime state |
 | [Secrets](./secrets.md) | Read-only view of Infisical secrets |
 | [Firewall](./firewall.md) | Open TCP ports for services that need direct access |
-| [Settings](./settings.md) | Server info, teardown schedule, notifications |
+| [Settings](./settings.md) | Server info, teardown schedule, lifecycle, notifications |
 | [Integrations](./integrations.md) | Databricks sync and other third-party hookups |
 
 Each page is covered in its own short guide — linked above. Start with the [Dashboard](./dashboard.md) guide if you're brand new.

--- a/docs/user-guides/settings.md
+++ b/docs/user-guides/settings.md
@@ -56,7 +56,9 @@ what survives and how long the spin-up takes.
   from it. Everything on the server survives, across all stacks, and the boot
   is faster because the system does not reinstall itself. In exchange the
   container images age: they stay at whatever was pulled when the snapshot line
-  started.
+  started. There is no refresh button yet — switching to Rebuild for one cycle
+  is currently the only way to pull newer images, and that costs you everything
+  the R2 backup does not cover.
 
 The block always names the mode currently in use and what it means, so you can
 read the setting even when you cannot change it.

--- a/docs/user-guides/settings.md
+++ b/docs/user-guides/settings.md
@@ -6,7 +6,7 @@ order: 7
 
 # Settings
 
-![Settings page header introducing the Infrastructure Information, Scheduled Teardown, and Email Notifications blocks](./assets/settings-header.png)
+![Top of the Settings page, showing the start of the Infrastructure Information block](./assets/settings-header.png)
 
 The Settings page is split into four blocks: **Infrastructure Information** (read-only), **Scheduled Teardown**, **Lifecycle**, and **Email Notifications**.
 

--- a/docs/user-guides/settings.md
+++ b/docs/user-guides/settings.md
@@ -43,8 +43,11 @@ The cron worker can auto-teardown your stack on a daily schedule so you don't pa
 ## Lifecycle
 
 How your stack is torn down at night and brought back the next day. Both
-options stop the server, so both save the same amount of money — they differ in
-what survives and how long the spin-up takes.
+options stop the server, which is where nearly all the saving comes from. They
+differ in what survives, how long the spin-up takes, and — slightly — in cost:
+Snapshot keeps disk images, and Hetzner bills those by used space. Measured on
+a real stack that is roughly 10 GB used, two retained snapshots come to a
+little under 30 cents a month. Small against a server, but not zero.
 
 - **Rebuild** — Destroy everything and rebuild from a clean Ubuntu image each
   time. Container images are pulled fresh, so stacks tracking `:latest` stay

--- a/docs/user-guides/settings.md
+++ b/docs/user-guides/settings.md
@@ -8,7 +8,7 @@ order: 7
 
 ![Settings page header introducing the Infrastructure Information, Scheduled Teardown, and Email Notifications blocks](./assets/settings-header.png)
 
-The Settings page is split into three blocks: **Infrastructure Information** (read-only), **Scheduled Teardown**, and **Email Notifications**.
+The Settings page is split into four blocks: **Infrastructure Information** (read-only), **Scheduled Teardown**, **Lifecycle**, and **Email Notifications**.
 
 ## Infrastructure Information
 
@@ -39,6 +39,36 @@ The cron worker can auto-teardown your stack on a daily schedule so you don't pa
 - **Delay Teardown by 4 Hours** — Pushes the next teardown back by 4 hours. Useful when you're mid-session. Limited to 3 extensions per UTC day by default.
 
 > If your admin has set `allow_disable_auto_shutdown = false`, the toggle is visible but locked — you can still use the delay button.
+
+## Lifecycle
+
+How your stack is torn down at night and brought back the next day. Both
+options stop the server, so both save the same amount of money — they differ in
+what survives and how long the spin-up takes.
+
+- **Rebuild** — Destroy everything and rebuild from a clean Ubuntu image each
+  time. Container images are pulled fresh, so stacks tracking `:latest` stay
+  current. What survives is only what the R2 backup covers: Gitea, Dify,
+  HedgeDoc, Planka and Metabase. Anything else — tables you created in
+  Postgres, dashboards you built in Grafana, Kestra run history, notebooks you
+  have not committed — is gone the next morning.
+- **Snapshot** — Take a disk snapshot before destroying the server and restore
+  from it. Everything on the server survives, across all stacks, and the boot
+  is faster because the system does not reinstall itself. In exchange the
+  container images age: they stay at whatever was pulled when the snapshot line
+  started.
+
+The block always names the mode currently in use and what it means, so you can
+read the setting even when you cannot change it.
+
+> **Only the stack administrator can change this.** For everyone else the
+> toggle is greyed out. Switching to Rebuild also asks for confirmation,
+> because it cannot be undone: the next teardown regenerates every service
+> password, and existing snapshots can no longer be restored after that.
+
+Committing your work to the workspace repository is worth doing either way. The
+repository lives in Gitea, which is backed up under both options — it is the
+one place your work is safe regardless of which mode the stack is on.
 
 ## Email Notifications
 


### PR DESCRIPTION
Nexus-Stack has two teardown/spin-up pairs. Which one fits depends on how a stack is used — not on which is newer — so this makes it a setting the stack owner chooses, and renames the workflows to say what they do.

## Why it is a real choice

Measured on this stack today, identical six-service set, cold build versus restore:

| Step | Rebuild | Snapshot | Δ |
|---|---:|---:|---:|
| Deploy stacks | 305s | 177s | −128s |
| Apply infrastructure | 23s | 39s | +16s |
| Install Cloudflare Tunnel | 92s | 102s | +10s |
| **Total spin-up steps** | **556s** | **456s** | **−100s** |

Speed is the weaker argument. The stronger one is what survives a teardown. The R2 persistence layer covers five stacks by name — Gitea, Dify, HedgeDoc, Planka, Metabase. A stack's own Postgres tables, Grafana dashboards, Kestra run history and uncommitted notebooks are not in it.

Neither answer is right for everyone. A strictly repo-driven course loses little to a nightly rebuild and gains fresh images every morning. A course where people build things in a UI would lose that work every night. Hence a setting.

## What this adds

**`GET/POST /api/lifecycle`.** Reading is open to any Access-authenticated caller so the page can show the current state; writing requires `ADMIN_EMAIL`.

Admin-only is not decoration. Switching to Rebuild is not reversible in effect: the next teardown runs an untargeted `tofu destroy` that rotates all 81 generated credentials, after which the epoch guard refuses every existing snapshot for good. A student on the Access whitelist reaches this endpoint like anyone else, so the guard is the only thing between them and that.

**A Lifecycle panel on the Settings page**, styled like Scheduled Teardown. The active mode is always named in the info line together with what it keeps and what happens to images, so the setting stays legible when the control is greyed out. `GET` returns `canEdit`, computed by reusing `requireAdmin` rather than re-implementing the comparison, so what the UI renders and what `POST` enforces cannot drift.

Two independent layers on purpose: the UI greys the control (`.toggle-switch.disabled` — the same treatment Scheduled Teardown already uses), and `POST` answers 403 regardless. Calling the API directly does not get past it.

## Workflow names

GitHub sorts the Actions sidebar alphabetically and offers no grouping, so the name is the only lever. Seventeen entries were scattered — the whole infrastructure lifecycle sat at D, I, S and T with "Sync docs to website" in the middle of it.

```
CI: Python Tests                  Ops: Cleanup Orphaned Resources
CI: Release Please                Ops: Toggle Silent Mode
CI: Validate Workflows            Setup: Control Plane
Docs: Sync to Website             Setup: First-Time Deploy
Lifecycle: Spin Up (Rebuild)      ⚠️ Destroy All Infrastructure
Lifecycle: Spin Up (Snapshot)
Lifecycle: Teardown (Rebuild)
Lifecycle: Teardown (Snapshot)
```

The safety-relevant part is the pair. Before, `Teardown Nexus-Stack` read as "the normal one" and `(Snapshot)` as a variant. They are two mutually exclusive pairs, and mixing them is what the epoch guard exists to catch. Both halves now carry their lifecycle's name, so the pairing is visible at the moment of clicking.

Destroy All takes no prefix — the emoji sorts past every letter, so it lands at the end away from the routine entries.

Names carrying a colon are quoted; `name: Ops: x` is invalid YAML.

## `legacy` is removed, not aliased

`legacy` was the original config value and described the pair wrongly: it is not deprecated. It is the permanent fallback whenever a snapshot is unusable, the only option across an architecture change, and `spin-up.yml` is the shared engine that the snapshot spin-up itself calls via `workflow_call`. Calling it legacy labelled the most load-bearing workflow in the repo as obsolete.

Migration rather than an alias, because an alias keeps a name alive that nobody should use. `schema.sql` rewrites `legacy` → `rebuild` and is applied on every `setup-control-plane` run, so every stack migrates on its next Control Plane deploy.

Ordering was checked and matters: the **Worker is deployed before** the migration runs, so the unattended nightly path never meets a value it cannot read. The **Pages Functions deploy after it**, leaving a minutes-long window during a deliberate deploy where the API answers 503 — it fails closed rather than dispatching the wrong pair. That is recorded in `schema.sql` next to the statement.

## Verification

Against real SQLite: a fresh install seeds `rebuild`, an existing `legacy` row migrates, and re-applying the file changes nothing.

The endpoint against a fake D1, every branch:

| Case | Result |
|---|---|
| No config row | default `rebuild` |
| `POST` valid mode | written, `changed: true`, previous reported |
| `POST rebuild` | carries the credential-rotation warning |
| `POST` unrecognised mode | 400, stored value untouched |
| `POST` as non-admin | 403, stored value untouched |
| `GET` as admin / student / anonymous | `canEdit` true / false / false |
| `GET` with an uppercase admin address | `canEdit` true |

Astro builds (9 pages); the Worker and the endpoint parse; all thirteen workflow files load and produce the intended sort order.

## Note on the base

This branch was rebased onto `main` after #666. An earlier revision was based on the commit before it and would have silently reverted the `DEBIAN_FRONTEND=noninteractive` fix, reintroducing the cloud-init hang. Caught because `tofu/stack/main.tf` appeared in a diff that should not have touched it; `main.tf` is now correctly absent from this PR.

## Not in this PR

An image-refresh path for `:latest` stacks under the snapshot lifecycle. Choosing Snapshot means images age from the day the snapshot line began, and thirteen stacks are on `:latest` today. That needs a `docker compose pull` + recreate + dangling-only prune, and it is a separate change.

## Summary by Sourcery

Let stack owners select and safely manage whether nightly infrastructure uses the rebuild or snapshot lifecycle.

New Features:
- Add an admin-controlled lifecycle setting that selects the stack’s rebuild or snapshot teardown and spin-up pair.
- Expose lifecycle status and editing controls in the Control Plane Settings page, including mode behavior and data-loss warnings.
- Add authenticated lifecycle API endpoints with admin-only, same-origin-protected writes and audit logging.

Bug Fixes:
- Migrate the lifecycle configuration from `legacy` to `rebuild` while refusing unknown or invalid stored values instead of dispatching a potentially destructive default.
- Prevent lifecycle workflow mismatches by deriving both workflow selections from one validated configuration value.

Enhancements:
- Rename GitHub Actions workflows to group and clearly distinguish CI, setup, operations, documentation, and rebuild or snapshot lifecycle actions.
- Improve lifecycle documentation and operator guidance around persistence, snapshot invalidation, migration, and safe workflow pairing.

CI:
- Configure CodeRabbit to comment on findings without setting a blocking changes-requested status.

Deployment:
- Apply the `legacy` to `rebuild` configuration migration during Control Plane deployments.

Documentation:
- Update administrator, user, proposal, and project guidance to document the selectable lifecycle modes and renamed workflows.

Chores:
- Add CSRF protection for state-changing lifecycle requests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Control Plane lifecycle settings for choosing between Rebuild and Snapshot modes.
  - Added status, validation, permission, confirmation, and error feedback for lifecycle changes.
  - Added secure API-based retrieval and updates for lifecycle configuration.

- **Improvements**
  - Renamed the Legacy lifecycle mode to Rebuild and migrated existing settings automatically.
  - Updated workflow labels across deployment, teardown, testing, documentation, and operations views.

- **Documentation**
  - Updated lifecycle guides with terminology, defaults, fallback behavior, permissions, and snapshot considerations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->