### PR TITLE
fix(deploy): Push the OpenSearch and Marquez usernames to Infisical

### DIFF
--- a/docs/stacks/marquez.md
+++ b/docs/stacks/marquez.md
@@ -55,8 +55,13 @@ and neither is an account you sign in with:
 
 | Secret | Used by |
 |---|---|
-| `MARQUEZ_DB_PASSWORD` | the lineage PostgreSQL |
-| `MARQUEZ_OPENSEARCH_PASSWORD` | the OpenSearch admin user |
+| `MARQUEZ_DB_USERNAME` / `MARQUEZ_DB_PASSWORD` | the lineage PostgreSQL |
+| `MARQUEZ_OPENSEARCH_USERNAME` / `MARQUEZ_OPENSEARCH_PASSWORD` | this stack's own OpenSearch |
+
+The OpenSearch username is `admin` rather than a `nexus-` name, because
+OpenSearch compiles that account name in and offers no way to change it
+through configuration — the reasoning is in
+[the OpenSearch stack doc](./opensearch.md#why-the-username-is-admin-and-not-nexus-opensearch).
 
 The OpenSearch password is one of the few in this project generated with
 special characters at all, and it is restricted to the three-character set

--- a/docs/stacks/opensearch.md
+++ b/docs/stacks/opensearch.md
@@ -45,8 +45,8 @@ can be switched off without touching the other.
 
 ## Credentials
 
-`OPENSEARCH_ADMIN_PASSWORD` is in Infisical under the `opensearch` folder.
-The username is `admin`.
+Both values are in Infisical under the `opensearch` folder:
+`OPENSEARCH_USERNAME` (which is `admin`) and `OPENSEARCH_ADMIN_PASSWORD`.
 
 You do not need it for Dashboards — Cloudflare Access already
 authenticated whoever reached the page, so the Dashboards login screen is

--- a/src/nexus_deploy/infisical.py
+++ b/src/nexus_deploy/infisical.py
@@ -722,6 +722,14 @@ def compute_folders(config: NexusConfig, env: BootstrapEnv) -> list[FolderSpec]:
             "opensearch",
             _filter_empty(
                 {
+                    # The username is pushed alongside the password, as every
+                    # other folder does, and here it earns its place twice
+                    # over: OpenSearch's account is `admin`, not the `nexus-`
+                    # name every other stack would lead a reader to expect.
+                    # The name is a compiled constant in the security
+                    # plugin's demo configurator and cannot be changed
+                    # through configuration — see docs/stacks/opensearch.md.
+                    "OPENSEARCH_USERNAME": "admin",
                     "OPENSEARCH_ADMIN_PASSWORD": config.opensearch_admin_password,
                 }
             ),
@@ -732,7 +740,14 @@ def compute_folders(config: NexusConfig, env: BootstrapEnv) -> list[FolderSpec]:
             "marquez",
             _filter_empty(
                 {
+                    # Marquez itself has no user management — Cloudflare
+                    # Access is its only gate — so these two name the
+                    # accounts behind it rather than a login. The Postgres
+                    # role follows the nexus- convention; the OpenSearch one
+                    # cannot, for the reason in the opensearch folder above.
+                    "MARQUEZ_DB_USERNAME": "nexus-marquez",
                     "MARQUEZ_DB_PASSWORD": config.marquez_db_password,
+                    "MARQUEZ_OPENSEARCH_USERNAME": "admin",
                     "MARQUEZ_OPENSEARCH_PASSWORD": config.marquez_opensearch_password,
                 }
             ),

--- a/tests/unit/__snapshots__/test_infisical.ambr
+++ b/tests/unit/__snapshots__/test_infisical.ambr
@@ -104,7 +104,9 @@
     }),
     'marquez': dict({
       'MARQUEZ_DB_PASSWORD': 'marquez_db_password-VALUE',
+      'MARQUEZ_DB_USERNAME': 'nexus-marquez',
       'MARQUEZ_OPENSEARCH_PASSWORD': 'marquez_opensearch_password-VALUE',
+      'MARQUEZ_OPENSEARCH_USERNAME': 'admin',
     }),
     'meilisearch': dict({
       'MEILISEARCH_MASTER_KEY': 'meilisearch_master_key-VALUE',
@@ -137,6 +139,7 @@
     }),
     'opensearch': dict({
       'OPENSEARCH_ADMIN_PASSWORD': 'opensearch_admin_password-VALUE',
+      'OPENSEARCH_USERNAME': 'admin',
     }),
     'pg-ducklake': dict({
       'PG_DUCKLAKE_DATABASE': 'ducklake',


### PR DESCRIPTION
## What you see today

Infisical shows a password with no indication of which account it belongs to:

```
opensearch  1
  OPENSEARCH_ADMIN_PASSWORD   ••••••••••••

marquez  2
  MARQUEZ_OPENSEARCH_PASSWORD ••••••••••••
```

## Why that matters more than usual here

The repo already follows the opposite convention — **30** `*_USERNAME` keys exist, from `GRAFANA_USERNAME` through `MINIO_ROOT_USER` and `SFTPGO_ADMIN_USERNAME`. Both new folders simply missed it.

And the missing name is the surprising one. OpenSearch's account is **`admin`**, not the `nexus-` name every other stack in this project would lead a reader to expect. Someone holding only the password would reasonably try `nexus-opensearch`, get an authentication failure, and find nothing in Infisical to correct them.

That name cannot be changed through configuration — it is a compiled constant in the security plugin's demo configurator (`static String ADMIN_USERNAME = "admin"`), documented as an exception in `docs/stacks/opensearch.md`. Since the deviation is permanent, making it visible where the password lives is the whole remedy available.

## What changed

| Folder | Added |
|---|---|
| `opensearch` | `OPENSEARCH_USERNAME` = `admin` |
| `marquez` | `MARQUEZ_OPENSEARCH_USERNAME` = `admin` |
| `marquez` | `MARQUEZ_DB_USERNAME` = `nexus-marquez` |

The third is included so the Marquez folder names **both** of its accounts. Adding only the OpenSearch one would have left the Postgres role unnamed and looked like an oversight in the other direction.

Both stack docs updated to match, and `docs/stacks/marquez.md` now links to the section explaining why one of its two accounts breaks the naming rule.

## Verification

Every name was checked against the compose file that actually consumes it rather than assumed:

```
stacks/opensearch/docker-compose.yml:  - OPENSEARCH_USERNAME=admin
stacks/marquez/docker-compose.yml:      SEARCH_USERNAME: admin
stacks/marquez/docker-compose.yml:      POSTGRES_USER: nexus-marquez
```

`ruff format --check`, `ruff check`, `mypy` (63 files), **1843 tests**, and the Infisical snapshot updated with exactly the three new keys and nothing else.

## How to test

Control Plane and deploy pipeline only — `spin-up.yml` is enough, no Terraform changes.

```bash
gh workflow run spin-up.yml --ref fix/opensearch-username-in-infisical
```

Afterwards the `opensearch` folder shows two entries and `marquez` shows four, with the usernames readable in plain text beside their passwords.

## Summary by Sourcery

Expose the OpenSearch and Marquez usernames alongside their passwords in Infisical and document the account naming conventions.

Bug Fixes:
- Add OpenSearch and Marquez account usernames to Infisical so stored passwords are clearly associated with their consuming accounts.

Enhancements:
- Update the OpenSearch and Marquez stack documentation to describe the stored usernames and explain OpenSearch's fixed `admin` account name.

Documentation:
- Document the newly exposed credential usernames and link Marquez's OpenSearch naming exception to the relevant OpenSearch guidance.

Tests:
- Update the Infisical snapshot to include the three new username keys.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated OpenSearch credential guidance to identify the administrator username as `admin` and clarify where credentials are stored.
  * Expanded Marquez credential documentation to distinguish PostgreSQL lineage credentials from OpenSearch credentials.
* **Configuration**
  * Credential provisioning now includes the required OpenSearch and Marquez usernames alongside their passwords for improved stack setup reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->