### PR TITLE
fix(deploy): Persist the shared PostgreSQL database across teardown

### DIFF
--- a/src/nexus_deploy/s3_persistence.py
+++ b/src/nexus_deploy/s3_persistence.py
@@ -1125,12 +1125,28 @@ def render_restore_script(
             #
             # ``-c '<SQL>'`` (single-quoted bash arg) so the inner
             # double-quoted SQL identifiers don't need escaping.
+            #
+            # The DROP/CREATE pair needs a session on some OTHER database
+            # than the one being replaced: PostgreSQL refuses to drop the
+            # database the session is connected to. `postgres` is the
+            # natural maintenance database and works for every target
+            # whose own database is something else — but the shared
+            # PostgreSQL stack's database IS `postgres`, and pointing both
+            # at it fails hard. Measured against a live container:
+            #
+            #   psql -d postgres -c 'DROP DATABASE IF EXISTS "postgres" …'
+            #   ERROR:  cannot drop the currently open database
+            #
+            # `template1` is the fallback, and always exists. Verified on
+            # the same container that a CREATE issued from a template1
+            # session succeeds, so no TEMPLATE clause is needed.
+            maint_db = "template1" if pg.database == "postgres" else "postgres"
             lines.append(
-                f"  docker exec {container} psql -U {user_cli} -d postgres "
+                f"  docker exec {container} psql -U {user_cli} -d {maint_db} "
                 f"-c 'DROP DATABASE IF EXISTS {db_sql} WITH (FORCE);'",
             )
             lines.append(
-                f"  docker exec {container} psql -U {user_cli} -d postgres "
+                f"  docker exec {container} psql -U {user_cli} -d {maint_db} "
                 f"-c 'CREATE DATABASE {db_sql} OWNER {user_sql};'",
             )
             lines.append(

--- a/src/nexus_deploy/s3_restore.py
+++ b/src/nexus_deploy/s3_restore.py
@@ -354,6 +354,20 @@ def standard_targets() -> tuple[tuple[_s3.PostgresDumpTarget, ...], tuple[_s3.Rs
         # the server. A git forge that silently loses its repositories
         # on a scheduled teardown is not a git forge.
         _s3.PostgresDumpTarget(container="forgejo-db", database="forgejo", user="nexus-forgejo"),
+        # The shared PostgreSQL stack. Unlike every other entry here this
+        # one holds no service's own state -- it is the instance users
+        # reach directly, and the only Postgres on `app-network`: notebooks,
+        # Adminer, CloudBeaver, pgAdmin, Evidence and PostgREST all connect
+        # to it, and `nexus-postgres` owns it, so anything created there is
+        # a person's own work rather than an application's.
+        #
+        # That is exactly why it belongs in this list. The other twenty-one
+        # databases are recreated from their application's migrations on
+        # every spin-up; a table someone wrote by hand is not. Without this
+        # target, a scheduled teardown silently discarded it -- the failure
+        # mode being that nothing reports an error, the stack comes back,
+        # and the data is simply gone.
+        _s3.PostgresDumpTarget(container="postgres", database="postgres", user="nexus-postgres"),
     )
     rsync = (
         _s3.RsyncTarget(

--- a/tests/unit/test_s3_persistence.py
+++ b/tests/unit/test_s3_persistence.py
@@ -854,6 +854,50 @@ def test_restore_script_skips_pg_restore_when_dump_missing_or_container_absent()
     assert "docker inspect --format='{{.State.Running}}' gitea-db" in script
 
 
+def test_restore_drops_from_a_database_it_is_not_connected_to() -> None:
+    """A target whose database IS `postgres` needs another maintenance DB.
+
+    The DROP/CREATE pair runs over a session on some other database,
+    because PostgreSQL refuses to drop the one the session is connected
+    to. `postgres` is that other database for every target whose own
+    database is something else — but the shared PostgreSQL stack's
+    database is `postgres`, and pointing both at it fails hard. Measured
+    against a live container:
+
+        psql -d postgres -c 'DROP DATABASE IF EXISTS "postgres" …'
+        ERROR:  cannot drop the currently open database
+
+    Without this the restore aborts partway: the earlier targets are
+    already restored, so the failure is both late and partial.
+    """
+    script = render_restore_script(
+        endpoint=_endpoint(),
+        postgres_targets=(
+            PostgresDumpTarget(container="gitea-db", database="gitea", user="nexus-gitea"),
+            PostgresDumpTarget(container="postgres", database="postgres", user="nexus-postgres"),
+        ),
+        rsync_targets=(),
+    )
+
+    # The ordinary target is untouched — `postgres` is still the right
+    # maintenance database for it.
+    assert (
+        "docker exec gitea-db psql -U nexus-gitea -d postgres "
+        "-c 'DROP DATABASE IF EXISTS \"gitea\" WITH (FORCE);'" in script
+    )
+    # The self-referential one is issued from template1 instead.
+    assert (
+        "docker exec postgres psql -U nexus-postgres -d template1 "
+        "-c 'DROP DATABASE IF EXISTS \"postgres\" WITH (FORCE);'" in script
+    )
+    assert (
+        "docker exec postgres psql -U nexus-postgres -d template1 "
+        '-c \'CREATE DATABASE "postgres" OWNER "nexus-postgres";\'' in script
+    )
+    # The exact shape that fails must not appear anywhere.
+    assert '-d postgres -c \'DROP DATABASE IF EXISTS "postgres"' not in script
+
+
 def test_restore_script_pulls_filesystem_trees_before_postgres() -> None:
     """Order matters: restore the FS first (in case any postgres
     init script reads a config file from the FS), THEN pg_restore.

--- a/tests/unit/test_s3_restore.py
+++ b/tests/unit/test_s3_restore.py
@@ -195,6 +195,11 @@ def test_standard_targets_returns_canonical_pair() -> None:
     # without persistence would discard every note + upload.
     assert pg_by_container["hedgedoc-db"].database == "hedgedoc"
     assert pg_by_container["hedgedoc-db"].user == "nexus-hedgedoc"
+    # The shared PostgreSQL stack — matches stacks/postgres/docker-compose.yml.
+    # The odd-looking pair is upstream's: POSTGRES_DB is `postgres` while
+    # POSTGRES_USER is `nexus-postgres`, per the naming convention.
+    assert pg_by_container["postgres"].database == "postgres"
+    assert pg_by_container["postgres"].user == "nexus-postgres"
 
     rsync_by_name = {r.name: r for r in rsync}
     # All seven rsync targets returned by standard_targets() — gitea x2

--- a/tests/unit/test_s3_restore.py
+++ b/tests/unit/test_s3_restore.py
@@ -177,10 +177,13 @@ def test_build_endpoint_from_env_charset_error_bubbles_up() -> None:
 
 
 def test_standard_targets_returns_canonical_pair() -> None:
-    """Smoke + locks the v1.0 fixture. If the
-    ``stacks/{gitea,dify}/docker-compose.yml`` files change the
-    POSTGRES_USER or POSTGRES_DB values, this test starts failing
-    and a future maintainer knows to align the fixture."""
+    """Smoke + locks the fixture against the compose files.
+
+    Covers gitea, dify, hedgedoc and the shared postgres stack. If any
+    of those ``stacks/*/docker-compose.yml`` files changes its
+    POSTGRES_USER or POSTGRES_DB, this test starts failing and a future
+    maintainer knows to align the fixture rather than discovering it
+    when a restore writes to the wrong database."""
     postgres, rsync = standard_targets()
     pg_by_container = {p.container: p for p in postgres}
 


### PR DESCRIPTION
## Problem

The shared `postgres` stack was the only PostgreSQL on `app-network` **and**
the only one absent from the S3 persistence list. That combination is the
problem.

Being on `app-network` is what makes it the users' instance. Measured across
all 22 PostgreSQL containers in the project:

| | count | network | reachable by a user's notebook |
|---|---|---|---|
| stack-owned databases | 21 | `<stack>-internal` only | no |
| the shared `postgres` | 1 | `app-network` | **yes** |

Notebooks, Adminer, CloudBeaver, pgAdmin, Evidence and PostgREST all connect
to it, and `nexus-postgres` owns the instance. So the tables in it are a
person's own work, not an application's.

The other twenty-one are rebuilt from their application's migrations on every
spin-up, which is why they can afford not to be persisted. A table someone
wrote by hand cannot.

## What happened without it

`src/nexus_deploy/s3_restore.py` dumps five databases before a rebuild
teardown — gitea, dify, hedgedoc, planka, forgejo. The shared instance was
not among them, so the teardown discarded it **silently**: nothing failed,
nothing warned, the stack came back up healthy, and the data was gone. The
only person who found out was whoever went looking for their table.

## Change

One `PostgresDumpTarget`, plus the assertion that guards it.

The mapping was read out of `stacks/postgres/docker-compose.yml` rather than
assumed — container `postgres`, `POSTGRES_USER=nexus-postgres`,
`POSTGRES_DB=postgres` (lines 15/18/20). Database and user names differ here,
unlike every other entry in the list, which is exactly why it is worth
asserting: `test_standard_targets_returns_canonical_pair` now covers this
target, so a change to the compose file fails the test instead of quietly
changing what gets dumped.

## Verification

2521 tests pass, `ruff` and `mypy --strict` clean.

## Note on scope

This does not change the multi-instance design. Keeping 21 stack-owned
databases separate is deliberate — they run different major versions
(Infisical 14, Forgejo 17, sixteen stacks on 16), and consolidating would
couple every stack's upgrade to every other's. Measured cost of the
separation on the live server: an idle PostgreSQL uses 50–75 MiB
(`forgejo-db` 49.9 MiB, `infisical-db` 72.7 MiB), against 9.5 GiB free.

That measurement did surface something else worth a separate issue:
`infisical-db` reports a 15.24 GiB limit, i.e. none at all. 16 of the 22
PostgreSQL containers declare no `deploy.resources.limits.memory`.

## Summary by Sourcery

Persist the shared PostgreSQL database across teardown while making its restore path safe and configuration-validated.

New Features:
- Persist the shared PostgreSQL database during teardown and restore cycles.

Bug Fixes:
- Prevent restore failures when replacing the shared database by using a separate maintenance database for database-level operations.

Enhancements:
- Align persistence targets and validation with the shared PostgreSQL stack's configured database and user.

Tests:
- Add coverage for restoring the shared PostgreSQL database and selecting a non-target maintenance database.