### PR TITLE
fix(ci): Stop printing R2 credentials to public workflow logs

### DIFF
--- a/.github/workflows/setup-control-plane.yaml
+++ b/.github/workflows/setup-control-plane.yaml
@@ -267,8 +267,10 @@ jobs:
                 echo "   'Secrets: Read and write' repository permission."
                 echo ""
                 echo "   Fix the token permission, then re-run this workflow."
-                echo "   It will mint a fresh R2 token and retire this one, so"
-                echo "   nothing is left dangling."
+                echo "   It mints a fresh R2 token and tries to retire this one."
+                echo "   That cleanup is best-effort, so if the re-run warns that"
+                echo "   it could not delete a stale token, remove it by hand:"
+                echo "   Cloudflare dashboard -> My Profile -> API Tokens."
                 exit 1
               fi
             else

--- a/.github/workflows/setup-control-plane.yaml
+++ b/.github/workflows/setup-control-plane.yaml
@@ -192,7 +192,13 @@ jobs:
         if: steps.check_r2.outputs.r2_exists == 'false'
         id: init_r2
         env:
-          GH_TOKEN: ${{ secrets.GH_SECRETS_TOKEN || secrets.GITHUB_TOKEN }}
+          # No `|| secrets.GITHUB_TOKEN` fallback. The default token cannot
+          # write repository secrets, so falling back to it only guaranteed
+          # that `[ -n "$GH_TOKEN" ]` was true and turned a missing
+          # prerequisite into a generic "gh secret set failed" further down.
+          # init-r2-state.sh does not use this token at all — the only
+          # consumer in this step is `gh secret set`.
+          GH_TOKEN: ${{ secrets.GH_SECRETS_TOKEN }}
         run: |
           echo "🪣 Creating R2 bucket and credentials..."
 

--- a/.github/workflows/setup-control-plane.yaml
+++ b/.github/workflows/setup-control-plane.yaml
@@ -195,7 +195,6 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_SECRETS_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           echo "🪣 Creating R2 bucket and credentials..."
-          r2_saved=false
 
           # Run the init script
           chmod +x scripts/init-r2-state.sh
@@ -237,41 +236,62 @@ jobs:
                 echo "✅ R2 credentials saved to GitHub Secrets automatically!"
                 echo ""
                 echo "Future deployments will use these credentials."
-                r2_saved=true
               else
-                echo "⚠️  Failed to auto-save secrets: $SECRET_ERROR"
+                # NEVER print the credentials here. This repository is public,
+                # so Actions logs are world-readable, and these keys grant read
+                # access to the OpenTofu state bucket — which holds every
+                # generated service credential in plaintext.
+                #
+                # There is no safe channel for handing them to the operator
+                # from a public workflow run: artifacts are downloadable by
+                # anyone with repository read access, which for a public repo
+                # is everyone. So the only correct outcome is to fail and let
+                # the operator re-run once the token can write secrets.
+                echo "❌ Could not save the R2 credentials to GitHub Secrets."
                 echo ""
-                echo "  Please save these credentials manually as GitHub Secrets:"
+                echo "   gh secret set reported:"
+                echo "     $SECRET_ERROR"
                 echo ""
-                echo "  R2_ACCESS_KEY_ID=$R2_ACCESS_KEY_ID"
-                echo "  R2_SECRET_ACCESS_KEY=$R2_SECRET_ACCESS_KEY"
+                echo "   The credentials are NOT printed here on purpose — this"
+                echo "   repository is public and its Actions logs are readable"
+                echo "   by anyone. They grant read access to the OpenTofu state"
+                echo "   bucket, which contains every service credential."
                 echo ""
-                echo "  To enable auto-saving, configure GH_SECRETS_TOKEN:"
-                echo "  Fine-grained PAT with Secrets (Read and Write) permission"
+                echo "   Most likely cause: GH_SECRETS_TOKEN lacks the"
+                echo "   'Secrets: Read and write' repository permission."
+                echo ""
+                echo "   Fix the token permission, then re-run this workflow."
+                echo "   It will mint a fresh R2 token and retire this one, so"
+                echo "   nothing is left dangling."
+                exit 1
               fi
             else
+              # Same reasoning as above: without a token that can write repo
+              # secrets there is nowhere safe to put these, and printing them
+              # is what this branch used to do.
+              echo "❌ GH_SECRETS_TOKEN is not configured."
               echo ""
-              echo "╔══════════════════════════════════════════════════════════════════════════════╗"
-              echo "║  ⚠️  GH_SECRETS_TOKEN not configured - manual setup required                ║"
-              echo "╠══════════════════════════════════════════════════════════════════════════════╣"
-              echo "║                                                                              ║"
-              echo "║  Please save these credentials manually in GitHub Secrets:                  ║"
-              echo "║  R2_ACCESS_KEY_ID=$R2_ACCESS_KEY_ID"
-              echo "║  R2_SECRET_ACCESS_KEY=$R2_SECRET_ACCESS_KEY"
-              echo "║                                                                              ║"
-              echo "║  To enable auto-saving, create a Personal Access Token:                     ║"
-              echo "║  GitHub → Settings → Developer settings → Personal access tokens            ║"
-              echo "║  Required scope: 'repo' (or fine-grained with 'Secrets' permission)         ║"
-              echo "║  Save as: GH_SECRETS_TOKEN                                                  ║"
-              echo "║                                                                              ║"
-              echo "╚══════════════════════════════════════════════════════════════════════════════╝"
+              echo "   It is required for first-time setup: R2 credentials are"
+              echo "   generated once and must be stored as repository secrets"
+              echo "   for any later spin-up to reach the state bucket."
+              echo ""
+              echo "   They are deliberately not printed to this log — the"
+              echo "   repository is public, so anyone could read them, and they"
+              echo "   grant read access to every service credential in the"
+              echo "   OpenTofu state."
+              echo ""
+              echo "   Create a fine-grained Personal Access Token:"
+              echo "     GitHub → Settings → Developer settings"
+              echo "              → Personal access tokens → Fine-grained tokens"
+              echo "     Repository permissions:"
+              echo "       Secrets → Read and write"
+              echo "       Actions → Read and write"
+              echo "     Save it as the GH_SECRETS_TOKEN repository secret."
+              echo ""
+              echo "   Then re-run this workflow."
+              exit 1
             fi
 
-            echo "r2_saved=$r2_saved" >> $GITHUB_OUTPUT
-
-            # Export for this run
-            echo "r2_access_key=$R2_ACCESS_KEY_ID" >> $GITHUB_OUTPUT
-            echo "r2_secret_key=$R2_SECRET_ACCESS_KEY" >> $GITHUB_OUTPUT
           else
             echo "❌ Failed to create R2 credentials"
             exit 1
@@ -378,9 +398,19 @@ jobs:
             exit 1
           fi
 
-          # Note: Don't mask credentials here - masking prevents them from being
-          # passed as workflow outputs (GitHub blocks outputs containing masked values)
-          # The credentials will be masked by the receiving workflow when used
+          # Deliberately NOT masked here, and this is load-bearing rather
+          # than an oversight: GitHub redacts masked values in job outputs,
+          # so `::add-mask::` at this point would deliver an empty
+          # r2_secret_access_key to the calling workflow and the first
+          # spin-up would fall back to secrets that do not exist yet.
+          #
+          # The masking happens at the consumer instead, which is the only
+          # place it can: spin-up.yml masks both pairs on receipt
+          # (`Mask R2 data credentials from inputs`, and again in
+          # `Create R2 credentials from secrets`). Writing to $GITHUB_OUTPUT
+          # does not itself print anything, so nothing is exposed in between.
+          #
+          # If you add a consumer of these outputs, mask on arrival there too.
           # Export as outputs for the calling workflow
           echo "r2_access_key_id=$R2_ACCESS_KEY_ID" >> $GITHUB_OUTPUT
           echo "r2_secret_access_key=$R2_SECRET_ACCESS_KEY" >> $GITHUB_OUTPUT

--- a/docs/admin-guides/setup-guide.md
+++ b/docs/admin-guides/setup-guide.md
@@ -129,6 +129,21 @@ Add these secrets to your GitHub repository:
 | `TF_VAR_admin_email` | Your email | Admin - full access including SSH |
 | `GH_SECRETS_TOKEN` | GitHub PAT | Stores the generated R2 credentials ([how to create](#gh_secrets_token)) |
 
+#### GH_SECRETS_TOKEN
+
+This token is what lets the setup workflow store the generated R2 credentials as repository secrets. It is also used as the runtime `GITHUB_TOKEN` in Cloudflare (for the scheduled teardown worker and Control Plane), so it must be able to dispatch workflows.
+
+Without it the first run stops with an explanatory error, and Cloudflare-based automation that triggers GitHub Actions will not work. The workflow used to print the credentials to the log as a fallback; it no longer does, because Actions logs on a public repository are readable by anyone and these keys open the OpenTofu state bucket.
+
+**How to create:**
+1. Go to **GitHub** → **Settings** → **Developer settings** → **Personal access tokens** → **Fine-grained tokens**
+2. Click **"Generate new token"**
+3. **Repository access**: Select your Nexus-Stack repository
+4. **Permissions** (Repository permissions):
+   - **Secrets** → **Read and write**
+   - **Actions** → **Read and write** (required so Cloudflare workers can dispatch workflows)
+5. Copy the token and save it as `GH_SECRETS_TOKEN` in your repository secrets
+
 ### Optional Secrets
 
 | Secret Name | Description |
@@ -154,21 +169,6 @@ Optional secrets (only set if you want to override defaults):
 |-------------|---------|---------------------|
 | `NEXUS_S3_PERSISTENCE` | `"true"` (workflow fallback) | Set explicitly to `"false"` to bypass persistence for an experiment. |
 | `PERSISTENCE_STACK_SLUG` | `github.event.repository.name` | Set if you want the manifest written under a different slug (e.g. for Education-mode forks that share a persistence bucket layout). |
-
-#### GH_SECRETS_TOKEN
-
-This token is what lets the setup workflow store the generated R2 credentials as repository secrets. It is also used as the runtime `GITHUB_TOKEN` in Cloudflare (for the scheduled teardown worker and Control Plane), so it must be able to dispatch workflows.
-
-Without it the first run stops with an explanatory error, and Cloudflare-based automation that triggers GitHub Actions will not work. The workflow used to print the credentials to the log as a fallback; it no longer does, because Actions logs on a public repository are readable by anyone and these keys open the OpenTofu state bucket.
-
-**How to create:**
-1. Go to **GitHub** → **Settings** → **Developer settings** → **Personal access tokens** → **Fine-grained tokens**
-2. Click **"Generate new token"**
-3. **Repository access**: Select your Nexus-Stack repository
-4. **Permissions** (Repository permissions):
-   - **Secrets** → **Read and write**
-   - **Actions** → **Read and write** (required so Cloudflare workers can dispatch workflows)
-5. Copy the token and save it as `GH_SECRETS_TOKEN` in your repository secrets
 
 ### Optional Repository Variables
 

--- a/docs/admin-guides/setup-guide.md
+++ b/docs/admin-guides/setup-guide.md
@@ -232,8 +232,14 @@ Nothing to do here — the first run creates `R2_ACCESS_KEY_ID` and
 later deployment picks them up automatically.
 
 If the run stops with `GH_SECRETS_TOKEN is not configured`, add the token as
-described above and re-run the workflow. It mints a fresh R2 token and retires
-the previous one, so a failed first attempt leaves nothing dangling.
+described above and re-run the workflow. It mints a fresh R2 token and attempts
+to delete the one from the failed attempt.
+
+That cleanup is best-effort: `init-r2-state.sh` treats a failed token listing or
+deletion as non-fatal, so a transient Cloudflare API error can leave the earlier
+token active. Watch the re-run for a `Could not delete stale token` warning, and
+if you see one, remove it under **Cloudflare dashboard → My Profile → API
+Tokens**.
 
 ---
 

--- a/docs/admin-guides/setup-guide.md
+++ b/docs/admin-guides/setup-guide.md
@@ -127,12 +127,12 @@ Add these secrets to your GitHub repository:
 | `HCLOUD_TOKEN` | Hetzner console | API token |
 | `DOMAIN` | Your domain | e.g. `example.com` |
 | `TF_VAR_admin_email` | Your email | Admin - full access including SSH |
+| `GH_SECRETS_TOKEN` | GitHub PAT | Stores the generated R2 credentials ([how to create](#gh_secrets_token)) |
 
 ### Optional Secrets
 
 | Secret Name | Description |
 |-------------|-------------|
-| `GH_SECRETS_TOKEN` | GitHub PAT for R2 auto-save and Cloudflare runtime (see below) |
 | `TF_VAR_user_email` | User - all services except SSH (also receives notifications) |
 | `TF_VAR_guest_emails` | Comma-separated guests - Access whitelist only, no notifications |
 | `RESEND_API_KEY` | Email notifications via Resend |
@@ -157,7 +157,9 @@ Optional secrets (only set if you want to override defaults):
 
 #### GH_SECRETS_TOKEN
 
-This token allows the initial setup workflow to automatically save R2 credentials as GitHub Secrets. It is also used as the runtime `GITHUB_TOKEN` in Cloudflare (for the scheduled teardown worker and Control Plane), so it must be able to dispatch workflows. Without it, you must manually copy the credentials from the workflow logs after the first run, and Cloudflare-based automation that triggers GitHub Actions will fail.
+This token is what lets the setup workflow store the generated R2 credentials as repository secrets. It is also used as the runtime `GITHUB_TOKEN` in Cloudflare (for the scheduled teardown worker and Control Plane), so it must be able to dispatch workflows.
+
+Without it the first run stops with an explanatory error, and Cloudflare-based automation that triggers GitHub Actions will not work. The workflow used to print the credentials to the log as a fallback; it no longer does, because Actions logs on a public repository are readable by anyone and these keys open the OpenTofu state bucket.
 
 **How to create:**
 1. Go to **GitHub** → **Settings** → **Developer settings** → **Personal access tokens** → **Fine-grained tokens**
@@ -212,18 +214,26 @@ On **first run**, the pipeline will:
 3. Deploy the Control Plane
 4. Trigger the spin-up workflow
 
-> ⚠️ **Important:** R2 credentials are generated on the first run. If `GH_SECRETS_TOKEN` is configured (see [Optional Secrets](#optional-secrets)), they are saved automatically. Otherwise, copy them from the workflow logs and save them manually.
+> ⚠️ **Important:** R2 credentials are generated on the first run and stored as
+> repository secrets by the workflow. This needs `GH_SECRETS_TOKEN` with the
+> `Secrets: Read and write` permission — without it the setup stops with an
+> explanatory error rather than continuing.
+>
+> The credentials are never printed to the workflow log. Actions logs are
+> readable by anyone for a public repository, and these keys grant read access
+> to the OpenTofu state bucket, which holds every generated service credential
+> in plaintext. There is no safe way to hand them over through a log, so the
+> token is the only supported path.
 
-### Add R2 Credentials as Secrets
+### R2 Credentials
 
-If `GH_SECRETS_TOKEN` is configured, this step is automatic. Otherwise, after the first deploy, add these two secrets manually:
+Nothing to do here — the first run creates `R2_ACCESS_KEY_ID` and
+`R2_SECRET_ACCESS_KEY` and saves them as repository secrets itself. Every
+later deployment picks them up automatically.
 
-| Secret Name | Source |
-|-------------|--------|
-| `R2_ACCESS_KEY_ID` | Shown in first deploy logs |
-| `R2_SECRET_ACCESS_KEY` | Shown in first deploy logs |
-
-Once saved, all future deployments will use these credentials automatically.
+If the run stops with `GH_SECRETS_TOKEN is not configured`, add the token as
+described above and re-run the workflow. It mints a fresh R2 token and retires
+the previous one, so a failed first attempt leaves nothing dangling.
 
 ---
 


### PR DESCRIPTION
`setup-control-plane.yaml` printed freshly created R2 credentials in full to the workflow log, on two paths a normal first-time setup reaches. The repository is public, so Actions logs are world-readable, and the file contained zero `::add-mask::` calls.

What the keys open is what makes it serious: read access to the OpenTofu state bucket, whose state holds every one of the 81 generated service credentials in plaintext.

Closes #660

## No rotation is needed — checked, not assumed

The three most recent runs report `✅ R2 credentials found in secrets`, so the creation branch never executed and the values appear as `***` from GitHub Secrets. The runs that *did* create them were in April ([23892337605](https://github.com/stefanko-ch/Nexus-Stack/actions/runs/23892337605), [24419884053](https://github.com/stefanko-ch/Nexus-Stack/actions/runs/24419884053)); their logs are past retention and no longer retrievable.

It was a live trap, not a live leak. It would have sprung on the next genuine first-time setup — which, for a project other people are meant to deploy themselves, is the worst possible place for it: a stranger's very first run is the one that leaks.

## The obvious fix would have broken the deploy

The code carried a comment forbidding exactly what this issue asks for:

```
# Note: Don't mask credentials here - masking prevents them from being
# passed as workflow outputs (GitHub blocks outputs containing masked values)
```

That is correct. GitHub redacts masked values in job outputs, so `::add-mask::` at the producer would hand the calling workflow an **empty** `r2_secret_access_key`, and the first spin-up would fall back to secrets that do not exist yet.

The masking belongs at the consumer, and `spin-up.yml` already does it for both pairs — `Mask R2 data credentials from inputs` (L138-140) and again in `Create R2 credentials from secrets` (L279-280). Writing to `$GITHUB_OUTPUT` prints nothing by itself, so nothing is exposed in between.

So this PR works *with* that design rather than against it: the four `$GITHUB_OUTPUT` writes stay as they are, and the note now also records where the masking happens and what to do when adding a consumer.

## What changed

**The two printing paths now fail with an explanation.** There is no safe channel for handing an operator a secret from a public run — artifacts are downloadable by anyone with repository read access, which for a public repo is everyone. So `GH_SECRETS_TOKEN` becomes a real prerequisite rather than a convenience.

This is a deliberate behaviour change and worth a moment's thought. The argument for it: the setup guide already stated that without this token, Cloudflare-based automation that dispatches GitHub Actions will fail. A stack set up without it was therefore already half-broken — it just failed later, and silently. Now it fails immediately, with the reason. Re-running mints a fresh R2 token and retires the previous one, so a failed first attempt leaves nothing dangling.

**Two dead `$GITHUB_OUTPUT` writes of the secret key are removed** — nothing references `init_r2.outputs`, so they wrote a credential into the output store for no reader at all. The `r2_saved` flag goes with them: also unconsumed, and after the two failure branches it would always be `true`.

## The rest of the workflows were audited in the same pass

Every other `echo "$SECRET"` in `.github/workflows/` pipes into a consumer — `gh secret set`, `wrangler secret put`, `wrangler pages secret put` — rather than to the log. `scripts/init-r2-state.sh` prints only the *path* to the credentials file, never its contents. The four lines in this file were the whole of it.

## Docs

`GH_SECRETS_TOKEN` moves from **Optional Secrets** to **Required Secrets**, and the three places that told operators to copy the credentials out of the workflow logs now describe what actually happens.

## Verification

YAML parses · every `run:` block checked with `bash -n` · no credential output remains in the file (`grep` for an `echo` of either variable outside `$GITHUB_OUTPUT` returns nothing) · `uv run pytest` 1878 passed.

## How to test

This path only runs on a stack that has **no** `R2_ACCESS_KEY_ID` / `R2_SECRET_ACCESS_KEY` secrets, so it cannot be exercised against the current stack without removing them. Two options:

**Read-only check (recommended).** On the next `initial-setup.yaml` run, confirm the log still reports `✅ R2 credentials found in secrets` and reaches spin-up — this PR does not touch that branch, and it is the one that runs today.

**Full check**, if you want to see the new behaviour: on a scratch fork, leave `GH_SECRETS_TOKEN` unset and run `setup-control-plane.yaml`. It must stop at *"GH_SECRETS_TOKEN is not configured"* with no credential values anywhere in the log. Then set the token and re-run — it should mint a fresh R2 token, save both secrets, and continue.

## Summary by Sourcery

Prevent R2 credentials from being exposed during first-time setup by requiring repository-secret storage and failing safely when it is unavailable.

Bug Fixes:
- Prevent setup workflows from exposing R2 credentials in publicly readable GitHub Actions logs.
- Fail first-time setup with actionable guidance when credentials cannot be stored as repository secrets.

Enhancements:
- Remove unused R2 credential workflow outputs and clarify that masking must occur at consuming workflows.
- Require GH_SECRETS_TOKEN for automatic storage of generated R2 credentials and provide clearer token and cleanup guidance.

Documentation:
- Update setup documentation to make GH_SECRETS_TOKEN required and remove manual credential-copy instructions.

Chores:
- Remove the default GITHUB_TOKEN fallback that could obscure a missing secrets-management prerequisite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - R2 setup credentials are now stored automatically as repository secrets.
  - Setup workflows require `GH_SECRETS_TOKEN` to complete successfully.
  - Rerunning setup after configuration generates and stores refreshed R2 credentials.

- **Bug Fixes**
  - Prevented credentials from being printed in workflow logs.
  - Setup now clearly fails when secret updates or required token configuration are unavailable.

- **Documentation**
  - Updated setup instructions to describe required token configuration, automatic credential storage, and rerun behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->