### PR TITLE
chore(tofu): Upgrade the server base image to Ubuntu 26.04 LTS

### DIFF
--- a/.github/actions/nexus-config-tfvars/action.yml
+++ b/.github/actions/nexus-config-tfvars/action.yml
@@ -10,7 +10,7 @@ description: >-
 # maintaining the D1 reads, the firewall sync and the Hetzner S3 lookup twice
 # and having them drift.
 #
-# `server_image` defaults to ubuntu-24.04, which is what the legacy path
+# `server_image` defaults to ubuntu-26.04, which is what the legacy path
 # passes. That keeps snapshot awareness OUT of spin-up.yml entirely: it
 # supplies a default like it always did, and only the snapshot workflow ever
 # passes an image id. The fallback path therefore stays independent of the
@@ -25,10 +25,10 @@ description: >-
 inputs:
   server_image:
     description: >-
-      Hetzner image to build from — `ubuntu-24.04` for a normal build, or a
+      Hetzner image to build from — `ubuntu-26.04` for a normal build, or a
       numeric snapshot image id to restore from.
     required: false
-    default: 'ubuntu-24.04'
+    default: 'ubuntu-26.04'
   enabled_services:
     description: Comma-separated service list; read from D1 when empty.
     required: false
@@ -103,7 +103,7 @@ runs:
         # Exactly two legitimate shapes, and the alternation says so
         # rather than approximating it:
         #   - an image name, which always starts with a letter
-        #     (ubuntu-24.04, debian-12, rocky-9)
+        #     (ubuntu-26.04, debian-12, rocky-9)
         #   - a numeric snapshot id, which is digits only (422646995)
         #
         # A single character class would also admit things like `123abc`,
@@ -113,7 +113,7 @@ runs:
         # opaque `tofu apply` image error instead of by name here.
         if ! printf '%s' "$SERVER_IMAGE" | grep -qE '^([a-z][a-z0-9.-]{0,62}|[0-9]{1,19})$'; then
           echo "❌ server_image is not a valid Hetzner image reference: '$SERVER_IMAGE'"
-          echo "   Expected an image name (e.g. ubuntu-24.04) or a numeric"
+          echo "   Expected an image name (e.g. ubuntu-26.04) or a numeric"
           echo "   snapshot id. Refusing to write it into config.tfvars."
           exit 1
         fi

--- a/.github/workflows/destroy-all.yml
+++ b/.github/workflows/destroy-all.yml
@@ -136,7 +136,7 @@ jobs:
           cat > tofu/stack/config.tfvars << EOF
           server_type     = "${{ vars.SERVER_TYPE || 'cx43' }}"
           server_location = "${{ vars.SERVER_LOCATION || 'hel1' }}"
-          server_image    = "ubuntu-24.04"
+          server_image    = "ubuntu-26.04"
           ssh_public_key_path  = "~/.ssh/id_ed25519.pub"
           ssh_private_key_path = "~/.ssh/id_ed25519"
           domain              = "${{ secrets.DOMAIN }}"

--- a/.github/workflows/spin-up-snapshot.yml
+++ b/.github/workflows/spin-up-snapshot.yml
@@ -39,7 +39,7 @@ on:
         default: false
         type: boolean
       force_fresh:
-        description: 'Ignore any snapshot and build from ubuntu-24.04. Use this to escape a bad snapshot, or to move to a new base image.'
+        description: 'Ignore any snapshot and build from ubuntu-26.04. Use this to escape a bad snapshot, or to move to a new base image.'
         required: false
         default: false
         type: boolean
@@ -96,7 +96,7 @@ jobs:
           fresh() {
             {
               echo "mode=fresh"
-              echo "server_image=ubuntu-24.04"
+              echo "server_image=ubuntu-26.04"
               echo "min_disk_gb="
               echo "arch="
               # R2 restore is the entire recovery story when no snapshot
@@ -106,7 +106,7 @@ jobs:
           }
 
           if [ "${{ github.event.inputs.force_fresh }}" = "true" ]; then
-            echo "🔄 force_fresh requested — building from ubuntu-24.04"
+            echo "🔄 force_fresh requested — building from ubuntu-26.04"
             fresh
             exit 0
           fi

--- a/.github/workflows/spin-up.yml
+++ b/.github/workflows/spin-up.yml
@@ -14,7 +14,7 @@ on:
         default: false
         type: boolean
       server_image:
-        description: 'Hetzner image to build from. Empty = ubuntu-24.04. A numeric image id restores from that snapshot.'
+        description: 'Hetzner image to build from. Empty = ubuntu-26.04. A numeric image id restores from that snapshot.'
         required: false
         default: ''
         type: string
@@ -74,7 +74,7 @@ on:
         required: false
         type: string
       server_image:
-        description: 'Hetzner image to build from. Empty = ubuntu-24.04. A numeric image id restores from that snapshot.'
+        description: 'Hetzner image to build from. Empty = ubuntu-26.04. A numeric image id restores from that snapshot.'
         required: false
         default: ''
         type: string
@@ -332,7 +332,7 @@ jobs:
         # Shared with spin-up-snapshot.yml — see
         # .github/actions/nexus-config-tfvars.
         #
-        # The `|| 'ubuntu-24.04'` is load-bearing, not decoration: the
+        # The `|| 'ubuntu-26.04'` is load-bearing, not decoration: the
         # action's own `default:` only applies when a key is ABSENT, and
         # `with:` always sends this one. An unset workflow input would
         # otherwise arrive as an empty string and fail the image
@@ -342,8 +342,8 @@ jobs:
         uses: ./.github/actions/nexus-config-tfvars
         with:
           # Empty on the normal path — the action defaults to
-          # ubuntu-24.04. Only spin-up-snapshot.yml ever passes an id.
-          server_image: ${{ inputs.server_image || 'ubuntu-24.04' }}
+          # ubuntu-26.04. Only spin-up-snapshot.yml ever passes an id.
+          server_image: ${{ inputs.server_image || 'ubuntu-26.04' }}
           enabled_services: ${{ inputs.enabled_services }}
           server_type: ${{ vars.SERVER_TYPE }}
           server_location: ${{ vars.SERVER_LOCATION }}
@@ -489,7 +489,7 @@ jobs:
           #   (c) the second SSH connection won't compete with apt
           #       for I/O.
           # Bumped to 6 minutes — cloud-init's apt-get upgrade -y can
-          # take 4-5 min on a fresh Ubuntu 24.04 image when there's
+          # take 4-5 min on a fresh Ubuntu image when there's
           # a kernel update.
           for i in {1..72}; do
             if ssh -o StrictHostKeyChecking=no -o ConnectTimeout=5 -o BatchMode=yes \

--- a/.github/workflows/teardown-snapshot.yml
+++ b/.github/workflows/teardown-snapshot.yml
@@ -134,7 +134,7 @@ jobs:
           cat > tofu/stack/config.tfvars << EOF
           server_type     = "${{ vars.SERVER_TYPE || 'cx43' }}"
           server_location = "${{ vars.SERVER_LOCATION || 'hel1' }}"
-          server_image    = "ubuntu-24.04"
+          server_image    = "ubuntu-26.04"
           ssh_public_key_path  = "~/.ssh/id_ed25519.pub"
           ssh_private_key_path = "~/.ssh/id_ed25519"
           domain              = "${{ secrets.DOMAIN }}"

--- a/.github/workflows/teardown.yml
+++ b/.github/workflows/teardown.yml
@@ -157,7 +157,7 @@ jobs:
           cat > tofu/stack/config.tfvars << EOF
           server_type     = "${{ vars.SERVER_TYPE || 'cx43' }}"
           server_location = "${{ vars.SERVER_LOCATION || 'hel1' }}"
-          server_image    = "ubuntu-24.04"
+          server_image    = "ubuntu-26.04"
           ssh_public_key_path  = "~/.ssh/id_ed25519.pub"
           ssh_private_key_path = "~/.ssh/id_ed25519"
           domain              = "${{ secrets.DOMAIN }}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ Nexus-Stack is an **open-source infrastructure-as-code project** that provides o
 - **Cloud Provider**: Hetzner Cloud
 - **Security**: Cloudflare Zero Trust, Cloudflare Tunnel, Cloudflare Access
 - **Containers**: Docker, Docker Compose
-- **OS**: Ubuntu 24.04 (ARM-based cax11 servers)
+- **OS**: Ubuntu 26.04 LTS (x86 `cx43` servers; see the stack-addition notes for the ARM history)
 - **Shell**: Bash scripts
 - **Build Tool**: Make
 
@@ -128,7 +128,7 @@ gh workflow run destroy-all.yml -f confirm=DESTROY  # Full cleanup
 ```
 
 **Two lifecycles.** `spin-up.yml` / `teardown.yml` destroy and rebuild from
-`ubuntu-24.04`. `spin-up-snapshot.yml` / `teardown-snapshot.yml` take a Hetzner
+`ubuntu-26.04`. `spin-up-snapshot.yml` / `teardown-snapshot.yml` take a Hetzner
 disk snapshot and restore from it — faster, and the only path that preserves
 data for stacks outside the five the R2 layer covers.
 
@@ -868,7 +868,7 @@ Use prefixes that match commit types:
 - This is a **public open-source project** - code should be clean, well-documented, and secure
 - **Never commit directly to `main`** - always use feature branches and PRs
 - Target platform is **macOS** for local development
-- Server runs **Ubuntu 24.04**
+- Server runs **Ubuntu 26.04 LTS**
 - Always test changes before committing
 - Keep README.md updated when adding features
 - Follow best security practices to protect sensitive data

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 ## What This Does
 
 ### Infrastructure
-- **Hetzner Cloud Server** - x86 (default `cx43` in `hel1`, Intel-shared 8 vCPU / 16 GB RAM / 160 GB) running Ubuntu 24.04 — defaults switched permanently from ARM in 2026-05 because (a) Hetzner ARM EU capacity has been unavailable since 2026-01-22, and (b) Hetzner's 2025+ pricing flipped — ARM is now ~40% more expensive than the equivalent x86 spec. Smaller x86 alternatives (`cpx32` AMD 4-vCPU/8-GB, `cx32` Intel 4-vCPU/8-GB) and ARM (`cax*`) variants are supported via the `SERVER_TYPE` / `SERVER_LOCATION` repo variables for users who want to override the default — see [docs/admin-guides/setup-guide.md](docs/admin-guides/setup-guide.md#optional-repository-variables) for the canonical list
+- **Hetzner Cloud Server** - x86 (default `cx43` in `hel1`, Intel-shared 8 vCPU / 16 GB RAM / 160 GB) running Ubuntu 26.04 LTS — defaults switched permanently from ARM in 2026-05 because (a) Hetzner ARM EU capacity has been unavailable since 2026-01-22, and (b) Hetzner's 2025+ pricing flipped — ARM is now ~40% more expensive than the equivalent x86 spec. Smaller x86 alternatives (`cpx32` AMD 4-vCPU/8-GB, `cx32` Intel 4-vCPU/8-GB) and ARM (`cax*`) variants are supported via the `SERVER_TYPE` / `SERVER_LOCATION` repo variables for users who want to override the default — see [docs/admin-guides/setup-guide.md](docs/admin-guides/setup-guide.md#optional-repository-variables) for the canonical list
 - **Cloudflare Tunnel** - All traffic routed through Cloudflare, zero open ports
 - **Cloudflare Access** - Email OTP authentication for all services
 - **Remote State** - OpenTofu state stored in Cloudflare R2

--- a/control-plane/functions/api/_utils/workflow-selection.js
+++ b/control-plane/functions/api/_utils/workflow-selection.js
@@ -4,7 +4,7 @@
  * Nexus-Stack has two pairs:
  *
  *   rebuild   teardown.yml / spin-up.yml
- *             destroy everything, rebuild from ubuntu-24.04
+ *             destroy everything, rebuild from ubuntu-26.04
  *   snapshot  teardown-snapshot.yml / spin-up-snapshot.yml
  *             snapshot the disk, destroy only the server, restore from
  *             the image

--- a/control-plane/functions/api/lifecycle.js
+++ b/control-plane/functions/api/lifecycle.js
@@ -3,7 +3,7 @@
 // Nexus-Stack has two lifecycles and they are a genuine choice, not a
 // migration with an old and a new side:
 //
-//   rebuild   Destroy everything, rebuild from ubuntu-24.04 on the next
+//   rebuild   Destroy everything, rebuild from ubuntu-26.04 on the next
 //             spin-up. Fresh OS and freshly pulled images every time, so
 //             nothing drifts and `:latest` stacks stay current. Costs a
 //             few minutes per spin-up, and anything not covered by the

--- a/control-plane/schema.sql
+++ b/control-plane/schema.sql
@@ -99,7 +99,7 @@ INSERT OR IGNORE INTO config (key, value) VALUES
     ('notify_on_spinup', 'true'),
     ('silent_mode', 'false'),
     -- Which lifecycle workflow pair to dispatch: 'rebuild' (destroy and
-    -- rebuild from ubuntu-24.04) or 'snapshot' (snapshot the disk,
+    -- rebuild from ubuntu-26.04) or 'snapshot' (snapshot the disk,
     -- destroy only the server, restore from the image).
     --
     -- ONE key, not one per workflow. Two independent keys could drift,

--- a/docs/admin-guides/snapshot-lifecycle.md
+++ b/docs/admin-guides/snapshot-lifecycle.md
@@ -10,7 +10,7 @@ Nexus-Stack has two teardown/spin-up pairs. This guide covers the second one, wh
 
 | Mode | Shown in Actions as | Files | What happens |
 |---|---|---|---|
-| `rebuild` | **Lifecycle: Teardown (Rebuild)**<br>**Lifecycle: Spin Up (Rebuild)** | `teardown.yml`<br>`spin-up.yml` | Destroy everything, rebuild from `ubuntu-24.04` |
+| `rebuild` | **Lifecycle: Teardown (Rebuild)**<br>**Lifecycle: Spin Up (Rebuild)** | `teardown.yml`<br>`spin-up.yml` | Destroy everything, rebuild from `ubuntu-26.04` |
 | `snapshot` | **Lifecycle: Teardown (Snapshot)**<br>**Lifecycle: Spin Up (Snapshot)** | `teardown-snapshot.yml`<br>`spin-up-snapshot.yml` | Snapshot the disk, destroy only the server, restore from the image |
 
 **The default is `rebuild`.** Nothing changes until you switch.
@@ -115,7 +115,7 @@ Rebuild teardown rotates every generated credential, so **every existing
 snapshot becomes unrestorable from that moment on**. Going back is cheap;
 going back and then forward again means starting the snapshot line over. The rebuild workflows were never modified and do not depend on anything the snapshot path added.
 
-For a single run rather than a permanent switch, `spin-up-snapshot.yml` takes `force_fresh=true`, which ignores any snapshot and builds from `ubuntu-24.04`.
+For a single run rather than a permanent switch, `spin-up-snapshot.yml` takes `force_fresh=true`, which ignores any snapshot and builds from `ubuntu-26.04`.
 
 ---
 
@@ -159,7 +159,7 @@ This is the **designed** behaviour, not a fault. A snapshot is only used when it
 - its credential epoch no longer matches
 - its architecture or disk size cannot be satisfied by any available server type
 
-In every case the spin-up falls back to a normal `ubuntu-24.04` build **with R2 restore enabled**, so the five R2-covered stacks keep their data. The other stacks come back empty — the same as the rebuild path has always behaved.
+In every case the spin-up falls back to a normal `ubuntu-26.04` build **with R2 restore enabled**, so the five R2-covered stacks keep their data. The other stacks come back empty — the same as the rebuild path has always behaved.
 
 The workflow log names the reason.
 

--- a/docs/assets/architecture-overview.svg
+++ b/docs/assets/architecture-overview.svg
@@ -61,7 +61,7 @@
 
   <!-- Server -->
   <rect x="270" y="390" width="340" height="34" rx="5" fill="#1a1a2e" stroke="#2a2a3e" stroke-width="1"/>
-  <text x="440" y="412" fill="#c0c0c0" font-size="10" text-anchor="middle">Server: Ubuntu 24.04 ARM (cax31)</text>
+  <text x="440" y="412" fill="#c0c0c0" font-size="10" text-anchor="middle">Server: Ubuntu 26.04 x86 (cx43)</text>
 
   <!-- Arrow: through firewall -> server -->
   <line x1="345" y1="364" x2="345" y2="390" stroke="#f6821f" stroke-width="1.5" marker-end="url(#ao)"/>

--- a/docs/proposals/0002-hetzner-disk-snapshots.md
+++ b/docs/proposals/0002-hetzner-disk-snapshots.md
@@ -13,7 +13,7 @@ The headline is speed, but the stronger argument is coverage: RFC 0001's R2 laye
 
 ### What the current cycle repeats
 
-Every teardown destroys the whole stack; every spin-up rebuilds it from `ubuntu-24.04`. Most of that rebuild is work already done: patching Ubuntu, installing Docker, and pulling the same container images.
+Every teardown destroys the whole stack; every spin-up rebuilds it from `ubuntu-26.04`. Most of that rebuild is work already done: patching Ubuntu, installing Docker, and pulling the same container images.
 
 Measured across real workflow runs (May–August 2026):
 
@@ -122,7 +122,7 @@ lifecycle {
 }
 ```
 
-Load-bearing, not tidiness. Without it a snapshot-restored server is one rebuild spin-up away from destruction: `spin-up.yml` supplies `ubuntu-24.04` and `select-capacity` rewrites `server_type`/`server_location`, so OpenTofu would plan a **replacement** of the live server. `image` and `user_data` are ForceNew, which makes it a silent data-loss path rather than a diff someone notices.
+Load-bearing, not tidiness. Without it a snapshot-restored server is one rebuild spin-up away from destruction: `spin-up.yml` supplies `ubuntu-26.04` and `select-capacity` rewrites `server_type`/`server_location`, so OpenTofu would plan a **replacement** of the live server. `image` and `user_data` are ForceNew, which makes it a silent data-loss path rather than a diff someone notices.
 
 It costs nothing operationally: the documented resize flow is teardown → set `SERVER_TYPE` → spin-up, so the server is always created fresh with the new values.
 

--- a/src/nexus_deploy/__main__.py
+++ b/src/nexus_deploy/__main__.py
@@ -3171,7 +3171,7 @@ def _snapshot_resolve(args: list[str]) -> int:
     - 0: a usable snapshot was found; restore from it.
     - 1: no usable snapshot. NOT an error — a first-ever spin-up, a
       pruned image and a rotated credential epoch all land here, and
-      all three must degrade to a normal ``ubuntu-24.04`` build. The
+      all three must degrade to a normal ``ubuntu-26.04`` build. The
       workflow branches on this rather than failing.
     - 2: the lookup itself failed (auth, network, schema). The
       workflow should stop, because "cannot tell" is not the same as

--- a/src/nexus_deploy/hetzner_snapshot.py
+++ b/src/nexus_deploy/hetzner_snapshot.py
@@ -2,7 +2,7 @@
 teardown/spin-up cycle.
 
 The default lifecycle destroys the whole stack on teardown and rebuilds
-it from ``ubuntu-24.04`` on the next spin-up. Most of that rebuild is
+it from ``ubuntu-26.04`` on the next spin-up. Most of that rebuild is
 repetition: patching Ubuntu, installing Docker, and pulling the same
 container images again — the single largest block of a spin-up.
 
@@ -579,7 +579,7 @@ def resolve_latest(
     ``None`` is the ordinary "take the fresh path" answer, not an error:
     a first-ever spin-up, a pruned-away snapshot and a rotated
     credential epoch are all normal states that must degrade to a
-    regular ``ubuntu-24.04`` build rather than fail the workflow.
+    regular ``ubuntu-26.04`` build rather than fail the workflow.
 
     When ``expect_epoch`` is given, a snapshot whose epoch differs is
     rejected. That is the guard against the legacy untargeted ``tofu

--- a/src/nexus_deploy/setup.py
+++ b/src/nexus_deploy/setup.py
@@ -473,11 +473,15 @@ def ensure_rclone(ssh: SSHClient) -> bool:
     BEFORE the probe runs, which is what this helper does.
 
     Raises :class:`subprocess.CalledProcessError` on install failure.
-    The Ubuntu 24.04 main repo carries rclone 1.60.1, which is old
-    enough that ``rclone lsf`` returns rc=0 with empty stdout for a
-    missing object (newer rclone versions return non-zero). The
-    rendered restore script in ``s3_persistence.render_restore_script``
-    accounts for this by checking lsf's STDOUT, not its exit code.
+
+    Whatever the distro repo carries is fine, and the restore script is
+    written not to care. Ubuntu 24.04 shipped rclone 1.60.1, old enough
+    that ``rclone lsf`` returned rc=0 with empty stdout for a missing
+    object where newer versions return non-zero; 26.04 carries a newer
+    one. ``s3_persistence.render_restore_script`` therefore lists the
+    ``snapshots/`` prefix and greps the listing for ``latest.txt``
+    rather than probing the object directly, so a missing snapshot is
+    an absent line rather than an exit code that differs by version.
     """
     check = ssh.run("command -v rclone", check=False)
     if check.returncode == 0:

--- a/tests/unit/test_s3_persistence.py
+++ b/tests/unit/test_s3_persistence.py
@@ -978,7 +978,7 @@ def test_restore_script_rejects_unknown_phase() -> None:
 
 
 def test_restore_script_detects_missing_latest_via_lsf_stdout_not_exit_code() -> None:
-    """Ubuntu 24.04's apt rclone (v1.60.1) returns rc=0 with empty
+    """Older apt rclone (Ubuntu 24.04 shipped v1.60.1) returns rc=0 with empty
     stdout for a missing remote object, so an ``if ! rclone lsf ...``
     check NEVER fires the fresh-start branch on that version — the
     script falls through to ``copyto`` (also rc=0, no local file

--- a/tests/unit/test_select_capacity_cli.py
+++ b/tests/unit/test_select_capacity_cli.py
@@ -47,7 +47,7 @@ def tfvars_with_legacy_pair(tmp_path: Path) -> Path:
     path.write_text(
         'server_type     = "cx43"\n'
         'server_location = "hel1"\n'
-        'server_image    = "ubuntu-24.04"\n'
+        'server_image    = "ubuntu-26.04"\n'
         'domain          = "example.com"\n',
         encoding="utf-8",
     )
@@ -456,7 +456,7 @@ def test_select_capacity_preserves_other_tfvars_lines(
     )
     _select_capacity(["--tfvars", str(tfvars_with_legacy_pair)])
     rewritten = tfvars_with_legacy_pair.read_text()
-    assert 'server_image    = "ubuntu-24.04"' in rewritten
+    assert 'server_image    = "ubuntu-26.04"' in rewritten
     assert 'domain          = "example.com"' in rewritten
 
 
@@ -471,7 +471,7 @@ def test_select_capacity_preserves_trailing_inline_comments(
     path.write_text(
         'server_type = "cx43" # primary instance class\n'
         'server_location = "hel1"  // hel1 was first in the list\n'
-        'server_image = "ubuntu-24.04"\n',
+        'server_image = "ubuntu-26.04"\n',
         encoding="utf-8",
     )
     monkeypatch.setenv("HCLOUD_TOKEN", "t")

--- a/tests/unit/test_snapshot_cli.py
+++ b/tests/unit/test_snapshot_cli.py
@@ -390,7 +390,7 @@ def test_resolve_not_found_is_rc1_not_rc2(monkeypatch: pytest.MonkeyPatch) -> No
     """No snapshot is a normal state, not a failure.
 
     First-ever spin-up, pruned image, rotated epoch — all land here and
-    all must degrade to a fresh ubuntu-24.04 build. Returning 2 would
+    all must degrade to a fresh ubuntu-26.04 build. Returning 2 would
     fail the workflow on a perfectly ordinary first deploy.
     """
     monkeypatch.setattr(_hsnap, "resolve_latest", lambda *a, **k: None)

--- a/tofu/stack/main.tf
+++ b/tofu/stack/main.tf
@@ -654,8 +654,9 @@ resource "hcloud_server" "main" {
     # This had worked for months purely because no upgraded package
     # happened to ask anything. That is luck, not a property.
     export DEBIAN_FRONTEND=noninteractive
-    # needrestart ships enabled on 24.04 and prompts about restarting
-    # services after a library upgrade. `a` applies automatically.
+    # needrestart has shipped enabled since 22.04 and prompts about
+    # restarting services after a library upgrade. `a` applies
+    # automatically.
     export NEEDRESTART_MODE=a
 
     if [ ! -f /opt/docker-server/.image-provisioned ]; then
@@ -767,9 +768,11 @@ resource "hcloud_server" "main" {
 
   # image / user_data / server_type / location are create-only.
   #
-  # Without this, a snapshot-restored server is one legacy spin-up away
-  # from destruction: spin-up.yml hardcodes `server_image =
-  # "ubuntu-26.04"` and select-capacity rewrites server_type/location,
+  # Without this, a snapshot-restored server is one rebuild spin-up away
+  # from destruction: spin-up.yml supplies the base image through its
+  # `inputs.server_image || 'ubuntu-26.04'` fallback — not a hardcode,
+  # but the same effect when nothing overrides it — and select-capacity
+  # rewrites server_type/location,
   # so tofu would plan a REPLACEMENT of the live server and take every
   # stack's data with it. image and user_data are ForceNew on
   # hcloud_server, which makes that a silent data-loss path rather than

--- a/tofu/stack/main.tf
+++ b/tofu/stack/main.tf
@@ -769,7 +769,7 @@ resource "hcloud_server" "main" {
   #
   # Without this, a snapshot-restored server is one legacy spin-up away
   # from destruction: spin-up.yml hardcodes `server_image =
-  # "ubuntu-24.04"` and select-capacity rewrites server_type/location,
+  # "ubuntu-26.04"` and select-capacity rewrites server_type/location,
   # so tofu would plan a REPLACEMENT of the live server and take every
   # stack's data with it. image and user_data are ForceNew on
   # hcloud_server, which makes that a silent data-loss path rather than

--- a/tofu/stack/variables.tf
+++ b/tofu/stack/variables.tf
@@ -55,7 +55,7 @@ variable "server_location" {
 variable "server_image" {
   description = "OS image for the server"
   type        = string
-  default     = "ubuntu-24.04"
+  default     = "ubuntu-26.04"
 }
 
 variable "ipv6_only" {


### PR DESCRIPTION
Closes #650

24.04 is supported until April 2029, so this is about not drifting three years behind rather than urgency.

The blocker #650 named — *"verify the snapshot mechanism on the known-good 24.04 first"* — cleared today: a full `Teardown (Snapshot)` → `Spin Up (Snapshot)` cycle ran end to end, destroying the server and restoring it from image `#423792562`.

## Functional changes

Ten sites: the `server_image` default in `variables.tf`, the four workflows that write `config.tfvars`, the `|| 'ubuntu-24.04'` fallback in `spin-up.yml`, the `fresh()` branch in `spin-up-snapshot.yml`, the composite action's default, and three test fixtures asserting the exact tfvars string.

## Two docstrings deliberately not find-replaced

Both describe a property of 24.04 rather than a version number, and would have become false:

> The Ubuntu 24.04 main repo carries rclone 1.60.1, which is old enough that `rclone lsf` returns rc=0 with empty stdout for a missing object (newer rclone versions return non-zero).

26.04 carries a newer rclone. So I checked what actually depends on that behaviour: `render_restore_script` lists the `snapshots/` prefix and greps the listing for `latest.txt` rather than probing the object directly. A missing snapshot is therefore an **absent line**, not an exit code that differs by version — the logic is already version-agnostic, and the comments now say so instead of pinning a claim to 24.04.

## Two references that were stale in a second way

- `CLAUDE.md` called the OS "Ubuntu 24.04 (ARM-based cax11 servers)"
- `docs/assets/architecture-overview.svg` said "Ubuntu 24.04 ARM (cax31)"

Both predate the permanent switch to x86 `cx43` in 2026-05, so both were
wrong about the architecture as well as the version. The SVG is the one visible
in the README, which is where it was spotted.

All graphics were checked, not just that one: the other two SVGs
(`architecture-quickstart`, `architecture-security`) carry no OS or
architecture text at all, and the 48 PNGs are UI screenshots from the user
guides plus two logos — nothing that can go stale this way.

The README prose keeps its ARM mentions deliberately: it explains why the
default moved away from ARM in 2026-05 and notes that `cax*` variants are still
supported via `SERVER_TYPE`. That is history and current fact, not drift.

## Verification

`uv run pytest` 1736 passed · `ruff check` clean · `mypy --strict` clean over 61 files · `tofu validate` succeeds · every workflow parses and every `run:` block passes `bash -n`.

**Not verified against a real boot.** That needs one fresh-mode spin-up, which is the point of merging this on a day with no users and no data on the stack.

## The risk, unchanged from #650

26.04 ships **Rust coreutils (uutils)**, and this project runs a lot of bash over SSH — the deploy pipeline, the rendered `s3_persistence` snapshot/restore scripts with `rclone` and `pg_dump`, and the per-service configure hooks. uutils differs from GNU in flag details, and those failures are quiet rather than loud.

Today already demonstrated how that class behaves: a `keyboard-configuration` update turned every cold spin-up into a permanent hang, and the cause took an hour to find from a single changed variable. This PR changes the whole base image, which is why it is on its own rather than bundled with anything.

## Sequencing for the first run

A snapshot pins the OS, so the upgrade cannot happen through a restore. The first spin-up after this **must be fresh mode**, and the two 24.04-era snapshots from today become dead weight and should be pruned.

## What to watch in that run

- `Install Cloudflare Tunnel via SSH` — where today's apt hang surfaced. A clean run shows `SSH ready + host provisioned (attempt N)` with a low N.
- `Deploy stacks` — where a uutils flag difference would show up, and quietly.
- Whether `rclone` installs from the 26.04 repo at all, since `ensure_rclone` shells out to `apt-get install -y rclone`.

## Summary by Sourcery

Upgrade the infrastructure’s default server image to Ubuntu 26.04 LTS across provisioning, lifecycle workflows, documentation, and validation coverage.

Enhancements:
- Upgrade the default server base image and all rebuild and snapshot-fallback paths from Ubuntu 24.04 to Ubuntu 26.04 LTS.
- Update lifecycle documentation and project metadata to reflect the Ubuntu 26.04 LTS x86 `cx43` default.
- Clarify snapshot restore compatibility across rclone versions and remove outdated Ubuntu-specific assumptions.

Documentation:
- Update lifecycle guides, architecture references, and project documentation for the Ubuntu 26.04 LTS base image and current server architecture.

Tests:
- Update fixtures and assertions to verify Ubuntu 26.04 image references.