### PR TITLE
fix(deploy): Make the Portainer hook idempotent and name degraded hooks

### DIFF
--- a/src/nexus_deploy/orchestrator.py
+++ b/src/nexus_deploy/orchestrator.py
@@ -46,7 +46,7 @@ import re
 import shlex
 import socket
 import subprocess
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Literal
@@ -142,6 +142,22 @@ _SECRET_ASSIGNMENT_RE = re.compile(
     r"\s*=\s*\S+",
     re.IGNORECASE,
 )
+
+
+def _hook_names_suffix(names: Sequence[str]) -> str:
+    """Render ``" (a, b)"`` for a non-empty name list, else ``""``.
+
+    Appended to a count in a phase detail so ``failed=1`` becomes
+    ``failed=1 (portainer)``. Empty stays empty rather than printing
+    ``()``, which would add noise to the common all-green line.
+
+    Hook names come from a fixed registry and are validated against
+    ``[A-Za-z0-9_-]+`` when the RESULT line is parsed, so nothing
+    operator-supplied reaches this string.
+    """
+    if not names:
+        return ""
+    return f" ({', '.join(names)})"
 
 
 def _transport_detail(exc: BaseException) -> str:
@@ -414,13 +430,18 @@ class Orchestrator:
                 status="failed",
                 detail=f"unexpected ({type(exc).__name__})",
             )
+        # Name the hooks behind every non-configured outcome. A count
+        # on its own sends the reader to a second log to find out which
+        # service it was.
+        not_ready = _hook_names_suffix(result.skipped_not_ready_hooks)
         if result.failed > 0:
             return PhaseResult(
                 name="services-configure",
                 status="partial",
                 detail=(
                     f"configured={result.configured} already-configured={result.already_configured} "
-                    f"skipped-not-ready={result.skipped_not_ready} failed={result.failed}"
+                    f"skipped-not-ready={result.skipped_not_ready}{not_ready} "
+                    f"failed={result.failed}{_hook_names_suffix(result.failed_hooks)}"
                 ),
             )
         return PhaseResult(
@@ -428,7 +449,7 @@ class Orchestrator:
             status="ok",
             detail=(
                 f"configured={result.configured} already-configured={result.already_configured} "
-                f"skipped-not-ready={result.skipped_not_ready}"
+                f"skipped-not-ready={result.skipped_not_ready}{not_ready}"
             ),
         )
 

--- a/src/nexus_deploy/pipeline.py
+++ b/src/nexus_deploy/pipeline.py
@@ -784,10 +784,18 @@ def run_snapshot(
 
 _PHASE_MARKERS = {"ok": "✓", "partial": "⚠", "failed": "✗", "skipped": "—"}
 
-# GitHub's workflow-command parser reads `%`, CR and LF as structure.
-# A detail line carrying any of them would truncate or split the
-# annotation, so they go in percent-encoded.
-_GA_ESCAPES = str.maketrans({"%": "%25", "\r": "%0D", "\n": "%0A"})
+# GitHub's workflow-command parser reads `%`, CR and LF as structure,
+# so a message carrying any of them would truncate or split the
+# annotation. Mirrors `escapeData` in actions/toolkit's command.ts.
+_GA_DATA_ESCAPES = str.maketrans({"%": "%25", "\r": "%0D", "\n": "%0A"})
+
+# The property section — everything between `::warning ` and the
+# closing `::` — additionally delimits on `:` and `,`, so those need
+# encoding too (`escapeProperty` in the same file). Our titles are
+# built as "<section>: <phase>" and so always contain a colon; phase
+# names never contain a comma today, but the encoding is defined by
+# the parser rather than by what we happen to pass it.
+_GA_PROPERTY_ESCAPES = str.maketrans({"%": "%25", "\r": "%0D", "\n": "%0A", ":": "%3A", ",": "%2C"})
 
 # A phase whose status is degraded but not fatal. `failed` is included
 # even though it also aborts the run: the abort message names the
@@ -822,8 +830,8 @@ def _github_annotations(
             level = _GA_ANNOTATED.get(phase.status)
             if level is None:
                 continue
-            title = f"{label}: {phase.name}".translate(_GA_ESCAPES)
-            body = (phase.detail or phase.status).translate(_GA_ESCAPES)
+            title = f"{label}: {phase.name}".translate(_GA_PROPERTY_ESCAPES)
+            body = (phase.detail or phase.status).translate(_GA_DATA_ESCAPES)
             lines.append(f"::{level} title={title}::{body}")
     return lines
 

--- a/src/nexus_deploy/pipeline.py
+++ b/src/nexus_deploy/pipeline.py
@@ -784,6 +784,49 @@ def run_snapshot(
 
 _PHASE_MARKERS = {"ok": "✓", "partial": "⚠", "failed": "✗", "skipped": "—"}
 
+# GitHub's workflow-command parser reads `%`, CR and LF as structure.
+# A detail line carrying any of them would truncate or split the
+# annotation, so they go in percent-encoded.
+_GA_ESCAPES = str.maketrans({"%": "%25", "\r": "%0D", "\n": "%0A"})
+
+# A phase whose status is degraded but not fatal. `failed` is included
+# even though it also aborts the run: the abort message names the
+# phase, but an annotation puts it in the run summary next to the
+# partials rather than only in the step log.
+_GA_ANNOTATED = {"partial": "warning", "failed": "error"}
+
+
+def _github_annotations(
+    sections: tuple[tuple[str, OrchestratorResult], ...],
+) -> list[str]:
+    """Render GitHub Actions annotations for degraded phases.
+
+    Why this exists: ``partial`` deliberately keeps the exit code at 0
+    (see :func:`run_pipeline` — PR #535 tightened that, because a
+    non-zero exit under ``shell: bash -e`` fails a workflow whose
+    deploy actually succeeded). The cost of that contract is that a
+    degraded phase is visible **only** to somebody who opens the step
+    log and reads it: the run, the job and the step all stay green.
+
+    An annotation restores the signal without touching the exit code.
+    It surfaces in the run summary and against the step in the UI, so
+    a partial phase is something an operator sees rather than
+    something they have to go looking for.
+
+    Returns the lines; the caller writes them. Empty when nothing is
+    degraded, so a clean run adds no output at all.
+    """
+    lines: list[str] = []
+    for label, sub_result in sections:
+        for phase in sub_result.phases:
+            level = _GA_ANNOTATED.get(phase.status)
+            if level is None:
+                continue
+            title = f"{label}: {phase.name}".translate(_GA_ESCAPES)
+            body = (phase.detail or phase.status).translate(_GA_ESCAPES)
+            lines.append(f"::{level} title={title}::{body}")
+    return lines
+
 
 def write_phase_log(
     sections: tuple[tuple[str, OrchestratorResult], ...],
@@ -801,6 +844,12 @@ def write_phase_log(
 
     ``stream`` defaults to ``sys.stderr`` at call time rather than at
     import, so a caller that redirects stderr still gets captured.
+
+    Degraded phases additionally get a GitHub Actions annotation, for
+    the same reason this function is shared in the first place: the
+    alternative — a second emitter beside each call site — is how the
+    abort paths lost their phase log. Annotations are emitted only
+    under ``GITHUB_ACTIONS``, so local runs and tests stay clean.
     """
     out = stream if stream is not None else sys.stderr
     for label, sub_result in sections:
@@ -809,6 +858,9 @@ def write_phase_log(
             marker = _PHASE_MARKERS.get(phase.status, "?")
             detail = f" — {phase.detail}" if phase.detail else ""
             out.write(f"  {marker} {phase.name}: {phase.status}{detail}\n")
+    if os.environ.get("GITHUB_ACTIONS") == "true":
+        for line in _github_annotations(sections):
+            out.write(f"{line}\n")
 
 
 def format_done_banner(result: PipelineResult) -> str:

--- a/src/nexus_deploy/services.py
+++ b/src/nexus_deploy/services.py
@@ -253,6 +253,16 @@ def render_portainer_hook(config: NexusConfig, env: BootstrapEnv) -> str:
     this endpoint is the one we POST credentials to, and an error
     payload is not a safe thing to echo into a public CI log.
 
+    Both captures end ``|| true`` with a ``:-000`` default rather than
+    the ``|| echo "000"`` used elsewhere in this module. curl already
+    writes ``000`` through ``-w`` when it never gets a response *and*
+    exits non-zero, so the fallback appends a second one and the
+    capture becomes the six-character ``000000``. That is harmless
+    where the value is only equality-tested against a success code,
+    which is what the other call sites do — but this hook prints the
+    code in its failure diagnostic and branches on it, so a malformed
+    value would be both misleading and unmatched.
+
     Secrets reach jq via env vars (``NEXUS_U`` / ``NEXUS_P``) and are
     referenced in the filter as ``env.NEXUS_U`` / ``env.NEXUS_P`` —
     NEVER as positional ``--arg`` values, which would put them in
@@ -277,7 +287,8 @@ def render_portainer_hook(config: NexusConfig, env: BootstrapEnv) -> str:
 portainer_hook() {{
     {wait}
     ADMIN_CHECK=$(curl -s -o /dev/null -w '%{{http_code}}' --max-time 10 \\
-        'http://localhost:9090/api/users/admin/check' 2>/dev/null || echo "000")
+        'http://localhost:9090/api/users/admin/check' 2>/dev/null || true)
+    ADMIN_CHECK=${{ADMIN_CHECK:-000}}
     if [ "$ADMIN_CHECK" = "204" ]; then
         echo "RESULT hook=portainer status=already-configured"
         return 0
@@ -288,7 +299,8 @@ portainer_hook() {{
         -X POST 'http://localhost:9090/api/users/admin/init' \\
         --max-time 30 \\
         -H 'Content-Type: application/json' \\
-        --data-binary @- 2>/dev/null || echo "000")
+        --data-binary @- 2>/dev/null || true)
+    INIT_CODE=${{INIT_CODE:-000}}
     case "$INIT_CODE" in
         2??)
             echo "RESULT hook=portainer status=configured"

--- a/src/nexus_deploy/services.py
+++ b/src/nexus_deploy/services.py
@@ -148,6 +148,27 @@ class SetupResult:
         return sum(1 for h in self.hooks if h.status == "failed")
 
     @property
+    def failed_hooks(self) -> tuple[str, ...]:
+        """Names of the hooks that failed, in the order they ran.
+
+        A bare ``failed=1`` forces whoever reads the phase log to
+        reconstruct which of the enabled services it was — from a
+        second log, or by re-running. The names are already here; the
+        summary just never carried them.
+        """
+        return tuple(h.name for h in self.hooks if h.status == "failed")
+
+    @property
+    def skipped_not_ready_hooks(self) -> tuple[str, ...]:
+        """Names of the hooks that timed out waiting for their service.
+
+        Same argument as :attr:`failed_hooks`: this is a degraded
+        outcome, and a count alone does not say which service never
+        came up.
+        """
+        return tuple(h.name for h in self.hooks if h.status == "skipped-not-ready")
+
+    @property
     def is_success(self) -> bool:
         """All hooks ended in a non-failed terminal state."""
         return self.failed == 0
@@ -209,6 +230,29 @@ fi
 def render_portainer_hook(config: NexusConfig, env: BootstrapEnv) -> str:
     """Portainer first-init: ``POST /api/users/admin/init`` (no auth).
 
+    Idempotent via a **pre-check**, the same shape as the n8n and
+    Metabase hooks: ``GET /api/users/admin/check`` answers 204 when an
+    administrator already exists and 404 when none does
+    (``api/http/handler/users/admin_check.go``). A re-run therefore
+    reports ``already-configured`` without attempting a second write.
+
+    Both branches key on the **HTTP status code**, never on the prose
+    in an error body. An earlier revision matched the response against
+    ``already initialized`` and every re-run landed in ``failed``: that
+    string is the name of Portainer's Go identifier
+    (``errAdminAlreadyInitialized``), while the text it actually puts
+    on the wire is ``An administrator user already exists``. Matching
+    an identifier instead of the payload is silently wrong for as long
+    as nobody re-runs the hook.
+
+    The POST's status code is kept as a second signal — 409 is
+    Portainer's conflict for an existing administrator — so the hook is
+    still correct if an admin appears between the check and the write.
+
+    Only the status code is logged on failure, never the response body:
+    this endpoint is the one we POST credentials to, and an error
+    payload is not a safe thing to echo into a public CI log.
+
     Secrets reach jq via env vars (``NEXUS_U`` / ``NEXUS_P``) and are
     referenced in the filter as ``env.NEXUS_U`` / ``env.NEXUS_P`` —
     NEVER as positional ``--arg`` values, which would put them in
@@ -232,19 +276,31 @@ def render_portainer_hook(config: NexusConfig, env: BootstrapEnv) -> str:
     return f"""
 portainer_hook() {{
     {wait}
+    ADMIN_CHECK=$(curl -s -o /dev/null -w '%{{http_code}}' --max-time 10 \\
+        'http://localhost:9090/api/users/admin/check' 2>/dev/null || echo "000")
+    if [ "$ADMIN_CHECK" = "204" ]; then
+        echo "RESULT hook=portainer status=already-configured"
+        return 0
+    fi
     BODY=$(NEXUS_U={username_q} NEXUS_P={password_q} jq -n \\
         '{{Username: env.NEXUS_U, Password: env.NEXUS_P}}')
-    RESP=$(printf '%s' "$BODY" | curl -s -X POST 'http://localhost:9090/api/users/admin/init' \\
+    INIT_CODE=$(printf '%s' "$BODY" | curl -s -o /dev/null -w '%{{http_code}}' \\
+        -X POST 'http://localhost:9090/api/users/admin/init' \\
         --max-time 30 \\
         -H 'Content-Type: application/json' \\
-        --data-binary @- 2>/dev/null || echo "")
-    if echo "$RESP" | grep -q '"Id"'; then
-        echo "RESULT hook=portainer status=configured"
-    elif echo "$RESP" | grep -q 'already initialized'; then
-        echo "RESULT hook=portainer status=already-configured"
-    else
-        echo "RESULT hook=portainer status=failed"
-    fi
+        --data-binary @- 2>/dev/null || echo "000")
+    case "$INIT_CODE" in
+        2??)
+            echo "RESULT hook=portainer status=configured"
+            ;;
+        409)
+            echo "RESULT hook=portainer status=already-configured"
+            ;;
+        *)
+            echo "  ⚠ portainer admin init returned HTTP $INIT_CODE (admin/check=$ADMIN_CHECK)" >&2
+            echo "RESULT hook=portainer status=failed"
+            ;;
+    esac
 }}
 portainer_hook
 """

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -1003,6 +1003,49 @@ def test_phase_services_configure_partial_when_failed(
     assert "failed=1" in result.detail
 
 
+def test_phase_services_configure_names_the_failing_hooks(
+    orchestrator: Orchestrator, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The detail must say *which* hook failed.
+
+    A bare ``failed=1`` over six enabled services is not a diagnosis;
+    recovering the name previously meant correlating three workflow
+    runs.
+    """
+    from nexus_deploy.services import HookResult, SetupResult
+
+    fake = SetupResult(
+        hooks=(
+            HookResult(name="portainer", status="failed"),
+            HookResult(name="metabase", status="skipped-not-ready"),
+            HookResult(name="lakefs", status="failed"),
+        )
+    )
+    monkeypatch.setattr(
+        "nexus_deploy.orchestrator._services.run_admin_setups", lambda *_a, **_kw: fake
+    )
+    result = orchestrator._phase_services_configure(MagicMock())
+    assert result.status == "partial"
+    assert "failed=2 (portainer, lakefs)" in result.detail
+    assert "skipped-not-ready=1 (metabase)" in result.detail
+
+
+def test_phase_services_configure_omits_empty_name_lists(
+    orchestrator: Orchestrator, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An all-green line must not gain a stray ``()``."""
+    from nexus_deploy.services import HookResult, SetupResult
+
+    fake = SetupResult(hooks=(HookResult(name="x", status="configured"),))
+    monkeypatch.setattr(
+        "nexus_deploy.orchestrator._services.run_admin_setups", lambda *_a, **_kw: fake
+    )
+    result = orchestrator._phase_services_configure(MagicMock())
+    assert result.status == "ok"
+    assert "()" not in result.detail
+    assert result.detail == "configured=1 already-configured=0 skipped-not-ready=0"
+
+
 def test_phase_gitea_configure_ok_populates_state(
     orchestrator: Orchestrator, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/unit/test_pipeline.py
+++ b/tests/unit/test_pipeline.py
@@ -1459,6 +1459,104 @@ def test_write_phase_log_renders_every_section_in_order() -> None:
     assert out.index("early") < out.index("late")
 
 
+# ---------------------------------------------------------------------------
+# GitHub Actions annotations for degraded phases (#682)
+# ---------------------------------------------------------------------------
+
+
+def _phase_log(
+    *phases: PhaseResult,
+    label: str = "run-all",
+    env: dict[str, str] | None = None,
+    monkeypatch: Any = None,
+) -> str:
+    import io
+
+    if monkeypatch is not None:
+        monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+        for key, value in (env or {}).items():
+            monkeypatch.setenv(key, value)
+    buf = io.StringIO()
+    write_phase_log(((label, _result(*phases)),), stream=buf)
+    return buf.getvalue()
+
+
+def test_partial_phase_gets_a_warning_annotation_under_actions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A degraded phase must be visible without opening the step log.
+
+    ``partial`` deliberately keeps rc=0 (PR #535), so run, job and step
+    all stay green. The annotation is what carries the signal into the
+    run summary instead.
+    """
+    out = _phase_log(
+        PhaseResult(name="services-configure", status="partial", detail="failed=1 (portainer)"),
+        env={"GITHUB_ACTIONS": "true"},
+        monkeypatch=monkeypatch,
+    )
+    assert "::warning title=run-all: services-configure::failed=1 (portainer)" in out
+
+
+def test_failed_phase_gets_an_error_annotation(monkeypatch: pytest.MonkeyPatch) -> None:
+    out = _phase_log(
+        PhaseResult(name="stack-sync", status="failed", detail="rc=255"),
+        env={"GITHUB_ACTIONS": "true"},
+        monkeypatch=monkeypatch,
+    )
+    assert "::error title=run-all: stack-sync::rc=255" in out
+
+
+def test_clean_run_emits_no_annotations(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An all-green run must not add noise to the summary."""
+    out = _phase_log(
+        PhaseResult(name="a", status="ok", detail="fine"),
+        PhaseResult(name="b", status="skipped", detail="not enabled"),
+        env={"GITHUB_ACTIONS": "true"},
+        monkeypatch=monkeypatch,
+    )
+    assert "::warning" not in out
+    assert "::error" not in out
+
+
+def test_no_annotations_outside_github_actions(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Local runs and tests get the human log only."""
+    out = _phase_log(
+        PhaseResult(name="services-configure", status="partial", detail="failed=1 (portainer)"),
+        monkeypatch=monkeypatch,
+    )
+    assert "⚠ services-configure: partial" in out
+    assert "::warning" not in out
+
+
+def test_annotation_escapes_workflow_command_characters(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`%`, CR and LF are structure to GitHub's parser.
+
+    An unescaped newline in a detail would split the annotation and
+    drop everything after it.
+    """
+    out = _phase_log(
+        PhaseResult(name="p", status="partial", detail="100% done\nsecond line"),
+        env={"GITHUB_ACTIONS": "true"},
+        monkeypatch=monkeypatch,
+    )
+    assert "::warning title=run-all: p::100%25 done%0Asecond line" in out
+
+
+def test_annotation_falls_back_to_status_when_detail_is_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An annotation with an empty body says nothing at all."""
+    out = _phase_log(
+        PhaseResult(name="p", status="partial"),
+        env={"GITHUB_ACTIONS": "true"},
+        monkeypatch=monkeypatch,
+    )
+    assert "::warning title=run-all: p::partial" in out
+
+
 def test_post_bootstrap_abort_prints_the_phase_log_before_raising(
     project_root: Path,
     fake_tofu_runner: MagicMock,

--- a/tests/unit/test_pipeline.py
+++ b/tests/unit/test_pipeline.py
@@ -1495,7 +1495,7 @@ def test_partial_phase_gets_a_warning_annotation_under_actions(
         env={"GITHUB_ACTIONS": "true"},
         monkeypatch=monkeypatch,
     )
-    assert "::warning title=run-all: services-configure::failed=1 (portainer)" in out
+    assert "::warning title=run-all%3A services-configure::failed=1 (portainer)" in out
 
 
 def test_failed_phase_gets_an_error_annotation(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1504,7 +1504,7 @@ def test_failed_phase_gets_an_error_annotation(monkeypatch: pytest.MonkeyPatch) 
         env={"GITHUB_ACTIONS": "true"},
         monkeypatch=monkeypatch,
     )
-    assert "::error title=run-all: stack-sync::rc=255" in out
+    assert "::error title=run-all%3A stack-sync::rc=255" in out
 
 
 def test_clean_run_emits_no_annotations(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1542,7 +1542,7 @@ def test_annotation_escapes_workflow_command_characters(
         env={"GITHUB_ACTIONS": "true"},
         monkeypatch=monkeypatch,
     )
-    assert "::warning title=run-all: p::100%25 done%0Asecond line" in out
+    assert "::warning title=run-all%3A p::100%25 done%0Asecond line" in out
 
 
 def test_annotation_falls_back_to_status_when_detail_is_empty(
@@ -1554,7 +1554,27 @@ def test_annotation_falls_back_to_status_when_detail_is_empty(
         env={"GITHUB_ACTIONS": "true"},
         monkeypatch=monkeypatch,
     )
-    assert "::warning title=run-all: p::partial" in out
+    assert "::warning title=run-all%3A p::partial" in out
+
+
+def test_annotation_title_escapes_property_delimiters(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The property section delimits on `:` and `,`, the message does not.
+
+    GitHub's parser uses two escape sets (`escapeProperty` vs
+    `escapeData` in actions/toolkit). A comma in a title would start a
+    second property; a colon can close the property section early. The
+    same characters in the message body are literal and must stay
+    readable.
+    """
+    out = _phase_log(
+        PhaseResult(name="a,b", status="partial", detail="x, y: z"),
+        label="run:all",
+        env={"GITHUB_ACTIONS": "true"},
+        monkeypatch=monkeypatch,
+    )
+    assert "::warning title=run%3Aall%3A a%2Cb::x, y: z" in out
 
 
 def test_post_bootstrap_abort_prints_the_phase_log_before_raising(

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -188,6 +188,26 @@ def test_render_portainer_hook_treats_any_2xx_as_configured() -> None:
     assert "2??)" in script
 
 
+def test_render_portainer_hook_captures_a_single_status_code() -> None:
+    """`|| echo "000"` would double curl's own transport code.
+
+    On a connection failure curl writes ``000`` through ``-w`` *and*
+    exits non-zero, so the fallback appends a second one and the
+    capture becomes the six-character ``000000``. Harmless where a
+    value is only equality-tested against a success code — this hook
+    prints it and branches on it.
+    """
+    script = render_portainer_hook(_make_config(), _make_env())
+    assert "/api/users/admin/check' 2>/dev/null || true)" in script
+    assert "--data-binary @- 2>/dev/null || true)" in script
+    assert script.count("${ADMIN_CHECK:-000}") == 1
+    assert script.count("${INIT_CODE:-000}") == 1
+    # The shared readiness preamble still carries the older
+    # `|| echo "000"`; it is only equality-tested there, so it is left
+    # alone rather than changed under an unrelated PR.
+    assert 'echo "000"' in script
+
+
 def test_render_n8n_hook_uses_admin_email_from_env() -> None:
     """n8n needs admin_email — comes from BootstrapEnv, not NexusConfig."""
     script = render_n8n_hook(_make_config(), _make_env(admin_email="alice@example.com"))

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -153,6 +153,41 @@ def test_render_portainer_hook_skips_when_password_empty() -> None:
     assert script.strip() == 'echo "RESULT hook=portainer status=skipped-not-ready"'
 
 
+def test_render_portainer_hook_checks_before_it_writes() -> None:
+    """The admin pre-check must precede the init POST.
+
+    Order is the whole point: if the POST came first, a re-run would
+    hit the conflict path and depend on the backstop rather than
+    avoiding the write entirely. Compare positions rather than mere
+    presence, which a reordering would not catch.
+    """
+    script = render_portainer_hook(_make_config(), _make_env())
+    assert script.index("/api/users/admin/check") < script.index("/api/users/admin/init")
+
+
+def test_render_portainer_hook_never_echoes_the_response_body() -> None:
+    """Only the status code may be logged on failure.
+
+    This hook POSTs credentials; its error payload is not something to
+    echo into a public CI log. The diagnostic carries the two codes and
+    nothing else.
+    """
+    script = render_portainer_hook(_make_config(), _make_env())
+    assert "-o /dev/null" in script  # response discarded, code kept via -w
+    assert 'echo "$RESP"' not in script
+    assert "$INIT_CODE" in script
+
+
+def test_render_portainer_hook_treats_any_2xx_as_configured() -> None:
+    """Success is a 2xx class, not one hardcoded code.
+
+    The previous revision looked for `"Id"` in the body; keying on the
+    class keeps the hook correct if Portainer answers 201 instead.
+    """
+    script = render_portainer_hook(_make_config(), _make_env())
+    assert "2??)" in script
+
+
 def test_render_n8n_hook_uses_admin_email_from_env() -> None:
     """n8n needs admin_email — comes from BootstrapEnv, not NexusConfig."""
     script = render_n8n_hook(_make_config(), _make_env(admin_email="alice@example.com"))
@@ -1115,8 +1150,23 @@ def test_round_5_idempotent_skip_via_substring_match() -> None:
     Each hook has a distinct "already configured" signal. Pin them
     so refactors don't accidentally drop the check.
     """
+    # Portainer: pre-check on GET /api/users/admin/check (204 = an
+    # administrator exists), plus 409 from the init POST as a backstop.
+    #
+    # This assertion used to read `"already initialized" in portainer`,
+    # commented "Portainer's API response substring". It was not one.
+    # That text is the name of Portainer's Go identifier
+    # (`errAdminAlreadyInitialized`); what the handler puts on the wire
+    # is "An administrator user already exists". So the hook's
+    # already-configured branch could never be reached, every re-run
+    # reported `failed`, and this test pinned the broken string in
+    # place — which is why it survived. Assert on the status codes: a
+    # code is a contract, an error message is prose.
     portainer = render_portainer_hook(_make_config(), _make_env())
-    assert "already initialized" in portainer  # Portainer's API response substring
+    assert "/api/users/admin/check" in portainer
+    assert '"$ADMIN_CHECK" = "204"' in portainer
+    assert "409)" in portainer
+    assert "already initialized" not in portainer
 
     n8n = render_n8n_hook(_make_config(), _make_env())
     assert "showSetupOnFirstLoad" in n8n  # n8n's settings probe
@@ -1303,6 +1353,30 @@ def test_setup_result_counters() -> None:
 def test_setup_result_empty_is_success() -> None:
     """Zero hooks = no failures = success."""
     assert SetupResult(hooks=()).is_success is True
+
+
+def test_setup_result_names_the_degraded_hooks() -> None:
+    """Counts alone cost a debugging cycle; the names were already here.
+
+    ``failed=1`` over six enabled services means opening a second log
+    to find out which one. Both degraded outcomes get named.
+    """
+    r = SetupResult(
+        hooks=(
+            HookResult(name="portainer", status="failed"),
+            HookResult(name="n8n", status="configured"),
+            HookResult(name="metabase", status="skipped-not-ready"),
+            HookResult(name="lakefs", status="failed"),
+        )
+    )
+    assert r.failed_hooks == ("portainer", "lakefs")
+    assert r.skipped_not_ready_hooks == ("metabase",)
+
+
+def test_setup_result_degraded_names_empty_when_all_fine() -> None:
+    r = SetupResult(hooks=(HookResult(name="portainer", status="already-configured"),))
+    assert r.failed_hooks == ()
+    assert r.skipped_not_ready_hooks == ()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes a hook that failed on every re-run, and the two gaps that let it go unnoticed for as long as it did.

Closes #681
Closes #682

## The defect

Every spin-up dispatched against a server where Portainer had already been configured reported:

```
⚠ services-configure: partial — configured=0 already-configured=0 skipped-not-ready=0 failed=1
```

The hook *has* an already-configured branch. It could never be reached, because it matched the init response against `already initialized` — which is the name of Portainer's Go identifier, `errAdminAlreadyInitialized`. The text the handler actually puts on the wire is different:

```go
// api/http/handler/users/handler.go
errAdminAlreadyInitialized = errors.New("An administrator user already exists")
```

So the match never fired and every re-run fell through to `failed`. Someone matched an identifier instead of the payload, and nothing downstream could tell the difference.

## Why it survived

A unit test asserted the same string:

```python
assert "already initialized" in portainer  # Portainer's API response substring
```

The comment states a fact about Portainer's API that was never checked. The test only confirmed that the code contains what the code contains — it pinned the defect in place rather than catching it. That is worse than no test, because it reads as coverage.

## The fix

The pattern the n8n and Metabase hooks already use: pre-check before writing.

```
GET /api/users/admin/check   204 = an administrator exists
                             404 = none yet
```

Both branches now key on **HTTP status codes** rather than prose. A code is a contract; an error message is not. The init POST's 409 is kept as a backstop for an administrator appearing between the check and the write, and success is matched as the 2xx *class* instead of `"Id"` in the body — a 201 would previously have read as failure.

On failure only the two status codes are logged, never the response body. This is the endpoint we POST credentials to.

## Two gaps that turned one defect into a three-run investigation

**`failed=1` did not say which hook.** Recovering that meant diffing three workflow runs and correlating them against `infisical-provision` status. With one hook-bearing service enabled it was tractable; with a normal service set it would not have been. The phase now names every non-configured hook — `failed=1 (portainer)`, `skipped-not-ready=1 (metabase)`. The names were already in `SetupResult`; only the summary dropped them. Empty lists render as nothing, so the all-green line is unchanged.

**A `partial` phase reports success.** That is deliberate and stays: PR #535 tightened `rc=0`-on-partial because a non-zero exit under `shell: bash -e` fails a workflow whose deploy actually succeeded. The exit code is untouched here. The cost of that contract is that run, job and step all stay green, so the degradation is visible only to somebody who opens the step log and reads it — which is exactly how this went unnoticed.

`write_phase_log` now also emits GitHub Actions annotations for degraded phases, so they land in the run summary without touching the exit code. Guarded by `GITHUB_ACTIONS`, so local runs and tests are unchanged. `%`, CR and LF are percent-encoded — an unescaped newline would split the annotation and drop everything after it.

It hangs off `write_phase_log` rather than sitting beside it, for the reason that function's own docstring records: a second emitter per call site is how the abort paths lost their phase log in the first place.

## Evidence

Three runs on the same branch and service set, differing only in whether the server already existed:

| Run | Server | `services-configure` |
|---|---|---|
| [32935827478](https://github.com/stefanko-ch/Nexus-Stack/actions/runs/32935827478) | fresh (First-Time Deploy) | `ok — configured=1` |
| [32936992975](https://github.com/stefanko-ch/Nexus-Stack/actions/runs/32936992975) | existing — `loaded-existing` | `partial — failed=1` |
| [32937842432](https://github.com/stefanko-ch/Nexus-Stack/actions/runs/32937842432) | fresh after teardown | `ok — configured=1` |

## Verification

`uv run pytest` 1876 passed (+15) · `ruff check` and `ruff format --check` clean · `mypy --strict` clean over 30 modules · the rendered hook checked with `bash -n` and `shellcheck` · no documentation references the phase details, so nothing to sync.

## How to test

`spin-up.yml` is sufficient — no infrastructure resources change.

```bash
gh workflow run spin-up.yml --ref fix/portainer-hook-idempotence-and-hook-names
```

The assertion that matters needs the **second** run against the same server, which is the case that used to fail:

1. Run the spin-up once. Portainer is configured; the phase reports `configured=1`.
2. Run it again **without a teardown in between**.
3. The phase must now report `ok — configured=0 already-configured=1 …`, where it previously reported `partial — failed=1`.

If anything does fail, the diagnosis is in the line itself rather than in a second log — which is the other half of this PR.

## Summary by Sourcery

Make Portainer re-runs safe and expose degraded deployment phases with actionable hook names and workflow annotations.

Bug Fixes:
- Make the Portainer deployment hook idempotent by detecting existing administrators through HTTP status codes and handling successful and conflict responses reliably.

Enhancements:
- Include affected hook names in degraded service-configuration summaries.
- Surface partial and failed phases as GitHub Actions annotations without changing deployment exit-code behavior.
- Avoid logging Portainer response bodies while retaining status-code diagnostics.

Tests:
- Add coverage for Portainer pre-check ordering, status handling, safe diagnostics, named degraded hooks, and GitHub Actions annotation escaping.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GitHub Actions now receive warning or error annotations for partially completed or failed phases.
  * Phase details identify skipped and failed service hooks when applicable.

* **Bug Fixes**
  * Improved Portainer setup handling for existing administrators and successful responses.
  * Sensitive response bodies are no longer included in failure logs.
  * Local runs remain free of GitHub Actions annotations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->