### PR TITLE
fix(stacks): Run cAdvisor without privileged: true

### DIFF
--- a/docs/stacks/grafana.md
+++ b/docs/stacks/grafana.md
@@ -54,3 +54,49 @@ The stack comes with three ready-to-use dashboards:
 ```
 
 > ✅ **Auto-configured:** Admin password is set via environment variables during deployment. Dashboards and datasources are pre-provisioned. Credentials are available in Infisical.
+
+### cAdvisor runs unprivileged
+
+cAdvisor collects the per-container CPU, memory and network metrics behind
+the Docker overview dashboard. It runs **without** `privileged: true`, which
+is worth knowing because most examples on the internet include that flag.
+
+cAdvisor's own documentation names two situations that require it, and
+neither applies here:
+
+- **Process metrics** (`--enable_metrics=process`), which additionally need
+  `--pid=host`. Not enabled. Every metric the shipped dashboards query —
+  `container_cpu_usage_seconds_total`, `container_memory_usage_bytes`,
+  `container_last_seen`, `container_network_receive_bytes_total`,
+  `container_network_transmit_bytes_total` — is read from the cgroup
+  hierarchy under the read-only `/sys` mount.
+- **RHEL and CentOS**, which confine containers more tightly. The servers
+  run Ubuntu 26.04.
+
+`/dev/kmsg` is passed through explicitly as a device. cAdvisor reads it to
+detect OOM kills, and that is the one thing the privileged flag was
+providing without saying so.
+
+The reason to care: a privileged container holds every Linux capability, an
+unconfined seccomp profile and access to host devices. This stack also
+mounts the Docker socket, so a compromise of the monitoring stack would be
+a compromise of the host — and monitoring is by design the one stack wired
+to reach all the others.
+
+**If a panel goes blank after a deploy**, check in this order:
+
+```bash
+# 1. Is cAdvisor exporting at all?
+ssh nexus "docker exec grafana-cadvisor wget -qO- http://localhost:8080/healthz"
+
+# 2. Does the specific metric exist?
+ssh nexus "docker exec grafana-cadvisor wget -qO- http://localhost:8080/metrics | grep -c container_cpu_usage_seconds_total"
+
+# 3. Anything permission-shaped in the log?
+ssh nexus "docker logs grafana-cadvisor 2>&1 | grep -iE 'permission|denied|failed to'"
+```
+
+A metric missing at step 2 with a permission error at step 3 would mean this
+host needs more than the current configuration grants. That has not been
+observed on Ubuntu; if it happens, record which metric and which error here
+rather than restoring the flag silently.

--- a/docs/stacks/grafana.md
+++ b/docs/stacks/grafana.md
@@ -73,9 +73,12 @@ neither applies here:
 - **RHEL and CentOS**, which confine containers more tightly. The servers
   run Ubuntu 26.04.
 
-`/dev/kmsg` is passed through explicitly as a device. cAdvisor reads it to
-detect OOM kills, and that is the one thing the privileged flag was
-providing without saying so.
+`/dev/kmsg` is passed through explicitly as a device, and read-only:
+`- /dev/kmsg:/dev/kmsg:r`. cAdvisor reads it to detect OOM kills, and that
+is the one thing the privileged flag was providing without saying so. The
+`:r` matters — Docker defaults a device entry to `rwm`, which would grant
+write access to the host kernel log and give back part of what dropping
+`privileged` removed.
 
 The reason to care: a privileged container holds every Linux capability, an
 unconfined seccomp profile and access to host devices. This stack also

--- a/stacks/grafana/docker-compose.yml
+++ b/stacks/grafana/docker-compose.yml
@@ -112,7 +112,28 @@ services:
     image: ${IMAGE_CADVISOR:-ghcr.io/google/cadvisor:0.56}
     container_name: grafana-cadvisor
     restart: unless-stopped
-    privileged: true
+    # Deliberately NOT privileged. cAdvisor's own docs name two cases that
+    # require it, and neither applies here:
+    #
+    #   - process metrics (`--enable_metrics=process`), which also need
+    #     `--pid=host`. Not enabled; the dashboards in
+    #     provisioning/dashboards/json/ read container_cpu_usage_seconds_total,
+    #     container_memory_usage_bytes, container_last_seen and the network
+    #     counters, all of which come from the read-only /sys cgroup mount.
+    #   - RHEL and CentOS, which lock containers down further. The servers
+    #     run Ubuntu 26.04.
+    #
+    # A privileged container gets every capability, an unconfined seccomp
+    # profile and host device access. That matters more here than elsewhere:
+    # this is the one stack wired to observe all the others, and it mounts
+    # the Docker socket, so a compromise of it is a compromise of the host.
+    #
+    # /dev/kmsg is passed explicitly instead — cAdvisor reads it to detect
+    # OOM kills, which is the one capability the privileged flag was
+    # silently providing. See docs/stacks/grafana.md for what to check if a
+    # panel goes blank after this change.
+    devices:
+      - /dev/kmsg
     # Cardinality defuse (Conductor #23 highest-priority):
     # --docker_only=true        ignore non-Docker cgroups (k8s/systemd noise)
     # --store_container_labels=false

--- a/stacks/grafana/docker-compose.yml
+++ b/stacks/grafana/docker-compose.yml
@@ -133,7 +133,12 @@ services:
     # silently providing. See docs/stacks/grafana.md for what to check if a
     # panel goes blank after this change.
     devices:
-      - /dev/kmsg
+      # `:r` — read only. Docker's default for a device entry is `rwm`
+      # (read, write, mknod), which would let a compromised cAdvisor write
+      # arbitrary lines into the host kernel log. cAdvisor only reads
+      # /dev/kmsg, so granting more would undo part of what dropping
+      # `privileged` bought.
+      - /dev/kmsg:/dev/kmsg:r
     # Cardinality defuse (Conductor #23 highest-priority):
     # --docker_only=true        ignore non-Docker cgroups (k8s/systemd noise)
     # --store_container_labels=false


### PR DESCRIPTION
Closes #663

## What changed

`privileged: true` is gone from cAdvisor. `/dev/kmsg` is passed as an explicit device instead, and the flag's absence now carries a rationale where it previously carried none.

```diff
   container_name: grafana-cadvisor
   restart: unless-stopped
-  privileged: true
+  devices:
+    - /dev/kmsg
```

## Why it is safe here

The issue suggested trying the non-privileged configuration and confirming the dashboards still populate. Checking cAdvisor's own documentation first made the answer sharper than "try it": it names exactly two situations that require the flag.

- **Process metrics** (`--enable_metrics=process`), which additionally need `--pid=host`. Not enabled here.
- **RHEL and CentOS**, which confine containers more tightly. The servers run Ubuntu 26.04.

Every metric the shipped dashboards actually query is cgroup-derived and read through the read-only `/sys` mount that was already in place:

| Metric | Occurrences in `provisioning/dashboards/json/` |
|---|---|
| `container_memory_usage_bytes` | 5 |
| `container_cpu_usage_seconds_total` | 4 |
| `container_last_seen` | 2 |
| `container_network_receive_bytes_total` | 1 |
| `container_network_transmit_bytes_total` | 1 |

The volume set was already exactly cAdvisor's documented one, so the single capability the flag was providing without saying so is `/dev/kmsg`, which cAdvisor reads to detect OOM kills. That is now explicit.

## The part that matters beyond this stack

The issue makes the point well: monitoring is the one stack that exists to watch all the others, so it is wired to reach everything by design, and it mounts the Docker socket. A privileged container there is the widest blast radius in the deployment.

The read-only socket mount is unchanged — the issue is right that it is weaker than it sounds (it prevents writes to the socket *file*, not API calls through it), but that is a separate decision and no change was needed.

## Documentation

`docs/stacks/grafana.md` gains a section explaining why the flag is absent, since most examples online include it and the next reader will wonder. It ends with an ordered set of commands to run if a panel goes blank, and asks that a real failure be recorded with the metric and error rather than the flag restored silently.

## Not in scope

The issue's second point — unpinned images in this stack — was resolved separately in #699. All six Grafana-stack images now match `services.yaml`.

`forgejo-runner` still runs `privileged: true` on its docker-in-docker container. That one is documented at length in its own compose file as a deliberate, accepted trade-off, and is outside this issue.

## How to test

`spin-up.yml` is enough — no Terraform, DNS or Access changes.

```bash
gh workflow run spin-up.yml --ref fix/cadvisor-drop-privileged
```

Then confirm the Docker overview dashboard still populates, or check directly:

```bash
ssh nexus "docker exec grafana-cadvisor wget -qO- http://localhost:8080/metrics | grep -c container_cpu_usage_seconds_total"
ssh nexus "docker logs grafana-cadvisor 2>&1 | grep -iE 'permission|denied|failed to'"
```

A non-zero count on the first and nothing on the second means the change held.

## Summary by Sourcery

Reduce the Grafana monitoring stack's host-level privileges while retaining the cAdvisor metrics required by its dashboards.

Bug Fixes:
- Run cAdvisor without privileged container access while preserving OOM-kill detection through a read-only /dev/kmsg device.

Enhancements:
- Document the security rationale, platform assumptions, monitored metrics, and troubleshooting steps for the unprivileged cAdvisor configuration.

Documentation:
- Add guidance for diagnosing missing Grafana panels after deploying the unprivileged cAdvisor configuration.