### PR TITLE
docs: Point the stack docs at what replaced deploy.sh

### DIFF
--- a/docs/stacks/marimo.md
+++ b/docs/stacks/marimo.md
@@ -111,7 +111,7 @@ import os
 access_key = os.environ["R2_ACCESS_KEY"]
 ```
 
-The sync writes to a dedicated `.infisical.env` file (not `.env`) so secret keys can't accidentally collide with Compose's `${VAR}` interpolation. Multi-line values (e.g. PEM keys) are skipped with a warning — they need a different transport mechanism (mount-as-file). See `scripts/deploy.sh` "Sync Infisical secrets into Marimo" block for the full mechanism.
+The sync writes to a dedicated `.infisical.env` file (not `.env`) so secret keys can't accidentally collide with Compose's `${VAR}` interpolation. Multi-line values (e.g. PEM keys) are skipped with a warning — they need a different transport mechanism (mount-as-file). The mechanism lives in `src/nexus_deploy/secret_sync.py`, run by the orchestrator's `secret-sync marimo` phase.
 
 ## Memory limits
 

--- a/docs/stacks/pg-ducklake.md
+++ b/docs/stacks/pg-ducklake.md
@@ -76,7 +76,7 @@ SELECT event_type, COUNT(*) FROM events GROUP BY event_type;
 
 ### Storage Configuration
 
-When the spin-up workflow runs, the `service-env` phase (`_render_pg_ducklake` in `src/nexus_deploy/service_env.py`) writes `stacks/pg-ducklake/init/00-ducklake-bootstrap.sql`, which Postgres applies on first init as `/docker-entrypoint-initdb.d/00-ducklake-bootstrap.sql`. After every spin-up the `services-configure` phase (`render_pg_ducklake_hook` in `src/nexus_deploy/services.py`) re-applies the same file via `docker exec`, so credential rotation reaches existing data volumes.
+When the spin-up workflow runs, the `service-env` phase (`_render_pg_ducklake` in `src/nexus_deploy/service_env.py`) writes `stacks/pg-ducklake/init/00-ducklake-bootstrap.sql`, which Postgres applies on first init as `/docker-entrypoint-initdb.d/00-ducklake-bootstrap.sql`. On every later spin-up the `services-configure` phase (`render_pg_ducklake_hook` in `src/nexus_deploy/services.py`) attempts to re-apply the same file via `docker exec`, which is how credential rotation reaches an existing data volume. The hook first waits up to 30 seconds for `pg_isready`; if the container is not accepting connections by then it reports `skipped-not-ready` and returns **without** running `psql`. That is visible in the spin-up log as a phase result, and the remedy is to re-run the spin-up once the container is up — rotated credentials do not reach the volume until a run gets past that wait.
 
 **With Hetzner Object Storage** (default when configured):
 - Bucket: `nexus-<domain>-pgducklake` (created by OpenTofu, persists through teardown)

--- a/docs/stacks/pg-ducklake.md
+++ b/docs/stacks/pg-ducklake.md
@@ -56,7 +56,7 @@ Connect via pgAdmin (or any PostgreSQL client) and create a DuckLake table:
 -- Verify the extension is loaded
 SELECT * FROM pg_extension WHERE extname LIKE '%duck%';
 
--- Check current default storage path (configured by deploy.sh)
+-- Check current default storage path (configured by the service-env phase)
 SHOW ducklake.default_table_path;
 
 -- Create a DuckLake table - data is automatically stored as Parquet in S3
@@ -76,7 +76,7 @@ SELECT event_type, COUNT(*) FROM events GROUP BY event_type;
 
 ### Storage Configuration
 
-When the spin-up workflow runs, deploy.sh generates `/docker-entrypoint-initdb.d/00-ducklake-bootstrap.sql` and applies it on first init. After every spin-up the same script is also re-applied via `docker exec` to handle credential rotation on existing data volumes.
+When the spin-up workflow runs, the `service-env` phase (`_render_pg_ducklake` in `src/nexus_deploy/service_env.py`) writes `stacks/pg-ducklake/init/00-ducklake-bootstrap.sql`, which Postgres applies on first init as `/docker-entrypoint-initdb.d/00-ducklake-bootstrap.sql`. After every spin-up the `services-configure` phase (`render_pg_ducklake_hook` in `src/nexus_deploy/services.py`) re-applies the same file via `docker exec`, so credential rotation reaches existing data volumes.
 
 **With Hetzner Object Storage** (default when configured):
 - Bucket: `nexus-<domain>-pgducklake` (created by OpenTofu, persists through teardown)

--- a/docs/stacks/portainer.md
+++ b/docs/stacks/portainer.md
@@ -14,7 +14,7 @@ What you get out of the box:
 - Container view (state, restart, logs, exec into a shell, resource usage)
 - Image inspection (layers, env, entrypoint)
 - Volume + network management
-- Stack deployment with Docker Compose (rarely needed in this project — `scripts/deploy.sh` handles stack lifecycle — but useful for ad-hoc experiments)
+- Stack deployment with Docker Compose (rarely needed in this project — the deploy pipeline handles stack lifecycle via `run_compose_up` in `src/nexus_deploy/compose_runner.py` — but useful for ad-hoc experiments)
 
 | Setting | Value |
 |---------|-------|

--- a/docs/stacks/sftpgo.md
+++ b/docs/stacks/sftpgo.md
@@ -25,7 +25,7 @@ SFTPGo is a fully-featured SFTP/SCP/WebDAV/FTPS server with a web admin UI, per-
 | Website | [sftpgo.com](https://sftpgo.com) |
 | Source | [GitHub](https://github.com/drakkan/sftpgo) |
 
-> ✅ **Auto-configured:** The web admin user `nexus-sftpgo` is always bootstrapped on container start (via `SFTPGO_DEFAULT_ADMIN_*` env vars in the compose). The default SFTP user `nexus-default` with its R2-backed virtual filesystem is created by the `services-configure` phase (`render_sftpgo_hook` in `src/nexus_deploy/services.py`) only when the R2 datalake credentials (`R2_DATA_BUCKET` / `R2_DATA_ENDPOINT` / `R2_DATA_ACCESS_KEY` / `R2_DATA_SECRET_KEY`) are present in `SECRETS_JSON` — if any of them are missing, deploy logs a yellow warning and the user must be created manually in the SFTPGo admin UI. Credentials are available in Infisical under folder `sftpgo`, keys `SFTPGO_ADMIN_PASSWORD` and `SFTPGO_USER_PASSWORD`.
+> ✅ **Auto-configured:** The web admin user `nexus-sftpgo` is always bootstrapped on container start (via `SFTPGO_DEFAULT_ADMIN_*` env vars in the compose). The default SFTP user `nexus-default` with its R2-backed virtual filesystem is created by the `services-configure` phase (`render_sftpgo_hook` in `src/nexus_deploy/services.py`) only when the R2 datalake credentials (`R2_DATA_BUCKET` / `R2_DATA_ENDPOINT` / `R2_DATA_ACCESS_KEY` / `R2_DATA_SECRET_KEY`) are present in `SECRETS_JSON` — if any of them are missing, the hook logs a warning to stderr and the user must be created manually in the SFTPGo admin UI. Credentials are available in Infisical under folder `sftpgo`, keys `SFTPGO_ADMIN_PASSWORD` and `SFTPGO_USER_PASSWORD`.
 
 ### How to access
 

--- a/docs/stacks/sftpgo.md
+++ b/docs/stacks/sftpgo.md
@@ -25,7 +25,7 @@ SFTPGo is a fully-featured SFTP/SCP/WebDAV/FTPS server with a web admin UI, per-
 | Website | [sftpgo.com](https://sftpgo.com) |
 | Source | [GitHub](https://github.com/drakkan/sftpgo) |
 
-> ✅ **Auto-configured:** The web admin user `nexus-sftpgo` is always bootstrapped on container start (via `SFTPGO_DEFAULT_ADMIN_*` env vars in the compose). The default SFTP user `nexus-default` with its R2-backed virtual filesystem is created by `scripts/deploy.sh` only when the R2 datalake credentials (`R2_DATA_BUCKET` / `R2_DATA_ENDPOINT` / `R2_DATA_ACCESS_KEY` / `R2_DATA_SECRET_KEY`) are present in `SECRETS_JSON` — if any of them are missing, deploy logs a yellow warning and the user must be created manually in the SFTPGo admin UI. Credentials are available in Infisical under folder `sftpgo`, keys `SFTPGO_ADMIN_PASSWORD` and `SFTPGO_USER_PASSWORD`.
+> ✅ **Auto-configured:** The web admin user `nexus-sftpgo` is always bootstrapped on container start (via `SFTPGO_DEFAULT_ADMIN_*` env vars in the compose). The default SFTP user `nexus-default` with its R2-backed virtual filesystem is created by the `services-configure` phase (`render_sftpgo_hook` in `src/nexus_deploy/services.py`) only when the R2 datalake credentials (`R2_DATA_BUCKET` / `R2_DATA_ENDPOINT` / `R2_DATA_ACCESS_KEY` / `R2_DATA_SECRET_KEY`) are present in `SECRETS_JSON` — if any of them are missing, deploy logs a yellow warning and the user must be created manually in the SFTPGo admin UI. Credentials are available in Infisical under folder `sftpgo`, keys `SFTPGO_ADMIN_PASSWORD` and `SFTPGO_USER_PASSWORD`.
 
 ### How to access
 


### PR DESCRIPTION
Closes #691

`scripts/deploy.sh` was removed in Phase 4c (#505). Four stack docs still described it as the thing doing the work, which sends a reader looking for a file that is not there.

## Not a blanket swap

The issue asked for this explicitly, and it was right to: each sentence names a different phase, so replacing them all with "the deploy pipeline" would lose the pointer that makes the sentence useful.

| File | Was | Now points at |
|---|---|---|
| `marimo.md` | "See `scripts/deploy.sh` … block" | `src/nexus_deploy/secret_sync.py`, run by the `secret-sync marimo` phase |
| `sftpgo.md` | "created by `scripts/deploy.sh`" | `render_sftpgo_hook` in `services.py`, dispatched by `services-configure` |
| `pg-ducklake.md` (×2) | "configured by deploy.sh" / "deploy.sh generates …" | `_render_pg_ducklake` in `service_env.py` **and** `render_pg_ducklake_hook` in `services.py` |
| `portainer.md` | "`scripts/deploy.sh` handles stack lifecycle" | `run_compose_up` in `compose_runner.py` |

The pg-ducklake sentence was the one worth reading carefully. It attributed both halves of the mechanism to deploy.sh, when they are actually two different phases: `service-env` writes `stacks/pg-ducklake/init/00-ducklake-bootstrap.sql`, which Postgres applies on first init, and `services-configure` re-applies the same file via `docker exec` on every spin-up so credential rotation reaches existing data volumes. Both are named now.

## Left alone

`migration-to-python.md`, `src/nexus_deploy/README.md`, `README.md` and `CLAUDE.md` all reference `deploy.sh` in the past tense while describing its removal. Those are correct and stay.

## Verification

Every function name, module path and phase name written here was checked against the source rather than inferred:

```
ok  src/nexus_deploy/secret_sync.py
ok  render_sftpgo_hook in src/nexus_deploy/services.py
ok  _render_pg_ducklake in src/nexus_deploy/service_env.py
ok  render_pg_ducklake_hook in src/nexus_deploy/services.py
ok  run_compose_up in src/nexus_deploy/compose_runner.py
```

The issue's own check now returns only the two files it expects:

```bash
$ grep -rn 'deploy\.sh' docs/ examples/ src/ | cut -d: -f1 | sort -u
docs/admin-guides/migration-to-python.md
src/nexus_deploy/README.md
```

## Summary by Sourcery

Point stack documentation at the Python deployment phases and handlers that replaced `scripts/deploy.sh`.

Enhancements:
- Update stack documentation to reference the current deployment phases and source modules instead of the removed `scripts/deploy.sh` script, while preserving details about service configuration and credential rotation.

Documentation:
- Correct outdated `deploy.sh` references in the Marimo, SFTPGo, pg-ducklake, and Portainer stack guides.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated stack docs to point to the current deployment phases and handlers for Marimo, Portainer, SFTPGo, and pg-ducklake.
  * Clarified where secret sync, stack lifecycle actions, default storage-path setup, and default SFTP user creation now occur.
  * Added guidance that bootstrap SQL is generated and reapplied during service setup, including after credential rotation for existing data volumes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->