### PR TITLE
fix(deploy): Stop the Infisical clone URL overriding the internal one

### DIFF
--- a/docs/user-guides/integrations.md
+++ b/docs/user-guides/integrations.md
@@ -31,10 +31,19 @@ Inside the `nexus` scope, every key is prefixed with its Infisical folder: `<fol
 |---|---|
 | folder `postgres`, key `POSTGRES_USERNAME` | `postgres/POSTGRES_USERNAME` |
 | folder `redpanda`, key `REDPANDA_KAFKA_PUBLIC_URL` | `redpanda/REDPANDA_KAFKA_PUBLIC_URL` |
-| folder `forgejo`, key `FORGEJO_REPO_URL` | `forgejo/FORGEJO_REPO_URL` |
+| folder `forgejo`, key `FORGEJO_REPO_URL_PUBLIC` | `forgejo/FORGEJO_REPO_URL_PUBLIC` |
 | folder `r2-datalake`, keys `R2_ENDPOINT` / `R2_ACCESS_KEY` / `R2_SECRET_KEY` / `R2_BUCKET` | `r2-datalake/R2_ENDPOINT` etc. — see the [R2 data-lake tutorial](/docs/tutorials/databricks/r2-datalake/) |
 
 This matches the folder view on the Control Plane's Secrets page exactly, so whatever you can see there is also what the sync pushes.
+
+> **Why `FORGEJO_REPO_URL_PUBLIC` and not `FORGEJO_REPO_URL`:** there are two
+> clone URLs for the same repository. The one published here goes through
+> `git.<domain>`, the only endpoint reachable without a Cloudflare Access
+> browser login — which is what an external caller like Databricks needs.
+> The stacks running on the server clone over the internal Docker network
+> instead, using `http://forgejo:3000/...` from their own `.env`. They used
+> to share one name, and the Infisical copy quietly won inside the
+> containers.
 
 ### Drift cleanup
 

--- a/src/nexus_deploy/infisical.py
+++ b/src/nexus_deploy/infisical.py
@@ -947,15 +947,15 @@ def compute_folders(config: NexusConfig, env: BootstrapEnv) -> list[FolderSpec]:
             ),
         )
     )
-    # Forgejo hosts the workspace repo: FORGEJO_REPO_URL is built from
-    # DOMAIN + repo_owner + repo_name
+    # The public clone URL: DOMAIN + repo_owner + repo_name, via the
+    # git-proxy host. Published as FORGEJO_REPO_URL_PUBLIC below.
     # with the same `${REPO_NAME:-nexus-${DOMAIN//./-}-workspace}` fallback
     # the bash carried at L2300.
     repo_name = env.repo_name or (
         f"nexus-{env.domain.replace('.', '-')}-workspace" if env.domain else None
     )
     repo_owner = env.forgejo_repo_owner or admin_username
-    forgejo_repo_url = (
+    forgejo_repo_url_public = (
         f"https://{service_host('git', env.domain, env.subdomain_separator)}"
         f"/{repo_owner}/{repo_name}.git"
         if env.domain and repo_owner and repo_name
@@ -974,10 +974,21 @@ def compute_folders(config: NexusConfig, env: BootstrapEnv) -> list[FolderSpec]:
             ),
         )
     )
-    # Forgejo now hosts the workspace repo, so FORGEJO_REPO_URL is
-    # published here. It points at the git-proxy hostname rather than
-    # the forge's own: that is the only endpoint reachable without a
-    # Cloudflare Access browser login, which a git client cannot do.
+    # Forgejo now hosts the workspace repo. The URL published here is
+    # the PUBLIC one — it points at the git-proxy hostname, the only
+    # endpoint reachable without a Cloudflare Access browser login,
+    # which a git client cannot complete. It is what an external
+    # consumer needs: Databricks Repos, a laptop, hosted CI.
+    #
+    # The name carries _PUBLIC deliberately. The workspace stacks get
+    # a different URL under the bare name FORGEJO_REPO_URL — the
+    # internal http://forgejo:3000/... form — written into their .env
+    # by service_env's workspace block. Both names used to be
+    # FORGEJO_REPO_URL, and since secret_sync writes every Infisical
+    # key unprefixed into .infisical.env, which compose reads AFTER
+    # .env, the public URL silently won inside the containers. Their
+    # .netrc says `machine forgejo`, so a private workspace repo then
+    # failed to authenticate. See #694.
     #
     # FORGEJO_RUNNER_SECRET is deliberately NOT published here, which
     # breaks the convention that every generated credential lands in
@@ -1006,7 +1017,7 @@ def compute_folders(config: NexusConfig, env: BootstrapEnv) -> list[FolderSpec]:
                     "FORGEJO_ADMIN_PASSWORD": config.forgejo_admin_password,
                     "FORGEJO_USER_USERNAME": env.forgejo_user_username,
                     "FORGEJO_USER_PASSWORD": config.forgejo_user_password,
-                    "FORGEJO_REPO_URL": forgejo_repo_url,
+                    "FORGEJO_REPO_URL_PUBLIC": forgejo_repo_url_public,
                     "FORGEJO_DB_PASSWORD": config.forgejo_db_password,
                 }
             ),

--- a/src/nexus_deploy/service_env.py
+++ b/src/nexus_deploy/service_env.py
@@ -1735,6 +1735,18 @@ def render_all_env_files(
 # meltano / prefect when Forgejo is enabled).
 # ---------------------------------------------------------------------------
 
+# FORGEJO_REPO_URL here is the INTERNAL url (http://forgejo:3000/...),
+# which is what the containers clone over the Docker network and what
+# their `.netrc` line `machine forgejo` authenticates against. The
+# public git-proxy url lives in Infisical under the distinct name
+# FORGEJO_REPO_URL_PUBLIC — sharing the bare name meant the Infisical
+# copy overwrote this one inside the containers, because compose reads
+# .infisical.env after .env. See #694.
+#
+# Do NOT rename FORGEJO_REPO_URL here: examples/workspace-seeds/prefect/
+# prefect.yaml reads it, and seeded files are create-only, so existing
+# user repos would keep the old name and break.
+
 # Marker pair for idempotent strip+append. Block markers are pinned
 # strings: ``_strip_forgejo_block()`` finds (and removes) any block a
 # previous run wrote before appending the new one. Diverging markers

--- a/tests/unit/__snapshots__/test_infisical.ambr
+++ b/tests/unit/__snapshots__/test_infisical.ambr
@@ -50,7 +50,7 @@
     }),
     'forgejo': dict({
       'FORGEJO_ADMIN_USERNAME': 'nexus-test-user',
-      'FORGEJO_REPO_URL': 'https://git.snapshot.test/snapshot-org/snapshot-repo.git',
+      'FORGEJO_REPO_URL_PUBLIC': 'https://git.snapshot.test/snapshot-org/snapshot-repo.git',
       'FORGEJO_USER_USERNAME': 'snapshot-user',
     }),
     'garage': dict({

--- a/tests/unit/test_infisical.py
+++ b/tests/unit/test_infisical.py
@@ -217,7 +217,7 @@ def test_compute_folders_ssh_optional() -> None:
     assert ssh.secrets == {"SSH_PRIVATE_KEY_BASE64": "b64-key"}
 
 
-def test_compute_folders_repo_url_falls_back_to_default_repo_name() -> None:
+def test_compute_folders_public_repo_url_falls_back_to_default_repo_name() -> None:
     """`${REPO_NAME:-nexus-${DOMAIN//./-}-workspace}` mirror.
 
     The URL lives in the forgejo folder: Forgejo hosts the workspace
@@ -228,7 +228,7 @@ def test_compute_folders_repo_url_falls_back_to_default_repo_name() -> None:
     folders = compute_folders(config, BootstrapEnv(domain="ex.example.com"))
     forgejo = next(f for f in folders if f.name == "forgejo")
     assert (
-        forgejo.secrets["FORGEJO_REPO_URL"]
+        forgejo.secrets["FORGEJO_REPO_URL_PUBLIC"]
         == "https://git.ex.example.com/bob/nexus-ex-example-com-workspace.git"
     )
 
@@ -1106,7 +1106,7 @@ def test_forgejo_folder_carries_every_generated_credential() -> None:
         "FORGEJO_ADMIN_USERNAME": "nexus-admin",
         "FORGEJO_ADMIN_PASSWORD": "fj-admin",
         "FORGEJO_USER_PASSWORD": "fj-user",
-        "FORGEJO_REPO_URL": "https://git.example.com/nexus-admin/nexus-example-com-workspace.git",
+        "FORGEJO_REPO_URL_PUBLIC": "https://git.example.com/nexus-admin/nexus-example-com-workspace.git",
         "FORGEJO_DB_PASSWORD": "fj-db",
     }
 
@@ -1138,7 +1138,7 @@ def test_forgejo_folder_drops_unset_credentials() -> None:
     assert forgejo.secrets["FORGEJO_DB_PASSWORD"] == "fj-db"
 
 
-def test_forgejo_folder_publishes_the_workspace_repo_url() -> None:
+def test_forgejo_folder_publishes_the_public_workspace_repo_url() -> None:
     """Forgejo hosts the workspace repo, so the URL belongs here.
 
     This assertion used to be the opposite: while Gitea still held
@@ -1149,6 +1149,24 @@ def test_forgejo_folder_publishes_the_workspace_repo_url() -> None:
     folders = compute_folders(config, BootstrapEnv(domain="example.com"))
     forgejo = next(f for f in folders if f.name == "forgejo")
 
-    assert forgejo.secrets["FORGEJO_REPO_URL"].endswith("-workspace.git")
+    assert forgejo.secrets["FORGEJO_REPO_URL_PUBLIC"].endswith("-workspace.git")
     gitea = next(f for f in folders if f.name == "gitea")
     assert "GITEA_REPO_URL" not in gitea.secrets
+
+
+def test_the_two_clone_urls_never_share_a_name() -> None:
+    """Infisical must not publish the bare ``FORGEJO_REPO_URL``.
+
+    ``secret_sync`` writes every Infisical key unprefixed into a stack's
+    ``.infisical.env``, and compose reads that AFTER ``.env`` — so a key
+    sharing the workspace block's name silently replaces the internal
+    clone URL inside the container, whose ``.netrc`` authenticates
+    ``machine forgejo``. That was #694; the names must stay distinct.
+    """
+    config = _make_config(admin_username="bob")
+    folders = compute_folders(config, BootstrapEnv(domain="example.com"))
+    for folder in folders:
+        assert "FORGEJO_REPO_URL" not in folder.secrets, (
+            f"folder {folder.name!r} publishes the bare name — it would "
+            "override the internal URL in every workspace stack"
+        )


### PR DESCRIPTION
Two different clone URLs for the same repository shared one name, and the wrong one reached the containers.

Closes #694

## The collision

| Written by | Into | Value |
|---|---|---|
| `service_env`'s workspace block | `stacks/<svc>/.env` | `http://forgejo:3000/<owner>/<repo>.git` |
| Infisical `forgejo` folder, via `secret_sync` | `stacks/<svc>/.infisical.env` | `https://git.<domain>/<owner>/<repo>.git` |

`secret_sync` writes every Infisical key **unprefixed** for jupyter and marimo (`key_prefix=""`), and those compose files declare:

```yaml
env_file:
  - path: .env
    required: false
  - path: .infisical.env
    required: false
```

Compose lets the **last** file win, so the container ends up with the git-proxy URL — while the `.netrc` written two lines above in the same entrypoint says `machine forgejo`. The host does not match, so a private workspace repo has no credentials and the clone fails. All five workspace stacks are affected: jupyter, marimo, code-server, meltano, prefect.

## Why the Infisical side is the one that gets renamed

The obvious alternative — rename the workspace block's variable — is the one that breaks users:

- `examples/workspace-seeds/prefect/prefect.yaml` reads `{{ $FORGEJO_REPO_URL }}`
- seeded files are **create-only**: the seed loop POSTs and counts HTTP 422 as `SKIPPED`, so a user's existing copy is never rewritten

Every workspace repo already seeded would keep the old name and stop resolving it. So the block keeps `FORGEJO_REPO_URL`, and Infisical publishes `FORGEJO_REPO_URL_PUBLIC`.

That name is also the more honest one. The public URL is not redundant — it has real consumers that the internal one cannot serve: Databricks Repos, a laptop, hosted CI. None of them can complete a Cloudflare Access browser login, which is exactly why `git-proxy` exists.

## Changes

- `infisical.py` publishes `FORGEJO_REPO_URL_PUBLIC`; the local variable is renamed to match, so the build site says which URL it is
- `service_env.py`'s workspace block carries a note that its `FORGEJO_REPO_URL` is the internal one, why the public one is separate, and an explicit "do not rename this — prefect.yaml is seeded"
- `docs/user-guides/integrations.md` gets the new Databricks scope key and a short explanation of the two URLs

## A regression test that was checked against a real regression

```python
for folder in folders:
    assert "FORGEJO_REPO_URL" not in folder.secrets
```

A guard is only worth having if it fires. I reintroduced the collision in `infisical.py` and re-ran it:

```
mit Kollision:  FÄNGT SIE
ohne Kollision: grün
```

## Not introduced by the Forgejo migration

`GITEA_REPO_URL` sat in the Infisical `gitea` folder with the identical shape on `main` before #690. The rename is what put it in a diff and got it read.

## Verification

`uv run pytest` 1838 passed · `uv run mypy` clean over 63 files · `ruff` clean.

## How to test

The observable needs one of the five workspace stacks enabled — they were all off in the last spin-up, which is why this never showed up:

```bash
# enable jupyter (or marimo / code-server) in the Control Plane, then
gh workflow run spin-up.yml
```

Open Jupyter: `/home/jovyan/work/<repo>` should contain the workspace repo, and `~/.netrc` should hold one line with mode 600. Before this change, the entrypoint logged `Warning: Failed to clone https://git.<domain>/...` and the directory stayed empty.

Anything reading `forgejo/FORGEJO_REPO_URL` from the Databricks secret scope needs the key renamed to `forgejo/FORGEJO_REPO_URL_PUBLIC` — worth checking if you have a notebook that uses it.

## Summary by Sourcery

Separate the public Forgejo repository URL from the internal workspace URL to prevent secret synchronization from breaking authenticated repository clones.

Bug Fixes:
- Prevent the public Infisical clone URL from overriding the internal workspace clone URL, allowing private workspace repositories to authenticate and clone successfully.

Enhancements:
- Distinguish public and internal Forgejo repository URLs across generated secrets and workspace environment configuration.
- Document the separate clone URLs and update the Databricks integration key accordingly.

Documentation:
- Update integration documentation to reference `forgejo/FORGEJO_REPO_URL_PUBLIC` and explain when each clone URL should be used.

Tests:
- Add regression coverage ensuring Infisical never publishes the internal `FORGEJO_REPO_URL` name.