### PR TITLE
fix(stacks): Pin the stateful stacks and their compose fallbacks

### DIFF
--- a/docs/stacks/README.md
+++ b/docs/stacks/README.md
@@ -4,7 +4,11 @@ This document provides an overview of all available Docker stacks in Nexus-Stack
 
 ## Docker Image Versions
 
-Images are pinned to **major versions** where supported for automatic security patches while avoiding breaking changes. Anything holding persistent state is pinned to an exact version or a digest instead — a surprise major on the next spin-up would meet data written by the previous one. Versions are defined in [`services.yaml`](../../services.yaml).
+**No stack that holds persistent state is left on `:latest`.** A tag that moved between two spin-ups would meet data written by the previous one, so `latest` is reserved for presentation-layer and dev tools that keep nothing beyond a cache, and for viewers over somebody else's state such as Kafka-UI and S3 Manager.
+
+How tightly a stateful stack is pinned below that depends on what upstream's tags actually promise. A PostgreSQL major is an on-disk-format boundary, so `16-alpine` is a safe pin that still collects security patches. An application whose tags carry no such guarantee gets an exact version, or a digest where upstream publishes no version tags at all.
+
+Two stateful stacks do still follow a rolling tag — `pg_ducklake` (`18-main`) and Prefect (`3-latest`) — because upstream publishes nothing narrower. They are marked in the table rather than hidden. `services.yaml` is the source of truth for every value below; where this table and that file disagree, the file is right.
 
 | Service | Image | Tag | Strategy |
 |---------|-------|-----|----------|
@@ -24,14 +28,14 @@ Images are pinned to **major versions** where supported for automatic security p
 | Dinky | `dinkydocker/dinky-standalone-server` | `1.2.5-flink1.20` | Exact ¹ |
 | Dozzle | `amir20/dozzle` | `v10.5.3` | Exact ¹ |
 | Draw.io | `jgraph/drawio` | `latest` | Latest ² |
-| Grafana | `grafana/grafana` | `12` | Major |
-| Hoppscotch | `hoppscotch/hoppscotch` | `latest` | Latest ² |
+| Grafana | `grafana/grafana` | `11.6` | Minor |
+| Hoppscotch | `hoppscotch/hoppscotch` | `2025.12.1` | Exact ¹ |
 | Prometheus | `prom/prometheus` | `v3` | Major |
 | Loki | `grafana/loki` | `3` | Major |
 | Promtail | `grafana/promtail` | `3` | Major |
 | cAdvisor | `gcr.io/cadvisor/cadvisor` | `v0.56` | Minor |
 | Node Exporter | `prom/node-exporter` | `v1` | Major |
-| Portainer | `portainer/portainer-ce` | `2` | Major |
+| Portainer | `portainer/portainer-ce` | `2.40.0` | Exact ¹ |
 | Uptime Kuma | `louislam/uptime-kuma` | `2` | Major |
 | n8n | `n8nio/n8n` | `1.123.75` | Exact ⁴ |
 | OpenMetadata Server | `docker.getcollate.io/openmetadata/server` | `1.6.6` | Exact ¹ |
@@ -43,7 +47,7 @@ Images are pinned to **major versions** where supported for automatic security p
 | Kestra | `kestra/kestra` | `v1.0` | Minor |
 | Infisical | `infisical/infisical` | `v0.155.5` | Exact ¹ |
 | Metabase | `metabase/metabase` | `v0.60.6.2` | Exact ¹ |
-| Mailpit | `axllent/mailpit` | `v1` | Major |
+| Mailpit | `axllent/mailpit` | `v1.28` | Minor |
 | IT-Tools | `corentinth/it-tools` | `latest` | Latest ² |
 | Jupyter PySpark | `quay.io/jupyter/pyspark-notebook` | `python-3.13` | Minor |
 | Excalidraw | `excalidraw/excalidraw` | `latest` | Latest ² |
@@ -62,14 +66,14 @@ Images are pinned to **major versions** where supported for automatic security p
 | PostgreSQL (Gitea DB) | `postgres` | `16-alpine` | Major |
 | LakeFS | `treeverse/lakefs` | `1.73.0` | Exact ¹ |
 | Mage | `mageai/mageai` | `0.9.79` | Exact ¹ |
-| MinIO | `minio/minio` | `latest` | Latest ² |
+| MinIO | `quay.io/minio/minio` | `RELEASE.2025-09-07T16-13-09Z` | Exact ¹ |
 | NocoDB | `nocodb/nocodb` | `0.301.2` | Exact ¹ |
 | PostgreSQL (NocoDB DB) | `postgres` | `16-alpine` | Major |
 | Ollama | `ollama/ollama` | `0.15.1` | Exact ¹ |
 | Open WebUI | `ghcr.io/open-webui/open-webui` | `v0.8.3` | Exact ¹ |
 | RustFS | `rustfs/rustfs` | `1.0.0-alpha.82` | Exact ¹ |
 | S3 Manager | `cloudlena/s3manager` | `latest` | Latest ² |
-| Marimo | `ghcr.io/marimo-team/marimo` | `latest-sql` | Latest ² |
+| Marimo | `nexus-marimo` (custom build) | `latest-sql-spark` | Latest ² |
 | Meilisearch | `getmeili/meilisearch` | `v1.43.1` | Exact ¹ |
 | HedgeDoc | `quay.io/hedgedoc/hedgedoc` | `1.10.3` | Exact ¹ |
 | PostgreSQL (HedgeDoc DB) | `postgres` | `16-alpine` | Major |
@@ -85,7 +89,7 @@ Images are pinned to **major versions** where supported for automatic security p
 | PostgreSQL (Standalone) | `postgres` | `17-alpine` | Major |
 | pg_ducklake | `pgducklake/pgducklake` | `18-main` | Rolling ⚠️ |
 | pgAdmin | `dpage/pgadmin4` | `9` | Major |
-| Prefect | `prefecthq/prefect` | `3-latest` | Major |
+| Prefect | `prefecthq/prefect` | `3-latest` | Rolling ⚠️ |
 | PostgreSQL (Prefect DB) | `postgres` | `16-alpine` | Major |
 | Dify API | `langgenius/dify-api` | `1.13.0` | Exact ¹ |
 | Dify Web | `langgenius/dify-web` | `1.13.0` | Exact ¹ |
@@ -99,8 +103,8 @@ Images are pinned to **major versions** where supported for automatic security p
 | SeaweedFS | `chrislusf/seaweedfs` | `3.82` | Minor |
 | Redpanda | `redpandadata/redpanda` | `v24.3` | Minor |
 | Redpanda Console | `redpandadata/console` | `v2.8` | Minor |
-| Redpanda Connect | `redpandadata/connect` | `latest` | Latest ² |
-| Redpanda Datagen | `redpandadata/connect` | `latest` | Latest ² |
+| Redpanda Connect | `redpandadata/connect` | `4.43.0` | Exact ¹ |
+| Redpanda Datagen | `redpandadata/connect` | `4.43.0` | Exact ¹ |
 | RisingWave | `risingwavelabs/risingwave` | `v2.8.1` | Exact ¹ |
 | SFTPGo | `drakkan/sftpgo` | `v2.7.1` | Exact ¹ |
 | Sling | `nexus-sling` (custom build) | `1.5.13` | Exact ³ |

--- a/docs/stacks/README.md
+++ b/docs/stacks/README.md
@@ -124,7 +124,7 @@ Two stateful stacks do still follow a rolling tag — `pg_ducklake` (`18-main`) 
 | PostgreSQL (Windmill DB) | `postgres` | `16-alpine` | Major |
 
 ¹ No major version tags available, requires manual updates.
-² Only `latest` tags published, no semantic versions available.
+² Allow-listed for `latest`: presentation-layer and dev tools that keep nothing beyond a cache, plus viewers over another system's state such as Kafka-UI and S3 Manager. The reason is what the image holds, not what upstream tags — several of these do publish versions, and pinning them would still buy nothing a re-pull cannot undo.
 ³ Custom build (ARM64 support or additional connectors/dependencies).
 ⁴ Held on the 1.x line deliberately: upstream is at 2.x, and moving a stack that stores workflow definitions, credentials and execution history across a major needs its own migration.
 ⚠️ **Rolling** — the tag moves, and upstream publishes nothing narrower to pin to. Accepted only where no alternative exists, and only for stacks whose data survives an image change. Each of these needs a compatibility check before a deliberate refresh, because a rolling tag can cross a major without the name changing.

--- a/docs/stacks/README.md
+++ b/docs/stacks/README.md
@@ -30,11 +30,11 @@ Two stateful stacks do still follow a rolling tag — `pg_ducklake` (`18-main`) 
 | Draw.io | `jgraph/drawio` | `latest` | Latest ² |
 | Grafana | `grafana/grafana` | `11.6` | Minor |
 | Hoppscotch | `hoppscotch/hoppscotch` | `2025.12.1` | Exact ¹ |
-| Prometheus | `prom/prometheus` | `v3` | Major |
+| Prometheus | `prom/prometheus` | `v3.9.1` | Exact ¹ |
 | Loki | `grafana/loki` | `3` | Major |
 | Promtail | `grafana/promtail` | `3` | Major |
-| cAdvisor | `gcr.io/cadvisor/cadvisor` | `v0.56` | Minor |
-| Node Exporter | `prom/node-exporter` | `v1` | Major |
+| cAdvisor | `ghcr.io/google/cadvisor` | `0.56` | Minor |
+| Node Exporter | `prom/node-exporter` | `v1.10.2` | Exact ¹ |
 | Portainer | `portainer/portainer-ce` | `2.40.0` | Exact ¹ |
 | Uptime Kuma | `louislam/uptime-kuma` | `2` | Major |
 | n8n | `n8nio/n8n` | `1.123.75` | Exact ⁴ |
@@ -127,6 +127,8 @@ Two stateful stacks do still follow a rolling tag — `pg_ducklake` (`18-main`) 
 ² Only `latest` tags published, no semantic versions available.
 ³ Custom build (ARM64 support or additional connectors/dependencies).
 ⁴ Held on the 1.x line deliberately: upstream is at 2.x, and moving a stack that stores workflow definitions, credentials and execution history across a major needs its own migration.
+⚠️ **Rolling** — the tag moves, and upstream publishes nothing narrower to pin to. Accepted only where no alternative exists, and only for stacks whose data survives an image change. Each of these needs a compatibility check before a deliberate refresh, because a rolling tag can cross a major without the name changing.
+
 ⁵ No version tags published at all — only `latest`, `lowa`, `trial` and commit SHAs, and the SHA tags are single-arch. Pinned to the digest of the multi-arch manifest list, which keeps amd64 and arm64. Holds state in a volume, so `latest` was not an option.
 
 **Strategies:**

--- a/docs/stacks/README.md
+++ b/docs/stacks/README.md
@@ -4,7 +4,7 @@ This document provides an overview of all available Docker stacks in Nexus-Stack
 
 ## Docker Image Versions
 
-Images are pinned to **major versions** where supported for automatic security patches while avoiding breaking changes. Versions are defined in [`services.yaml`](../../services.yaml).
+Images are pinned to **major versions** where supported for automatic security patches while avoiding breaking changes. Anything holding persistent state is pinned to an exact version or a digest instead — a surprise major on the next spin-up would meet data written by the previous one. Versions are defined in [`services.yaml`](../../services.yaml).
 
 | Service | Image | Tag | Strategy |
 |---------|-------|-----|----------|
@@ -12,7 +12,7 @@ Images are pinned to **major versions** where supported for automatic security p
 | Adminer | `adminer` | `latest` | Latest ² |
 | Appsmith | `appsmith/appsmith-ce` | `v1.98` | Minor |
 | Big-AGI | `ghcr.io/enricoros/big-agi` | `v2.0.4` | Exact ¹ |
-| Budibase | `budibase/budibase` | `latest` | Latest ² |
+| Budibase | `budibase/budibase` | `v3.43.0` | Exact ¹ |
 | Chroma | `chromadb/chroma` | `1.5.9` | Exact ¹ |
 | CloudBeaver | `dbeaver/cloudbeaver` | `24` | Major |
 | ClickHouse | `clickhouse/clickhouse-server` | `25.8.16.34` | Exact ¹ |
@@ -33,7 +33,7 @@ Images are pinned to **major versions** where supported for automatic security p
 | Node Exporter | `prom/node-exporter` | `v1` | Major |
 | Portainer | `portainer/portainer-ce` | `2` | Major |
 | Uptime Kuma | `louislam/uptime-kuma` | `2` | Major |
-| n8n | `n8nio/n8n` | `1` | Major |
+| n8n | `n8nio/n8n` | `1.123.75` | Exact ⁴ |
 | OpenMetadata Server | `docker.getcollate.io/openmetadata/server` | `1.6.6` | Exact ¹ |
 | OpenMetadata Ingestion | `docker.getcollate.io/openmetadata/ingestion` | `1.6.6` | Exact ¹ |
 | Elasticsearch (OpenMetadata) | `docker.elastic.co/elasticsearch/elasticsearch` | `8.11.4` | Exact ¹ |
@@ -48,7 +48,7 @@ Images are pinned to **major versions** where supported for automatic security p
 | Jupyter PySpark | `quay.io/jupyter/pyspark-notebook` | `python-3.13` | Minor |
 | Excalidraw | `excalidraw/excalidraw` | `latest` | Latest ² |
 | Evidence | `evidencedev/devenv` | `latest` | Latest ² |
-| Filestash | `machines/filestash` | `latest` | Latest ² |
+| Filestash | `machines/filestash` | `@sha256:68171bf3…` | Digest ⁵ |
 | Flink JobManager | `flink` (custom build) | `1.20.1` | Exact ³ |
 | Flink TaskManager | `flink` (custom build) | `1.20.1` | Exact ³ |
 | Forgejo | `codeberg.org/forgejo/forgejo` | `15.0.7` | Exact ¹ |
@@ -61,7 +61,7 @@ Images are pinned to **major versions** where supported for automatic security p
 | Gitea | `gitea/gitea` | `1.23` | Major |
 | PostgreSQL (Gitea DB) | `postgres` | `16-alpine` | Major |
 | LakeFS | `treeverse/lakefs` | `1.73.0` | Exact ¹ |
-| Mage | `mageai/mageai` | `latest` | Latest ² |
+| Mage | `mageai/mageai` | `0.9.79` | Exact ¹ |
 | MinIO | `minio/minio` | `latest` | Latest ² |
 | NocoDB | `nocodb/nocodb` | `0.301.2` | Exact ¹ |
 | PostgreSQL (NocoDB DB) | `postgres` | `16-alpine` | Major |
@@ -122,6 +122,8 @@ Images are pinned to **major versions** where supported for automatic security p
 ¹ No major version tags available, requires manual updates.
 ² Only `latest` tags published, no semantic versions available.
 ³ Custom build (ARM64 support or additional connectors/dependencies).
+⁴ Held on the 1.x line deliberately: upstream is at 2.x, and moving a stack that stores workflow definitions, credentials and execution history across a major needs its own migration.
+⁵ No version tags published at all — only `latest`, `lowa`, `trial` and commit SHAs, and the SHA tags are single-arch. Pinned to the digest of the multi-arch manifest list, which keeps amd64 and arm64. Holds state in a volume, so `latest` was not an option.
 
 **Strategies:**
 - **Major** (e.g., `:12`) - Auto-patches, manual major upgrades only

--- a/docs/stacks/overview.md
+++ b/docs/stacks/overview.md
@@ -40,7 +40,7 @@ image: ${IMAGE_GRAFANA:-grafana/grafana:11.6}
 
 The tag shown in each table below is the value Nexus Stack ships with **right now** on `main`. Tags fall into three buckets:
 
-- **Pinned exact version** (e.g. `clickhouse/clickhouse-server:25.8.16.34`, `redpandadata/redpanda:v24.3.1`) — reproducible, deterministic, what you want in production.
+- **Pinned exact version** (e.g. `clickhouse/clickhouse-server:25.8.16.34`, `redpandadata/redpanda:v24.3`) — reproducible, deterministic, what you want in production.
 - **Pinned major (or major/minor)** (e.g. `gitea/gitea:1.23`, `dpage/pgadmin4:9`) — gets patch updates on next `docker pull`, locked against major version surprises.
 - **`:latest`** (e.g. `adminer:latest`, `corentinth/it-tools:latest`) — tracks upstream bleeding edge. Reserved for presentation-layer and dev tools that hold no persistent state, and for viewers over somebody else's state such as Kafka-UI and S3 Manager. No stateful stack is left on it.
 
@@ -88,7 +88,7 @@ Cloudflare Tunnels handle HTTPS perfectly, but a few services need raw TCP acces
 | **[Debezium](https://github.com/stefanko-ch/Nexus-Stack/blob/main/docs/stacks/debezium.md)** | `quay.io/debezium/connect:3.5.0` | Change data capture via Kafka Connect. Tails the PostgreSQL WAL (and MySQL/Mongo/SQL Server binlogs) and streams row-level changes into Redpanda topics — the standard way to get an event stream out of a boring OLTP database. |
 | **[Kafdrop](https://github.com/stefanko-ch/Nexus-Stack/blob/main/docs/stacks/kafdrop.md)** | `obsidiandynamics/kafdrop:4.2.0` | Minimalist read-only Kafka topic/consumer group viewer. Runs on ~100 MB RAM — the lightest option when you just need to peek at messages. |
 | **[Kafka-UI](https://github.com/stefanko-ch/Nexus-Stack/blob/main/docs/stacks/kafka-ui.md)** | `provectuslabs/kafka-ui:latest` | Provectus' open-source web UI for Kafka. Similar feature set to Redpanda Console and AKHQ — pick the one that matches your taste. |
-| **[Redpanda](https://github.com/stefanko-ch/Nexus-Stack/blob/main/docs/stacks/redpanda.md)** | `redpandadata/redpanda:v24.3.1` | Kafka API-compatible streaming platform written in C++ and Raft-based — same protocol as Kafka, no JVM, no ZooKeeper, lower tail latency. The data plane for every CDC and streaming pipeline in Nexus Stack. |
+| **[Redpanda](https://github.com/stefanko-ch/Nexus-Stack/blob/main/docs/stacks/redpanda.md)** | `redpandadata/redpanda:v24.3` | Kafka API-compatible streaming platform written in C++ and Raft-based — same protocol as Kafka, no JVM, no ZooKeeper, lower tail latency. The data plane for every CDC and streaming pipeline in Nexus Stack. |
 | **[Redpanda Connect](https://github.com/stefanko-ch/Nexus-Stack/blob/main/docs/stacks/redpanda-connect.md)** | `redpandadata/connect:4.43.0` | Declarative stream-processing framework (formerly Benthos). YAML-defined pipelines with 200+ inputs/outputs/processors for real-time ETL, enrichment, and routing. |
 | **[Redpanda Console](https://github.com/stefanko-ch/Nexus-Stack/blob/main/docs/stacks/redpanda-console.md)** | `redpandadata/console:v2.8.0` | Modern web UI for browsing topics, consumer groups, schema registry, and ACLs. The recommended first-stop GUI if you're running Redpanda. |
 | **[Redpanda Datagen](https://github.com/stefanko-ch/Nexus-Stack/blob/main/docs/stacks/redpanda-datagen.md)** | `redpandadata/connect:4.43.0` | Synthetic test data generator for Redpanda topics. Handy for reproducing pipeline issues or load-testing downstream consumers without hitting production sources. |

--- a/docs/stacks/overview.md
+++ b/docs/stacks/overview.md
@@ -35,14 +35,14 @@ Disabling a stack reverses every one of those steps. Nothing is left behind on C
 Every stack Docker Compose file uses an environment variable default pattern:
 
 ```yaml
-image: ${IMAGE_GRAFANA:-grafana/grafana:latest}
+image: ${IMAGE_GRAFANA:-grafana/grafana:11.6}
 ```
 
 The tag shown in each table below is the value Nexus Stack ships with **right now** on `main`. Tags fall into three buckets:
 
 - **Pinned exact version** (e.g. `clickhouse/clickhouse-server:25.8.16.34`, `redpandadata/redpanda:v24.3.1`) — reproducible, deterministic, what you want in production.
 - **Pinned major (or major/minor)** (e.g. `gitea/gitea:1.23`, `dpage/pgadmin4:9`) — gets patch updates on next `docker pull`, locked against major version surprises.
-- **`:latest`** (e.g. `grafana/grafana:latest`, `n8nio/n8n:latest`) — tracks upstream bleeding edge. Fine for personal use, risky for production.
+- **`:latest`** (e.g. `adminer:latest`, `corentinth/it-tools:latest`) — tracks upstream bleeding edge. Reserved for presentation-layer and dev tools that hold no persistent state, and for viewers over somebody else's state such as Kafka-UI and S3 Manager. No stateful stack is left on it.
 
 You override any image via the matching `IMAGE_*` environment variable in your deployment — useful for pinning `:latest` stacks to a specific version, or for testing a pre-release tag.
 
@@ -109,7 +109,7 @@ Cloudflare Tunnels handle HTTPS perfectly, but a few services need raw TCP acces
 
 | Stack | Image | Description |
 |-------|-------|-------------|
-| **[Filestash](https://github.com/stefanko-ch/Nexus-Stack/blob/main/docs/stacks/filestash.md)** | `machines/filestash:latest` | Web file manager with pluggable backends: S3, SFTP, FTP, WebDAV, Dropbox, Google Drive. Think "Google Drive UI for whichever storage you already own". |
+| **[Filestash](https://github.com/stefanko-ch/Nexus-Stack/blob/main/docs/stacks/filestash.md)** | `machines/filestash@sha256:68171bf3…` | Web file manager with pluggable backends: S3, SFTP, FTP, WebDAV, Dropbox, Google Drive. Think "Google Drive UI for whichever storage you already own". |
 | **[Garage](https://github.com/stefanko-ch/Nexus-Stack/blob/main/docs/stacks/garage.md)** | `dxflrs/garage:v2.2.0` | Lightweight geo-distributed S3-compatible storage from the Deuxfleurs collective. Designed to run on heterogeneous nodes, e.g. a laptop + a VPS + a Raspberry Pi as one cluster. |
 | **[LakeFS](https://github.com/stefanko-ch/Nexus-Stack/blob/main/docs/stacks/lakefs.md)** | `treeverse/lakefs:1.73.0` | Git-like branches, commits, and merges for an S3 bucket. Enables "reproduce Tuesday's report" workflows by snapshotting the data lake state at each dbt run. Configured to use Hetzner Object Storage as the backing bucket. |
 | **[MinIO](https://github.com/stefanko-ch/Nexus-Stack/blob/main/docs/stacks/minio.md)** | `quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z` | The reference open-source S3-compatible object store. Battle-tested, widely supported by every SDK that speaks S3, picked by default when in doubt. |
@@ -124,8 +124,8 @@ Cloudflare Tunnels handle HTTPS perfectly, but a few services need raw TCP acces
 |-------|-------|-------------|
 | **[Dagster](https://github.com/stefanko-ch/Nexus-Stack/blob/main/docs/stacks/dagster.md)** | `nexus-dagster:1.12.21` | Python orchestrator built around Software-Defined Assets and data lineage. Great fit for dbt + Python analytics stacks. Uses a Nexus-built image that layers your dependencies on top of the official base. |
 | **[Kestra](https://github.com/stefanko-ch/Nexus-Stack/blob/main/docs/stacks/kestra.md)** | `kestra/kestra:v1.0` | YAML-defined declarative workflow orchestration. Event-driven, plugin-rich, and language-agnostic. Pinned to the Kestra LTS track — the default image already bundles every official plugin (Databricks JDBC, Snowflake, Trino, Postgres, ~15 more). Always protected by Cloudflare Access — it touches every downstream system. |
-| **[Mage](https://github.com/stefanko-ch/Nexus-Stack/blob/main/docs/stacks/mage.md)** | `mageai/mageai:latest` | Notebook-style data pipeline builder. A good middle ground if Dagster feels too abstract and Jupyter feels too loose. |
-| **[n8n](https://github.com/stefanko-ch/Nexus-Stack/blob/main/docs/stacks/n8n.md)** | `n8nio/n8n:latest` | Fair-code workflow automation — Zapier/Make alternative with 400+ integrations and self-hostable license. The go-to tool for "when X happens, do Y" glue work. |
+| **[Mage](https://github.com/stefanko-ch/Nexus-Stack/blob/main/docs/stacks/mage.md)** | `mageai/mageai:0.9.79` | Notebook-style data pipeline builder. A good middle ground if Dagster feels too abstract and Jupyter feels too loose. |
+| **[n8n](https://github.com/stefanko-ch/Nexus-Stack/blob/main/docs/stacks/n8n.md)** | `n8nio/n8n:1.123.75` | Fair-code workflow automation — Zapier/Make alternative with 400+ integrations and self-hostable license. The go-to tool for "when X happens, do Y" glue work. |
 | **[Prefect](https://github.com/stefanko-ch/Nexus-Stack/blob/main/docs/stacks/prefect.md)** | `prefecthq/prefect:3-latest` | Python-native orchestrator — flows are plain Python decorated with `@flow`. Deploys a Prefect Server, worker, and UI as separate containers. |
 | **[Windmill](https://github.com/stefanko-ch/Nexus-Stack/blob/main/docs/stacks/windmill.md)** | `ghcr.io/windmill-labs/windmill:1.624.0` | Developer-focused workflow and internal-tools platform. Write scripts in TypeScript/Python/Go/Bash, auto-generate forms, compose flows. Ships with an LSP container for in-browser autocomplete. |
 | **[Woodpecker CI](https://github.com/stefanko-ch/Nexus-Stack/blob/main/docs/stacks/woodpecker-ci.md)** | `woodpeckerci/woodpecker-server:v3.13.0` | Lightweight Docker-native CI/CD. Reads a `.woodpecker.yaml` and runs each step in a disposable container. Ships with a sibling **`woodpeckerci/woodpecker-agent:v3.13.0`** runner. Pairs naturally with Gitea for a fully self-hosted Git + CI setup. |
@@ -145,7 +145,7 @@ Cloudflare Tunnels handle HTTPS perfectly, but a few services need raw TCP acces
 | Stack | Image | Description |
 |-------|-------|-------------|
 | **[Apache Superset](https://github.com/stefanko-ch/Nexus-Stack/blob/main/docs/stacks/superset.md)** | `apache/superset:6.0.0` | Power-user BI and data exploration with SQL Lab, 40+ chart types, and Jinja-templated dashboards. Fits the "data team wants real tooling" use case. |
-| **[Budibase](https://github.com/stefanko-ch/Nexus-Stack/blob/main/docs/stacks/budibase.md)** | `budibase/budibase:latest` | Low-code internal-tools builder. Drag-and-drop forms, tables, and auto-generated CRUD apps on top of your existing databases or APIs. |
+| **[Budibase](https://github.com/stefanko-ch/Nexus-Stack/blob/main/docs/stacks/budibase.md)** | `budibase/budibase:v3.43.0` | Low-code internal-tools builder. Drag-and-drop forms, tables, and auto-generated CRUD apps on top of your existing databases or APIs. |
 | **[Jupyter](https://github.com/stefanko-ch/Nexus-Stack/blob/main/docs/stacks/jupyter.md)** | `quay.io/jupyter/pyspark-notebook:python-3.13` | JupyterLab with PySpark preinstalled and pre-connected to the Spark cluster stack. The interactive data-exploration workhorse. |
 | **[Marimo](https://github.com/stefanko-ch/Nexus-Stack/blob/main/docs/stacks/marimo.md)** | `ghcr.io/marimo-team/marimo:latest-sql` | Modern Python notebook with reactive execution (change a cell and dependents re-run automatically) and built-in SQL cells. Notebooks are stored as plain `.py` files — git-friendly. |
 | **[Metabase](https://github.com/stefanko-ch/Nexus-Stack/blob/main/docs/stacks/metabase.md)** | `metabase/metabase:v0.60.6.2` | Friendly self-service BI — point at a database, get an ask-a-question-in-plain-English UI, build dashboards in minutes. Best fit for non-technical stakeholders. |
@@ -157,10 +157,10 @@ Cloudflare Tunnels handle HTTPS perfectly, but a few services need raw TCP acces
 | Stack | Image | Description |
 |-------|-------|-------------|
 | **[Dozzle](https://github.com/stefanko-ch/Nexus-Stack/blob/main/docs/stacks/dozzle.md)** | `amir20/dozzle:v10.5.3` | Realtime Docker logs in the browser. The "no-SSH `docker logs -f`" — pick a container in the sidebar, stream its logs live, search/filter, open multiple in tabs. Subscribes to the Docker socket read-only. Stateless, ~30 MB image. |
-| **[Grafana](https://github.com/stefanko-ch/Nexus-Stack/blob/main/docs/stacks/grafana.md)** | `grafana/grafana:latest` | The observability stack, bundled: Grafana + Prometheus + Loki + Promtail + cAdvisor + Node Exporter. Ships with pre-provisioned dashboards for Docker containers, Loki logs, and host metrics — working observability out of the box. Always protected. |
+| **[Grafana](https://github.com/stefanko-ch/Nexus-Stack/blob/main/docs/stacks/grafana.md)** | `grafana/grafana:11.6` | The observability stack, bundled: Grafana + Prometheus + Loki + Promtail + cAdvisor + Node Exporter. Ships with pre-provisioned dashboards for Docker containers, Loki logs, and host metrics — working observability out of the box. Always protected. |
 | **[Quickwit](https://github.com/stefanko-ch/Nexus-Stack/blob/main/docs/stacks/quickwit.md)** | `quickwit/quickwit:0.8.1` | Rust-based log search engine, designed to store indexes on cheap object storage (S3/MinIO) instead of expensive SSD. Elasticsearch alternative when you have terabytes of logs you rarely query. |
 | **[Telegraf](https://github.com/stefanko-ch/Nexus-Stack/blob/main/docs/stacks/telegraf.md)** | `telegraf:1.38.2` | InfluxData's metrics agent with 300+ input plugins. CLI-only — runs in the background, no web UI. Complements the Grafana stack when you need something Node Exporter doesn't cover. |
-| **[Uptime Kuma](https://github.com/stefanko-ch/Nexus-Stack/blob/main/docs/stacks/uptime-kuma.md)** | `louislam/uptime-kuma:latest` | A fancy self-hosted uptime monitor. Beautiful dashboards, Telegram/Slack/Discord alerts, public status pages. The reference "I need monitoring tonight" pick. |
+| **[Uptime Kuma](https://github.com/stefanko-ch/Nexus-Stack/blob/main/docs/stacks/uptime-kuma.md)** | `louislam/uptime-kuma:2` | A fancy self-hosted uptime monitor. Beautiful dashboards, Telegram/Slack/Discord alerts, public status pages. The reference "I need monitoring tonight" pick. |
 | **[Vector](https://github.com/stefanko-ch/Nexus-Stack/blob/main/docs/stacks/vector.md)** | `timberio/vector:0.54.0-alpine` | Ultra-fast observability pipeline in Rust — collect, transform, and route logs/metrics/traces. Think "unified Logstash + Fluentd + Telegraf at 10× the throughput". |
 
 ## Data quality & metadata
@@ -188,8 +188,8 @@ Cloudflare Tunnels handle HTTPS perfectly, but a few services need raw TCP acces
 | **[Gitea](https://github.com/stefanko-ch/Nexus-Stack/blob/main/docs/stacks/gitea.md)** | `gitea/gitea:1.23` | Self-hosted Git with pull requests, code review, releases, and a built-in Actions runner. The GitHub-at-home experience. PostgreSQL is included as a sibling container. |
 | **[Hoppscotch](https://github.com/stefanko-ch/Nexus-Stack/blob/main/docs/stacks/hoppscotch.md)** | `hoppscotch/hoppscotch:2025.12.1` | Open-source API testing client. REST, GraphQL, WebSocket, SSE, MQTT. Postman alternative with collections, environments, and history. |
 | **[IT-Tools](https://github.com/stefanko-ch/Nexus-Stack/blob/main/docs/stacks/it-tools.md)** | `corentinth/it-tools:latest` | Collection of ~80 daily-dev utilities: JSON/YAML formatters, hash generators, JWT decoder, base64, regex tester, cron parser, and friends. |
-| **[Mailpit](https://github.com/stefanko-ch/Nexus-Stack/blob/main/docs/stacks/mailpit.md)** | `axllent/mailpit:latest` | SMTP sink + web UI for intercepting test emails. Point any app's SMTP at Mailpit and inspect every email it would have sent — indispensable for developing email flows. |
-| **[Portainer](https://github.com/stefanko-ch/Nexus-Stack/blob/main/docs/stacks/portainer.md)** | `portainer/portainer-ce:latest` | Docker container management UI. Browse images, inspect volumes, tail logs, exec into containers. Always protected — it controls the entire Docker daemon. |
+| **[Mailpit](https://github.com/stefanko-ch/Nexus-Stack/blob/main/docs/stacks/mailpit.md)** | `axllent/mailpit:v1.28` | SMTP sink + web UI for intercepting test emails. Point any app's SMTP at Mailpit and inspect every email it would have sent — indispensable for developing email flows. |
+| **[Portainer](https://github.com/stefanko-ch/Nexus-Stack/blob/main/docs/stacks/portainer.md)** | `portainer/portainer-ce:2.40.0` | Docker container management UI. Browse images, inspect volumes, tail logs, exec into containers. Always protected — it controls the entire Docker daemon. |
 | **[Wetty](https://github.com/stefanko-ch/Nexus-Stack/blob/main/docs/stacks/wetty.md)** | `wettyoss/wetty:latest` | SSH terminal in the browser. Always protected — it literally gives you a shell on the host. The emergency break-glass access path when something is wrong and you can't ssh from your laptop. |
 | **[Wiki.js](https://github.com/stefanko-ch/Nexus-Stack/blob/main/docs/stacks/wikijs.md)** | `requarks/wiki:2.5.306` | Modern wiki and knowledge base with Markdown, WYSIWYG, Git sync, and fine-grained ACLs. Run it privately for team docs or `public = true` for a real public wiki. |
 
@@ -204,7 +204,7 @@ Cloudflare Tunnels handle HTTPS perfectly, but a few services need raw TCP acces
 
 | Stack | Image | Description |
 |-------|-------|-------------|
-| **[Infisical](https://github.com/stefanko-ch/Nexus-Stack/blob/main/docs/stacks/infisical.md)** | `infisical/infisical:latest` | Open-source secret management platform — the secrets store Nexus Stack uses *for itself*. Every other stack fetches its credentials from here at container startup. Always protected. |
+| **[Infisical](https://github.com/stefanko-ch/Nexus-Stack/blob/main/docs/stacks/infisical.md)** | `infisical/infisical:v0.155.5` | Open-source secret management platform — the secrets store Nexus Stack uses *for itself*. Every other stack fetches its credentials from here at container startup. Always protected. |
 
 ---
 

--- a/docs/stacks/overview.md
+++ b/docs/stacks/overview.md
@@ -40,8 +40,8 @@ image: ${IMAGE_GRAFANA:-grafana/grafana:11.6}
 
 The tag shown in each table below is the value Nexus Stack ships with **right now** on `main`. Tags fall into three buckets:
 
-- **Pinned exact version** (e.g. `clickhouse/clickhouse-server:25.8.16.34`, `redpandadata/redpanda:v24.3`) — reproducible, deterministic, what you want in production.
-- **Pinned major (or major/minor)** (e.g. `gitea/gitea:1.23`, `dpage/pgadmin4:9`) — gets patch updates on next `docker pull`, locked against major version surprises.
+- **Pinned exact version** (e.g. `clickhouse/clickhouse-server:25.8.16.34`, `treeverse/lakefs:1.73.0`) — reproducible, deterministic, what you want in production.
+- **Pinned major (or major/minor)** (e.g. `gitea/gitea:1.23`, `redpandadata/redpanda:v24.3`) — gets patch updates on next `docker pull`, locked against major version surprises.
 - **`:latest`** (e.g. `adminer:latest`, `corentinth/it-tools:latest`) — tracks upstream bleeding edge. Reserved for presentation-layer and dev tools that hold no persistent state, and for viewers over somebody else's state such as Kafka-UI and S3 Manager. No stateful stack is left on it.
 
 You override any image via the matching `IMAGE_*` environment variable in your deployment — useful for pinning `:latest` stacks to a specific version, or for testing a pre-release tag.

--- a/services.yaml
+++ b/services.yaml
@@ -108,7 +108,7 @@ services:
     website: "https://budibase.com"
     description: "Open-source low-code platform for building internal tools, CRUD apps, and dashboards."
     long_description: "Budibase lets you build internal tools and business apps in minutes. Connect to databases (PostgreSQL, MySQL, MongoDB), REST APIs, or use built-in tables. Drag-and-drop UI builder, role-based access control, workflow automation, and self-hosted deployment."
-    image: "budibase/budibase:latest"
+    image: "budibase/budibase:v3.43.0"
 
   chroma:
     subdomain: "chroma"
@@ -262,7 +262,7 @@ services:
     website: "https://www.filestash.app"
     description: "Web-based file manager with S3/FTP/SFTP/WebDAV backend support."
     long_description: "Filestash is a modern web file manager that connects to various storage backends including S3, FTP, SFTP, WebDAV, Git, and Dropbox. Features include file preview, image thumbnails, video streaming, full-text search, and a built-in text editor. Manage all your storage from one interface."
-    image: "machines/filestash:latest"
+    image: "machines/filestash@sha256:68171bf3ae791486056d59efb36e5fcc13ea0297465aaff3bd93f8ed69548e74"
     admin_path: "/admin"
 
   flink:
@@ -508,7 +508,7 @@ services:
     website: "https://www.mage.ai"
     description: "Modern data pipeline tool - build, run, and manage pipelines for ETL/ELT workflows."
     long_description: "Mage AI is a modern data pipeline tool for transforming and integrating data. Build ETL/ELT pipelines with a hybrid notebook-style interface, test with built-in unit tests, and deploy to production. Supports Python, SQL, and R with native integration for dbt, Spark, and major data warehouses."
-    image: "mageai/mageai:latest"
+    image: "mageai/mageai:0.9.79"
     support_images:
       postgres: "postgres:14-alpine"
 
@@ -600,7 +600,7 @@ services:
     website: "https://n8n.io"
     description: "Workflow automation tool with 400+ integrations for connecting apps and services."
     long_description: "n8n is a workflow automation platform with 400+ integrations. Connect apps, automate tasks, and build complex workflows with a visual editor. Supports webhooks, scheduled triggers, conditional logic, and custom JavaScript/Python code nodes. Self-hosted for full data control."
-    image: "n8nio/n8n:1"
+    image: "n8nio/n8n:1.123.75"
     support_images:
       postgres: "postgres:16-alpine"
 

--- a/stacks/budibase/docker-compose.yml
+++ b/stacks/budibase/docker-compose.yml
@@ -10,7 +10,7 @@
 
 services:
   budibase:
-    image: ${IMAGE_BUDIBASE:-budibase/budibase:latest}
+    image: ${IMAGE_BUDIBASE:-budibase/budibase:v3.43.0}
     container_name: budibase
     restart: unless-stopped
     ports:

--- a/stacks/filestash/docker-compose.yml
+++ b/stacks/filestash/docker-compose.yml
@@ -15,7 +15,7 @@
 
 services:
   filestash:
-    image: ${IMAGE_FILESTASH:-machines/filestash:latest}
+    image: ${IMAGE_FILESTASH:-machines/filestash@sha256:68171bf3ae791486056d59efb36e5fcc13ea0297465aaff3bd93f8ed69548e74}
     container_name: filestash
     restart: unless-stopped
     ports:

--- a/stacks/grafana/docker-compose.yml
+++ b/stacks/grafana/docker-compose.yml
@@ -20,7 +20,7 @@ services:
   # Grafana - Dashboards & Visualization
   # ---------------------------------------------------------------------------
   grafana:
-    image: ${IMAGE_GRAFANA:-grafana/grafana:latest}
+    image: ${IMAGE_GRAFANA:-grafana/grafana:11.6}
     container_name: grafana
     env_file:
       - .env
@@ -59,7 +59,7 @@ services:
   # Prometheus - Metrics Collection
   # ---------------------------------------------------------------------------
   prometheus:
-    image: ${IMAGE_PROMETHEUS:-prom/prometheus:latest}
+    image: ${IMAGE_PROMETHEUS:-prom/prometheus:v3.9.1}
     container_name: grafana-prometheus
     restart: unless-stopped
     command:
@@ -78,7 +78,7 @@ services:
   # Loki - Log Aggregation
   # ---------------------------------------------------------------------------
   loki:
-    image: ${IMAGE_LOKI:-grafana/loki:latest}
+    image: ${IMAGE_LOKI:-grafana/loki:3}
     container_name: grafana-loki
     restart: unless-stopped
     command: -config.file=/etc/loki/loki-config.yml
@@ -92,7 +92,7 @@ services:
   # Promtail - Log Collector (ships Docker logs to Loki)
   # ---------------------------------------------------------------------------
   promtail:
-    image: ${IMAGE_PROMTAIL:-grafana/promtail:latest}
+    image: ${IMAGE_PROMTAIL:-grafana/promtail:3}
     container_name: grafana-promtail
     restart: unless-stopped
     command: -config.file=/etc/promtail/promtail-config.yml
@@ -109,7 +109,7 @@ services:
   # cAdvisor - Container Metrics
   # ---------------------------------------------------------------------------
   cadvisor:
-    image: ${IMAGE_CADVISOR:-gcr.io/cadvisor/cadvisor:latest}
+    image: ${IMAGE_CADVISOR:-ghcr.io/google/cadvisor:0.56}
     container_name: grafana-cadvisor
     restart: unless-stopped
     privileged: true
@@ -140,7 +140,7 @@ services:
   # Node Exporter - Host Metrics (CPU, RAM, Disk, Network)
   # ---------------------------------------------------------------------------
   node-exporter:
-    image: ${IMAGE_NODE_EXPORTER:-prom/node-exporter:latest}
+    image: ${IMAGE_NODE_EXPORTER:-prom/node-exporter:v1.10.2}
     container_name: grafana-node-exporter
     restart: unless-stopped
     command:

--- a/stacks/infisical/docker-compose.yml
+++ b/stacks/infisical/docker-compose.yml
@@ -15,7 +15,7 @@
 
 services:
   infisical:
-    image: ${IMAGE_INFISICAL:-infisical/infisical:latest}
+    image: ${IMAGE_INFISICAL:-infisical/infisical:v0.155.5}
     container_name: infisical
     env_file:
       - .env

--- a/stacks/mage/docker-compose.yml
+++ b/stacks/mage/docker-compose.yml
@@ -15,7 +15,7 @@
 
 services:
   mage:
-    image: mageai/mageai:latest
+    image: ${IMAGE_MAGE:-mageai/mageai:0.9.79}
     container_name: mage
     restart: unless-stopped
     ports:

--- a/stacks/n8n/docker-compose.yml
+++ b/stacks/n8n/docker-compose.yml
@@ -10,7 +10,7 @@
 
 services:
   n8n:
-    image: ${IMAGE_N8N:-n8nio/n8n:latest}
+    image: ${IMAGE_N8N:-n8nio/n8n:1.123.75}
     container_name: n8n
     restart: unless-stopped
     ports:


### PR DESCRIPTION
Every image tag on a stateful stack now resolves to something that cannot change underneath it. Both halves needed work, and they were wrong in different ways.

Closes #662

## services.yaml — the authoritative source

```
budibase   :latest  ->  v3.43.0
mage       :latest  ->  0.9.79
filestash  :latest  ->  @sha256:68171bf3…
n8n        1        ->  1.123.75
```

**filestash is digest-pinned** because upstream publishes no version tags at all — only `latest`, `lowa`, `trial` and commit SHAs. The SHA tags are single-arch manifests without platform metadata, so they are worse than useless here; the digest is of the multi-arch manifest list and keeps both `linux/amd64` and `linux/arm64`. It holds state in `filestash_data:/app/data/state`, which made it the least defensible of the five to leave floating.

**n8n was pinned to the bare major `1`** while upstream is at 2.37. Pinned to the newest 1.x rather than moved to 2.x: that is a major upgrade of a stack holding workflow definitions, credentials and execution history, and it wants its own PR and a migration check.

Every chosen tag was checked for `linux/amd64` per the arch rule in `CLAUDE.md` — all four are amd64 + arm64.

## The compose fallbacks were a second, quieter problem

```yaml
image: ${IMAGE_BUDIBASE:-budibase/budibase:latest}
```

The `:-` default only fires when the env var is missing — which is not never: exactly what happens if `global-env` did not render, or on a manual `docker compose up` on the server. The fallback said "newest", so the failure mode of a missing variable was a **silent upgrade of a stateful service**.

Each fallback now equals the pinned version. That includes **infisical**, which was already pinned to `v0.155.5` in services.yaml but fell back to `:latest` — the one holding Postgres with every generated credential on the stack.

`mage` additionally had no env indirection at all (a bare `mageai/mageai:latest`) and so could not be overridden; it now uses `${IMAGE_MAGE:-…}` like the others.

## Not changed, and why

Five entries still end in `:latest` outside the literal allow-list in `CLAUDE.md`: dify's `ubuntu/squid`, garage's web UI, kafka-ui, s3manager, and windmill's LSP. All are support or presentation images with no persistent state — the category the exception describes, just not named in it. Worth deciding deliberately (extend the list, or pin them) rather than folding into a PR about stateful services.

## How to test

`gh workflow run spin-up.yml` and check the images actually pulled:

```bash
ssh nexus "docker ps --format '{{.Image}}' | sort"
```

None of the five should show `:latest`. The compose fallback is exercised by unsetting the variable — `docker compose config` in the stack directory resolves it without the env file.

## Summary by Sourcery

Pin stateful stack images and their compose fallbacks to prevent unintended upgrades while preserving explicit override support.

Bug Fixes:
- Prevent stateful services from silently upgrading when image environment variables are missing by aligning compose fallbacks with pinned image versions.

Enhancements:
- Pin stateful stack images to exact, minor, major, or multi-architecture digest references as appropriate, including Budibase, Filestash, Mage, n8n, Infisical, and observability components.
- Add consistent image override support for Mage and update image sources and versions across the documented stack catalog.
- Document the policy and exceptions for stateful image pinning, including deliberately rolling tags and digest-pinned images.

Documentation:
- Update stack documentation and image tables to reflect the new pinned versions and image-pinning policy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated Docker image versioning guidance to clarify pinning policies and rolling tags.
  - Documented exact or digest-based image versions across supported stacks.

- **Maintenance**
  - Pinned Budibase, Filestash, Infisical, Mage, and n8n images to stable versions.
  - Improved deployment reproducibility while retaining environment-based image overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->