### PR TITLE
fix(ci): Pass secrets to gh secret set via stdin, not --body

### DIFF
--- a/.github/workflows/setup-control-plane.yaml
+++ b/.github/workflows/setup-control-plane.yaml
@@ -121,7 +121,7 @@ jobs:
               # Note: We only save the Private Key as a secret.
               # The Public Key is passed as an output and not stored as a secret to avoid
               # "Skip output... contains secret" warnings in GitHub Actions.
-              if gh secret set SSH_PRIVATE_KEY -b "$SSH_PRIVATE_KEY" 2>/dev/null; then
+              if printf '%s' "$SSH_PRIVATE_KEY" | gh secret set SSH_PRIVATE_KEY 2>/dev/null; then
                 echo "✅ SSH Private Key saved to GitHub Secrets"
                 echo "ssh_key_created=true" >> $GITHUB_OUTPUT
               else
@@ -257,8 +257,9 @@ jobs:
 
           # The file existing is not the same as the values being usable.
           # `source` on a truncated or partially written file leaves either
-          # variable empty, `gh secret set -b ""` stores an empty secret
-          # happily, SAVE_FAILED stays 0, and the step reports success for a
+          # variable empty, `gh secret set` stores an empty secret happily
+          # whether the value arrives on stdin or via --body,
+          # SAVE_FAILED stays 0, and the step reports success for a
           # credential nothing downstream can use. The export step already
           # makes this check; by then the secrets have been written.
           if [ -z "$R2_ACCESS_KEY_ID" ] || [ -z "$R2_SECRET_ACCESS_KEY" ]; then
@@ -277,14 +278,20 @@ jobs:
           # flag stays empty, the second write runs, and the step reports
           # success for a credential it never stored. Which is precisely the
           # bug class this workflow is being hardened against.
+          # Piped rather than `--body "$VALUE"`: gh reads the secret from
+          # standard input when --body is omitted, keeping it out of the
+          # process argument list where anything on the runner could read it
+          # via /proc or ps. Same rule the service hooks in services.py
+          # follow. A pipeline reports its last command's exit status, so the
+          # `if !` check and SAVE_FAILED below are unaffected.
           SAVE_FAILED=0
           SAVE_ERROR=""
-          if ! OUTPUT=$(gh secret set R2_ACCESS_KEY_ID -b "$R2_ACCESS_KEY_ID" 2>&1); then
+          if ! OUTPUT=$(printf '%s' "$R2_ACCESS_KEY_ID" | gh secret set R2_ACCESS_KEY_ID 2>&1); then
             SAVE_FAILED=1
             SAVE_ERROR="$OUTPUT"
           fi
           if [ "$SAVE_FAILED" -eq 0 ]; then
-            if ! OUTPUT=$(gh secret set R2_SECRET_ACCESS_KEY -b "$R2_SECRET_ACCESS_KEY" 2>&1); then
+            if ! OUTPUT=$(printf '%s' "$R2_SECRET_ACCESS_KEY" | gh secret set R2_SECRET_ACCESS_KEY 2>&1); then
               SAVE_FAILED=1
               SAVE_ERROR="$OUTPUT"
             fi
@@ -440,8 +447,9 @@ jobs:
 
           # The file existing is not the same as the values being usable.
           # `source` on a truncated or partially written file leaves either
-          # variable empty, `gh secret set -b ""` stores an empty secret
-          # happily, SAVE_FAILED stays 0, and the step reports success for a
+          # variable empty, `gh secret set` stores an empty secret happily
+          # whether the value arrives on stdin or via --body,
+          # SAVE_FAILED stays 0, and the step reports success for a
           # credential nothing downstream can use. The export step already
           # makes this check; by then the secrets have been written.
           if [ -z "$R2_ACCESS_KEY_ID" ] || [ -z "$R2_SECRET_ACCESS_KEY" ]; then
@@ -462,12 +470,12 @@ jobs:
           # credential it never stored.
           SAVE_FAILED=0
           SAVE_ERROR=""
-          if ! OUTPUT=$(gh secret set R2_ACCESS_KEY_ID -b "$R2_ACCESS_KEY_ID" 2>&1); then
+          if ! OUTPUT=$(printf '%s' "$R2_ACCESS_KEY_ID" | gh secret set R2_ACCESS_KEY_ID 2>&1); then
             SAVE_FAILED=1
             SAVE_ERROR="$OUTPUT"
           fi
           if [ "$SAVE_FAILED" -eq 0 ]; then
-            if ! OUTPUT=$(gh secret set R2_SECRET_ACCESS_KEY -b "$R2_SECRET_ACCESS_KEY" 2>&1); then
+            if ! OUTPUT=$(printf '%s' "$R2_SECRET_ACCESS_KEY" | gh secret set R2_SECRET_ACCESS_KEY 2>&1); then
               SAVE_FAILED=1
               SAVE_ERROR="$OUTPUT"
             fi

--- a/.github/workflows/setup-control-plane.yaml
+++ b/.github/workflows/setup-control-plane.yaml
@@ -282,8 +282,18 @@ jobs:
           # standard input when --body is omitted, keeping it out of the
           # process argument list where anything on the runner could read it
           # via /proc or ps. Same rule the service hooks in services.py
-          # follow. A pipeline reports its last command's exit status, so the
-          # `if !` check and SAVE_FAILED below are unaffected.
+          # follow.
+          #
+          # The `if !` check and SAVE_FAILED below are unaffected, under
+          # either shell setting. This workflow declares no `shell:`, so
+          # Actions runs `bash -e {0}` — no pipefail — and the pipeline
+          # reports `gh secret set`'s status, which is the one that
+          # matters. (python-tests.yml sets `shell: bash` precisely
+          # because pipefail is NOT the default; without it a `pytest |
+          # tee` once hid three failing tests.) Were pipefail switched on
+          # here later, a printf that dies on EPIPE would also fail the
+          # step — which is still the correct outcome, since printf only
+          # breaks that way when gh has already exited.
           SAVE_FAILED=0
           SAVE_ERROR=""
           if ! OUTPUT=$(printf '%s' "$R2_ACCESS_KEY_ID" | gh secret set R2_ACCESS_KEY_ID 2>&1); then


### PR DESCRIPTION
Five writes of sensitive values passed them to `gh secret set` through `--body`, which puts them in the process argument list where anything running on the runner can read them via `/proc` or `ps`.

Closes #689

## Where

| Value | Path |
|---|---|
| `SSH_PRIVATE_KEY` | SSH key generation |
| `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY` | first-time setup |
| the same pair again | token-recreate |

`R2_DATA_BUCKET` keeps `--body`. It is a bucket name, not a secret.

## Severity, stated plainly

This is hardening, not an incident. GitHub-hosted runners are ephemeral and single-tenant, so the realistic reader of that argument list is another process in the same job — which here is code from this repository.

What makes it worth doing is that the repo committed to the opposite rule in #688, and `src/nexus_deploy/services.py` has followed it all along: its hook docstrings call out that secrets reach `jq` through env vars and bodies reach `curl` through stdin, "NEVER as positional `--arg` values, which would put them in jq's argv (visible via `ps`)". A convention the largest consumer ignores is one the next contributor will reasonably ignore too.

## The mechanism

`gh` reads the value from standard input when `--body` is omitted — from `gh secret set --help` (2.92.0):

> `-b, --body string   The value for the secret (reads from standard input if not specified)`

Note `--body-file` does **not** exist on this command and must not be used; it fails with `unknown flag`. That mistake was live in `docs/admin-guides/monitoring-integration.md` and was fixed in #688.

## Two properties measured rather than assumed

The new comment asserts both, so both were checked:

```
$ if ! OUT=$(printf '%s' x | false 2>&1); then echo caught; fi
caught
```

A pipeline reports its **last** command's exit status, so the existing `if !` checks and the `SAVE_FAILED` / `SAVE_ERROR` handling added in #687 keep working unchanged — the failure is still caught, the message still captured.

```
$ printf '%s' abc | wc -c   →  3
$ echo abc | wc -c          →  4
```

`printf '%s'`, not `echo`: no trailing newline, so the value is stored verbatim. A stray `\n` in an R2 key is exactly the class of bug the `tr -d '[:space:]'` calls elsewhere in this file exist to undo.

## Also

Two comments justified the empty-value guard by naming `gh secret set -b ""`. The guard is still needed — an empty string is accepted the same way on stdin — but the reasoning had to stop pointing at a flag the code no longer uses.

## Verification

Workflow YAML parses; every `run:` block checked with `bash -n`; no `--body` remains on a sensitive value.

```bash
grep -n 'gh secret set' .github/workflows/setup-control-plane.yaml
```

## How to test

Not triggerable on a stack whose R2 secrets are valid — the first-time and recreate paths both require them absent or broken. The change is mechanical and the two behavioural properties above are the ones that could have broken; both are verified. On a scratch fork, a first-time setup exercises all five writes.

## Summary by Sourcery

Store sensitive GitHub Actions secrets through standard input to keep credentials out of runner process arguments.

Bug Fixes:
- Prevent sensitive SSH and R2 credential values from being exposed in runner process arguments when storing them as GitHub Actions secrets.

Enhancements:
- Preserve secret values verbatim while retaining existing validation and error handling for secret writes.

CI:
- Harden setup and token-recreation workflow paths by passing sensitive secret values to the GitHub CLI through standard input.