### PR TITLE
fix(ci): Make orphan cleanup fail when it cannot tell

### DIFF
--- a/.github/workflows/cleanup-orphaned-resources.yml
+++ b/.github/workflows/cleanup-orphaned-resources.yml
@@ -23,76 +23,131 @@ jobs:
       - name: Install jq
         run: sudo apt-get update && sudo apt-get install -y jq
 
+      # Values reach bash through env: rather than `${{ }}` interpolation.
+      # An expression is substituted into the script TEXT before bash parses
+      # it, so a value carrying shell syntax would execute in a job holding
+      # the Cloudflare API token. Same treatment destroy-all.yml got in #656.
       - name: Cleanup D1 Database
+        env:
+          CF_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CF_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          DOMAIN: ${{ secrets.DOMAIN }}
         run: |
+          set -euo pipefail
+
           echo "🔍 Finding D1 Database..."
           # Resource prefix is derived from domain (e.g., stefanko.ch -> nexus-stefanko-ch)
-          DOMAIN="${{ secrets.DOMAIN }}"
           RESOURCE_PREFIX="nexus-${DOMAIN//./-}"
           D1_DATABASE_NAME="${RESOURCE_PREFIX}-db"
 
-          # Get all D1 databases
-          D1_DATABASES_RESPONSE=$(curl -s \
-            "https://api.cloudflare.com/client/v4/accounts/${{ secrets.CLOUDFLARE_ACCOUNT_ID }}/d1/database" \
-            -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" \
-            -H "Content-Type: application/json")
-
-          D1_DATABASE_ID=$(echo "$D1_DATABASES_RESPONSE" | jq -r ".result[] | select(.name == \"$D1_DATABASE_NAME\") | .uuid" 2>/dev/null || echo "")
-
-          if [ -n "$D1_DATABASE_ID" ] && [ "$D1_DATABASE_ID" != "null" ]; then
-            echo "  Found D1 Database ID: $D1_DATABASE_ID"
-
-            # Delete the database
-            D1_DELETE_RESPONSE=$(curl -s -X DELETE \
-              "https://api.cloudflare.com/client/v4/accounts/${{ secrets.CLOUDFLARE_ACCOUNT_ID }}/d1/database/$D1_DATABASE_ID" \
-              -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" \
-              -H "Content-Type: application/json")
-
-            if echo "$D1_DELETE_RESPONSE" | grep -q '"success":true'; then
-              echo "✅ D1 Database deleted"
-            else
-              echo "⚠️  Could not delete D1 Database"
-              echo "$D1_DELETE_RESPONSE" | jq '.' 2>/dev/null || echo "$D1_DELETE_RESPONSE"
-            fi
-          else
-            echo "⚠️  D1 Database not found (may already be deleted)"
+          # The distinction this whole step turns on: "nothing orphaned" is a
+          # success, "could not tell" is not. The previous form collapsed both
+          # into an empty id via `|| echo ""`, so a 401 or a 5xx read as
+          # "nothing to do" and the run went green while the orphan kept
+          # costing money and holding its name against the next setup.
+          if ! LIST_BODY=$(curl -sS --fail-with-body \
+            "https://api.cloudflare.com/client/v4/accounts/${CF_ACCOUNT_ID}/d1/database" \
+            -H "Authorization: Bearer ${CF_API_TOKEN}" \
+            -H "Content-Type: application/json"); then
+            echo "❌ Could not list D1 databases — the API call itself failed."
+            echo "   Not treating that as 'nothing to clean up': an orphan may"
+            echo "   still exist. Check the token's D1 permission and re-run."
+            exit 1
           fi
+
+          if ! echo "$LIST_BODY" | jq -e '.success == true' >/dev/null 2>&1; then
+            echo "❌ Cloudflare rejected the D1 listing:"
+            echo "$LIST_BODY" | jq -r '.errors[]?.message // "no error message"' 2>/dev/null \
+              || echo "   (response was not JSON)"
+            exit 1
+          fi
+
+          D1_DATABASE_ID=$(echo "$LIST_BODY" \
+            | jq -r --arg name "$D1_DATABASE_NAME" \
+                '.result[] | select(.name == $name) | .uuid')
+
+          if [ -z "$D1_DATABASE_ID" ]; then
+            echo "✅ No D1 database named '${D1_DATABASE_NAME}' — nothing to clean up."
+            exit 0
+          fi
+
+          echo "  Found D1 Database ID: $D1_DATABASE_ID"
+          if ! DELETE_BODY=$(curl -sS --fail-with-body -X DELETE \
+            "https://api.cloudflare.com/client/v4/accounts/${CF_ACCOUNT_ID}/d1/database/${D1_DATABASE_ID}" \
+            -H "Authorization: Bearer ${CF_API_TOKEN}" \
+            -H "Content-Type: application/json"); then
+            echo "❌ Delete request for D1 database ${D1_DATABASE_ID} failed."
+            echo "$DELETE_BODY"
+            exit 1
+          fi
+
+          if ! echo "$DELETE_BODY" | jq -e '.success == true' >/dev/null 2>&1; then
+            echo "❌ Cloudflare refused to delete D1 database ${D1_DATABASE_ID}:"
+            echo "$DELETE_BODY" | jq -r '.errors[]?.message // "no error message"' 2>/dev/null \
+              || echo "   (response was not JSON)"
+            exit 1
+          fi
+          echo "✅ D1 Database deleted"
 
       - name: Cleanup Access Application
+        env:
+          CF_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CF_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
+          DOMAIN: ${{ secrets.DOMAIN }}
         run: |
+          set -euo pipefail
+
           echo "🔍 Finding Access Application..."
-          ACCESS_APP_DOMAIN="control.${{ secrets.DOMAIN }}"
+          ACCESS_APP_DOMAIN="control.${DOMAIN}"
 
-          # Get all Access applications for the zone
-          ACCESS_APPS_RESPONSE=$(curl -s \
-            "https://api.cloudflare.com/client/v4/zones/${{ secrets.CLOUDFLARE_ZONE_ID }}/access/apps" \
-            -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" \
-            -H "Content-Type: application/json")
-
-          ACCESS_APP_ID=$(echo "$ACCESS_APPS_RESPONSE" | jq -r ".result[] | select(.domain == \"$ACCESS_APP_DOMAIN\") | .id" 2>/dev/null || echo "")
-
-          if [ -n "$ACCESS_APP_ID" ] && [ "$ACCESS_APP_ID" != "null" ]; then
-            echo "  Found Access Application ID: $ACCESS_APP_ID"
-
-            # Delete the Access Application
-            ACCESS_DELETE_RESPONSE=$(curl -s -X DELETE \
-              "https://api.cloudflare.com/client/v4/zones/${{ secrets.CLOUDFLARE_ZONE_ID }}/access/apps/$ACCESS_APP_ID" \
-              -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" \
-              -H "Content-Type: application/json")
-
-            if echo "$ACCESS_DELETE_RESPONSE" | grep -q '"success":true'; then
-              echo "✅ Access Application deleted"
-            else
-              echo "⚠️  Could not delete Access Application"
-              echo "$ACCESS_DELETE_RESPONSE" | jq '.' 2>/dev/null || echo "$ACCESS_DELETE_RESPONSE"
-            fi
-          else
-            echo "⚠️  Access Application not found (may already be deleted)"
+          if ! LIST_BODY=$(curl -sS --fail-with-body \
+            "https://api.cloudflare.com/client/v4/zones/${CF_ZONE_ID}/access/apps" \
+            -H "Authorization: Bearer ${CF_API_TOKEN}" \
+            -H "Content-Type: application/json"); then
+            echo "❌ Could not list Access applications — the API call itself failed."
+            echo "   Not treating that as 'nothing to clean up': an orphaned app"
+            echo "   would keep gating control.${DOMAIN}. Check the token's"
+            echo "   Access permission and re-run."
+            exit 1
           fi
+
+          if ! echo "$LIST_BODY" | jq -e '.success == true' >/dev/null 2>&1; then
+            echo "❌ Cloudflare rejected the Access listing:"
+            echo "$LIST_BODY" | jq -r '.errors[]?.message // "no error message"' 2>/dev/null \
+              || echo "   (response was not JSON)"
+            exit 1
+          fi
+
+          ACCESS_APP_ID=$(echo "$LIST_BODY" \
+            | jq -r --arg d "$ACCESS_APP_DOMAIN" \
+                '.result[] | select(.domain == $d) | .id')
+
+          if [ -z "$ACCESS_APP_ID" ]; then
+            echo "✅ No Access application for '${ACCESS_APP_DOMAIN}' — nothing to clean up."
+            exit 0
+          fi
+
+          echo "  Found Access Application ID: $ACCESS_APP_ID"
+          if ! DELETE_BODY=$(curl -sS --fail-with-body -X DELETE \
+            "https://api.cloudflare.com/client/v4/zones/${CF_ZONE_ID}/access/apps/${ACCESS_APP_ID}" \
+            -H "Authorization: Bearer ${CF_API_TOKEN}" \
+            -H "Content-Type: application/json"); then
+            echo "❌ Delete request for Access application ${ACCESS_APP_ID} failed."
+            echo "$DELETE_BODY"
+            exit 1
+          fi
+
+          if ! echo "$DELETE_BODY" | jq -e '.success == true' >/dev/null 2>&1; then
+            echo "❌ Cloudflare refused to delete Access application ${ACCESS_APP_ID}:"
+            echo "$DELETE_BODY" | jq -r '.errors[]?.message // "no error message"' 2>/dev/null \
+              || echo "   (response was not JSON)"
+            exit 1
+          fi
+          echo "✅ Access Application deleted"
 
       - name: Summary
         run: |
           echo ""
-          echo "✅ Cleanup complete!"
+          echo "✅ Cleanup complete — every step above verified its own result."
           echo ""
           echo "You can now deploy via GitHub Actions again."

--- a/.github/workflows/cleanup-orphaned-resources.yml
+++ b/.github/workflows/cleanup-orphaned-resources.yml
@@ -45,8 +45,14 @@ jobs:
           # into an empty id via `|| echo ""`, so a 401 or a 5xx read as
           # "nothing to do" and the run went green while the orphan kept
           # costing money and holding its name against the next setup.
-          if ! LIST_BODY=$(curl -sS --fail-with-body \
-            "https://api.cloudflare.com/client/v4/accounts/${CF_ACCOUNT_ID}/d1/database" \
+          # per_page is set explicitly because the endpoint paginates and the
+          # documented default is 20. Without it, an account holding more than
+          # 20 databases could have the orphan sitting on page 2, and the
+          # unpaginated first page would say "nothing to clean up" — the very
+          # lie this step exists to stop telling. --max-time bounds a stalled
+          # connection, and the listing is safe to retry because it is a read.
+          if ! LIST_BODY=$(curl -sS --fail-with-body --max-time 30 --retry 3 \
+            "https://api.cloudflare.com/client/v4/accounts/${CF_ACCOUNT_ID}/d1/database?per_page=1000" \
             -H "Authorization: Bearer ${CF_API_TOKEN}" \
             -H "Content-Type: application/json"); then
             echo "❌ Could not list D1 databases — the API call itself failed."
@@ -62,9 +68,35 @@ jobs:
             exit 1
           fi
 
-          D1_DATABASE_ID=$(echo "$LIST_BODY" \
-            | jq -r --arg name "$D1_DATABASE_NAME" \
-                '.result[] | select(.name == $name) | .uuid')
+          # "I saw everything" has to be established before "I saw nothing
+          # matching" is allowed to mean anything.
+          SEEN=$(echo "$LIST_BODY" | jq -r '.result | length')
+          TOTAL=$(echo "$LIST_BODY" | jq -r '.result_info.total_count // empty')
+          if [ -n "$TOTAL" ] && [ "$TOTAL" -gt "$SEEN" ]; then
+            echo "❌ The listing returned ${SEEN} of ${TOTAL} D1 databases."
+            echo "   An orphan beyond the first page cannot be ruled out, so this"
+            echo "   step will not report 'nothing to clean up'. Delete it from the"
+            echo "   Cloudflare dashboard, or raise per_page in this workflow."
+            exit 1
+          fi
+
+          # .result[]? rather than .result[]: a "result": null response would
+          # abort jq mid-pipeline and surface as a raw iteration error instead
+          # of the diagnostics prepared above.
+          MATCHES=$(echo "$LIST_BODY" \
+            | jq -c --arg name "$D1_DATABASE_NAME" \
+                '[.result[]? | select(.name == $name) | .uuid]')
+          MATCH_COUNT=$(echo "$MATCHES" | jq -r 'length')
+
+          if [ "$MATCH_COUNT" -gt 1 ]; then
+            echo "❌ ${MATCH_COUNT} D1 databases are named '${D1_DATABASE_NAME}':"
+            echo "$MATCHES" | jq -r '.[] | "     " + .'
+            echo "   Deleting by name is ambiguous here, so this step stops rather"
+            echo "   than guessing which one is the orphan."
+            exit 1
+          fi
+
+          D1_DATABASE_ID=$(echo "$MATCHES" | jq -r '.[0] // ""')
 
           if [ -z "$D1_DATABASE_ID" ]; then
             echo "✅ No D1 database named '${D1_DATABASE_NAME}' — nothing to clean up."
@@ -72,7 +104,10 @@ jobs:
           fi
 
           echo "  Found D1 Database ID: $D1_DATABASE_ID"
-          if ! DELETE_BODY=$(curl -sS --fail-with-body -X DELETE \
+          # --max-time but no --retry: a DELETE that timed out may already have
+          # succeeded server-side, and a blind retry would then report a
+          # spurious 404 as a failure.
+          if ! DELETE_BODY=$(curl -sS --fail-with-body --max-time 30 -X DELETE \
             "https://api.cloudflare.com/client/v4/accounts/${CF_ACCOUNT_ID}/d1/database/${D1_DATABASE_ID}" \
             -H "Authorization: Bearer ${CF_API_TOKEN}" \
             -H "Content-Type: application/json"); then
@@ -100,8 +135,11 @@ jobs:
           echo "🔍 Finding Access Application..."
           ACCESS_APP_DOMAIN="control.${DOMAIN}"
 
-          if ! LIST_BODY=$(curl -sS --fail-with-body \
-            "https://api.cloudflare.com/client/v4/zones/${CF_ZONE_ID}/access/apps" \
+          # Paginated like the D1 listing, and for the same reason set
+          # explicitly — a zone with many Access applications would otherwise
+          # hide the orphan behind the first page.
+          if ! LIST_BODY=$(curl -sS --fail-with-body --max-time 30 --retry 3 \
+            "https://api.cloudflare.com/client/v4/zones/${CF_ZONE_ID}/access/apps?per_page=1000" \
             -H "Authorization: Bearer ${CF_API_TOKEN}" \
             -H "Content-Type: application/json"); then
             echo "❌ Could not list Access applications — the API call itself failed."
@@ -118,9 +156,30 @@ jobs:
             exit 1
           fi
 
-          ACCESS_APP_ID=$(echo "$LIST_BODY" \
-            | jq -r --arg d "$ACCESS_APP_DOMAIN" \
-                '.result[] | select(.domain == $d) | .id')
+          SEEN=$(echo "$LIST_BODY" | jq -r '.result | length')
+          TOTAL=$(echo "$LIST_BODY" | jq -r '.result_info.total_count // empty')
+          if [ -n "$TOTAL" ] && [ "$TOTAL" -gt "$SEEN" ]; then
+            echo "❌ The listing returned ${SEEN} of ${TOTAL} Access applications."
+            echo "   An orphan beyond the first page cannot be ruled out, so this"
+            echo "   step will not report 'nothing to clean up'. Delete it from the"
+            echo "   Cloudflare dashboard, or raise per_page in this workflow."
+            exit 1
+          fi
+
+          MATCHES=$(echo "$LIST_BODY" \
+            | jq -c --arg d "$ACCESS_APP_DOMAIN" \
+                '[.result[]? | select(.domain == $d) | .id]')
+          MATCH_COUNT=$(echo "$MATCHES" | jq -r 'length')
+
+          if [ "$MATCH_COUNT" -gt 1 ]; then
+            echo "❌ ${MATCH_COUNT} Access applications claim '${ACCESS_APP_DOMAIN}':"
+            echo "$MATCHES" | jq -r '.[] | "     " + .'
+            echo "   Deleting by domain is ambiguous here, so this step stops rather"
+            echo "   than guessing which one is the orphan."
+            exit 1
+          fi
+
+          ACCESS_APP_ID=$(echo "$MATCHES" | jq -r '.[0] // ""')
 
           if [ -z "$ACCESS_APP_ID" ]; then
             echo "✅ No Access application for '${ACCESS_APP_DOMAIN}' — nothing to clean up."
@@ -128,7 +187,10 @@ jobs:
           fi
 
           echo "  Found Access Application ID: $ACCESS_APP_ID"
-          if ! DELETE_BODY=$(curl -sS --fail-with-body -X DELETE \
+          # --max-time but no --retry: a DELETE that timed out may already have
+          # succeeded server-side, and a blind retry would then report a
+          # spurious 404 as a failure.
+          if ! DELETE_BODY=$(curl -sS --fail-with-body --max-time 30 -X DELETE \
             "https://api.cloudflare.com/client/v4/zones/${CF_ZONE_ID}/access/apps/${ACCESS_APP_ID}" \
             -H "Authorization: Bearer ${CF_API_TOKEN}" \
             -H "Content-Type: application/json"); then

--- a/.github/workflows/toggle-silent-mode.yml
+++ b/.github/workflows/toggle-silent-mode.yml
@@ -25,12 +25,22 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           DOMAIN: ${{ secrets.DOMAIN }}
+          # Through env: rather than `${{ }}` in the script. The value is a
+          # `type: choice` limited to 'true'/'false', so GitHub constrains it
+          # today and nothing here is exploitable. The pattern is removed
+          # anyway: an expression is substituted into the script text before
+          # bash parses it, and this one lands inside a SQL literal inside a
+          # shell command. Widening the input to a free-form string later
+          # would open both at once, with nothing at that line to warn.
+          SILENT_MODE: ${{ inputs.enabled }}
         run: |
+          set -euo pipefail
+
           D1_DB_NAME="nexus-${DOMAIN//./-}-db"
           npx wrangler@4 d1 execute "$D1_DB_NAME" --remote \
-            --command "INSERT OR REPLACE INTO config (key, value, updated_at) VALUES ('silent_mode', '${{ inputs.enabled }}', datetime('now'))"
+            --command "INSERT OR REPLACE INTO config (key, value, updated_at) VALUES ('silent_mode', '${SILENT_MODE}', datetime('now'))"
 
-          if [ "${{ inputs.enabled }}" = "true" ]; then
+          if [ "$SILENT_MODE" = "true" ]; then
             echo "🔇 Silent mode ENABLED - automated emails suppressed"
             echo "   Run this workflow with enabled=false to re-enable emails"
           else

--- a/.github/workflows/toggle-silent-mode.yml
+++ b/.github/workflows/toggle-silent-mode.yml
@@ -36,6 +36,20 @@ jobs:
         run: |
           set -euo pipefail
 
+          # Fail closed on anything but the two accepted values. `type: choice`
+          # constrains the input today, so this never fires — but the value is
+          # interpolated into a SQL string literal below, and the declaration
+          # that keeps it safe sits 30 lines away in a different block. Should
+          # the input ever widen to a free-form string, this line refuses
+          # instead of letting a quote rewrite the statement.
+          case "$SILENT_MODE" in
+            true|false) ;;
+            *)
+              echo "❌ Refusing to run: enabled must be 'true' or 'false', got '${SILENT_MODE}'."
+              exit 1
+              ;;
+          esac
+
           D1_DB_NAME="nexus-${DOMAIN//./-}-db"
           npx wrangler@4 d1 execute "$D1_DB_NAME" --remote \
             --command "INSERT OR REPLACE INTO config (key, value, updated_at) VALUES ('silent_mode', '${SILENT_MODE}', datetime('now'))"

--- a/scripts/cleanup-orphaned-resources.sh
+++ b/scripts/cleanup-orphaned-resources.sh
@@ -110,6 +110,15 @@ if ! D1_DATABASES_RESPONSE=$(curl -sS --fail-with-body --max-time 30 --retry 3 \
     echo "    Not treating that as 'nothing to clean up': an orphan may still"
     echo "    exist. Check the token's D1 permission and re-run."
     FAILED=1
+elif ! echo "$D1_DATABASES_RESPONSE" | jq -e '.success == true' >/dev/null 2>&1; then
+    # --fail-with-body catches an HTTP error status, but Cloudflare also
+    # reports failures as HTTP 200 with "success": false. Without this the
+    # next line would read a null .result as zero databases and the script
+    # would say "nothing to clean up" — the false all-clear this file exists
+    # to stop producing.
+    echo -e "${RED}  ✗ Cloudflare rejected the D1 listing:${NC}"
+    echo "    $(echo "$D1_DATABASES_RESPONSE" | jq -r '.errors[]?.message // "no error message"' 2>/dev/null || echo "(response was not JSON)")"
+    FAILED=1
 else
     D1_SEEN=$(echo "$D1_DATABASES_RESPONSE" | jq -r '.result | length')
     D1_TOTAL=$(echo "$D1_DATABASES_RESPONSE" | jq -r '.result_info.total_count // empty')
@@ -165,6 +174,10 @@ if ! ACCESS_APPS_RESPONSE=$(curl -sS --fail-with-body --max-time 30 --retry 3 \
     echo -e "${RED}  ✗ Could not list Access applications — the API call itself failed.${NC}"
     echo "    An orphaned app would keep gating $ACCESS_APP_DOMAIN. Check the"
     echo "    token's Access permission and re-run."
+    FAILED=1
+elif ! echo "$ACCESS_APPS_RESPONSE" | jq -e '.success == true' >/dev/null 2>&1; then
+    echo -e "${RED}  ✗ Cloudflare rejected the Access listing:${NC}"
+    echo "    $(echo "$ACCESS_APPS_RESPONSE" | jq -r '.errors[]?.message // "no error message"' 2>/dev/null || echo "(response was not JSON)")"
     FAILED=1
 else
     AC_SEEN=$(echo "$ACCESS_APPS_RESPONSE" | jq -r '.result | length')

--- a/scripts/cleanup-orphaned-resources.sh
+++ b/scripts/cleanup-orphaned-resources.sh
@@ -17,9 +17,15 @@ TOFU_DIR="$PROJECT_ROOT/tofu"
 # Colors
 RED='\033[0;31m'
 GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
 CYAN='\033[0;36m'
 NC='\033[0m'
+
+# Failure accumulator, kept separate from any message variable: a step that
+# fails while writing nothing to either stream must still be distinguishable
+# from a step that worked. The script continues past a failure so a broken
+# D1 delete does not hide an orphaned Access application, then exits non-zero
+# at the end.
+FAILED=0
 
 echo -e "${CYAN}Cleaning up orphaned Cloudflare resources...${NC}"
 echo ""
@@ -93,31 +99,55 @@ ACCESS_APP_DOMAIN="control.${TF_VAR_domain:-unknown}"
 
 echo -e "${CYAN}Step 1: Deleting D1 Database '${D1_DATABASE_NAME}'...${NC}"
 
-# Get all D1 databases
-D1_DATABASES_RESPONSE=$(curl -s \
-    "https://api.cloudflare.com/client/v4/accounts/$TF_VAR_cloudflare_account_id/d1/database" \
+# Get all D1 databases. per_page is explicit because the endpoint paginates
+# with a documented default of 20 — an orphan on page 2 would otherwise look
+# like no orphan at all.
+if ! D1_DATABASES_RESPONSE=$(curl -sS --fail-with-body --max-time 30 --retry 3 \
+    "https://api.cloudflare.com/client/v4/accounts/$TF_VAR_cloudflare_account_id/d1/database?per_page=1000" \
     -H "Authorization: Bearer $TF_VAR_cloudflare_api_token" \
-    -H "Content-Type: application/json")
-
-D1_DATABASE_ID=$(echo "$D1_DATABASES_RESPONSE" | jq -r ".result[] | select(.name == \"$D1_DATABASE_NAME\") | .uuid" 2>/dev/null || echo "")
-
-if [ -n "$D1_DATABASE_ID" ] && [ "$D1_DATABASE_ID" != "null" ]; then
-    echo "  Found D1 Database ID: $D1_DATABASE_ID"
-    
-    # Delete the database
-    D1_DELETE_RESPONSE=$(curl -s -X DELETE \
-        "https://api.cloudflare.com/client/v4/accounts/$TF_VAR_cloudflare_account_id/d1/database/$D1_DATABASE_ID" \
-        -H "Authorization: Bearer $TF_VAR_cloudflare_api_token" \
-        -H "Content-Type: application/json")
-    
-    if echo "$D1_DELETE_RESPONSE" | grep -q '"success":true'; then
-        echo -e "${GREEN}  ✓ D1 Database deleted${NC}"
-    else
-        echo -e "${YELLOW}  ⚠️  Could not delete D1 Database${NC}"
-        echo "    Response: $(echo "$D1_DELETE_RESPONSE" | jq -r '.errors[0].message // "Unknown error"' 2>/dev/null || echo "Parse error")"
-    fi
+    -H "Content-Type: application/json"); then
+    echo -e "${RED}  ✗ Could not list D1 databases — the API call itself failed.${NC}"
+    echo "    Not treating that as 'nothing to clean up': an orphan may still"
+    echo "    exist. Check the token's D1 permission and re-run."
+    FAILED=1
 else
-    echo -e "${YELLOW}  ⚠️  D1 Database not found (may already be deleted)${NC}"
+    D1_SEEN=$(echo "$D1_DATABASES_RESPONSE" | jq -r '.result | length')
+    D1_TOTAL=$(echo "$D1_DATABASES_RESPONSE" | jq -r '.result_info.total_count // empty')
+    D1_MATCHES=$(echo "$D1_DATABASES_RESPONSE" \
+        | jq -c --arg name "$D1_DATABASE_NAME" '[.result[]? | select(.name == $name) | .uuid]')
+    D1_MATCH_COUNT=$(echo "$D1_MATCHES" | jq -r 'length')
+    D1_DATABASE_ID=$(echo "$D1_MATCHES" | jq -r '.[0] // ""')
+
+    if [ -n "$D1_TOTAL" ] && [ "$D1_TOTAL" -gt "$D1_SEEN" ]; then
+        echo -e "${RED}  ✗ The listing returned $D1_SEEN of $D1_TOTAL D1 databases.${NC}"
+        echo "    An orphan beyond the first page cannot be ruled out."
+        FAILED=1
+    elif [ "$D1_MATCH_COUNT" -gt 1 ]; then
+        echo -e "${RED}  ✗ $D1_MATCH_COUNT D1 databases are named '$D1_DATABASE_NAME'.${NC}"
+        echo "    Deleting by name is ambiguous, so this step stops rather than guessing."
+        FAILED=1
+    elif [ -z "$D1_DATABASE_ID" ]; then
+        echo -e "${GREEN}  ✓ No D1 database named '$D1_DATABASE_NAME' — nothing to clean up.${NC}"
+    else
+        echo "  Found D1 Database ID: $D1_DATABASE_ID"
+
+        # --max-time but no --retry: a DELETE that timed out may already have
+        # succeeded, and a blind retry would report the resulting 404 as failure.
+        if ! D1_DELETE_RESPONSE=$(curl -sS --fail-with-body --max-time 30 -X DELETE \
+            "https://api.cloudflare.com/client/v4/accounts/$TF_VAR_cloudflare_account_id/d1/database/$D1_DATABASE_ID" \
+            -H "Authorization: Bearer $TF_VAR_cloudflare_api_token" \
+            -H "Content-Type: application/json"); then
+            echo -e "${RED}  ✗ Delete request for D1 database $D1_DATABASE_ID failed.${NC}"
+            echo "    $D1_DELETE_RESPONSE"
+            FAILED=1
+        elif echo "$D1_DELETE_RESPONSE" | jq -e '.success == true' >/dev/null 2>&1; then
+            echo -e "${GREEN}  ✓ D1 Database deleted${NC}"
+        else
+            echo -e "${RED}  ✗ Cloudflare refused to delete D1 database $D1_DATABASE_ID:${NC}"
+            echo "    $(echo "$D1_DELETE_RESPONSE" | jq -r '.errors[]?.message // "no error message"' 2>/dev/null || echo "(response was not JSON)")"
+            FAILED=1
+        fi
+    fi
 fi
 
 # =============================================================================
@@ -127,31 +157,51 @@ fi
 echo ""
 echo -e "${CYAN}Step 2: Deleting Access Application for '${ACCESS_APP_DOMAIN}'...${NC}"
 
-# Get all Access applications for the zone
-ACCESS_APPS_RESPONSE=$(curl -s \
-    "https://api.cloudflare.com/client/v4/zones/$TF_VAR_cloudflare_zone_id/access/apps" \
+# Get all Access applications for the zone. Paginated like the D1 listing.
+if ! ACCESS_APPS_RESPONSE=$(curl -sS --fail-with-body --max-time 30 --retry 3 \
+    "https://api.cloudflare.com/client/v4/zones/$TF_VAR_cloudflare_zone_id/access/apps?per_page=1000" \
     -H "Authorization: Bearer $TF_VAR_cloudflare_api_token" \
-    -H "Content-Type: application/json")
-
-ACCESS_APP_ID=$(echo "$ACCESS_APPS_RESPONSE" | jq -r ".result[] | select(.domain == \"$ACCESS_APP_DOMAIN\") | .id" 2>/dev/null || echo "")
-
-if [ -n "$ACCESS_APP_ID" ] && [ "$ACCESS_APP_ID" != "null" ]; then
-    echo "  Found Access Application ID: $ACCESS_APP_ID"
-    
-    # Delete the Access Application
-    ACCESS_DELETE_RESPONSE=$(curl -s -X DELETE \
-        "https://api.cloudflare.com/client/v4/zones/$TF_VAR_cloudflare_zone_id/access/apps/$ACCESS_APP_ID" \
-        -H "Authorization: Bearer $TF_VAR_cloudflare_api_token" \
-        -H "Content-Type: application/json")
-    
-    if echo "$ACCESS_DELETE_RESPONSE" | grep -q '"success":true'; then
-        echo -e "${GREEN}  ✓ Access Application deleted${NC}"
-    else
-        echo -e "${YELLOW}  ⚠️  Could not delete Access Application${NC}"
-        echo "    Response: $(echo "$ACCESS_DELETE_RESPONSE" | jq -r '.errors[0].message // "Unknown error"' 2>/dev/null || echo "Parse error")"
-    fi
+    -H "Content-Type: application/json"); then
+    echo -e "${RED}  ✗ Could not list Access applications — the API call itself failed.${NC}"
+    echo "    An orphaned app would keep gating $ACCESS_APP_DOMAIN. Check the"
+    echo "    token's Access permission and re-run."
+    FAILED=1
 else
-    echo -e "${YELLOW}  ⚠️  Access Application not found (may already be deleted)${NC}"
+    AC_SEEN=$(echo "$ACCESS_APPS_RESPONSE" | jq -r '.result | length')
+    AC_TOTAL=$(echo "$ACCESS_APPS_RESPONSE" | jq -r '.result_info.total_count // empty')
+    AC_MATCHES=$(echo "$ACCESS_APPS_RESPONSE" \
+        | jq -c --arg d "$ACCESS_APP_DOMAIN" '[.result[]? | select(.domain == $d) | .id]')
+    AC_MATCH_COUNT=$(echo "$AC_MATCHES" | jq -r 'length')
+    ACCESS_APP_ID=$(echo "$AC_MATCHES" | jq -r '.[0] // ""')
+
+    if [ -n "$AC_TOTAL" ] && [ "$AC_TOTAL" -gt "$AC_SEEN" ]; then
+        echo -e "${RED}  ✗ The listing returned $AC_SEEN of $AC_TOTAL Access applications.${NC}"
+        echo "    An orphan beyond the first page cannot be ruled out."
+        FAILED=1
+    elif [ "$AC_MATCH_COUNT" -gt 1 ]; then
+        echo -e "${RED}  ✗ $AC_MATCH_COUNT Access applications claim '$ACCESS_APP_DOMAIN'.${NC}"
+        echo "    Deleting by domain is ambiguous, so this step stops rather than guessing."
+        FAILED=1
+    elif [ -z "$ACCESS_APP_ID" ]; then
+        echo -e "${GREEN}  ✓ No Access application for '$ACCESS_APP_DOMAIN' — nothing to clean up.${NC}"
+    else
+        echo "  Found Access Application ID: $ACCESS_APP_ID"
+
+        if ! ACCESS_DELETE_RESPONSE=$(curl -sS --fail-with-body --max-time 30 -X DELETE \
+            "https://api.cloudflare.com/client/v4/zones/$TF_VAR_cloudflare_zone_id/access/apps/$ACCESS_APP_ID" \
+            -H "Authorization: Bearer $TF_VAR_cloudflare_api_token" \
+            -H "Content-Type: application/json"); then
+            echo -e "${RED}  ✗ Delete request for Access application $ACCESS_APP_ID failed.${NC}"
+            echo "    $ACCESS_DELETE_RESPONSE"
+            FAILED=1
+        elif echo "$ACCESS_DELETE_RESPONSE" | jq -e '.success == true' >/dev/null 2>&1; then
+            echo -e "${GREEN}  ✓ Access Application deleted${NC}"
+        else
+            echo -e "${RED}  ✗ Cloudflare refused to delete Access application $ACCESS_APP_ID:${NC}"
+            echo "    $(echo "$ACCESS_DELETE_RESPONSE" | jq -r '.errors[]?.message // "no error message"' 2>/dev/null || echo "(response was not JSON)")"
+            FAILED=1
+        fi
+    fi
 fi
 
 # =============================================================================
@@ -159,6 +209,14 @@ fi
 # =============================================================================
 
 echo ""
-echo -e "${GREEN}Cleanup complete!${NC}"
+# The success line lives inside the success branch. Previously it printed
+# unconditionally, so a run that failed to delete anything still ended on
+# "Cleanup complete!" with status 0 — the exact shape CLAUDE.md warns about.
+if [ "$FAILED" -ne 0 ]; then
+    echo -e "${RED}Cleanup did NOT complete — see the errors above.${NC}"
+    echo "Resources may still exist and will hold their names against the next setup."
+    exit 1
+fi
+echo -e "${GREEN}Cleanup complete — every step above verified its own result.${NC}"
 echo ""
 echo "You can now deploy via GitHub Actions again."


### PR DESCRIPTION
The workflow deletes orphaned Cloudflare resources and finished green whether or not the deletion worked.

Closes #671

## The defect

Both lookups ended in `|| echo ""`, collapsing two different outcomes into one empty id: **"no orphan exists"** and **"the API call failed"**. A 401, a 5xx or a malformed body read as nothing-to-do, and the run reached `Cleanup complete` with exit 0 — while the orphan kept costing money and holding a name the next `initial-setup` would collide with. The deletes only printed a warning when Cloudflare rejected them.

That is the pattern `CLAUDE.md` names outright:

> **NEVER silently swallow errors in critical operations.** […] Green checkmarks on failed workflows are misleading and dangerous.

## What it does now

The asymmetry the step turns on is explicit: **nothing to delete** exits 0 and says so; **could not tell** exits 1 and says which call failed and what to check.

- both listings and both deletes verify `.success == true` with `jq -e`, rather than grepping for a substring
- `curl --fail-with-body --show-error`, so an HTTP error is an error rather than a body to parse
- `set -euo pipefail`

## Secrets out of the script text

Values reach bash through `env:` instead of expression interpolation. An expression is substituted into the script *text* before bash parses it, so a value carrying shell syntax would run in a job holding the Cloudflare API token — the treatment `destroy-all.yml` got in #656.

## toggle-silent-mode.yml, checked in the same pass

The issue asked for it rather than having it found a third time. It carried the same interpolation, with `inputs.enabled` landing inside a SQL literal inside a shell command.

**Not exploitable:** it is a `type: choice` limited to `true`/`false`, so GitHub constrains the value. Removed anyway — widening the input to a free-form string later would open both injections at once, and nothing at that line would warn.

## Verification

YAML parses; every `run:` block checked with `bash -n`; no `${{ }}` remains inside any `run:` in either file.

## How to test

`gh workflow run cleanup-orphaned-resources.yml` on a stack with nothing orphaned should now say so explicitly and exit 0. The failure path needs a token without D1 or Access permission — it must exit 1 naming the failed call, where it previously reported success.

## Summary by Sourcery

Make Cloudflare orphan cleanup fail closed when resource state or deletion results cannot be verified.

Bug Fixes:
- Make orphaned Cloudflare resource cleanup fail clearly when API lookups, pagination, ambiguous matches, or deletions cannot be verified instead of reporting false success.

Enhancements:
- Harden D1 and Access cleanup workflows and scripts with explicit API success validation, pagination checks, retry and timeout handling, and distinct no-resource outcomes.
- Pass workflow values through environment variables and validate silent-mode input to avoid shell-script interpolation risks.

CI:
- Update cleanup and silent-mode GitHub Actions workflows to use fail-closed error handling and verified Cloudflare API operations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup workflow reliability with stronger error detection and validation.
  * Cleanup operations now fail clearly when resource listing or deletion encounters an error.
  * Missing resources continue to be handled safely without failing the workflow.
  * Improved workflow safety when processing silent-mode settings and Cloudflare credentials.
  * Completion messages now confirm that preceding cleanup steps were verified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->