### PR TITLE
docs: Add conventions for verifiable claims and exit-status checks

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -37,6 +37,21 @@ This is the largest class of real issues in this repo's recent history. When a P
 
 If a PR's prose contradicts one of these files, flag it as a factual error with the specific file path and snippet. Don't accept hand-waves about "usually" or "typically" for things that are concretely configured.
 
+### 4a. Claims about runtime behaviour, especially in error messages
+
+The same rule applies to sentences a *user will read while something is broken* — failure messages in workflows and scripts, recovery instructions, and the operator guides. These are written from the author's mental model rather than checked against the code, so they drift silently: nothing executes a sentence.
+
+Flag any claim of this shape unless the surrounding code guarantees it:
+
+- **"X was already deleted / created / saved"** where the operation runs `|| true`, `2>/dev/null`, or is otherwise best-effort. It may not have happened, and a recovery message is the worst place to be confidently wrong.
+- **"the next run will take path Y"** without checking the condition that selects the path. In `setup-control-plane.yaml` that is `check_r2`, which requires *both* R2 secrets to be non-empty — so an incomplete pair takes the first-time path, not the recreate path.
+- **"nothing is left behind"** for a cleanup that does not verify its own result.
+- Documentation quoting an error string that the code does not print verbatim. An operator searching the log finds nothing. Prefer making the messages identical over documenting two variants.
+
+When a guarantee cannot be given, say so: *"this step cannot determine which"* is a better failure message than a confident wrong one, and it tells the operator to go look.
+
+Real examples, all from PR #687 review: a recovery message asserted deleted secrets that a `|| true` may have left in place; another said the next run takes a path it does not take; a documented error string matched only one of two code paths.
+
 ## 5. Error handling in critical operations
 
 Flag `|| echo "..."`, `2>/dev/null || true`, or similar patterns that silence errors in destructive operations:
@@ -45,6 +60,32 @@ Flag `|| echo "..."`, `2>/dev/null || true`, or similar patterns that silence er
 - Deployment steps that affect running services
 
 For these paths, the correct pattern is an `if ! …; then echo "ERROR: …"; exit 1; fi` block. `|| echo` is acceptable only for reading optional values, cleaning up temporary state, or appending to a log file that must not break the flow.
+
+### 5a. The failure indicator must be the exit status, never a by-product
+
+A `|| true` is the obvious version of this bug. The subtle version passes the rule above and still swallows the failure — watch for it specifically, because it reads as careful code:
+
+```bash
+# WRONG — the message doubles as the flag
+SAVE_ERROR=""
+if ! OUTPUT=$(gh secret set KEY -b "$VALUE" 2>&1); then SAVE_ERROR="$OUTPUT"; fi
+if [ -z "$SAVE_ERROR" ]; then …continue as if it worked… fi
+```
+
+A command that exits non-zero while writing nothing to either stream leaves `SAVE_ERROR` empty, so the failure is indistinguishable from success. Keep the status and the message in separate variables:
+
+```bash
+# RIGHT
+SAVE_FAILED=0
+SAVE_ERROR=""
+if ! OUTPUT=$(gh secret set KEY -b "$VALUE" 2>&1); then SAVE_FAILED=1; SAVE_ERROR="$OUTPUT"; fi
+if [ "$SAVE_FAILED" -ne 0 ]; then echo "  ${SAVE_ERROR:-(no output)}"; exit 1; fi
+```
+
+Two related shapes worth flagging in the same breath:
+
+- **A success message outside the success branch.** `cmd || true` followed by an unconditional `echo "✅ done"` does not merely hide a failure, it asserts the opposite.
+- **Validating the container instead of the content.** Checking that a credentials file *exists* is not the same as checking that the values in it are non-empty — `gh secret set -b ""` stores an empty secret and reports success. Where a value must be usable, test the value.
 
 ## 6. Documentation conventions — watch for these specifically
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -43,7 +43,7 @@ The same rule applies to sentences a *user will read while something is broken* 
 
 Flag any claim of this shape unless the surrounding code guarantees it:
 
-- **"X was already deleted / created / saved"** where the operation runs `|| true`, `2>/dev/null`, or is otherwise best-effort. It may not have happened, and a recovery message is the worst place to be confidently wrong.
+- **"X was already deleted / created / saved"** where the operation *discards its exit status* — `|| true`, `|| echo …`, or an unchecked call. The operation may not have happened, and a recovery message is the worst place to be confidently wrong. Note that `2>/dev/null` alone does **not** qualify: it hides the diagnostic, not the status, so a caller that checks the status still knows what happened. `cmd 2>/dev/null || true` is best-effort because of the `|| true`.
 - **"the next run will take path Y"** without checking the condition that selects the path. In `setup-control-plane.yaml` that is `check_r2`, which requires *both* R2 secrets to be non-empty — so an incomplete pair takes the first-time path, not the recreate path.
 - **"nothing is left behind"** for a cleanup that does not verify its own result.
 - Documentation quoting an error string that the code does not print verbatim. An operator searching the log finds nothing. Prefer making the messages identical over documenting two variants.
@@ -68,8 +68,8 @@ A `|| true` is the obvious version of this bug. The subtle version passes the ru
 ```bash
 # WRONG — the message doubles as the flag
 SAVE_ERROR=""
-if ! OUTPUT=$(gh secret set KEY -b "$VALUE" 2>&1); then SAVE_ERROR="$OUTPUT"; fi
-if [ -z "$SAVE_ERROR" ]; then …continue as if it worked… fi
+if ! OUTPUT=$(printf '%s' "$VALUE" | gh secret set KEY 2>&1); then SAVE_ERROR="$OUTPUT"; fi
+if [ -z "$SAVE_ERROR" ]; then : "continues as if it worked"; fi
 ```
 
 A command that exits non-zero while writing nothing to either stream leaves `SAVE_ERROR` empty, so the failure is indistinguishable from success. Keep the status and the message in separate variables:
@@ -78,14 +78,16 @@ A command that exits non-zero while writing nothing to either stream leaves `SAV
 # RIGHT
 SAVE_FAILED=0
 SAVE_ERROR=""
-if ! OUTPUT=$(gh secret set KEY -b "$VALUE" 2>&1); then SAVE_FAILED=1; SAVE_ERROR="$OUTPUT"; fi
+if ! OUTPUT=$(printf '%s' "$VALUE" | gh secret set KEY 2>&1); then SAVE_FAILED=1; SAVE_ERROR="$OUTPUT"; fi
 if [ "$SAVE_FAILED" -ne 0 ]; then echo "  ${SAVE_ERROR:-(no output)}"; exit 1; fi
 ```
 
+Both snippets pipe the value in rather than passing `gh secret set --body "$VALUE"`: `gh` reads the secret from standard input when `--body` is omitted, which keeps it out of the process argument list. Same rule as the service hooks in `src/nexus_deploy/services.py`.
+
 Two related shapes worth flagging in the same breath:
 
-- **A success message outside the success branch.** `cmd || true` followed by an unconditional `echo "✅ done"` does not merely hide a failure, it asserts the opposite.
-- **Validating the container instead of the content.** Checking that a credentials file *exists* is not the same as checking that the values in it are non-empty — `gh secret set -b ""` stores an empty secret and reports success. Where a value must be usable, test the value.
+- **A success message outside the success branch.** `cmd || true` forces the compound status to zero, so the failure is hidden from `set -e` and from any later check; an unconditional `echo "✅ done"` then states the opposite of what happened. The success line belongs inside the zero-status branch.
+- **Validating the container instead of the content.** Checking that a credentials file *exists* is not the same as checking that the values in it are non-empty. Handed an empty string, `gh secret set` stores an empty secret and exits zero, so the step reports success for something nothing downstream can use. Where a value must be usable, test the value.
 
 ## 6. Documentation conventions — watch for these specifically
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -229,7 +229,7 @@ ssh nexus "docker logs <service>"  # View container logs
    ```bash
    # BAD - the message doubles as the flag
    SAVE_ERROR=""
-   if ! OUTPUT=$(gh secret set KEY -b "$VALUE" 2>&1); then SAVE_ERROR="$OUTPUT"; fi
+   if ! OUTPUT=$(printf '%s' "$VALUE" | gh secret set KEY 2>&1); then SAVE_ERROR="$OUTPUT"; fi
    if [ -z "$SAVE_ERROR" ]; then : "continue as if it worked"; fi
    ```
 
@@ -237,15 +237,22 @@ ssh nexus "docker logs <service>"  # View container logs
    leaves `SAVE_ERROR` empty, and the failure becomes indistinguishable
    from success. Keep status and message in separate variables
    (`SAVE_FAILED` / `SAVE_ERROR`), and print `${SAVE_ERROR:-(no output)}`
-   so the silent case still says something.
+   so the silent case still says something. The snippet pipes the value
+   in rather than passing `--body "$VALUE"`: `gh secret set` reads from
+   standard input when `--body` is omitted, keeping the secret out of the
+   process argument list — the same rule the service hooks follow.
 
    Two relatives of the same bug:
    - **A success message outside the success branch.** `cmd || true`
-     followed by an unconditional `echo "✅ done"` does not hide the
-     failure, it asserts the opposite.
+     forces the compound status to zero, hiding the failure from `set -e`
+     and from any later check — and an unconditional `echo "✅ done"` then
+     states the opposite of what happened. The success line belongs inside
+     the zero-status branch.
    - **Validating the container, not the content.** That a credentials
-     file *exists* is not that its values are usable — `gh secret set -b ""`
-     stores an empty secret and reports success. Test the value.
+     file *exists* is not that its values are usable. Handed an empty
+     string, `gh secret set` stores an empty secret and exits zero, so the
+     step reports success for something nothing downstream can use. Test
+     the value, not just the file.
 
 ### Claims must be verifiable — especially in error messages
 
@@ -255,15 +262,18 @@ reads while something is already broken.
 
 **Before writing any claim about what the system does — in an error message,
 a recovery instruction, a PR description, an issue, or a guide — point at the
-code that makes it true.** One `grep` is enough. If it cannot be checked in
-that moment, write the uncertainty instead: *"this step cannot determine
-which"* is a better message than a confident wrong one.
+code that makes it true.** A search locates the relevant code; it does not
+establish the claim. Read the path you found: branch conditions, exit-status
+handling, retries, and what the caller does with the result are all invisible
+to `grep`. If it cannot be checked in that moment, write the uncertainty
+instead: *"this step cannot determine which"* is a better message than a
+confident wrong one.
 
 The recurring shapes, all observed in this repo:
 
 | Claim | What to check first |
 |---|---|
-| "X was already deleted / saved / created" | Does that operation run under `\|\| true` or `2>/dev/null`? Then it is best-effort and you cannot assert it. |
+| "X was already deleted / saved / created" | Does that operation *discard its exit status* — `\|\| true`, `\|\| echo …`, or an unchecked call? Then it is best-effort and you cannot assert it. `2>/dev/null` alone does not qualify: it hides the diagnostic, not the status. |
 | "the next run takes path Y" | Read the condition that selects the path. In `setup-control-plane.yaml` that is `check_r2`, which needs **both** R2 secrets — an incomplete pair takes the first-time path. |
 | "nothing is left behind" | Does the cleanup verify its own result, or only attempt it? |
 | A doc quoting an error string | Does the code print it verbatim? Two code paths with near-identical wording means a log search finds only one. Make the messages identical rather than documenting both. |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -222,6 +222,67 @@ ssh nexus "docker logs <service>"  # View container logs
    - Green checkmarks on failed workflows are misleading and dangerous
    - Errors provide critical debugging information
 
+6. **The failure indicator is the exit status — never a by-product.**
+   `|| true` is the obvious version. This is the version that survives
+   review, because it looks careful:
+
+   ```bash
+   # BAD - the message doubles as the flag
+   SAVE_ERROR=""
+   if ! OUTPUT=$(gh secret set KEY -b "$VALUE" 2>&1); then SAVE_ERROR="$OUTPUT"; fi
+   if [ -z "$SAVE_ERROR" ]; then : "continue as if it worked"; fi
+   ```
+
+   A command that exits non-zero while writing nothing to either stream
+   leaves `SAVE_ERROR` empty, and the failure becomes indistinguishable
+   from success. Keep status and message in separate variables
+   (`SAVE_FAILED` / `SAVE_ERROR`), and print `${SAVE_ERROR:-(no output)}`
+   so the silent case still says something.
+
+   Two relatives of the same bug:
+   - **A success message outside the success branch.** `cmd || true`
+     followed by an unconditional `echo "✅ done"` does not hide the
+     failure, it asserts the opposite.
+   - **Validating the container, not the content.** That a credentials
+     file *exists* is not that its values are usable — `gh secret set -b ""`
+     stores an empty secret and reports success. Test the value.
+
+### Claims must be verifiable — especially in error messages
+
+Code gets executed; prose does not. Sentences about system behaviour drift
+silently, and the place they hurt most is a failure message, which someone
+reads while something is already broken.
+
+**Before writing any claim about what the system does — in an error message,
+a recovery instruction, a PR description, an issue, or a guide — point at the
+code that makes it true.** One `grep` is enough. If it cannot be checked in
+that moment, write the uncertainty instead: *"this step cannot determine
+which"* is a better message than a confident wrong one.
+
+The recurring shapes, all observed in this repo:
+
+| Claim | What to check first |
+|---|---|
+| "X was already deleted / saved / created" | Does that operation run under `\|\| true` or `2>/dev/null`? Then it is best-effort and you cannot assert it. |
+| "the next run takes path Y" | Read the condition that selects the path. In `setup-control-plane.yaml` that is `check_r2`, which needs **both** R2 secrets — an incomplete pair takes the first-time path. |
+| "nothing is left behind" | Does the cleanup verify its own result, or only attempt it? |
+| A doc quoting an error string | Does the code print it verbatim? Two code paths with near-identical wording means a log search finds only one. Make the messages identical rather than documenting both. |
+| "this test / run covers X" | Trace it. A rebuild spin-up does not exercise a restored Postgres data directory, because `s3_restore` persists that database as a `pg_dump`, not as a filesystem tree. |
+
+**Never report an action as done before its tool call has returned.** Write the
+sentence after the result, not while planning the call — a wrong "I have
+updated the issue" cannot be caught by tests, reviewers, or CI, only by the
+user going to look.
+
+**When copying an adjacent pattern, audit it once.** Consistency is right in
+this repo, but copying transfers defects too: `SAVE_ERROR`-as-flag came from a
+sibling step, and `|| echo "000"` — which doubles curl's own transport code into
+the six-character `000000` — is still the house style throughout
+`src/nexus_deploy/services.py`. Ask why the original looks that way. There it is
+harmless, because the value is only compared against a success code; in a hook
+that *prints* the code or branches on it with `case`, it is not. The answer
+usually reveals that your case differs.
+
 ### Service Account Naming Convention
 
 All service accounts MUST use the `nexus-` prefix to prevent default username guessing:

--- a/docs/admin-guides/monitoring-integration.md
+++ b/docs/admin-guides/monitoring-integration.md
@@ -170,7 +170,7 @@ HTTPServer(('0.0.0.0', 9999), Handler).serve_forever()
 # token from your production central-monitoring tier — never paste it
 # into `--body "..."`.
 gh secret set MONITORING_ENDPOINT --body "http://<your-runner-tunnel>:9999"
-printf 'test-token-123' | gh secret set MONITORING_TOKEN --body-file -
+printf 'test-token-123' | gh secret set MONITORING_TOKEN
 # Or use the GitHub UI: Settings → Secrets and variables → Actions → New
 # repository secret (the value is typed into a password field, no shell at all).
 


### PR DESCRIPTION
Writes down two rules drawn from defects that recurred across #684, #685 and #687, so the next occurrence is caught by review rather than rediscovered.

No code changes — `.github/copilot-instructions.md` (what the PR reviewer checks) and `CLAUDE.md` (what agents follow while writing).

## Why these two rules and not a general "be careful"

Both come from actual review findings in the last three PRs, not from principle. Each recurred after being fixed once, which is the signal that a convention is missing rather than an individual mistake.

## 1. The failure indicator must be the exit status, never a by-product

Section 5 of the Copilot instructions already flags `|| true` and `2>/dev/null || true`. It does not catch the version that passes that rule and still swallows the failure:

```bash
SAVE_ERROR=""
if ! OUTPUT=$(gh secret set KEY -b "$VALUE" 2>&1); then SAVE_ERROR="$OUTPUT"; fi
if [ -z "$SAVE_ERROR" ]; then …continue as if it worked… fi
```

A command that exits non-zero while writing nothing to either stream leaves `SAVE_ERROR` empty, so failure becomes indistinguishable from success.

This shape reads as careful error handling, which is exactly why it survived review in two separate steps of `setup-control-plane.yaml` — including in the PR whose entire purpose was removing swallowed failures.

Documented with its two relatives:

- **A success message outside the success branch.** `cmd || true` followed by an unconditional `echo "✅ done"` does not hide the failure — it asserts the opposite.
- **Validating the container, not the content.** That a credentials file *exists* is not that its values are usable: `gh secret set -b ""` stores an empty secret and reports success.

## 2. Claims about behaviour must point at code

Code is executed; prose is not. Sentences about system behaviour drift silently, and the place they hurt most is a failure message — read by someone while something is already broken.

Four wrong claims shipped in the last three PRs before review caught them:

| Claim | Reality |
|---|---|
| "the validation step already deleted the stale secrets" | that delete runs `\|\| true` — best-effort, unknowable from there |
| "the next run takes this same path" | `check_r2` needs **both** R2 secrets; an incomplete pair takes the first-time path |
| "nothing is left dangling" | the cleanup did not verify its own result |
| a documented error string | only one of the two code paths printed it verbatim |

The new section lists each shape with what to check first — one `grep` in every case. Where a guarantee cannot be given, the rule is to write the uncertainty: *"this step cannot determine which"* is a better failure message than a confident wrong one.

Two process rules go with it, neither of which is a code rule:

- **Never report an action as done before its tool call has returned.** A wrong "I have updated the issue" cannot be caught by tests, reviewers or CI — only by the user going to look.
- **Audit an adjacent pattern before copying it.** Consistency is right in this repo, but copying transfers defects as readily as conventions. `SAVE_ERROR`-as-flag came from a sibling step; `|| echo "000"` is still the house style in `services.py`, where it is harmless because the value is only compared against a success code — and was not harmless in a hook that printed it.

## Numbering

Added as `4a` and `5a` rather than new top-level sections, so existing cross-references to sections 5-9 still resolve. `CLAUDE.md` gains a sixth bullet under Error Handling Principles plus one new subsection.

## Verification

Every factual claim in the new text was checked against the code rather than written from memory:

- `check_r2` requires both secrets — `setup-control-plane.yaml:183`
- `s3_restore` persists Forgejo's database as a `pg_dump`, not a filesystem tree — `s3_restore.py:356` vs `:371`
- the `|| echo "000"` pattern is still present in `services.py`

One claim did not survive that check: the draft said the pattern appears in "nine places" and the count is eight — a stale number from an earlier count, which is precisely the drift the section is about. Replaced with the reason it is harmless there rather than a count, since a number in a long-lived document drifts again on the next commit.

## Summary by Sourcery

Document review and authoring conventions that make failure handling and claims about system behaviour verifiable against the code.

Enhancements:
- Document conventions requiring runtime-behaviour claims to be verified against code, especially in error messages and recovery guidance.
- Document that command exit status, rather than captured output, must determine failure and reinforce validation of values instead of only their containers.
- Add guidance to verify tool-call results before reporting actions as complete and to audit adjacent patterns before copying them.

Documentation:
- Update Copilot review instructions and Claude guidance with verifiable-claims and exit-status error-handling conventions.
- Correct the monitoring integration example to pipe the token through standard input when setting the secret.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for accurately documenting runtime behavior, command outcomes, and recovery instructions.
  * Clarified that command success or failure must be evaluated independently from captured output, including silent failures.
  * Added verification guidance for credential contents and other runtime values rather than relying solely on file presence.
  * Strengthened review standards for validating success messages against actual command results and implementation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->