### PR TITLE
feat(ci): Check that services answer after a spin-up

### DIFF
--- a/.github/workflows/spin-up.yml
+++ b/.github/workflows/spin-up.yml
@@ -1078,13 +1078,23 @@ jobs:
           # `[::]:` and, where a compose file says so, on `127.0.0.1:`.
           # Matching one address form silently skipped the others.
           #
+          # curl's exit status is kept alongside the HTTP code, because the
+          # code alone cannot tell a dead port from a healthy non-HTTP one:
+          # both report 000. Measured: nothing listening exits 7, a listener
+          # that speaks something other than HTTP exits 1 or 52. Only 7 means
+          # nothing accepted the connection. This matters because the
+          # generated docker-compose.firewall.yml publishes the tcp_ports from
+          # services.yaml — Postgres 5432, Redpanda 9092, ClickHouse 9004,
+          # SFTP 2022 and more — so without this a dozen healthy databases
+          # would be reported as broken on every run.
+          #
           # The whole loop is inside `{ ...; wait; }` so that `wait` runs
           # in the same subshell that spawned the probes. A pipeline's
           # right-hand side is its own subshell; a `wait` placed after
           # `done` belongs to the parent and would not wait for anything,
           # leaving the probes orphaned and their output lost.
           # shellcheck disable=SC2016
-          REMOTE_PROBE: 'docker ps -a --format "{{.Names}}\t{{.State}}\t{{.Status}}\t{{.Ports}}" 2>/dev/null | { while IFS="$(printf "\t")" read -r n st stat pts; do case "$st" in running) ;; restarting) printf "%s\t-\tRESTARTING\n" "$n"; continue ;; exited) printf "%s\t-\tEXITED:%s\n" "$n" "$(printf "%s" "$stat" | grep -oE "\([0-9]+\)" | tr -cd "0-9")"; continue ;; *) printf "%s\t-\tSTATE:%s\n" "$n" "$st"; continue ;; esac; pt=$(printf "%s" "$pts" | grep -oE ":[0-9]+->" | head -1 | tr -cd "0-9"); if [ -z "$pt" ]; then printf "%s\t-\tNOPORT\n" "$n"; else ( c=$(curl -s -o /dev/null -w "%{http_code}" --max-time 4 "http://localhost:$pt/" 2>/dev/null); printf "%s\t%s\t%s\n" "$n" "$pt" "${c:-000}" ) & fi; done; wait; }'
+          REMOTE_PROBE: 'docker ps -a --format "{{.Names}}\t{{.State}}\t{{.Status}}\t{{.Ports}}" 2>/dev/null | { while IFS="$(printf "\t")" read -r n st stat pts; do case "$st" in running) ;; restarting) printf "%s\t-\tRESTARTING\n" "$n"; continue ;; exited) printf "%s\t-\tEXITED:%s\n" "$n" "$(printf "%s" "$stat" | grep -oE "\([0-9]+\)" | tr -cd "0-9")"; continue ;; *) printf "%s\t-\tSTATE:%s\n" "$n" "$st"; continue ;; esac; pt=$(printf "%s" "$pts" | grep -oE ":[0-9]+->" | head -1 | tr -cd "0-9"); if [ -z "$pt" ]; then printf "%s\t-\tNOPORT\n" "$n"; else ( c=$(curl -s -o /dev/null -w "%{http_code}" --max-time 4 "http://localhost:$pt/" 2>/dev/null); rc=$?; if [ "$rc" = "0" ]; then printf "%s\t%s\t%s\n" "$n" "$pt" "${c:-000}"; elif [ "$rc" = "7" ]; then printf "%s\t%s\tDEAD\n" "$n" "$pt"; else printf "%s\t%s\tNOHTTP:%s\n" "$n" "$pt" "$rc"; fi ) & fi; done; wait; }'
         run: |
           set -uo pipefail
 
@@ -1107,7 +1117,13 @@ jobs:
           fi
 
           if [ "$SSH_FAILED" -ne 0 ]; then
-            echo "::warning title=smoke-check::Could not reach the server over ssh, so no service check ran. $(head -c 300 /tmp/smoke-ssh.err 2>/dev/null || echo '(no stderr)')"
+            # ssh exits non-zero both when the connection fails and when the
+            # remote command does, and this step cannot tell which. Saying
+            # "could not reach the server" would be a guess. Newlines are
+            # folded out because a multi-line ::warning payload silently
+            # truncates at the first one.
+            SSH_ERR=$(tr '\n\r' '  ' < /tmp/smoke-ssh.err 2>/dev/null | head -c 300)
+            echo "::warning title=smoke-check::No service check ran: ssh exited non-zero, which means either the server was unreachable or the probe itself failed on it. stderr: ${SSH_ERR:-(empty)}"
             exit 0
           fi
 
@@ -1148,6 +1164,27 @@ jobs:
                 printf '  FAIL  %-26s %-7s restart loop\n' "$name" ""
                 echo "::warning title=smoke-check: $name::Container is in a restart loop — it starts, fails, and is restarted. Check its logs for the crash reason."
                 ;;
+              # A listener that answered something other than HTTP. Healthy
+              # by every measure this step can take: the port accepted the
+              # connection. Databases, brokers and SFTP land here.
+              NOHTTP:*)
+                quiet=$((quiet + 1))
+                printf '  --    %-26s :%-6s listening, not an HTTP service\n' "$name" "$port"
+                ;;
+              # Nothing accepted the connection (curl exit 7). The container
+              # runs but the process inside never started listening.
+              DEAD)
+                faulty=$((faulty + 1))
+                printf '  FAIL  %-26s :%-6s nothing listening\n' "$name" "$port"
+                echo "::warning title=smoke-check: $name::Container is running but nothing is listening on port $port. The deploy finished; this service did not come up."
+                ;;
+              # The service answered — it is up, and it is erroring. A
+              # different problem from silence, so a different message.
+              5??)
+                faulty=$((faulty + 1))
+                printf '  FAIL  %-26s :%-6s %s\n' "$name" "$port" "$code"
+                echo "::warning title=smoke-check: $name::Answered with HTTP $code on port $port, so the process is up but failing — usually a bad config or an unreachable dependency."
+                ;;
               # created / paused / dead. Never normal after a deploy, but
               # the state is all this step knows — it must not claim a
               # port was probed when none was.
@@ -1156,16 +1193,19 @@ jobs:
                 printf '  FAIL  %-26s %-7s %s\n' "$name" "" "$code"
                 echo "::warning title=smoke-check: $name::Container is in Docker state '${code#STATE:}', neither running nor cleanly exited. No port was probed."
                 ;;
+              # Everything above is accounted for, so this is a result the
+              # probe did not anticipate. Report it as unclassified rather
+              # than assert a cause.
               *)
                 faulty=$((faulty + 1))
                 printf '  FAIL  %-26s :%-6s %s\n' "$name" "$port" "$code"
-                echo "::warning title=smoke-check: $name::Container is running but nothing answered on port $port (curl reported $code). The deploy finished; this service did not come up."
+                echo "::warning title=smoke-check: $name::Unclassified probe result '$code' on port $port. This is a gap in the check rather than a diagnosis — please report it."
                 ;;
             esac
           done <<< "$REPORT"
 
           echo ""
-          echo "[smoke] $healthy answering, $faulty faulty, $quiet with nothing to probe"
+          echo "[smoke] $healthy answering HTTP, $faulty faulty, $quiet with no HTTP endpoint to check"
 
       - name: Show spin-up info
         run: |

--- a/.github/workflows/spin-up.yml
+++ b/.github/workflows/spin-up.yml
@@ -1091,11 +1091,20 @@ jobs:
           # the captured stderr, which is the difference between reporting
           # "docker failed" and inventing "no containers".
           #
-          # curl's exit status is kept alongside the HTTP code, because the
-          # code alone cannot tell a dead port from a healthy non-HTTP one:
-          # both report 000. Measured: nothing listening exits 7, a listener
-          # that speaks something other than HTTP exits 1 or 52. Only 7 means
-          # nothing accepted the connection. This matters because the
+          # The HTTP code alone cannot tell a dead port from a healthy
+          # non-HTTP one: both report 000. The decisive signal is
+          # %{time_connect}, which is exactly zero when no TCP handshake
+          # completed — stripping "." and "0" from it leaves an empty string
+          # in precisely that case. Measured:
+          #
+          #   nothing listening       rc=7   time_connect=0.000000
+          #   listening, non-HTTP     rc=1   time_connect=0.000535
+          #   listening, then silent  rc=52  time_connect=0.000542
+          #   unroutable, hangs       rc=28  time_connect=0.000000
+          #
+          # The exit code alone would misfile the last row, because 28 occurs
+          # both when the handshake never completed and when a connected peer
+          # goes quiet. This matters because the
           # generated docker-compose.firewall.yml publishes the tcp_ports from
           # services.yaml — Postgres 5432, Redpanda 9092, ClickHouse 9004,
           # SFTP 2022 and more — so without this a dozen healthy databases
@@ -1107,7 +1116,7 @@ jobs:
           # `done` belongs to the parent and would not wait for anything,
           # leaving the probes orphaned and their output lost.
           # shellcheck disable=SC2016
-          REMOTE_PROBE: 'docker ps -a --format "{{.Names}}\t{{.State}}\t{{.Status}}\t{{.Ports}}" | { while IFS="$(printf "\t")" read -r n st stat pts; do case "$st" in running) ;; restarting) printf "%s\t-\tRESTARTING\n" "$n"; continue ;; exited) printf "%s\t-\tEXITED:%s\n" "$n" "$(printf "%s" "$stat" | grep -oE "\([0-9]+\)" | tr -cd "0-9")"; continue ;; *) printf "%s\t-\tSTATE:%s\n" "$n" "$st"; continue ;; esac; plist=$(printf "%s" "$pts" | grep -oE ":[0-9]+->" | sed "s/[^0-9]//g" | sort -un); if [ -z "$plist" ]; then printf "%s\t-\tNOPORT\n" "$n"; else for pt in $plist; do ( c=$(curl -s -o /dev/null -w "%{http_code}" --max-time 4 "http://localhost:$pt/" 2>/dev/null); rc=$?; if [ "$rc" = "0" ]; then printf "%s\t%s\t%s\n" "$n" "$pt" "${c:-000}"; elif [ "$rc" = "7" ]; then printf "%s\t%s\tDEAD\n" "$n" "$pt"; else printf "%s\t%s\tNOHTTP:%s\n" "$n" "$pt" "$rc"; fi ) & done; fi; done; wait; }'
+          REMOTE_PROBE: 'docker ps -a --format "{{.Names}}\t{{.State}}\t{{.Status}}\t{{.Ports}}" | { while IFS="$(printf "\t")" read -r n st stat pts; do case "$st" in running) ;; restarting) printf "%s\t-\tRESTARTING\n" "$n"; continue ;; exited) printf "%s\t-\tEXITED:%s\n" "$n" "$(printf "%s" "$stat" | grep -oE "\([0-9]+\)" | tr -cd "0-9")"; continue ;; *) printf "%s\t-\tSTATE:%s\n" "$n" "$st"; continue ;; esac; plist=$(printf "%s" "$pts" | grep -oE ":[0-9]+->" | sed "s/[^0-9]//g" | sort -un); if [ -z "$plist" ]; then printf "%s\t-\tNOPORT\n" "$n"; else for pt in $plist; do ( o=$(curl -s -o /dev/null -w "%{http_code} %{time_connect}" --max-time 4 "http://localhost:$pt/" 2>/dev/null); rc=$?; c=${o%% *}; tc=$(printf "%s" "${o##* }" | tr -d ".0"); if [ "$rc" = "0" ]; then printf "%s\t%s\t%s\n" "$n" "$pt" "${c:-000}"; elif [ -z "$tc" ]; then printf "%s\t%s\tDEAD\n" "$n" "$pt"; elif [ "$rc" = "28" ]; then printf "%s\t%s\tHUNG\n" "$n" "$pt"; else printf "%s\t%s\tNOHTTP:%s\n" "$n" "$pt" "$rc"; fi ) & done; fi; done; wait; }'
         run: |
           set -uo pipefail
 
@@ -1187,6 +1196,15 @@ jobs:
               NOHTTP:*)
                 quiet=$((quiet + 1))
                 printf '  --    %-26s :%-6s listening, not an HTTP service\n' "$name" "$port"
+                ;;
+              # Connected, then nothing for the whole timeout. Every non-HTTP
+              # service on this box answers or closes immediately, so a peer
+              # that accepts and goes quiet is anomalous rather than exotic.
+              # Reported as what was observed, without naming a cause.
+              HUNG)
+                faulty=$((faulty + 1))
+                printf '  FAIL  %-26s :%-6s accepted, then silent\n' "$name" "$port"
+                echo "::warning title=smoke-check: $name::Port $port accepted the connection and then sent nothing for 4s. Something is listening but not responding."
                 ;;
               # Nothing accepted the connection (curl exit 7). The container
               # runs but the process inside never started listening.

--- a/.github/workflows/spin-up.yml
+++ b/.github/workflows/spin-up.yml
@@ -1078,6 +1078,19 @@ jobs:
           # `[::]:` and, where a compose file says so, on `127.0.0.1:`.
           # Matching one address form silently skipped the others.
           #
+          # Every published host port is probed, not just the first. Three
+          # stacks publish several — garage, risingwave, seaweedfs — and
+          # RisingWave shows why it matters: its first port is the Postgres
+          # wire protocol and its dashboard is on the second, so stopping at
+          # the first would have left the dashboard permanently unchecked.
+          # Ports are deduplicated because Docker lists the same one twice
+          # when it binds both 0.0.0.0 and [::].
+          #
+          # docker's stderr is deliberately NOT suppressed: if the daemon is
+          # down, that message travels back over the ssh channel and lands in
+          # the captured stderr, which is the difference between reporting
+          # "docker failed" and inventing "no containers".
+          #
           # curl's exit status is kept alongside the HTTP code, because the
           # code alone cannot tell a dead port from a healthy non-HTTP one:
           # both report 000. Measured: nothing listening exits 7, a listener
@@ -1094,7 +1107,7 @@ jobs:
           # `done` belongs to the parent and would not wait for anything,
           # leaving the probes orphaned and their output lost.
           # shellcheck disable=SC2016
-          REMOTE_PROBE: 'docker ps -a --format "{{.Names}}\t{{.State}}\t{{.Status}}\t{{.Ports}}" 2>/dev/null | { while IFS="$(printf "\t")" read -r n st stat pts; do case "$st" in running) ;; restarting) printf "%s\t-\tRESTARTING\n" "$n"; continue ;; exited) printf "%s\t-\tEXITED:%s\n" "$n" "$(printf "%s" "$stat" | grep -oE "\([0-9]+\)" | tr -cd "0-9")"; continue ;; *) printf "%s\t-\tSTATE:%s\n" "$n" "$st"; continue ;; esac; pt=$(printf "%s" "$pts" | grep -oE ":[0-9]+->" | head -1 | tr -cd "0-9"); if [ -z "$pt" ]; then printf "%s\t-\tNOPORT\n" "$n"; else ( c=$(curl -s -o /dev/null -w "%{http_code}" --max-time 4 "http://localhost:$pt/" 2>/dev/null); rc=$?; if [ "$rc" = "0" ]; then printf "%s\t%s\t%s\n" "$n" "$pt" "${c:-000}"; elif [ "$rc" = "7" ]; then printf "%s\t%s\tDEAD\n" "$n" "$pt"; else printf "%s\t%s\tNOHTTP:%s\n" "$n" "$pt" "$rc"; fi ) & fi; done; wait; }'
+          REMOTE_PROBE: 'docker ps -a --format "{{.Names}}\t{{.State}}\t{{.Status}}\t{{.Ports}}" | { while IFS="$(printf "\t")" read -r n st stat pts; do case "$st" in running) ;; restarting) printf "%s\t-\tRESTARTING\n" "$n"; continue ;; exited) printf "%s\t-\tEXITED:%s\n" "$n" "$(printf "%s" "$stat" | grep -oE "\([0-9]+\)" | tr -cd "0-9")"; continue ;; *) printf "%s\t-\tSTATE:%s\n" "$n" "$st"; continue ;; esac; plist=$(printf "%s" "$pts" | grep -oE ":[0-9]+->" | sed "s/[^0-9]//g" | sort -un); if [ -z "$plist" ]; then printf "%s\t-\tNOPORT\n" "$n"; else for pt in $plist; do ( c=$(curl -s -o /dev/null -w "%{http_code}" --max-time 4 "http://localhost:$pt/" 2>/dev/null); rc=$?; if [ "$rc" = "0" ]; then printf "%s\t%s\t%s\n" "$n" "$pt" "${c:-000}"; elif [ "$rc" = "7" ]; then printf "%s\t%s\tDEAD\n" "$n" "$pt"; else printf "%s\t%s\tNOHTTP:%s\n" "$n" "$pt" "$rc"; fi ) & done; fi; done; wait; }'
         run: |
           set -uo pipefail
 
@@ -1128,7 +1141,11 @@ jobs:
           fi
 
           if [ -z "$REPORT" ]; then
-            echo "::warning title=smoke-check::The server was reachable but Docker listed no containers at all."
+            # ssh succeeded but nothing came back. `docker ps` keeps its
+            # stderr now, so if the daemon is down its message is in the
+            # captured file — quote it rather than assert an empty list.
+            EMPTY_ERR=$(tr '\n\r' '  ' < /tmp/smoke-ssh.err 2>/dev/null | head -c 300)
+            echo "::warning title=smoke-check::The server was reachable but the probe returned nothing. Docker reported: ${EMPTY_ERR:-(nothing on stderr, so it genuinely listed no containers)}"
             exit 0
           fi
 

--- a/.github/workflows/spin-up.yml
+++ b/.github/workflows/spin-up.yml
@@ -9,7 +9,7 @@ on:
         default: ''
         type: string
       smoke_check:
-        description: 'Check that every enabled service answers on its port after the deploy (adds ~10s)'
+        description: 'Check every container after the deploy: answering on its port, exited, or restart-looping (adds ~10s)'
         required: false
         default: true
         type: boolean
@@ -79,7 +79,7 @@ on:
         required: false
         type: string
       smoke_check:
-        description: 'Check that every enabled service answers on its port after the deploy'
+        description: 'Check every container after the deploy: answering on its port, exited, or restart-looping'
         required: false
         default: true
         type: boolean
@@ -1068,52 +1068,104 @@ jobs:
         env:
           # Single-quoted on the way in so THIS shell does not touch it —
           # every expansion below belongs to the shell on the server.
+          #
+          # `docker ps -a`, not `docker ps`: a container that crashed on
+          # boot is no longer running, so listing only running containers
+          # would hide the exact condition this step exists to catch.
+          #
+          # The port is taken from any `<addr>:<port>-><cport>` binding
+          # rather than `0.0.0.0:` alone — Docker also publishes on
+          # `[::]:` and, where a compose file says so, on `127.0.0.1:`.
+          # Matching one address form silently skipped the others.
+          #
+          # The whole loop is inside `{ ...; wait; }` so that `wait` runs
+          # in the same subshell that spawned the probes. A pipeline's
+          # right-hand side is its own subshell; a `wait` placed after
+          # `done` belongs to the parent and would not wait for anything,
+          # leaving the probes orphaned and their output lost.
           # shellcheck disable=SC2016
-          REMOTE_PROBE: 'docker ps --format "{{.Names}}\t{{.Ports}}" 2>/dev/null | while IFS="$(printf "\t")" read -r n pts; do pt=$(printf "%s" "$pts" | grep -oE "0\.0\.0\.0:[0-9]+" | head -1 | cut -d: -f2); if [ -z "$pt" ]; then printf "%s\tNOPORT\tNOPORT\n" "$n"; else ( c=$(curl -s -o /dev/null -w "%{http_code}" --max-time 4 "http://localhost:$pt/" 2>/dev/null); printf "%s\t%s\t%s\n" "$n" "$pt" "${c:-000}" ) & fi; done; wait'
+          REMOTE_PROBE: 'docker ps -a --format "{{.Names}}\t{{.State}}\t{{.Status}}\t{{.Ports}}" 2>/dev/null | { while IFS="$(printf "\t")" read -r n st stat pts; do case "$st" in running) ;; restarting) printf "%s\t-\tRESTARTING\n" "$n"; continue ;; exited) printf "%s\t-\tEXITED:%s\n" "$n" "$(printf "%s" "$stat" | grep -oE "\([0-9]+\)" | tr -cd "0-9")"; continue ;; *) printf "%s\t-\tSTATE:%s\n" "$n" "$st"; continue ;; esac; pt=$(printf "%s" "$pts" | grep -oE ":[0-9]+->" | head -1 | tr -cd "0-9"); if [ -z "$pt" ]; then printf "%s\t-\tNOPORT\n" "$n"; else ( c=$(curl -s -o /dev/null -w "%{http_code}" --max-time 4 "http://localhost:$pt/" 2>/dev/null); printf "%s\t%s\t%s\n" "$n" "$pt" "${c:-000}" ) & fi; done; wait; }'
         run: |
           set -uo pipefail
 
-          # `docker ps` rather than services.yaml: it reports the port
-          # actually bound, which is the thing being verified. The YAML
-          # says what should have been bound, and a disagreement between
-          # the two is exactly the defect worth catching.
+          # Container state comes from Docker rather than services.yaml:
+          # the YAML says what should have been bound, Docker reports what
+          # was. A disagreement between the two is exactly the defect
+          # worth catching, and consulting the YAML would hide it.
           #
           # Probes run ON the server and in parallel, so wall-clock is the
           # slowest single probe rather than their sum. That matters when
           # things are broken: twenty dead services sequentially at
           # --max-time 4 would cost 80s; in parallel it stays at 4.
-          REPORT=$(ssh -o BatchMode=yes -o ConnectTimeout=15 nexus "$REMOTE_PROBE" 2>/dev/null || true)
+          #
+          # Status and output are kept apart: an empty report has three
+          # possible causes and the annotation must not guess which.
+          SSH_FAILED=0
+          REPORT=""
+          if ! REPORT=$(ssh -o BatchMode=yes -o ConnectTimeout=15 nexus "$REMOTE_PROBE" 2>/tmp/smoke-ssh.err); then
+            SSH_FAILED=1
+          fi
 
-          if [ -z "$REPORT" ]; then
-            echo "::warning title=smoke-check::Could not reach the server over ssh — no service check ran"
+          if [ "$SSH_FAILED" -ne 0 ]; then
+            echo "::warning title=smoke-check::Could not reach the server over ssh, so no service check ran. $(head -c 300 /tmp/smoke-ssh.err 2>/dev/null || echo '(no stderr)')"
             exit 0
           fi
 
-          healthy=0; unreachable=0; noport=0
+          if [ -z "$REPORT" ]; then
+            echo "::warning title=smoke-check::The server was reachable but Docker listed no containers at all."
+            exit 0
+          fi
+
+          healthy=0; faulty=0; quiet=0
           while IFS="$(printf '\t')" read -r name port code; do
             [ -n "$name" ] || continue
             case "$code" in
               # Any HTTP status means the application answered. A 401 or
               # 403 is a service that is up and wants a login — success,
-              # not a failure. Only "no connection" and 5xx are faults.
+              # not a failure. Only refused connections and 5xx are faults.
               2??|3??|4??)
                 healthy=$((healthy + 1))
                 printf '  ok    %-26s :%-6s %s\n' "$name" "$port" "$code"
                 ;;
               NOPORT)
-                noport=$((noport + 1))
+                quiet=$((quiet + 1))
                 printf '  --    %-26s %-7s no published port (internal-only)\n' "$name" ""
                 ;;
+              # A one-shot container that finished cleanly. The stacks do
+              # contain these (lakekeeper-bootstrap, openmetadata-migrate),
+              # so a zero exit is the job being done, not a failure.
+              EXITED:0)
+                quiet=$((quiet + 1))
+                printf '  --    %-26s %-7s ran once and exited cleanly\n' "$name" ""
+                ;;
+              EXITED:*)
+                faulty=$((faulty + 1))
+                printf '  FAIL  %-26s %-7s %s\n' "$name" "" "$code"
+                echo "::warning title=smoke-check: $name::Container exited with a non-zero status (${code#EXITED:}). The deploy finished; this service is not running."
+                ;;
+              RESTARTING)
+                faulty=$((faulty + 1))
+                printf '  FAIL  %-26s %-7s restart loop\n' "$name" ""
+                echo "::warning title=smoke-check: $name::Container is in a restart loop — it starts, fails, and is restarted. Check its logs for the crash reason."
+                ;;
+              # created / paused / dead. Never normal after a deploy, but
+              # the state is all this step knows — it must not claim a
+              # port was probed when none was.
+              STATE:*)
+                faulty=$((faulty + 1))
+                printf '  FAIL  %-26s %-7s %s\n' "$name" "" "$code"
+                echo "::warning title=smoke-check: $name::Container is in Docker state '${code#STATE:}', neither running nor cleanly exited. No port was probed."
+                ;;
               *)
-                unreachable=$((unreachable + 1))
+                faulty=$((faulty + 1))
                 printf '  FAIL  %-26s :%-6s %s\n' "$name" "$port" "$code"
-                echo "::warning title=smoke-check: $name::Container is running but nothing answered on port $port (curl reported $code). The deploy succeeded; this service did not come up."
+                echo "::warning title=smoke-check: $name::Container is running but nothing answered on port $port (curl reported $code). The deploy finished; this service did not come up."
                 ;;
             esac
           done <<< "$REPORT"
 
           echo ""
-          echo "[smoke] $healthy answering, $unreachable not answering, $noport without a published port"
+          echo "[smoke] $healthy answering, $faulty faulty, $quiet with nothing to probe"
 
       - name: Show spin-up info
         run: |

--- a/.github/workflows/spin-up.yml
+++ b/.github/workflows/spin-up.yml
@@ -8,6 +8,11 @@ on:
         required: false
         default: ''
         type: string
+      smoke_check:
+        description: 'Check that every enabled service answers on its port after the deploy (adds ~10s)'
+        required: false
+        default: true
+        type: boolean
       silent_mode:
         description: 'Suppress all automated emails for this run (persists in D1 until reset via toggle-silent-mode workflow)'
         required: false
@@ -73,6 +78,11 @@ on:
         description: 'SSH Private Key (from setup-control-plane, for initial setup)'
         required: false
         type: string
+      smoke_check:
+        description: 'Check that every enabled service answers on its port after the deploy'
+        required: false
+        default: true
+        type: boolean
       server_image:
         description: 'Hetzner image to build from. Empty = ubuntu-26.04. A numeric image id restores from that snapshot.'
         required: false
@@ -1045,6 +1055,65 @@ jobs:
             echo "--- Docker Start Log ---"
             cat /tmp/docker-start.log || true
           fi
+
+      # Runs after the deploy, so a failure here means "the deploy
+      # finished and something is not answering" — never "the deploy
+      # failed". It therefore does not fail the job: the server is up,
+      # and one silent side service should not look like a broken
+      # spin-up. Failures surface as annotations instead, the same way
+      # degraded phases have since #688.
+      - name: Check services answer
+        if: inputs.smoke_check
+        continue-on-error: true
+        env:
+          # Single-quoted on the way in so THIS shell does not touch it —
+          # every expansion below belongs to the shell on the server.
+          # shellcheck disable=SC2016
+          REMOTE_PROBE: 'docker ps --format "{{.Names}}\t{{.Ports}}" 2>/dev/null | while IFS="$(printf "\t")" read -r n pts; do pt=$(printf "%s" "$pts" | grep -oE "0\.0\.0\.0:[0-9]+" | head -1 | cut -d: -f2); if [ -z "$pt" ]; then printf "%s\tNOPORT\tNOPORT\n" "$n"; else ( c=$(curl -s -o /dev/null -w "%{http_code}" --max-time 4 "http://localhost:$pt/" 2>/dev/null); printf "%s\t%s\t%s\n" "$n" "$pt" "${c:-000}" ) & fi; done; wait'
+        run: |
+          set -uo pipefail
+
+          # `docker ps` rather than services.yaml: it reports the port
+          # actually bound, which is the thing being verified. The YAML
+          # says what should have been bound, and a disagreement between
+          # the two is exactly the defect worth catching.
+          #
+          # Probes run ON the server and in parallel, so wall-clock is the
+          # slowest single probe rather than their sum. That matters when
+          # things are broken: twenty dead services sequentially at
+          # --max-time 4 would cost 80s; in parallel it stays at 4.
+          REPORT=$(ssh -o BatchMode=yes -o ConnectTimeout=15 nexus "$REMOTE_PROBE" 2>/dev/null || true)
+
+          if [ -z "$REPORT" ]; then
+            echo "::warning title=smoke-check::Could not reach the server over ssh — no service check ran"
+            exit 0
+          fi
+
+          healthy=0; unreachable=0; noport=0
+          while IFS="$(printf '\t')" read -r name port code; do
+            [ -n "$name" ] || continue
+            case "$code" in
+              # Any HTTP status means the application answered. A 401 or
+              # 403 is a service that is up and wants a login — success,
+              # not a failure. Only "no connection" and 5xx are faults.
+              2??|3??|4??)
+                healthy=$((healthy + 1))
+                printf '  ok    %-26s :%-6s %s\n' "$name" "$port" "$code"
+                ;;
+              NOPORT)
+                noport=$((noport + 1))
+                printf '  --    %-26s %-7s no published port (internal-only)\n' "$name" ""
+                ;;
+              *)
+                unreachable=$((unreachable + 1))
+                printf '  FAIL  %-26s :%-6s %s\n' "$name" "$port" "$code"
+                echo "::warning title=smoke-check: $name::Container is running but nothing answered on port $port (curl reported $code). The deploy succeeded; this service did not come up."
+                ;;
+            esac
+          done <<< "$REPORT"
+
+          echo ""
+          echo "[smoke] $healthy answering, $unreachable not answering, $noport without a published port"
 
       - name: Show spin-up info
         run: |

--- a/docs/admin-guides/debugging.md
+++ b/docs/admin-guides/debugging.md
@@ -38,8 +38,9 @@ first, since a stack like RisingWave puts its Postgres wire protocol on one
 port and its dashboard on another. It does not assume any of them speaks
 HTTP, though: a port nothing is listening on and a healthy database that
 simply is not a web server look identical in an HTTP status code. So the
-check reads curl's exit status too, and only a failure to connect at all
-counts as a fault.
+check measures whether the TCP connection was established at all, which
+keeps a non-HTTP listener out of the fault column. What does count as a
+fault is listed in the table below.
 
 ```
   ok    forgejo                    :3202   200
@@ -68,6 +69,8 @@ How to read it:
 | `FAIL` with `5xx` | The service answered, so it is up and erroring — usually a bad config or an unreachable dependency. A different problem from silence. |
 | `FAIL` with `EXITED:<n>` | The container stopped with a non-zero status. It crashed rather than started. |
 | `FAIL` with `restart loop` | The container starts, fails, and Docker restarts it, over and over. Its logs hold the crash reason. |
+| `FAIL` with `STATE:<x>` | The container is in a Docker state that is neither running nor cleanly exited — `created`, `paused` or `dead`. No port was probed. |
+| `FAIL` with anything else | A result the check did not anticipate. That is a gap in the check rather than a diagnosis of the service; worth reporting as a bug. |
 
 A `FAIL` never fails the workflow. The step runs *after* the deploy, so it
 reports "the deploy finished and this one service is silent" — the server

--- a/docs/admin-guides/debugging.md
+++ b/docs/admin-guides/debugging.md
@@ -29,17 +29,20 @@ If Wetty is enabled, access it via browser at `https://wetty.yourdomain.com`. Th
 ## Start Here: The Spin-Up Smoke Check
 
 Before debugging by hand, read the **Check services answer** step at the end
-of the last Spin Up run. It probes every running container on its published
-port and tells you which service is the problem — often before you notice
+of the last Spin Up run. It looks at every container on the server — running
+or not — and tells you which one is the problem, often before you notice
 anything is wrong.
 
 ```
   ok    forgejo                    :3202   200
   ok    portainer                  :9090   401
   --    kestra-postgres                    no published port (internal-only)
+  --    lakekeeper-bootstrap               ran once and exited cleanly
   FAIL  metabase                   :3000   000
+  FAIL  openmetadata                       EXITED:1
+  FAIL  woodpecker-agent                   restart loop
 
-[smoke] 42 answering, 1 not answering, 12 without a published port
+[smoke] 42 answering, 3 faulty, 13 with nothing to probe
 ```
 
 How to read it:
@@ -48,15 +51,18 @@ How to read it:
 |---|---|
 | `ok` with any 2xx/3xx/4xx | The application answered. `401` / `403` is a healthy service asking for a login, not a fault. |
 | `--` / `no published port` | Internal-only container (databases, sidecars). Nothing to probe — not an error. |
-| `FAIL` with `000` | Nothing accepted the connection. The container is running but the process inside never started listening. |
+| `--` / `ran once and exited cleanly` | A one-shot job that finished, such as `lakekeeper-bootstrap` or `openmetadata-migrate`. Expected. |
+| `FAIL` with `000` | Nothing accepted the connection. The container runs but the process inside never started listening. |
 | `FAIL` with `5xx` | The process listens but is erroring — usually a bad config or an unreachable dependency. |
+| `FAIL` with `EXITED:<n>` | The container stopped with a non-zero status. It crashed rather than started. |
+| `FAIL` with `restart loop` | The container starts, fails, and Docker restarts it, over and over. Its logs hold the crash reason. |
 
 A `FAIL` never fails the workflow. The step runs *after* the deploy, so it
 reports "the deploy finished and this one service is silent" — the server
 itself is up. Failures appear as run annotations at the top of the run
 summary, so you see them without opening the log.
 
-Each `FAIL` names the container and port, which is exactly what
+Each `FAIL` names the container, which is exactly what
 [Step 2](#step-2-check-container-logs) needs:
 
 ```bash
@@ -64,11 +70,11 @@ ssh nexus "docker logs metabase --tail 100"
 ```
 
 **Skipping it:** the check is on by default. When dispatching Spin Up, clear
-the *"Check that every enabled service answers on its port after the deploy"*
-checkbox if you are iterating on something unrelated and want the shortest
-cycle. It costs about ten seconds, and that stays true when things are
-broken: the probes run on the server in parallel, so twenty dead services
-cost one 4-second timeout, not twenty.
+the *"Check every container after the deploy"* checkbox if you are iterating
+on something unrelated and want the shortest cycle. It costs about ten
+seconds, and that stays true when things are broken: the probes run on the
+server in parallel, so twenty dead services cost one 4-second timeout, not
+twenty.
 
 ---
 

--- a/docs/admin-guides/debugging.md
+++ b/docs/admin-guides/debugging.md
@@ -33,10 +33,13 @@ of the last Spin Up run. It looks at every container on the server — running
 or not — and tells you which one is the problem, often before you notice
 anything is wrong.
 
-It probes each published port with HTTP but does not assume every port speaks
-it. A refused connection and a healthy database that simply is not a web
-server both look identical in an HTTP status code, so the check reads curl's
-exit status as well: only "connection refused" counts as a fault.
+It probes every published host port with HTTP — all of them, not just the
+first, since a stack like RisingWave puts its Postgres wire protocol on one
+port and its dashboard on another. It does not assume any of them speaks
+HTTP, though: a port nothing is listening on and a healthy database that
+simply is not a web server look identical in an HTTP status code. So the
+check reads curl's exit status too, and only a failure to connect at all
+counts as a fault.
 
 ```
   ok    forgejo                    :3202   200

--- a/docs/admin-guides/debugging.md
+++ b/docs/admin-guides/debugging.md
@@ -63,7 +63,8 @@ How to read it:
 | `--` / `no published port` | Internal-only container (databases, sidecars). Nothing to probe — not an error. |
 | `--` / `ran once and exited cleanly` | A one-shot job that finished, such as `lakekeeper-bootstrap` or `openmetadata-migrate`. Expected. |
 | `--` / `listening, not an HTTP service` | The port accepted the connection but answered something other than HTTP. Databases, brokers and SFTP land here — Postgres on 5432, Redpanda on 9092, ClickHouse on 9004. Healthy by every measure this check can take. |
-| `FAIL` / `nothing listening` | Nothing accepted the connection at all. The container runs but the process inside never started listening. |
+| `FAIL` / `nothing listening` | No TCP connection was established at all. The container runs but the process inside never started listening. |
+| `FAIL` / `accepted, then silent` | The port accepted the connection and then sent nothing for four seconds. Something is listening but not responding — distinct from a database that simply is not a web server, which answers or closes immediately. |
 | `FAIL` with `5xx` | The service answered, so it is up and erroring — usually a bad config or an unreachable dependency. A different problem from silence. |
 | `FAIL` with `EXITED:<n>` | The container stopped with a non-zero status. It crashed rather than started. |
 | `FAIL` with `restart loop` | The container starts, fails, and Docker restarts it, over and over. Its logs hold the crash reason. |

--- a/docs/admin-guides/debugging.md
+++ b/docs/admin-guides/debugging.md
@@ -33,16 +33,23 @@ of the last Spin Up run. It looks at every container on the server — running
 or not — and tells you which one is the problem, often before you notice
 anything is wrong.
 
+It probes each published port with HTTP but does not assume every port speaks
+it. A refused connection and a healthy database that simply is not a web
+server both look identical in an HTTP status code, so the check reads curl's
+exit status as well: only "connection refused" counts as a fault.
+
 ```
   ok    forgejo                    :3202   200
   ok    portainer                  :9090   401
+  --    postgres                   :5432   listening, not an HTTP service
   --    kestra-postgres                    no published port (internal-only)
   --    lakekeeper-bootstrap               ran once and exited cleanly
-  FAIL  metabase                   :3000   000
+  FAIL  metabase                   :3000   nothing listening
+  FAIL  superset                   :8088   503
   FAIL  openmetadata                       EXITED:1
   FAIL  woodpecker-agent                   restart loop
 
-[smoke] 42 answering, 3 faulty, 13 with nothing to probe
+[smoke] 42 answering HTTP, 4 faulty, 13 with no HTTP endpoint to check
 ```
 
 How to read it:
@@ -52,8 +59,9 @@ How to read it:
 | `ok` with any 2xx/3xx/4xx | The application answered. `401` / `403` is a healthy service asking for a login, not a fault. |
 | `--` / `no published port` | Internal-only container (databases, sidecars). Nothing to probe — not an error. |
 | `--` / `ran once and exited cleanly` | A one-shot job that finished, such as `lakekeeper-bootstrap` or `openmetadata-migrate`. Expected. |
-| `FAIL` with `000` | Nothing accepted the connection. The container runs but the process inside never started listening. |
-| `FAIL` with `5xx` | The process listens but is erroring — usually a bad config or an unreachable dependency. |
+| `--` / `listening, not an HTTP service` | The port accepted the connection but answered something other than HTTP. Databases, brokers and SFTP land here — Postgres on 5432, Redpanda on 9092, ClickHouse on 9004. Healthy by every measure this check can take. |
+| `FAIL` / `nothing listening` | Nothing accepted the connection at all. The container runs but the process inside never started listening. |
+| `FAIL` with `5xx` | The service answered, so it is up and erroring — usually a bad config or an unreachable dependency. A different problem from silence. |
 | `FAIL` with `EXITED:<n>` | The container stopped with a non-zero status. It crashed rather than started. |
 | `FAIL` with `restart loop` | The container starts, fails, and Docker restarts it, over and over. Its logs hold the crash reason. |
 

--- a/docs/admin-guides/debugging.md
+++ b/docs/admin-guides/debugging.md
@@ -26,6 +26,52 @@ If Wetty is enabled, access it via browser at `https://wetty.yourdomain.com`. Th
 
 ---
 
+## Start Here: The Spin-Up Smoke Check
+
+Before debugging by hand, read the **Check services answer** step at the end
+of the last Spin Up run. It probes every running container on its published
+port and tells you which service is the problem — often before you notice
+anything is wrong.
+
+```
+  ok    forgejo                    :3202   200
+  ok    portainer                  :9090   401
+  --    kestra-postgres                    no published port (internal-only)
+  FAIL  metabase                   :3000   000
+
+[smoke] 42 answering, 1 not answering, 12 without a published port
+```
+
+How to read it:
+
+| Line | Meaning |
+|---|---|
+| `ok` with any 2xx/3xx/4xx | The application answered. `401` / `403` is a healthy service asking for a login, not a fault. |
+| `--` / `no published port` | Internal-only container (databases, sidecars). Nothing to probe — not an error. |
+| `FAIL` with `000` | Nothing accepted the connection. The container is running but the process inside never started listening. |
+| `FAIL` with `5xx` | The process listens but is erroring — usually a bad config or an unreachable dependency. |
+
+A `FAIL` never fails the workflow. The step runs *after* the deploy, so it
+reports "the deploy finished and this one service is silent" — the server
+itself is up. Failures appear as run annotations at the top of the run
+summary, so you see them without opening the log.
+
+Each `FAIL` names the container and port, which is exactly what
+[Step 2](#step-2-check-container-logs) needs:
+
+```bash
+ssh nexus "docker logs metabase --tail 100"
+```
+
+**Skipping it:** the check is on by default. When dispatching Spin Up, clear
+the *"Check that every enabled service answers on its port after the deploy"*
+checkbox if you are iterating on something unrelated and want the shortest
+cycle. It costs about ten seconds, and that stays true when things are
+broken: the probes run on the server in parallel, so twenty dead services
+cost one 4-second timeout, not twenty.
+
+---
+
 ## Systematic Debugging Process
 
 When a service is not working, follow this systematic approach:


### PR DESCRIPTION
## What this fixes

A spin-up reports success once every container has started. "Started" is not "working" — a container whose process crashes on boot, or never binds its port, still counts as started. The `compose-up` phase says *"started and running"* because that is genuinely all it knows.

The result is that a broken service is discovered by a person opening the URL, possibly days later. Nothing in the pipeline looks at whether the thing that was deployed actually answers.

## What it does

A step after the deploy reads the ports Docker actually published, curls each one on the server, and classifies what came back:

```
  ok    forgejo                    :3202   200
  ok    portainer                  :9090   401
  --    kestra-postgres                    no published port (internal-only)
  FAIL  metabase                   :3000   000

[smoke] 42 answering, 1 not answering, 12 without a published port
```

| Result | Treated as |
|---|---|
| any 2xx / 3xx / 4xx | The application answered. `401` / `403` is a healthy service asking for a login, not a fault. |
| no published port | Internal-only container (databases, sidecars). Nothing to probe. |
| `000` | Nothing accepted the connection — the process never started listening. |
| 5xx | Listening but erroring, usually a bad config or an unreachable dependency. |

## Three deliberate properties

**It cannot fail the deploy.** The step runs after everything is deployed, so a fault here means "the deploy finished and one service is silent" — the server itself is up. One quiet side service should not make a working spin-up look broken. Faults surface as run annotations instead, the same mechanism degraded phases have used since #688.

**Its cost does not grow with the number of faults.** The probes run on the server and in parallel, so wall-clock is the slowest single probe rather than their sum. Twenty dead services cost one 4-second timeout, not eighty seconds. The failure case is exactly when you least want to wait.

**It reads `docker ps`, not `services.yaml`.** The YAML says which port *should* have been bound; Docker reports which one *was*. A disagreement between the two is precisely the defect worth catching, and consulting the YAML would hide it.

## Opt-out

On by default. The dispatch form carries a checkbox — clear it when iterating on something unrelated and you want the shortest cycle. `initial-setup.yaml` does not pass the input, so the `workflow_call` default (`true`) applies there; no change was needed in that workflow.

## Verification

- Classification logic exercised with stubbed `docker` and `curl` across all six cases (`200`, `302`, `401`, no-published-port, `000`, `502`) — each landed in the intended bucket, and only the two faults emitted a `::warning`.
- `ssh nexus` from the workflow shell confirmed working from a real run rather than assumed: run `32937842432` logs `Infisical token: found`, which is produced by an existing `ssh nexus` call. The alias is written by the pipeline; this step runs later in the same job.
- YAML parses; `actionlint` reports only the two pre-existing SC2086 findings at line 471, none in the new step.

## What this does not cover

This is reachability on the host only. It says nothing about whether a service is reachable through the Cloudflare Tunnel and Access, or whether it still has its data after a snapshot cycle. Those are separate layers and are not built here.

## Merge ordering

#701 also modifies `.github/workflows/spin-up.yml`. The two cannot be merged independently — whichever lands second needs a `git rebase origin/main`. Suggest merging #701 first and rebasing this branch afterwards.

## Summary by Sourcery

Add a post-deployment smoke check that identifies services which are not running or accepting connections without marking the spin-up job as failed.

New Features:
- Add an opt-out smoke-check workflow step that probes deployed services and reports container and port health after spin-up.
- Classify HTTP responses, non-HTTP listeners, unreachable ports, failed containers, restart loops, and other Docker states with run annotations.

Enhancements:
- Run service probes in parallel against ports published by Docker and keep health-check failures from failing the deployment job.

CI:
- Expose the smoke check as a default-enabled boolean input for dispatched and reusable spin-up workflows.

Documentation:
- Document how to interpret smoke-check output, investigate failures, and skip the check when needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional post-deployment smoke check for all deployed services, including HTTP and non-HTTP listeners.
  * The check runs automatically by default and can be skipped when manually starting a deployment.
  * Faulty services are highlighted without preventing the deployment workflow from completing.

* **Documentation**
  * Added guidance for interpreting smoke-check results and finding relevant service logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->