### PR TITLE
fix(control-plane): Let users stop the stack they can start

### DIFF
--- a/control-plane/functions/api/_utils/require-operator.js
+++ b/control-plane/functions/api/_utils/require-operator.js
@@ -1,0 +1,66 @@
+// Authorization guard for endpoints a stack's users may drive themselves.
+//
+// Sits between requireAdmin and no guard at all, because the Access
+// whitelist holds three roles with different standing:
+//
+//   ADMIN_EMAIL   the operator. Full access, including SSH.
+//   USER_EMAIL    the people the stack is for — students on a teaching
+//                 stack. May be a comma-separated list. All services
+//                 except SSH, and they receive notifications.
+//   GUEST_EMAILS  whitelist only, no notifications. Present to let
+//                 somebody look, not to let them act.
+//
+// Cloudflare Access authenticates all three identically, so without a
+// guard every endpoint is open to guests, and with requireAdmin it is
+// closed to the very people the stack exists for. Starting and stopping
+// your own stack is the reason the Control Plane is there; a guest doing
+// it to a stack somebody else is working on is not.
+//
+// Use it where the action is self-service — lifecycle and service
+// toggles. Keep requireAdmin for operator work: destroying
+// infrastructure, rotating the Control Plane's own secrets, opening host
+// firewall ports, mailing out the Infisical master credentials.
+//
+// Usage at the top of a handler, after the origin check:
+//   const denial = requireOperator(context.env, context.request);
+//   if (denial) return denial;
+import { getAccessUserEmail } from './cf-access-email.js';
+
+export function requireOperator(env, request) {
+  const adminEmail = (env.ADMIN_EMAIL || '').trim().toLowerCase();
+  if (!adminEmail) {
+    // Same failure mode as requireAdmin: with no admin configured there
+    // is no identity to compare against, and treating that as "allow"
+    // would turn a misconfiguration into an open endpoint.
+    return new Response(
+      JSON.stringify({
+        success: false,
+        error: 'Server misconfigured: ADMIN_EMAIL is not set',
+      }),
+      { status: 500, headers: { 'Content-Type': 'application/json' } }
+    );
+  }
+
+  // USER_EMAIL may be a single address or a comma-separated list — the
+  // same shape send-credentials.js already parses. An unset value leaves
+  // only the admin, which is the correct single-operator behaviour.
+  const userEmails = (env.USER_EMAIL || '')
+    .split(',')
+    .map((e) => e.trim().toLowerCase())
+    .filter(Boolean);
+
+  // Comparison is case-insensitive to match Cloudflare Access and
+  // identity-provider behaviour, as requireAdmin does.
+  const caller = (getAccessUserEmail(request) || '').trim().toLowerCase();
+  if (caller && (caller === adminEmail || userEmails.includes(caller))) {
+    return null;
+  }
+
+  return new Response(
+    JSON.stringify({
+      success: false,
+      error: 'Forbidden: this endpoint requires an operator or user account',
+    }),
+    { status: 403, headers: { 'Content-Type': 'application/json' } }
+  );
+}

--- a/control-plane/functions/api/_utils/require-operator.js
+++ b/control-plane/functions/api/_utils/require-operator.js
@@ -16,10 +16,18 @@
 // your own stack is the reason the Control Plane is there; a guest doing
 // it to a stack somebody else is working on is not.
 //
-// Use it where the action is self-service — lifecycle and service
-// toggles. Keep requireAdmin for operator work: destroying
-// infrastructure, rotating the Control Plane's own secrets, opening host
-// firewall ports, mailing out the Infisical master credentials.
+// Use it where the action is self-service. Today that is exactly three
+// endpoints: /api/spin-up, /api/teardown and the POST on /api/services.
+//
+// Keep requireAdmin everywhere else, including two that sound like they
+// belong here and do not. /api/lifecycle changes WHICH teardown and
+// spin-up pair the stack uses, which decides what survives a cycle —
+// a configuration choice with data-loss consequences, not an act of
+// running the stack. /api/scheduled-teardown sets the cost-control
+// timer that users are not meant to switch off. The rest is plainly
+// operator work: destroying infrastructure, redeploying the Control
+// Plane, opening host firewall ports, mailing the Infisical master
+// credentials.
 //
 // Usage at the top of a handler, after the origin check:
 //   const denial = requireOperator(context.env, context.request);

--- a/control-plane/functions/api/services.js
+++ b/control-plane/functions/api/services.js
@@ -15,6 +15,7 @@
 
 import { logApiCall, logError } from './_utils/logger.js';
 import { requireSameOrigin } from './_utils/require-same-origin.js';
+import { requireOperator } from './_utils/require-operator.js';
 
 /**
  * Validate service name to prevent injection attacks
@@ -151,6 +152,12 @@ export async function onRequestPost(context) {
   // valid Access session, so authenticating it first proves nothing.
   const crossSite = requireSameOrigin(request);
   if (crossSite) return crossSite;
+
+  // Enabling and disabling services is self-service and stays open to
+  // users. It is a POST that changes desired state for everyone on the
+  // stack, though, so a guest does not get it.
+  const denial = requireOperator(env, request);
+  if (denial) return denial;
 
   if (!env.NEXUS_DB) {
     return new Response(JSON.stringify({

--- a/control-plane/functions/api/spin-up.js
+++ b/control-plane/functions/api/spin-up.js
@@ -11,6 +11,7 @@ import { logApiCall, logError } from './_utils/logger.js';
 import { fetchWithTimeout } from './_utils/fetch-with-timeout.js';
 import { resolveLifecycle } from './_utils/workflow-selection.js';
 import { requireSameOrigin } from './_utils/require-same-origin.js';
+import { requireOperator } from './_utils/require-operator.js';
 
 /**
  * Get enabled services from D1
@@ -34,6 +35,13 @@ export async function onRequestPost(context) {
   // valid Access session, so authenticating it first proves nothing.
   const crossSite = requireSameOrigin(request);
   if (crossSite) return crossSite;
+
+  // Was previously open to every address on the Access whitelist,
+  // guests included. Users keep it — starting your own stack is the
+  // point of the Control Plane — but a guest is on the list to look,
+  // not to provision a server that costs money.
+  const denial = requireOperator(env, request);
+  if (denial) return denial;
 
   // Validate environment variables
   if (!env.GITHUB_TOKEN || !env.GITHUB_OWNER || !env.GITHUB_REPO) {

--- a/control-plane/functions/api/teardown.js
+++ b/control-plane/functions/api/teardown.js
@@ -9,7 +9,7 @@
 
 import { logApiCall, logError } from './_utils/logger.js';
 import { fetchWithTimeout } from './_utils/fetch-with-timeout.js';
-import { requireAdmin } from './_utils/require-admin.js';
+import { requireOperator } from './_utils/require-operator.js';
 import { resolveLifecycle } from './_utils/workflow-selection.js';
 import { requireSameOrigin } from './_utils/require-same-origin.js';
 
@@ -19,7 +19,12 @@ export async function onRequestPost(context) {
   // valid Access session, so authenticating it first proves nothing.
   const crossSite = requireSameOrigin(request);
   if (crossSite) return crossSite;
-  const denial = requireAdmin(env, request);
+  // Operator-level, not admin-only. Users must be able to stop the stack
+  // they can start — the asymmetry this replaces let a student begin
+  // paying for a server and then wait for somebody else to release it.
+  // Guests still cannot: tearing down a stack somebody is working on is
+  // not a spectator's call.
+  const denial = requireOperator(env, request);
   if (denial) return denial;
 
   // Validate environment variables

--- a/docs/admin-guides/setup-guide.md
+++ b/docs/admin-guides/setup-guide.md
@@ -150,6 +150,9 @@ Without it the first run stops with an explanatory error, and Cloudflare-based a
 |-------------|-------------|
 | `TF_VAR_user_email` | User - all services except SSH (also receives notifications) |
 | `TF_VAR_guest_emails` | Comma-separated guests - Access whitelist only, no notifications |
+| `RESEND_API_KEY` | Email notifications via Resend |
+| `DOCKERHUB_USERNAME` | Docker Hub username (higher pull limits) |
+| `DOCKERHUB_TOKEN` | Docker Hub access token |
 
 #### What each role may do in the Control Plane
 
@@ -180,9 +183,6 @@ Guests are on the Access whitelist to look. Put someone in
 `TF_VAR_user_email` rather than `TF_VAR_guest_emails` if they need to run
 the stack — a guest attempting a state-changing action gets an HTTP 403
 with an explanatory message, not a silent failure.
-| `RESEND_API_KEY` | Email notifications via Resend |
-| `DOCKERHUB_USERNAME` | Docker Hub username (higher pull limits) |
-| `DOCKERHUB_TOKEN` | Docker Hub access token |
 
 ### S3-Persistence Secrets (RFC 0001)
 

--- a/docs/admin-guides/setup-guide.md
+++ b/docs/admin-guides/setup-guide.md
@@ -150,6 +150,36 @@ Without it the first run stops with an explanatory error, and Cloudflare-based a
 |-------------|-------------|
 | `TF_VAR_user_email` | User - all services except SSH (also receives notifications) |
 | `TF_VAR_guest_emails` | Comma-separated guests - Access whitelist only, no notifications |
+
+#### What each role may do in the Control Plane
+
+Cloudflare Access authenticates all three roles identically — it decides
+who reaches the site, not what they may press once there. The Control
+Plane enforces the difference itself:
+
+| Action | Admin | User | Guest |
+|---|:--:|:--:|:--:|
+| View status, services, logs | ✅ | ✅ | ✅ |
+| Spin up / tear down the stack | ✅ | ✅ | — |
+| Enable / disable services | ✅ | ✅ | — |
+| Destroy all infrastructure | ✅ | — | — |
+| Open host firewall ports | ✅ | — | — |
+| Redeploy the Control Plane | ✅ | — | — |
+| Email the Infisical credentials | ✅ | — | — |
+| Change email and teardown settings | ✅ | — | — |
+| Databricks configuration and sync | ✅ | — | — |
+| SSH to the server | ✅ | — | — |
+
+The line is self-service versus operator work. Starting and stopping the
+stack you work on is the reason the Control Plane exists, so users get it.
+Destroying infrastructure, opening ports on the host firewall and mailing
+out the Infisical master credentials are not reversible by the person who
+triggered them, so they stay with the admin.
+
+Guests are on the Access whitelist to look. Put someone in
+`TF_VAR_user_email` rather than `TF_VAR_guest_emails` if they need to run
+the stack — a guest attempting a state-changing action gets an HTTP 403
+with an explanatory message, not a silent failure.
 | `RESEND_API_KEY` | Email notifications via Resend |
 | `DOCKERHUB_USERNAME` | Docker Hub username (higher pull limits) |
 | `DOCKERHUB_TOKEN` | Docker Hub access token |


### PR DESCRIPTION
Closes #703

## The problem

`spin-up.js` had no authorization guard and `teardown.js` required admin. A student could start a server and then had to wait for somebody else to release it — the only self-service action available was the one that starts billing.

## Why neither obvious fix was right

Dropping `requireAdmin` from teardown would leave it open to guests, who are on the Access whitelist to look rather than to act — tearing down a stack somebody else is working on is not a spectator's call.

Adding `requireAdmin` to spin-up would remove the feature the Control Plane exists for. That reasoning is already on the record: the same change was proposed by review on #698 and declined for exactly this reason.

So this adds a guard between the two.

## `requireOperator`

Admits `ADMIN_EMAIL` and any address in `USER_EMAIL` (which may be a comma-separated list, the same shape `send-credentials.js` already parses). Denies everyone else.

The three Access roles were always distinct in intent — admin has SSH, users receive notifications, guests get neither — but the Control Plane treated the last two identically, because Cloudflare Access decides who reaches the site, not what they may press once there.

| Endpoint | Before | After |
|---|---|---|
| `teardown.js` | admin | **operator** |
| `spin-up.js` | *(none)* | **operator** |
| `services.js` | *(none)* | **operator** |

Left on `requireAdmin`: `destroy`, `firewall`, `deploy`, `send-credentials`, `email-settings`, `scheduled-teardown`, and both Databricks endpoints. The line is self-service versus operator work — the admin keeps what the person who triggers it cannot undo.

## Checked for other callers

The scheduled-teardown Worker dispatches the GitHub workflow directly (`api.github.com/…/actions/workflows/…/dispatches`), not through these endpoints, so it has no Access identity to be denied. Nothing under `.github/` calls them either. Only browser traffic through Access reaches them.

## Verification

The guard was exercised directly against every case that matters:

```
Admin                ALLOWED
Admin (uppercase)    ALLOWED     ← case-insensitive, like requireAdmin
Student 1            ALLOWED
Student 2 (mixed)    ALLOWED     ← comma-separated list with spaces
Guest                denied 403
no identity          denied 403
ADMIN_EMAIL unset    denied 500  ← fails closed on misconfiguration
USER_EMAIL unset     ALLOWED     ← single-operator case preserved
```

Guard ordering was confirmed in all three handlers — `requireSameOrigin` still runs before the identity check, since a cross-site submission carries a valid Access session and authenticating it first proves nothing.

## Documentation

The setup guide listed the three roles as secrets with no statement of their effect, which is what let this asymmetry sit unnoticed. It now carries a table of what each role may do, and every row was checked against the guard actually present in each handler.

## How to test

Control Plane changes only — no Terraform, so `setup-control-plane.yaml` is enough.

1. As the admin, tear down and spin up. Both should work as before.
2. As a `TF_VAR_user_email` address, the same two actions should now work — this is the fix.
3. As a `TF_VAR_guest_emails` address, both should return HTTP 403 with `"Forbidden: this endpoint requires an operator or user account"`, and the status page should still load.

## Summary by Sourcery

Enforce operator-level access for self-service Control Plane actions while preserving administrator-only access for infrastructure and credential operations.

New Features:
- Allow configured stack users, in addition to administrators, to start and stop the stack and manage services.
- Add operator-level authorization that distinguishes administrators and users from read-only guests.

Bug Fixes:
- Prevent guests from performing state-changing Control Plane actions while allowing users to stop stacks they can start.

Documentation:
- Document the permissions associated with administrator, user, and guest roles in the Control Plane.