### PR TITLE
feat(control-plane): Show the actual host in the Infrastructure panel

### DIFF
--- a/.github/workflows/spin-up.yml
+++ b/.github/workflows/spin-up.yml
@@ -754,20 +754,72 @@ jobs:
             exit 0
           fi
 
-          # Server config values
-          SERVER_TYPE="${{ vars.SERVER_TYPE || 'cx43' }}"
-          SERVER_LOCATION="${{ vars.SERVER_LOCATION || 'hel1' }}"
+          # Read what was actually provisioned, not what was requested.
+          # `select-capacity` rewrites server_type / server_location in
+          # config.tfvars when the preferred pair is sold out — a repo
+          # variable cannot reflect that, so the panel would keep showing
+          # the preference while the box was something else. The tfvars
+          # file is the only place that knows the outcome.
+          TFVARS=tofu/stack/config.tfvars
+          SERVER_TYPE=$(sed -n 's/^[[:space:]]*server_type[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' "$TFVARS" | head -1)
+          SERVER_LOCATION=$(sed -n 's/^[[:space:]]*server_location[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' "$TFVARS" | head -1)
+          # Fall back to the request only if the file cannot be read — an
+          # approximate value beats an empty panel, but say so.
+          if [ -z "$SERVER_TYPE" ]; then
+            echo "⚠️  Could not read server_type from $TFVARS — falling back to the requested value"
+            SERVER_TYPE="${{ vars.SERVER_TYPE || 'cx43' }}"
+          fi
+          if [ -z "$SERVER_LOCATION" ]; then
+            SERVER_LOCATION="${{ vars.SERVER_LOCATION || 'hel1' }}"
+          fi
 
           # Escape values for safe SQL insertion (single quotes doubled)
           ESCAPED_SERVER_TYPE=${SERVER_TYPE//\'/\'\'}
           ESCAPED_SERVER_LOCATION=${SERVER_LOCATION//\'/\'\'}
           ESCAPED_DOMAIN=${DOMAIN//\'/\'\'}
 
+          # Host facts, in one round trip. Best-effort by construction:
+          # the panel is a convenience and a broken ssh must not fail a
+          # deploy that otherwise worked. A failure here leaves the
+          # previous values in D1 rather than blanking them — a stale
+          # reading is more useful than none, and the panel shows when
+          # each value was written.
+          #
+          # The OS is read from the box rather than from server_image
+          # because under the snapshot lifecycle that variable holds a
+          # Hetzner snapshot ID (e.g. 423792562), which is not an OS name.
+          # Reading /etc/os-release works under either lifecycle with no
+          # special-casing.
+          HOST_OS=""
+          HOST_DISK=""
+          HOST_DOCKER=""
+          if HOST_FACTS=$(timeout 60 ssh -o BatchMode=yes -o ConnectTimeout=15 nexus \
+                '. /etc/os-release 2>/dev/null && printf "OS=%s\n" "$PRETTY_NAME";
+                 printf "DISK=%s\n" "$(df -BG --output=size / 2>/dev/null | tail -1 | tr -d " G")";
+                 printf "DOCKER=%s\n" "$(docker --version 2>/dev/null | sed -n "s/^Docker version \([^,]*\),.*/\1/p")"' 2>/dev/null); then
+            HOST_OS=$(printf '%s' "$HOST_FACTS" | sed -n 's/^OS=//p' | head -1)
+            HOST_DISK=$(printf '%s' "$HOST_FACTS" | sed -n 's/^DISK=//p' | head -1)
+            HOST_DOCKER=$(printf '%s' "$HOST_FACTS" | sed -n 's/^DOCKER=//p' | head -1)
+            echo "🖥️  Host: ${HOST_OS:-?} · ${HOST_DISK:-?} GB disk · Docker ${HOST_DOCKER:-?}"
+          else
+            echo "⚠️  Could not read host facts over ssh — keeping the previous values in D1"
+          fi
+
           # Write config to D1
           npx wrangler@4 d1 execute "$D1_DATABASE_NAME" --remote --command "INSERT OR REPLACE INTO config (key, value, updated_at) VALUES ('server_type', '$ESCAPED_SERVER_TYPE', datetime('now'))"
           npx wrangler@4 d1 execute "$D1_DATABASE_NAME" --remote --command "INSERT OR REPLACE INTO config (key, value, updated_at) VALUES ('server_location', '$ESCAPED_SERVER_LOCATION', datetime('now'))"
           npx wrangler@4 d1 execute "$D1_DATABASE_NAME" --remote --command "INSERT OR REPLACE INTO config (key, value, updated_at) VALUES ('domain', '$ESCAPED_DOMAIN', datetime('now'))"
           npx wrangler@4 d1 execute "$D1_DATABASE_NAME" --remote --command "INSERT OR REPLACE INTO config (key, value, updated_at) VALUES ('last_spin_up', datetime('now'), datetime('now'))"
+
+          # Only write what was actually read. An empty string would
+          # replace a good previous reading with a blank field.
+          for pair in "host_os:$HOST_OS" "host_disk_gb:$HOST_DISK" "host_docker:$HOST_DOCKER"; do
+            key=${pair%%:*}
+            value=${pair#*:}
+            [ -n "$value" ] || continue
+            escaped=${value//\'/\'\'}
+            npx wrangler@4 d1 execute "$D1_DATABASE_NAME" --remote --command "INSERT OR REPLACE INTO config (key, value, updated_at) VALUES ('$key', '$escaped', datetime('now'))"
+          done
 
           if [ "${{ inputs.silent_mode }}" = "true" ]; then
             npx wrangler@4 d1 execute "$D1_DATABASE_NAME" --remote --command "INSERT OR REPLACE INTO config (key, value, updated_at) VALUES ('silent_mode', 'true', datetime('now'))"

--- a/.github/workflows/spin-up.yml
+++ b/.github/workflows/spin-up.yml
@@ -761,15 +761,32 @@ jobs:
           # the preference while the box was something else. The tfvars
           # file is the only place that knows the outcome.
           TFVARS=tofu/stack/config.tfvars
-          SERVER_TYPE=$(sed -n 's/^[[:space:]]*server_type[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' "$TFVARS" | head -1)
-          SERVER_LOCATION=$(sed -n 's/^[[:space:]]*server_location[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' "$TFVARS" | head -1)
-          # Fall back to the request only if the file cannot be read — an
-          # approximate value beats an empty panel, but say so.
+          SERVER_TYPE=""
+          SERVER_LOCATION=""
+          # Readability is checked rather than left to sed. Today a missing
+          # file happens to be survivable: the step runs under GitHub's
+          # default `bash -e` without pipefail, so `sed ... | head -1`
+          # carries head's zero status and the fallback below is reached.
+          # That is an accident of the pipe, not a decision — adding
+          # `set -o pipefail` later would silently turn the fallback into
+          # dead code. The guard makes the intent explicit and keeps sed's
+          # "No such file" out of the log.
+          if [ -r "$TFVARS" ]; then
+            SERVER_TYPE=$(sed -n 's/^[[:space:]]*server_type[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' "$TFVARS" | head -1)
+            SERVER_LOCATION=$(sed -n 's/^[[:space:]]*server_location[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' "$TFVARS" | head -1)
+          else
+            echo "⚠️  $TFVARS is not readable — the panel will show what was requested, not what was provisioned"
+          fi
+          # Fall back to the request only if the file could not be read — an
+          # approximate value beats an empty panel, but say so. Both values
+          # warn: capacity selection rewrites the location as readily as the
+          # type, so a silent fallback there is just as misleading.
           if [ -z "$SERVER_TYPE" ]; then
             echo "⚠️  Could not read server_type from $TFVARS — falling back to the requested value"
             SERVER_TYPE="${{ vars.SERVER_TYPE || 'cx43' }}"
           fi
           if [ -z "$SERVER_LOCATION" ]; then
+            echo "⚠️  Could not read server_location from $TFVARS — falling back to the requested value"
             SERVER_LOCATION="${{ vars.SERVER_LOCATION || 'hel1' }}"
           fi
 

--- a/.github/workflows/spin-up.yml
+++ b/.github/workflows/spin-up.yml
@@ -793,6 +793,11 @@ jobs:
           HOST_OS=""
           HOST_DISK=""
           HOST_DOCKER=""
+          # The remote script is single-quoted on purpose: $PRETTY_NAME and
+          # the command substitutions must be evaluated by the shell on the
+          # server, not by this one. Double quotes would expand them here,
+          # against the runner's empty environment, and ship three blanks.
+          # shellcheck disable=SC2016
           if HOST_FACTS=$(timeout 60 ssh -o BatchMode=yes -o ConnectTimeout=15 nexus \
                 '. /etc/os-release 2>/dev/null && printf "OS=%s\n" "$PRETTY_NAME";
                  printf "DISK=%s\n" "$(df -BG --output=size / 2>/dev/null | tail -1 | tr -d " G")";

--- a/control-plane/functions/api/info.js
+++ b/control-plane/functions/api/info.js
@@ -89,6 +89,9 @@ export async function onRequestGet(context) {
     let domain = null;
     let lastSpinUp = null;
     let lastTeardown = null;
+    let hostOs = null;
+    let hostDiskGb = null;
+    let hostDocker = null;
 
     if (env.NEXUS_DB) {
       serverType = await getConfig(env.NEXUS_DB, 'server_type', null);
@@ -96,6 +99,12 @@ export async function onRequestGet(context) {
       domain = await getConfig(env.NEXUS_DB, 'domain', null);
       lastSpinUp = await getConfig(env.NEXUS_DB, 'last_spin_up', null);
       lastTeardown = await getConfig(env.NEXUS_DB, 'last_teardown', null);
+      // Host facts, collected over ssh during the last spin-up. Absent
+      // when that lookup failed or on a stack deployed before this
+      // existed — the UI renders those as "—" rather than guessing.
+      hostOs = await getConfig(env.NEXUS_DB, 'host_os', null);
+      hostDiskGb = await getConfig(env.NEXUS_DB, 'host_disk_gb', null);
+      hostDocker = await getConfig(env.NEXUS_DB, 'host_docker', null);
     }
 
     // Fallback to env vars if D1 doesn't have values
@@ -123,6 +132,12 @@ export async function onRequestGet(context) {
       subdomainSeparator,
       lastSpinUp: lastSpinUp,
       lastTeardown: lastTeardown,
+      // Read from the box itself rather than derived from the server
+      // type: a snapshot restored onto a larger type ratchets the disk
+      // permanently upward, so type and disk can legitimately disagree.
+      os: hostOs,
+      diskGb: hostDiskGb,
+      docker: hostDocker,
     };
 
     // Get scheduled teardown config from D1

--- a/control-plane/src/pages/settings.astro
+++ b/control-plane/src/pages/settings.astro
@@ -16,6 +16,18 @@ import Layout from '../layouts/Layout.astro';
         <div class="info-item-value" id="info-server-location">Loading...</div>
       </div>
       <div class="info-item">
+        <div class="info-item-label">OS</div>
+        <div class="info-item-value" id="info-host-os">Loading...</div>
+      </div>
+      <div class="info-item">
+        <div class="info-item-label">Disk</div>
+        <div class="info-item-value" id="info-host-disk">Loading...</div>
+      </div>
+      <div class="info-item">
+        <div class="info-item-label">Docker</div>
+        <div class="info-item-value" id="info-host-docker">Loading...</div>
+      </div>
+      <div class="info-item">
         <div class="info-item-label">Domain</div>
         <div class="info-item-value highlight" id="info-domain">Loading...</div>
       </div>
@@ -141,6 +153,14 @@ import Layout from '../layouts/Layout.astro';
       document.getElementById('info-server-type').textContent = info.server?.type || 'Unknown';
       document.getElementById('info-server-location').textContent = info.server?.location || 'Unknown';
       document.getElementById('info-domain').textContent = info.server?.domain || 'Unknown';
+
+      // These three come from the server itself and are only present once
+      // a spin-up has collected them. An em dash rather than 'Unknown':
+      // the value was never read, which is different from being unknowable.
+      document.getElementById('info-host-os').textContent = info.server?.os || '—';
+      const diskGb = info.server?.diskGb;
+      document.getElementById('info-host-disk').textContent = diskGb ? `${diskGb} GB` : '—';
+      document.getElementById('info-host-docker').textContent = info.server?.docker || '—';
 
       const lastSpinUp = info.server?.lastSpinUp || info.time?.lastDeploy;
       const lastTeardown = info.server?.lastTeardown || info.time?.lastTeardown;

--- a/docs/user-guides/settings.md
+++ b/docs/user-guides/settings.md
@@ -16,16 +16,23 @@ Read-only facts about the current deployment.
 
 ![Infrastructure Information block listing read-only deployment facts: server type, location, domain, last spin-up and teardown timestamps, and uptime](./assets/settings-infrastructure-info.png)
 
+> The screenshot predates the **OS**, **Disk** and **Docker** rows and will be refreshed on the next capture pass. The alt text describes what the image shows rather than what the table below lists, so it is left as-is.
+
 | Field | Description |
 |-------|-------------|
-| **Server Type** | Hetzner server model (e.g. `cx43`) |
+| **Server Type** | Hetzner server model (e.g. `cx43`) — the one actually provisioned, which can differ from the one requested if that type was sold out |
 | **Location** | Hetzner datacenter code — EU options: `hel1` (Helsinki), `fsn1` (Falkenstein), `nbg1` (Nuremberg); US option: `ash` (Ashburn) |
+| **OS** | The distribution running on the box, read from it during the last spin-up |
+| **Disk** | Root filesystem size. Not derived from the server type: a snapshot restored onto a larger type ratchets the disk permanently upward, so the two can legitimately disagree |
+| **Docker** | Docker Engine version on the server |
 | **Domain** | Your root domain |
 | **Last Spin Up** | Timestamp of the most recent spin-up |
 | **Last Teardown** | Timestamp of the most recent teardown |
 | **Uptime** | Time elapsed since last spin-up |
 
 To change server type or location, edit `config.tfvars` and re-deploy — the Control Plane can't change these on the fly.
+
+**OS**, **Disk** and **Docker** are read from the server over SSH at the end of each spin-up. They show `—` on a stack that has not spun up since this was added, and after a teardown they keep the last reading rather than blanking — a value from the previous run is more useful than none, and there is no server to ask while the stack is down. If the collection fails, the spin-up still succeeds and logs a warning; the fields keep their previous values.
 
 ## Scheduled Teardown
 


### PR DESCRIPTION
Adds OS, disk and Docker version to the Infrastructure panel — and fixes the field that was already there but could be wrong.

Closes #678

## Server Type showed the requested type, not the provisioned one

The D1 write read `vars.SERVER_TYPE`. That is a repo variable, and `select-capacity` exists precisely to pick a **different** type when the preferred one is sold out — it rewrites `config.tfvars`, which a repo variable cannot reflect. After any capacity fallback the panel kept showing the preference while the box was something else.

Both values now come from `config.tfvars` after that step has run, the only place that knows the outcome. The repo variable remains as a fallback for an unreadable file, and says so in the log rather than silently approximating.

## Three facts read from the box

`/etc/os-release`, `df -BG /` and `docker --version`, in one SSH round trip at the end of the spin-up.

**OS comes from the server, not from `server_image`** — under the snapshot lifecycle that variable holds a Hetzner snapshot ID (e.g. `423792562`), not an OS name. Reading the box works under either lifecycle with no special-casing.

**Disk is included because it is genuinely not derivable from the server type**: a snapshot restored onto a larger type ratchets the disk permanently upward, so the two can legitimately disagree. vCPU and RAM *are* derivable, so they are left out rather than duplicated somewhere they could drift.

## Collection cannot break a deploy

Best-effort by construction. A broken SSH must not fail a spin-up that otherwise worked, so the step warns and moves on. It writes only the values it actually read — an empty string would replace a good previous reading with a blank field — and after a teardown the last reading stays, because there is no server to ask and a stale value beats none.

The UI shows `—` rather than `Unknown` where a value was never collected: never read is a different state from unknowable.

## Why it came up

The Ubuntu 26.04 rollout produced two deploy failures caused by the OS change itself (#677), and an operator looking at a broken stack had no way to answer "which OS is this box running?" from the UI. The panel described the booking; it said nothing about the machine.

## Verification

The shell was exercised, not eyeballed:

- `bash -n` over every `run:` block
- the tfvars extraction against a sample file — `cpx42` / `fsn1` parsed correctly
- the write loop in isolation, confirming an empty value is skipped rather than written

`npm run build` produces the same nine pages, and the three new ids appear in the built `settings/index.html`.

## Screenshot

`docs/user-guides/settings.md` carries a note that its screenshot predates the new rows. The alt text is deliberately unchanged: it describes what the image shows, and claiming rows the image does not contain would be worse than an outdated picture. Worth refreshing on the next capture pass — possibly alongside #668.

## How to test

`gh workflow run spin-up.yml`, then open the Settings page. Expect the OS line to read `Ubuntu 26.04 LTS`, the disk to match the provisioned type, and — the assertion that would have caught the original defect — **Server Type to match what `select-capacity: chose …` logged in that same run.**

## Summary by Sourcery

Show accurate provisioned server details and best-effort host facts in the Control Plane Infrastructure panel.

New Features:
- Display the provisioned host's operating system, root disk size, and Docker version in the Infrastructure panel.

Bug Fixes:
- Report the server type and location actually selected during capacity provisioning instead of the originally requested values.
- Prevent failed or incomplete host fact collection from breaking deployments or overwriting previously collected values.

Enhancements:
- Preserve host facts across teardown and distinguish unavailable historical data from values that have not yet been collected.

Documentation:
- Document the new infrastructure fields, their collection behavior, and the distinction between requested and provisioned server details.