### PR TITLE
feat(ci): Add actionlint as a pre-commit hook

### DIFF
--- a/.github/workflows/initial-setup.yaml
+++ b/.github/workflows/initial-setup.yaml
@@ -60,7 +60,7 @@ jobs:
           # Remove duplicates and empty values, sort
           SERVICES=$(echo "$SERVICES" | tr ',' '\n' | sort -u | grep -v '^$' | tr '\n' ',' | sed 's/,$//')
 
-          echo "enabled_services=$SERVICES" >> $GITHUB_OUTPUT
+          echo "enabled_services=$SERVICES" >> "$GITHUB_OUTPUT"
           echo "📋 Enabled services: $SERVICES"
 
       - name: Update D1 with selected services

--- a/.github/workflows/setup-control-plane.yaml
+++ b/.github/workflows/setup-control-plane.yaml
@@ -104,7 +104,7 @@ jobs:
             echo "${{ secrets.SSH_PUBLIC_KEY }}" > ~/.ssh/id_ed25519.pub
             chmod 600 ~/.ssh/id_ed25519
             chmod 644 ~/.ssh/id_ed25519.pub
-            echo "ssh_key_created=false" >> $GITHUB_OUTPUT
+            echo "ssh_key_created=false" >> "$GITHUB_OUTPUT"
           else
             echo "🔑 Generating new SSH key..."
             mkdir -p ~/.ssh
@@ -123,19 +123,19 @@ jobs:
               # "Skip output... contains secret" warnings in GitHub Actions.
               if printf '%s' "$SSH_PRIVATE_KEY" | gh secret set SSH_PRIVATE_KEY 2>/dev/null; then
                 echo "✅ SSH Private Key saved to GitHub Secrets"
-                echo "ssh_key_created=true" >> $GITHUB_OUTPUT
+                echo "ssh_key_created=true" >> "$GITHUB_OUTPUT"
               else
                 echo "⚠️  Failed to save SSH keys - GH_SECRETS_TOKEN may need 'repo' scope"
-                echo "ssh_key_created=false" >> $GITHUB_OUTPUT
+                echo "ssh_key_created=false" >> "$GITHUB_OUTPUT"
               fi
             else
               echo "⚠️  GH_SECRETS_TOKEN not set - SSH keys not saved"
-              echo "ssh_key_created=false" >> $GITHUB_OUTPUT
+              echo "ssh_key_created=false" >> "$GITHUB_OUTPUT"
             fi
           fi
 
           # Export public key for output (named ssh_pubkey to avoid GitHub Actions secret warning)
-          echo "ssh_pubkey=$(cat ~/.ssh/id_ed25519.pub)" >> $GITHUB_OUTPUT
+          echo "ssh_pubkey=$(cat ~/.ssh/id_ed25519.pub)" >> "$GITHUB_OUTPUT"
 
           # Export private key for output (for initial-setup passthrough to spin-up)
           # Note: Don't mask private key here - masking prevents it from being
@@ -146,7 +146,7 @@ jobs:
             echo "ssh_private_key<<SSHEOF"
             cat ~/.ssh/id_ed25519
             echo "SSHEOF"
-          } >> $GITHUB_OUTPUT
+          } >> "$GITHUB_OUTPUT"
 
       - name: Compute resource prefix
         id: prefix
@@ -155,8 +155,8 @@ jobs:
           DOMAIN="${{ secrets.DOMAIN }}"
           RESOURCE_PREFIX="nexus-${DOMAIN//./-}"
           PROJECT_NAME="${RESOURCE_PREFIX}-control"
-          echo "resource_prefix=$RESOURCE_PREFIX" >> $GITHUB_OUTPUT
-          echo "project_name=$PROJECT_NAME" >> $GITHUB_OUTPUT
+          echo "resource_prefix=$RESOURCE_PREFIX" >> "$GITHUB_OUTPUT"
+          echo "project_name=$PROJECT_NAME" >> "$GITHUB_OUTPUT"
           echo "Resource prefix: $RESOURCE_PREFIX"
           echo "Project name: $PROJECT_NAME"
 
@@ -181,10 +181,10 @@ jobs:
         id: check_r2
         run: |
           if [ -n "${{ secrets.R2_ACCESS_KEY_ID }}" ] && [ -n "${{ secrets.R2_SECRET_ACCESS_KEY }}" ]; then
-            echo "r2_exists=true" >> $GITHUB_OUTPUT
+            echo "r2_exists=true" >> "$GITHUB_OUTPUT"
             echo "✅ R2 credentials found in secrets"
           else
-            echo "r2_exists=false" >> $GITHUB_OUTPUT
+            echo "r2_exists=false" >> "$GITHUB_OUTPUT"
             echo "📦 No R2 credentials - will create new ones"
           fi
 
@@ -390,12 +390,12 @@ jobs:
           # Use if-else to prevent set -e from killing the script on aws failure
           if VALIDATION=$(aws s3api list-buckets --endpoint-url="$R2_ENDPOINT" --region auto 2>&1); then
             echo "✅ R2 credentials are valid"
-            echo "r2_valid=true" >> $GITHUB_OUTPUT
+            echo "r2_valid=true" >> "$GITHUB_OUTPUT"
           else
             VALIDATION_STATUS=$?
             echo "❌ R2 credentials are invalid (exit code $VALIDATION_STATUS)"
             echo "$VALIDATION"
-            echo "r2_valid=false" >> $GITHUB_OUTPUT
+            echo "r2_valid=false" >> "$GITHUB_OUTPUT"
 
             # Delete stale GitHub Secrets so init-r2-state.sh can recreate them
             if [ -n "$GH_TOKEN" ]; then
@@ -551,8 +551,8 @@ jobs:
           #
           # If you add a consumer of these outputs, mask on arrival there too.
           # Export as outputs for the calling workflow
-          echo "r2_access_key_id=$R2_ACCESS_KEY_ID" >> $GITHUB_OUTPUT
-          echo "r2_secret_access_key=$R2_SECRET_ACCESS_KEY" >> $GITHUB_OUTPUT
+          echo "r2_access_key_id=$R2_ACCESS_KEY_ID" >> "$GITHUB_OUTPUT"
+          echo "r2_secret_access_key=$R2_SECRET_ACCESS_KEY" >> "$GITHUB_OUTPUT"
           echo "✅ R2 credentials exported for spin-up workflow"
 
       - name: Ensure R2 state bucket exists
@@ -1018,10 +1018,15 @@ jobs:
             exit 1
           fi
 
-          # Output unified credentials for downstream workflows
-          echo "r2_data_access_key=$R2_ACCESS_KEY_ID" >> "$GITHUB_OUTPUT"
-          echo "r2_data_secret_key=$R2_SECRET_ACCESS_KEY" >> "$GITHUB_OUTPUT"
-          echo "r2_data_bucket=$BUCKET_NAME" >> "$GITHUB_OUTPUT"
+          # Output unified credentials for downstream workflows.
+          # Grouped rather than three separate redirects: one open of the
+          # file instead of three, which is what shellcheck's SC2129 asks
+          # for.
+          {
+            echo "r2_data_access_key=$R2_ACCESS_KEY_ID"
+            echo "r2_data_secret_key=$R2_SECRET_ACCESS_KEY"
+            echo "r2_data_bucket=$BUCKET_NAME"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Set Scheduled Teardown Worker secrets
         env:

--- a/.github/workflows/spin-up.yml
+++ b/.github/workflows/spin-up.yml
@@ -507,7 +507,7 @@ jobs:
               echo "✅ SSH ready + host provisioned (attempt $i)"
               break
             fi
-            if [ $i -eq 72 ]; then
+            if [ "$i" -eq 72 ]; then
               echo "❌ cloud-init did not complete after 6 minutes"
               echo "   Last attempt to surface diagnostic:"
               ssh -o StrictHostKeyChecking=no -o ConnectTimeout=5 -o BatchMode=yes \
@@ -595,7 +595,7 @@ jobs:
               echo "✅ Cloudflare Tunnel installed on attempt $attempt"
               break
             fi
-            if [ $attempt -eq 6 ]; then
+            if [ "$attempt" -eq 6 ]; then
               echo "❌ Tunnel install failed after 6 attempts — server unreachable or sshd misbehaving"
               exit 1
             fi

--- a/.github/workflows/validate-workflows.yaml
+++ b/.github/workflows/validate-workflows.yaml
@@ -19,10 +19,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
+      # No -ignore flags. SC2086 and SC2129 were suppressed here until every
+      # occurrence was fixed; the justifications ("noisy", "safe in workflow
+      # scripts") no longer describe anything present, and leaving them would
+      # let the class come back unseen.
+      #
+      # This job, not the pre-commit hook, is the real gate: actionlint only
+      # inspects `run:` blocks when a shellcheck binary is on PATH, and
+      # SILENTLY reports success when it is not. A contributor whose machine
+      # lacks it gets a green hook and no findings. The runner has shellcheck
+      # preinstalled, so this is where the guarantee lives.
       - name: Validate workflow files
         uses: raven-actions/actionlint@v2
         with:
           matcher: true
-          flags: "-ignore SC2086 -ignore SC2129"
-          # SC2086: Double quote warnings - noisy in GHA where unquoted expressions are common
-          # SC2129: Multiple redirections - safe in workflow scripts

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -118,3 +118,31 @@ repos:
           # SC2001: prefer parameter expansion — too noisy, sed/regex
           # readability often trumps perf savings here.
           - --exclude=SC1091,SC2001
+
+  # ---------------------------------------------------------------------------
+  # actionlint — the workflow YAMLs
+  # ---------------------------------------------------------------------------
+  # Added because the absence already cost something, and the evidence is a
+  # comment further up this file: a pytest step without `shell: bash` ran
+  # under GitHub's default `bash -e {0}`, which sets -e but NOT pipefail, so
+  # a failure inside a pipeline reported success and the workflow stayed
+  # green over it.
+  #
+  # actionlint also runs shellcheck over every `run:` block, which is where
+  # most of this repo's logic lives — the deploy path is Python, but the
+  # workflows around it are several thousand lines of bash.
+  #
+  # `files` is restricted to .github/workflows/ on purpose. actionlint is a
+  # workflow linter and does not understand composite actions: pointed at
+  # .github/actions/*/action.yml it reports `"jobs" section is missing`
+  # for every one of them.
+  #
+  # No --ignore flags: the repo is at zero findings as of this commit, which
+  # is the right state to add a gate in. Deliberate exceptions live inline as
+  # `# shellcheck disable=...` with a reason next to them — spin-up.yml has
+  # one for a single-quoted remote script that must not be expanded locally.
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.7
+    hooks:
+      - id: actionlint
+        files: ^\.github/workflows/.*\.ya?ml$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -141,6 +141,18 @@ repos:
   # is the right state to add a gate in. Deliberate exceptions live inline as
   # `# shellcheck disable=...` with a reason next to them — spin-up.yml has
   # one for a single-quoted remote script that must not be expanded locally.
+  #
+  # ⚠️ This hook is fast local feedback, NOT the gate. actionlint inspects
+  # `run:` blocks only when a `shellcheck` binary is on PATH, and it SILENTLY
+  # reports success when there is none — measured: the same workflow that
+  # yields an SC2086 finding with shellcheck present produces no output and
+  # exit 0 without it. On a machine without shellcheck this hook still checks
+  # workflow syntax, expressions and contexts, but not the shell inside.
+  #
+  # The guarantee lives in `.github/workflows/validate-workflows.yaml`, which
+  # runs actionlint on every push and PR touching .github/workflows/ on a
+  # runner that has shellcheck preinstalled. Install shellcheck locally
+  # (`brew install shellcheck`) to get the full check before pushing.
   - repo: https://github.com/rhysd/actionlint
     rev: v1.7.7
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -142,6 +142,19 @@ repos:
   # `# shellcheck disable=...` with a reason next to them — spin-up.yml has
   # one for a single-quoted remote script that must not be expanded locally.
   #
+  # First run is expensive and there is no warning before it. Upstream's
+  # `actionlint` id is `language: golang`, so pre-commit builds the binary
+  # from source — and when no `go` is on PATH it downloads a full Go
+  # toolchain first rather than failing. Measured on a machine without Go:
+  # 318 MB under ~/.cache/pre-commit/<repo>/golangenv-default, of which the
+  # toolchain in `.go/` is nearly all of it. Every run after that is ~0.2 s.
+  # Nothing needs installing by hand; budget the download once per clone.
+  #
+  # Two alternatives exist upstream if that trade is wrong for you:
+  # `actionlint-docker` (pulls rhysd/actionlint:1.7.7, needs a daemon) and
+  # `actionlint-system` (uses a `brew install actionlint` binary, no Go, but
+  # then the version is whatever brew has rather than the pinned rev).
+  #
   # ⚠️ This hook is fast local feedback, NOT the gate. actionlint inspects
   # `run:` blocks only when a `shellcheck` binary is on PATH, and it SILENTLY
   # reports success when there is none — measured: the same workflow that

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -453,9 +453,9 @@ which tofu cloudflared docker
 ### Pre-commit hooks (REQUIRED before Python edits)
 
 The repo ships a `.pre-commit-config.yaml` that runs `ruff format`,
-`ruff check`, `mypy`, and `shellcheck` on every commit. **The hook is
-not active until installed locally** — fresh clones don't get it
-automatically. Without it, formatter drift (e.g. long f-strings, set
+`ruff check`, `mypy`, `shellcheck`, and `actionlint` on every commit.
+**The hook is not active until installed locally** — fresh clones don't
+get it automatically. Without it, formatter drift (e.g. long f-strings, set
 comprehensions) lands on the branch, then CI fails on the `ruff format
 --check` step with a "would reformat N files" error.
 
@@ -469,6 +469,17 @@ uv run pre-commit install
 Verify it's wired up:
 ```bash
 ls -la .git/hooks/pre-commit  # should exist and be executable
+```
+
+**The first run after installing takes minutes and looks like a hang.**
+`actionlint` is a `language: golang` hook, so pre-commit builds it from
+source, and when no `go` is on PATH it downloads a whole Go toolchain
+first instead of failing — measured at 318 MB under `~/.cache/pre-commit/`.
+Nothing needs installing by hand and every later run is ~0.2 s; just don't
+interrupt the first one. Warm the cache deliberately if you'd rather not
+meet it mid-commit:
+```bash
+uv run pre-commit run actionlint --all-files
 ```
 
 **Don't rely on memory** — `ruff check` (which catches lint rules) and


### PR DESCRIPTION
Closes #722

## Why

The evidence sat in `.pre-commit-config.yaml` itself:

```
# missing `shell: bash` (no pipefail) and swallowed the exit code.
```

A step without `shell: bash` runs under GitHub's default `bash -e {0}` — `-e` set, `pipefail` not. A failure inside a pipeline reported success and the workflow stayed green over it. `actionlint` catches that class, and runs shellcheck over every `run:` block besides, which is where most of this repo's logic lives.

## Clearing the way first

Adding the gate meant getting to zero findings. There were 18, all shellcheck:

| Finding | Count | Fix |
|---|---|---|
| Unquoted `>> $GITHUB_OUTPUT` / `$GITHUB_ENV` | 15 | Quoted |
| Unquoted loop counters `$i`, `$attempt` | 2 | Quoted |
| `SC2129` — three consecutive redirects to one file | 1 | Grouped into `{ … } >> "$GITHUB_OUTPUT"` |

**Fixed rather than suppressed.** The redirects are harmless in practice — GitHub sets those variables to paths without spaces — but quoting costs nothing and is correct. Zero findings is the right state to add a gate in; a hook that ships with an ignore list invites the next exception.

## Two config details worth knowing

**`files` is restricted to `.github/workflows/`.** `actionlint` is a workflow linter and does not understand composite actions. Pointed at `.github/actions/*/action.yml` it reports:

```
.github/actions/nexus-bootstrap/action.yml:1:1: "jobs" section is missing in workflow
```

for every one of them. Scoping the hook is not a workaround for noise, it is the tool's actual boundary.

**No `--ignore` flags.** Deliberate exceptions stay inline as `# shellcheck disable=…` with the reason next to them — `spin-up.yml` already carries one for the single-quoted remote probe that must not expand in the runner's shell. A blanket ignore would have hidden that reasoning.

## Verified both directions

Passing on a clean tree proves nothing on its own, so the hook was tested against an injected fault — an invalid context property in a real workflow:

```
cleanup-orphaned-resources.yml:12:18: property "nonexistent_property" is not
defined in object type {action: string; …} [expression]
   |
12 |     runs-on: ${{ github.nonexistent_property }}
   |                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Reverted, green again, and `git status` showed only the three intended files changed.

## How to test

Nothing to deploy.

```bash
uv run pre-commit install     # if not already
uv run pre-commit run actionlint --all-files
```

Fresh clones need `pre-commit install` for the hook to fire at all — the same caveat `CLAUDE.md` already records for the existing hooks.
