### PR TITLE
fix(control-plane): Put the CSRF guard on the remaining POST endpoints

### DIFF
--- a/control-plane/functions/api/databricks-config.js
+++ b/control-plane/functions/api/databricks-config.js
@@ -9,6 +9,7 @@
 import { logApiCall, logError } from './_utils/logger.js';
 import { fetchWithTimeout } from './_utils/fetch-with-timeout.js';
 import { requireAdmin } from './_utils/require-admin.js';
+import { requireSameOrigin } from './_utils/require-same-origin.js';
 
 export async function onRequestGet(context) {
   const { env } = context;
@@ -44,6 +45,10 @@ export async function onRequestGet(context) {
 
 export async function onRequestPost(context) {
   const { env, request } = context;
+  // Origin before identity: a cross-site submission carries a perfectly
+  // valid Access session, so authenticating it first proves nothing.
+  const crossSite = requireSameOrigin(request);
+  if (crossSite) return crossSite;
   const denial = requireAdmin(env, request);
   if (denial) return denial;
 

--- a/control-plane/functions/api/databricks-sync.js
+++ b/control-plane/functions/api/databricks-sync.js
@@ -23,6 +23,7 @@ import { safeHttpsUrl } from './_utils/url.js';
 import { logApiCall, logError } from './_utils/logger.js';
 import { fetchAllInfisicalSecrets } from './_utils/infisical.js';
 import { requireAdmin } from './_utils/require-admin.js';
+import { requireSameOrigin } from './_utils/require-same-origin.js';
 
 const SCOPE_NAME = 'nexus';
 const UPSERT_BATCH = 10;
@@ -137,6 +138,10 @@ export async function onRequestGet(context) {
 
 export async function onRequestPost(context) {
   const { env, request } = context;
+  // Origin before identity: a cross-site submission carries a perfectly
+  // valid Access session, so authenticating it first proves nothing.
+  const crossSite = requireSameOrigin(request);
+  if (crossSite) return crossSite;
   const denial = requireAdmin(env, request);
   if (denial) return denial;
 

--- a/control-plane/functions/api/deploy.js
+++ b/control-plane/functions/api/deploy.js
@@ -1,7 +1,7 @@
 /**
  * Trigger Setup Control Plane workflow
  * POST /api/deploy (legacy endpoint name for backward compatibility)
- * 
+ *
  * Triggers the GitHub Actions setup-control-plane.yaml workflow.
  * Includes validation, error handling, and retry logic.
  */
@@ -9,6 +9,7 @@
 import { logApiCall, logError } from './_utils/logger.js';
 import { fetchWithTimeout } from './_utils/fetch-with-timeout.js';
 import { requireSameOrigin } from './_utils/require-same-origin.js';
+import { requireAdmin } from './_utils/require-admin.js';
 
 export async function onRequestPost(context) {
   const { env, request } = context;
@@ -17,12 +18,19 @@ export async function onRequestPost(context) {
   // valid Access session, so authenticating it first proves nothing.
   const crossSite = requireSameOrigin(request);
   if (crossSite) return crossSite;
-  
+
+  // Admin-only: this redeploys the Control Plane itself via the
+  // setup-control-plane workflow, which rotates its secrets and rebuilds the
+  // Pages project. That is operator work, not the per-student self-service
+  // that spin-up and the service toggles deliberately allow.
+  const denial = requireAdmin(env, request);
+  if (denial) return denial;
+
   // Validate environment variables
   if (!env.GITHUB_TOKEN || !env.GITHUB_OWNER || !env.GITHUB_REPO) {
-    return new Response(JSON.stringify({ 
-      success: false, 
-      error: 'Missing required environment variables' 
+    return new Response(JSON.stringify({
+      success: false,
+      error: 'Missing required environment variables'
     }), {
       status: 500,
       headers: { 'Content-Type': 'application/json' },
@@ -35,7 +43,7 @@ export async function onRequestPost(context) {
   });
 
   const url = `https://api.github.com/repos/${env.GITHUB_OWNER}/${env.GITHUB_REPO}/actions/workflows/setup-control-plane.yaml/dispatches`;
-  
+
   try {
     const response = await fetchWithTimeout(url, {
       method: 'POST',
@@ -50,12 +58,12 @@ export async function onRequestPost(context) {
 
     // GitHub returns 204 No Content on success
     if (response.status === 204) {
-      return new Response(JSON.stringify({ 
-        success: true, 
-        message: 'Deploy workflow triggered successfully' 
+      return new Response(JSON.stringify({
+        success: true,
+        message: 'Deploy workflow triggered successfully'
       }), {
         status: 200,
-        headers: { 
+        headers: {
           'Content-Type': 'application/json',
         },
       });
@@ -64,7 +72,7 @@ export async function onRequestPost(context) {
     // Handle errors
     const errorText = await response.text();
     let errorMessage = `Failed to trigger workflow: ${response.status}`;
-    
+
     try {
       const errorJson = JSON.parse(errorText);
       errorMessage = errorJson.message || errorMessage;
@@ -77,18 +85,18 @@ export async function onRequestPost(context) {
 
     console.error(`Deploy trigger failed: ${response.status} - ${errorMessage}`);
 
-    return new Response(JSON.stringify({ 
-      success: false, 
-      error: errorMessage 
+    return new Response(JSON.stringify({
+      success: false,
+      error: errorMessage
     }), {
       status: response.status,
       headers: { 'Content-Type': 'application/json' },
     });
   } catch (error) {
     console.error('Deploy endpoint error:', error);
-    return new Response(JSON.stringify({ 
-      success: false, 
-      error: 'Network error while triggering workflow' 
+    return new Response(JSON.stringify({
+      success: false,
+      error: 'Network error while triggering workflow'
     }), {
       status: 500,
       headers: { 'Content-Type': 'application/json' },

--- a/control-plane/functions/api/deploy.js
+++ b/control-plane/functions/api/deploy.js
@@ -8,9 +8,15 @@
 
 import { logApiCall, logError } from './_utils/logger.js';
 import { fetchWithTimeout } from './_utils/fetch-with-timeout.js';
+import { requireSameOrigin } from './_utils/require-same-origin.js';
 
 export async function onRequestPost(context) {
   const { env, request } = context;
+
+  // Origin before identity: a cross-site submission carries a perfectly
+  // valid Access session, so authenticating it first proves nothing.
+  const crossSite = requireSameOrigin(request);
+  if (crossSite) return crossSite;
   
   // Validate environment variables
   if (!env.GITHUB_TOKEN || !env.GITHUB_OWNER || !env.GITHUB_REPO) {

--- a/control-plane/functions/api/destroy.js
+++ b/control-plane/functions/api/destroy.js
@@ -8,9 +8,14 @@
 import { fetchWithTimeout } from './_utils/fetch-with-timeout.js';
 import { logApiCall, logError } from './_utils/logger.js';
 import { requireAdmin } from './_utils/require-admin.js';
+import { requireSameOrigin } from './_utils/require-same-origin.js';
 
 export async function onRequestPost(context) {
   const { env, request } = context;
+  // Origin before identity: a cross-site submission carries a perfectly
+  // valid Access session, so authenticating it first proves nothing.
+  const crossSite = requireSameOrigin(request);
+  if (crossSite) return crossSite;
   const denial = requireAdmin(env, request);
   if (denial) return denial;
 

--- a/control-plane/functions/api/email-settings.js
+++ b/control-plane/functions/api/email-settings.js
@@ -7,6 +7,7 @@
  */
 import { logApiCall, logError } from './_utils/logger.js';
 import { requireAdmin } from './_utils/require-admin.js';
+import { requireSameOrigin } from './_utils/require-same-origin.js';
 
 async function getConfig(db, key, defaultValue = null) {
   try {
@@ -57,6 +58,10 @@ export async function onRequestGet(context) {
 }
 
 export async function onRequestPost(context) {
+  // Origin before identity: a cross-site submission carries a perfectly
+  // valid Access session, so authenticating it first proves nothing.
+  const crossSite = requireSameOrigin(context.request);
+  if (crossSite) return crossSite;
   const denial = requireAdmin(context.env, context.request);
   if (denial) return denial;
 

--- a/control-plane/functions/api/firewall.js
+++ b/control-plane/functions/api/firewall.js
@@ -11,6 +11,7 @@
 
 import { logApiCall, logError } from './_utils/logger.js';
 import { requireAdmin } from './_utils/require-admin.js';
+import { requireSameOrigin } from './_utils/require-same-origin.js';
 
 /**
  * Validate service name to prevent injection attacks
@@ -163,6 +164,10 @@ export async function onRequestGet(context) {
  */
 export async function onRequestPost(context) {
   const { env, request } = context;
+  // Origin before identity: a cross-site submission carries a perfectly
+  // valid Access session, so authenticating it first proves nothing.
+  const crossSite = requireSameOrigin(request);
+  if (crossSite) return crossSite;
   const denial = requireAdmin(env, request);
   if (denial) return denial;
 

--- a/control-plane/functions/api/logs.js
+++ b/control-plane/functions/api/logs.js
@@ -1,3 +1,5 @@
+import { requireSameOrigin } from './_utils/require-same-origin.js';
+
 /**
  * Logs API
  * GET /api/logs - Get logs (with optional filters)
@@ -120,6 +122,11 @@ export async function onRequestGet(context) {
  */
 export async function onRequestPost(context) {
   const { env, request } = context;
+
+  // Origin before identity: a cross-site submission carries a perfectly
+  // valid Access session, so authenticating it first proves nothing.
+  const crossSite = requireSameOrigin(request);
+  if (crossSite) return crossSite;
   
   if (!env.NEXUS_DB) {
     return new Response(JSON.stringify({

--- a/control-plane/functions/api/scheduled-teardown.js
+++ b/control-plane/functions/api/scheduled-teardown.js
@@ -9,6 +9,7 @@
 import { logApiCall, logError } from './_utils/logger.js';
 import { getAccessUserEmail } from './_utils/cf-access-email.js';
 import { requireAdmin } from './_utils/require-admin.js';
+import { requireSameOrigin } from './_utils/require-same-origin.js';
 
 // D1 Helper Functions
 async function getConfig(db, key, defaultValue = null) {
@@ -237,6 +238,10 @@ export async function onRequestGet(context) {
 
 export async function onRequestPost(context) {
   const { env, request } = context;
+  // Origin before identity: a cross-site submission carries a perfectly
+  // valid Access session, so authenticating it first proves nothing.
+  const crossSite = requireSameOrigin(request);
+  if (crossSite) return crossSite;
   const denial = requireAdmin(env, request);
   if (denial) return denial;
   const userEmail = getAccessUserEmail(request) || '';

--- a/control-plane/functions/api/send-credentials.js
+++ b/control-plane/functions/api/send-credentials.js
@@ -9,6 +9,7 @@ import { fetchWithTimeout } from './_utils/fetch-with-timeout.js';
 import { logApiCall, logError } from './_utils/logger.js';
 import { safeHttpsUrl } from './_utils/url.js';
 import { getAccessUserEmail } from './_utils/cf-access-email.js';
+import { requireSameOrigin } from './_utils/require-same-origin.js';
 
 // Resend-accepted email formats. Hoisted to module scope so the regex
 // objects are created once per Worker boot instead of once per request.
@@ -20,6 +21,11 @@ const isValidResendEmail = (e) => PLAIN_EMAIL_RE.test(e) || BRACKETED_EMAIL_RE.t
 
 export async function onRequestPost(context) {
   const { env, request } = context;
+
+  // Origin before identity: a cross-site submission carries a perfectly
+  // valid Access session, so authenticating it first proves nothing.
+  const crossSite = requireSameOrigin(request);
+  if (crossSite) return crossSite;
 
   // Validate environment variables
   const requiredEnv = ['RESEND_API_KEY', 'ADMIN_EMAIL', 'DOMAIN'];

--- a/control-plane/functions/api/send-credentials.js
+++ b/control-plane/functions/api/send-credentials.js
@@ -10,6 +10,7 @@ import { logApiCall, logError } from './_utils/logger.js';
 import { safeHttpsUrl } from './_utils/url.js';
 import { getAccessUserEmail } from './_utils/cf-access-email.js';
 import { requireSameOrigin } from './_utils/require-same-origin.js';
+import { requireAdmin } from './_utils/require-admin.js';
 
 // Resend-accepted email formats. Hoisted to module scope so the regex
 // objects are created once per Worker boot instead of once per request.
@@ -26,6 +27,15 @@ export async function onRequestPost(context) {
   // valid Access session, so authenticating it first proves nothing.
   const crossSite = requireSameOrigin(request);
   if (crossSite) return crossSite;
+
+  // Admin-only, because the mail carries the Infisical *admin* login and
+  // Infisical holds every other service credential in the stack. The
+  // recipient is the caller (`userEmail` below), so without this guard any
+  // address on the Access whitelist — user_email, guest_emails — could have
+  // the master credentials delivered to itself. Spin-up and service toggles
+  // stay open to non-admins on purpose; this one cannot.
+  const denial = requireAdmin(env, request);
+  if (denial) return denial;
 
   // Validate environment variables
   const requiredEnv = ['RESEND_API_KEY', 'ADMIN_EMAIL', 'DOMAIN'];

--- a/control-plane/functions/api/services.js
+++ b/control-plane/functions/api/services.js
@@ -14,6 +14,7 @@
  */
 
 import { logApiCall, logError } from './_utils/logger.js';
+import { requireSameOrigin } from './_utils/require-same-origin.js';
 
 /**
  * Validate service name to prevent injection attacks
@@ -145,6 +146,11 @@ export async function onRequestGet(context) {
  */
 export async function onRequestPost(context) {
   const { env, request } = context;
+
+  // Origin before identity: a cross-site submission carries a perfectly
+  // valid Access session, so authenticating it first proves nothing.
+  const crossSite = requireSameOrigin(request);
+  if (crossSite) return crossSite;
 
   if (!env.NEXUS_DB) {
     return new Response(JSON.stringify({

--- a/control-plane/functions/api/setup.js
+++ b/control-plane/functions/api/setup.js
@@ -8,9 +8,14 @@
 import { fetchWithTimeout } from './_utils/fetch-with-timeout.js';
 import { logApiCall, logError } from './_utils/logger.js';
 import { requireAdmin } from './_utils/require-admin.js';
+import { requireSameOrigin } from './_utils/require-same-origin.js';
 
 export async function onRequestPost(context) {
   const { env, request } = context;
+  // Origin before identity: a cross-site submission carries a perfectly
+  // valid Access session, so authenticating it first proves nothing.
+  const crossSite = requireSameOrigin(request);
+  if (crossSite) return crossSite;
   const denial = requireAdmin(env, request);
   if (denial) return denial;
 

--- a/control-plane/functions/api/spin-up.js
+++ b/control-plane/functions/api/spin-up.js
@@ -10,6 +10,7 @@
 import { logApiCall, logError } from './_utils/logger.js';
 import { fetchWithTimeout } from './_utils/fetch-with-timeout.js';
 import { resolveLifecycle } from './_utils/workflow-selection.js';
+import { requireSameOrigin } from './_utils/require-same-origin.js';
 
 /**
  * Get enabled services from D1
@@ -27,7 +28,12 @@ async function getEnabledServicesFromD1(db) {
 }
 
 export async function onRequestPost(context) {
-  const { env } = context;
+  const { env, request } = context;
+
+  // Origin before identity: a cross-site submission carries a perfectly
+  // valid Access session, so authenticating it first proves nothing.
+  const crossSite = requireSameOrigin(request);
+  if (crossSite) return crossSite;
 
   // Validate environment variables
   if (!env.GITHUB_TOKEN || !env.GITHUB_OWNER || !env.GITHUB_REPO) {

--- a/control-plane/functions/api/teardown.js
+++ b/control-plane/functions/api/teardown.js
@@ -11,9 +11,14 @@ import { logApiCall, logError } from './_utils/logger.js';
 import { fetchWithTimeout } from './_utils/fetch-with-timeout.js';
 import { requireAdmin } from './_utils/require-admin.js';
 import { resolveLifecycle } from './_utils/workflow-selection.js';
+import { requireSameOrigin } from './_utils/require-same-origin.js';
 
 export async function onRequestPost(context) {
   const { env, request } = context;
+  // Origin before identity: a cross-site submission carries a perfectly
+  // valid Access session, so authenticating it first proves nothing.
+  const crossSite = requireSameOrigin(request);
+  if (crossSite) return crossSite;
   const denial = requireAdmin(env, request);
   if (denial) return denial;
 


### PR DESCRIPTION
Thirteen of the fourteen `onRequestPost` endpoints had no CSRF check. Only `lifecycle.js` used the `requireSameOrigin` helper that #667 added.

Closes #672

## Why it matters

Cloudflare Access authenticates the caller, but authentication is not intent. The Access identity travels in a cookie, so a logged-in browser attaches it to **any** request to this origin — including one triggered by a page the operator never wrote. The endpoint then sees a valid admin and does as it is told.

Among the unguarded ones: `deploy`, `destroy`, `spin-up`, `teardown`.

## Placement

The guard goes **before** `requireAdmin`, matching `lifecycle.js` and for the reason its comment gives: a cross-site submission carries a perfectly valid session, so authenticating it first proves nothing.

Two endpoints needed more than an insertion:

- `email-settings.js` reads `context.env` / `context.request` without destructuring
- `spin-up.js` destructured only `env`, so `request` had to come along — it had no identity check of any kind and dispatches a workflow

## Verified three ways

**The helper's behaviour**, against six shaped requests:

| Request | Result |
|---|---|
| same-origin, `application/json` | passes |
| cross-origin, `application/json` | 403 |
| `application/x-www-form-urlencoded` | 403 |
| `text/plain` | 403 |
| `application/json`, no Origin | passes |
| no Content-Type at all | 403 |

The `text/plain` row is the one worth pausing on: `request.json()` ignores the Content-Type, so a cross-site form with `enctype="text/plain"` and a carefully named field produces a body that parses as valid JSON. Requiring the header is what closes it. And a missing Origin passes on purpose — curl and server-to-server callers send none, and neither can be driven by a victim's browser.

**Guard ordering**: `crossSite` precedes `requireAdmin` in all eight files that have both.

**That the UI still works**: all 13 frontend POSTs already set `Content-Type: application/json`, and nothing server-side calls these endpoints — every outbound POST in `functions/` and `worker/` goes to `api.github.com` or `api.resend.com`.

`npm run build` still produces the same nine pages.

## How to test

Deploy the Control Plane and use it normally — every button posts JSON from the same origin and is unaffected. The guard is observable with:

```bash
curl -X POST https://control.<domain>/api/spin-up -d 'x=1'   # 403, Content-Type
```

(behind Access, so an authenticated session is needed to reach the endpoint at all).

## Summary by Sourcery

Protect Control Plane POST APIs from CSRF attacks and enforce administrator access for sensitive operations.

Bug Fixes:
- Protect all remaining Control Plane POST endpoints against cross-site requests by enforcing same-origin checks before authentication and authorization.
- Restrict deployment and credential-delivery operations to administrators.

Enhancements:
- Standardize CSRF protection across Control Plane API POST handlers while preserving same-origin JSON clients and non-browser callers without an Origin header.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security Enhancements**
  - Added same-origin protection to administrative POST actions, blocking cross-site submissions before processing.
  - Strengthened access controls for credential delivery and other sensitive operations with administrator verification.
  - Preserved existing validation, authentication, workflow, persistence, and error-handling behavior for legitimate requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->