### PR TITLE
perf(ci): Escalate the SSH retry instead of a flat 60s timeout

### DIFF
--- a/.github/workflows/spin-up.yml
+++ b/.github/workflows/spin-up.yml
@@ -578,6 +578,7 @@ jobs:
             # install script. ssh would swallow it as a password attempt
             # instead of running it, and the retry loop would keep
             # feeding a consumed script to a prompt nobody can answer.
+            attempt_started=$SECONDS
             if ssh -o StrictHostKeyChecking=no -o ConnectTimeout=$connect_timeout \
                  -o ServerAliveInterval=10 -o BatchMode=yes \
                  root@"$SERVER_IP" bash < /tmp/install-tunnel.sh; then
@@ -588,7 +589,14 @@ jobs:
               echo "❌ Tunnel install failed after 6 attempts — server unreachable or sshd misbehaving"
               exit 1
             fi
-            echo "⚠️  Attempt $attempt failed after ${connect_timeout}s (likely SSH banner timeout); retrying in ${backoff}s..."
+            # Report the MEASURED duration, not the configured timeout.
+            # They differ in the case that matters: a refused connection
+            # or an unreachable host fails in well under a second, while
+            # a banner timeout runs the clock out. Printing the limit
+            # would make both look identical and send whoever reads this
+            # looking for a slow server when the server said no.
+            elapsed=$((SECONDS - attempt_started))
+            echo "⚠️  Attempt $attempt failed after ${elapsed}s (timeout was ${connect_timeout}s); retrying in ${backoff}s..."
             sleep $backoff
           done
           rm -f /tmp/install-tunnel.sh

--- a/.github/workflows/spin-up.yml
+++ b/.github/workflows/spin-up.yml
@@ -542,20 +542,47 @@ jobs:
           # cold-starts (sshd reloading host keys, fail2ban tightening
           # filters mid-flight, etc.). The install script is fully
           # idempotent (stops + uninstalls cloudflared first), so a
-          # half-completed run + retry is safe. Total worst-case wait
-          # = 5 * 60s (ConnectTimeout) + 4 * 20s (sleep) ≈ 6 min.
-          for attempt in {1..5}; do
-            if ssh -o StrictHostKeyChecking=no -o ConnectTimeout=60 -o ServerAliveInterval=10 \
+          # half-completed run + retry is safe.
+          #
+          # ESCALATING timeout, not a flat 60s. The common failure is
+          # sshd not answering yet on a freshly booted server, and it
+          # clears within seconds — measured on run 32733248894, where
+          # attempt 1 burned the full 60s ConnectTimeout plus a 20s
+          # sleep, and attempt 2 then succeeded in ~12s. Eighty seconds
+          # spent on a problem that had already resolved.
+          #
+          # A short first probe finds that case immediately; the budget
+          # is spent on later attempts where a long timeout might
+          # actually be the difference. Worst case is comparable to the
+          # old flat form (~5 min vs ~6 min), but the COMMON case drops
+          # from ~80s to ~15s.
+          #
+          # Restores make this more likely, not less: the server is
+          # ready sooner, so the pipeline knocks earlier.
+          for attempt in {1..6}; do
+            # 10, 20, 30, 45, 60, 60
+            case $attempt in
+              1) connect_timeout=10; backoff=5  ;;
+              2) connect_timeout=20; backoff=10 ;;
+              3) connect_timeout=30; backoff=15 ;;
+              4) connect_timeout=45; backoff=20 ;;
+              *) connect_timeout=60; backoff=20 ;;
+            esac
+            # ConnectTimeout covers the TCP connect and the banner
+            # exchange only. Once the session is up the install runs
+            # unbounded, so a short value here cannot truncate the work.
+            if ssh -o StrictHostKeyChecking=no -o ConnectTimeout=$connect_timeout \
+                 -o ServerAliveInterval=10 \
                  root@"$SERVER_IP" bash < /tmp/install-tunnel.sh; then
               echo "✅ Cloudflare Tunnel installed on attempt $attempt"
               break
             fi
-            if [ $attempt -eq 5 ]; then
-              echo "❌ Tunnel install failed after 5 attempts — server unreachable or sshd misbehaving"
+            if [ $attempt -eq 6 ]; then
+              echo "❌ Tunnel install failed after 6 attempts — server unreachable or sshd misbehaving"
               exit 1
             fi
-            echo "⚠️  Attempt $attempt failed (likely SSH banner timeout); retrying in 20s..."
-            sleep 20
+            echo "⚠️  Attempt $attempt failed after ${connect_timeout}s (likely SSH banner timeout); retrying in ${backoff}s..."
+            sleep $backoff
           done
           rm -f /tmp/install-tunnel.sh
 

--- a/.github/workflows/spin-up.yml
+++ b/.github/workflows/spin-up.yml
@@ -536,7 +536,8 @@ jobs:
           SCRIPT
           sed -i 's/^          //' /tmp/install-tunnel.sh
 
-          # Retry the install-tunnel SSH up to 5 times with 20s gaps.
+          # Retry the install-tunnel SSH up to 6 times, with the
+          # connect timeout and the gap both escalating — schedule below.
           # Belt-and-suspenders: even with the readiness gate above, a
           # banner-exchange timeout can still happen on slow Hetzner
           # cold-starts (sshd reloading host keys, fail2ban tightening
@@ -571,8 +572,14 @@ jobs:
             # ConnectTimeout covers the TCP connect and the banner
             # exchange only. Once the session is up the install runs
             # unbounded, so a short value here cannot truncate the work.
+            # BatchMode=yes, as on the readiness probes above. Without it
+            # a failed key auth falls back to an interactive password
+            # prompt, which reads from stdin — and stdin here IS the
+            # install script. ssh would swallow it as a password attempt
+            # instead of running it, and the retry loop would keep
+            # feeding a consumed script to a prompt nobody can answer.
             if ssh -o StrictHostKeyChecking=no -o ConnectTimeout=$connect_timeout \
-                 -o ServerAliveInterval=10 \
+                 -o ServerAliveInterval=10 -o BatchMode=yes \
                  root@"$SERVER_IP" bash < /tmp/install-tunnel.sh; then
               echo "✅ Cloudflare Tunnel installed on attempt $attempt"
               break


### PR DESCRIPTION
## The measurement

From run 32733248894 — the first snapshot restore that actually ran end to end:

```
SSH ready + host provisioned (attempt 2)      ~10s
Attempt 1 failed (likely SSH banner timeout); retrying in 20s...
Cloudflare Tunnel installed on attempt 2
```

The step took **102 seconds**. Ten of those were the readiness gate. Eighty went to one failed SSH attempt burning the full `ConnectTimeout=60` plus a 20-second sleep, after which attempt 2 connected in about twelve seconds.

Eighty seconds spent on a problem that had already resolved.

## Why a flat 60s is the wrong shape

The common failure here is sshd not answering yet on a freshly booted server, and it clears within seconds. A 60-second first probe turns the cheapest case into the most expensive one — it waits out a condition that was gone almost immediately.

The timeout now escalates:

| attempt | 1 | 2 | 3 | 4 | 5 | 6 |
|---|---:|---:|---:|---:|---:|---:|
| ConnectTimeout | 10s | 20s | 30s | 45s | 60s | 60s |
| backoff after | 5s | 10s | 15s | 20s | 20s | – |

A short first probe finds the transient case immediately. The budget moves to later attempts, where a long timeout might actually be the difference rather than pure waiting.

```
worst case      380s -> 295s
first failure    80s ->  15s
```

`ConnectTimeout` covers the TCP connect and the banner exchange only — once the session is up the install runs unbounded, so the short early values cannot truncate the actual work.

## The interaction worth knowing

A restored server is ready *sooner* — readiness gate attempt 2 versus attempt 12 on a cold build. So the pipeline knocks earlier and hits sshd mid-startup more often, not less.

**The snapshot lifecycle makes this race more likely, and that is what made the slow retry worth fixing.** The faster path exposed the cost of the slow one.

## Context: what the snapshot actually saved

Like-for-like from the same day, identical six-service set, cold build versus restore:

| Step | Cold | Restore | Δ |
|---|---:|---:|---:|
| Deploy stacks | 305s | 177s | −128s |
| Apply infrastructure | 23s | 39s | +16s |
| Install Cloudflare Tunnel | 92s | 102s | +10s |
| **Total spin-up steps** | **556s** | **456s** | **−100s** |

The tunnel regression in that table is this bug, not a property of restoring. `Apply infrastructure` being slower is real and stays — Hetzner creates a server from a 320 GB snapshot image rather than the slim base image.

## Verification

`bash -n` over every `run:` block, YAML parses, the escalation table reproduced by running the `case` statement standalone.

**Not verified against a live failure**, because the failure is intermittent by nature — it only shows when sshd happens to be slow. The change is safe in the other direction: every path either behaves as before or fails faster, and the worst-case budget went down rather than up.

## Scope

One file, one loop. The readiness gate above it (`for i in {1..72}` with `sleep 5`) is untouched — it polls a marker rather than opening connections, so a flat interval is right there.

## Summary by Sourcery

Optimize Cloudflare Tunnel installation retries in the spin-up workflow for transient SSH startup failures.

Bug Fixes:
- Reduce delays when transient SSH banner failures occur during Cloudflare Tunnel installation on restored or freshly booted servers.
- Add non-interactive SSH authentication to prevent failed key authentication from consuming the installation script as password input.

Enhancements:
- Replace the flat SSH retry timeout with escalating connection timeouts and backoff intervals, reducing the common failure delay while lowering the worst-case retry budget.
- Improve retry diagnostics by reporting measured attempt duration alongside the configured timeout.