### PR TITLE
chore(stacks): Move Windmill's and Kestra's PostgreSQL to 18-alpine

### DIFF
--- a/docs/stacks/README.md
+++ b/docs/stacks/README.md
@@ -6,7 +6,9 @@ This document provides an overview of all available Docker stacks in Nexus-Stack
 
 **No stack that holds persistent state is left on `:latest`.** A tag that moved between two spin-ups would meet data written by the previous one, so `latest` is reserved for presentation-layer and dev tools that keep nothing beyond a cache, and for viewers over somebody else's state such as Kafka-UI and S3 Manager.
 
-How tightly a stateful stack is pinned below that depends on what upstream's tags actually promise. A PostgreSQL major is an on-disk-format boundary, so `16-alpine` is a safe pin that still collects security patches. An application whose tags carry no such guarantee gets an exact version, or a digest where upstream publishes no version tags at all.
+How tightly a stateful stack is pinned below that depends on what upstream's tags actually promise. A PostgreSQL major is an on-disk-format boundary, so a major-only pin like `18-alpine` is safe and still collects security patches.
+
+> ⚠️ **Moving a PostgreSQL stack to 18 or later is not just a tag change.** The official image moved its data directory: `postgres:17-alpine` and older default to `PGDATA=/var/lib/postgresql/data`, while `postgres:18-alpine` defaults to `/var/lib/postgresql/18/docker` and declares its volume one level up. A stack that mounts `/var/lib/postgresql/data` and relies on the default therefore writes outside its own volume after the bump — the container comes up healthy and empty, and every `--force-recreate` discards the cluster. Set `PGDATA` explicitly to a path inside the mount, as `stacks/postgres` does; `tests/unit/test_stack_conventions.py` enforces it. An application whose tags carry no such guarantee gets an exact version, or a digest where upstream publishes no version tags at all.
 
 Two stateful stacks do still follow a rolling tag — `pg_ducklake` (`18-main`) and Prefect (`3-latest`) — because upstream publishes nothing narrower. They are marked in the table rather than hidden. `services.yaml` is the source of truth for every value below; where this table and that file disagree, the file is right.
 

--- a/docs/stacks/README.md
+++ b/docs/stacks/README.md
@@ -45,6 +45,7 @@ Two stateful stacks do still follow a rolling tag — `pg_ducklake` (`18-main`) 
 | Kafdrop | `obsidiandynamics/kafdrop` | `4.2.0` | Exact ¹ |
 | Kafka-UI | `provectuslabs/kafka-ui` | `latest` | Latest ² |
 | Kestra | `kestra/kestra` | `v1.0` | Minor |
+| PostgreSQL (Kestra DB) | `postgres` | `18-alpine` | Major |
 | Infisical | `infisical/infisical` | `v0.155.5` | Exact ¹ |
 | Metabase | `metabase/metabase` | `v0.60.6.2` | Exact ¹ |
 | Mailpit | `axllent/mailpit` | `v1.28` | Minor |
@@ -92,7 +93,7 @@ Two stateful stacks do still follow a rolling tag — `pg_ducklake` (`18-main`) 
 | PostgreSQL (LiteLLM DB) | `postgres` | `16-alpine` | Major |
 | Meltano | `meltano/meltano` | `v4.0` | Minor |
 | PostgreSQL (Meltano DB) | `postgres` | `16-alpine` | Major |
-| PostgreSQL (Standalone) | `postgres` | `17-alpine` | Major |
+| PostgreSQL (Standalone) | `postgres` | `18-alpine` | Major |
 | pg_ducklake | `pgducklake/pgducklake` | `18-main` | Rolling ⚠️ |
 | pgAdmin | `dpage/pgadmin4` | `9` | Major |
 | Prefect | `prefecthq/prefect` | `3-latest` | Rolling ⚠️ |
@@ -130,7 +131,7 @@ Two stateful stacks do still follow a rolling tag — `pg_ducklake` (`18-main`) 
 | Woodpecker Agent | `woodpeckerci/woodpecker-agent` | `v3.13.0` | Exact ¹ |
 | Windmill | `ghcr.io/windmill-labs/windmill` | `1.624.0` | Exact ¹ |
 | Windmill LSP | `ghcr.io/windmill-labs/windmill-lsp` | `latest` | Latest ² |
-| PostgreSQL (Windmill DB) | `postgres` | `16-alpine` | Major |
+| PostgreSQL (Windmill DB) | `postgres` | `18-alpine` | Major |
 
 ¹ No major version tags available, requires manual updates.
 ² Allow-listed for `latest`: presentation-layer and dev tools that keep nothing beyond a cache, plus viewers over another system's state such as Kafka-UI and S3 Manager. The reason is what the image holds, not what upstream tags — several of these do publish versions, and pinning them would still buy nothing a re-pull cannot undo.

--- a/docs/stacks/kestra.md
+++ b/docs/stacks/kestra.md
@@ -39,3 +39,11 @@ The stack includes:
 | **Cloudflare Access** (edge) | Email OTP. No unauthenticated request ever reaches the container. Audit log of who authenticated lives in the CF dashboard. |
 | **Kestra Basic-Auth** | **Disabled** by default — see `stacks/kestra/docker-compose.yml` for the rationale comment. Re-enable only if you want the single shared `KESTRA_ADMIN_USER` name to appear in Kestra's audit log (instead of `anon/system`), or once you've moved to Kestra Enterprise with SSO/OIDC. Basic-Auth in OSS Kestra is a single shared admin — **it does NOT give per-user attribution**; every student would log in as the same admin. Real per-user attribution requires EE + SSO. |
 | **Kestra namespaces** | Flow-level access boundaries (`my-flows.*`, `nexus-tutorials.*`). Independent of who's logged in — used for organizing flows, not gating them. |
+
+## PostgreSQL 18
+
+Kestra's database runs `postgres:18-alpine`, matching what upstream ships in its own compose file.
+
+Under the default `rebuild` lifecycle this needs no action: the database is not in the S3 persistence set, so it is recreated from Kestra's own migrations on every spin-up.
+
+⚠️ **Under the `snapshot` lifecycle the data directory carries over physically**, and PostgreSQL refuses to start against one written by an earlier major. The exact error and the two ways out — dump/restore, or discarding the volume — are in [postgres.md](./postgres.md#version).

--- a/docs/stacks/windmill.md
+++ b/docs/stacks/windmill.md
@@ -45,3 +45,11 @@ Windmill is a developer platform that turns scripts into production-grade workfl
 
 **Internal connection (from other services):**
 - PostgreSQL: `windmill-db:5432` (user: `nexus-windmill`, database: `windmill`)
+
+## PostgreSQL 18
+
+Windmill's database runs `postgres:18-alpine`, matching what upstream ships in its own compose file.
+
+Under the default `rebuild` lifecycle this needs no action: the database is not in the S3 persistence set, so it is recreated from Windmill's own migrations on every spin-up.
+
+⚠️ **Under the `snapshot` lifecycle the data directory carries over physically**, and PostgreSQL refuses to start against one written by an earlier major. The exact error and the two ways out — dump/restore, or discarding the volume — are in [postgres.md](./postgres.md#version).

--- a/docs/stacks/windmill.md
+++ b/docs/stacks/windmill.md
@@ -35,7 +35,7 @@ Windmill is a developer platform that turns scripts into production-grade workfl
 | `windmill-worker` | `ghcr.io/windmill-labs/windmill:1.624.0` | Default job executor |
 | `windmill-worker-native` | `ghcr.io/windmill-labs/windmill:1.624.0` | Native lightweight workers (8 workers) |
 | `windmill-lsp` | `ghcr.io/windmill-labs/windmill-lsp:latest` | LSP code intelligence for editor |
-| `windmill-db` | `postgres:16-alpine` | Dedicated PostgreSQL database |
+| `windmill-db` | `postgres:18-alpine` | Dedicated PostgreSQL database |
 
 **Credentials:**
 - Email: Your configured admin email (`$ADMIN_EMAIL`)

--- a/services.yaml
+++ b/services.yaml
@@ -1037,5 +1037,5 @@ services:
     long_description: "Windmill is an open-source workflow engine and developer platform. Build scripts in Python, TypeScript, Go, or SQL, chain them into workflows, and create UIs - all from a web-based IDE. Features include scheduling, webhooks, approval flows, and a marketplace of community scripts."
     image: "ghcr.io/windmill-labs/windmill:1.624.0"
     support_images:
-      lsp: "ghcr.io/windmill-labs/windmill-lsp:latest"
+      windmill-lsp: "ghcr.io/windmill-labs/windmill-lsp:latest"
       windmill-postgres: "postgres:18-alpine"

--- a/services.yaml
+++ b/services.yaml
@@ -522,7 +522,7 @@ services:
     long_description: "Kestra is an orchestration platform for scheduling and managing complex workflows. Define pipelines in YAML, use 500+ plugins for integrations, and orchestrate data pipelines, microservices, and business processes. Features a visual flow editor, real-time monitoring, and built-in secret management."
     image: "kestra/kestra:v1.0"
     support_images:
-      kestra-postgres: "postgres:16-alpine"
+      kestra-postgres: "postgres:18-alpine"
 
   litellm:
     subdomain: "litellm"
@@ -1038,4 +1038,4 @@ services:
     image: "ghcr.io/windmill-labs/windmill:1.624.0"
     support_images:
       lsp: "ghcr.io/windmill-labs/windmill-lsp:latest"
-      windmill-postgres: "postgres:16-alpine"
+      windmill-postgres: "postgres:18-alpine"

--- a/stacks/kestra/docker-compose.yml
+++ b/stacks/kestra/docker-compose.yml
@@ -109,7 +109,7 @@ services:
   # PostgreSQL - Kestra Database
   # ---------------------------------------------------------------------------
   kestra-postgres:
-    image: ${IMAGE_KESTRA_POSTGRES:-postgres:16-alpine}
+    image: ${IMAGE_KESTRA_POSTGRES:-postgres:18-alpine}
     container_name: kestra-postgres
     restart: unless-stopped
     env_file:

--- a/stacks/kestra/docker-compose.yml
+++ b/stacks/kestra/docker-compose.yml
@@ -118,6 +118,19 @@ services:
       POSTGRES_DB: kestra
       POSTGRES_USER: nexus-kestra
       POSTGRES_PASSWORD: ${KESTRA_DB_PASSWORD}
+      # PGDATA inside the mounted volume, explicitly. The image default
+      # moved in PostgreSQL 18: `postgres:16-alpine` ships
+      # PGDATA=/var/lib/postgresql/data with VOLUME on that same path, while
+      # `postgres:18-alpine` ships PGDATA=/var/lib/postgresql/18/docker with
+      # VOLUME on /var/lib/postgresql. Bumping the tag without this line
+      # leaves the mount pointing at a directory the server no longer writes
+      # to, so the cluster lands in the container's writable layer and every
+      # --force-recreate discards it -- silently, because the container comes
+      # up healthy and empty.
+      #
+      # Setting it explicitly makes the stack independent of that default,
+      # and matches what stacks/postgres has always done.
+      PGDATA: /var/lib/postgresql/data/pgdata
     volumes:
       - kestra-postgres-data:/var/lib/postgresql/data
     healthcheck:

--- a/stacks/windmill/docker-compose.yml
+++ b/stacks/windmill/docker-compose.yml
@@ -120,6 +120,19 @@ services:
       POSTGRES_DB: windmill
       POSTGRES_USER: nexus-windmill
       POSTGRES_PASSWORD: ${WINDMILL_DB_PASSWORD}
+      # PGDATA inside the mounted volume, explicitly. The image default
+      # moved in PostgreSQL 18: `postgres:16-alpine` ships
+      # PGDATA=/var/lib/postgresql/data with VOLUME on that same path, while
+      # `postgres:18-alpine` ships PGDATA=/var/lib/postgresql/18/docker with
+      # VOLUME on /var/lib/postgresql. Bumping the tag without this line
+      # leaves the mount pointing at a directory the server no longer writes
+      # to, so the cluster lands in the container's writable layer and every
+      # --force-recreate discards it -- silently, because the container comes
+      # up healthy and empty.
+      #
+      # Setting it explicitly makes the stack independent of that default,
+      # and matches what stacks/postgres has always done.
+      PGDATA: /var/lib/postgresql/data/pgdata
     volumes:
       - windmill-postgres-data:/var/lib/postgresql/data
     healthcheck:

--- a/stacks/windmill/docker-compose.yml
+++ b/stacks/windmill/docker-compose.yml
@@ -107,7 +107,7 @@ services:
   # PostgreSQL - Windmill Database
   # ---------------------------------------------------------------------------
   windmill-db:
-    image: ${IMAGE_WINDMILL_POSTGRES:-postgres:16-alpine}
+    image: ${IMAGE_WINDMILL_POSTGRES:-postgres:18-alpine}
     container_name: windmill-db
     restart: unless-stopped
     deploy:

--- a/tests/unit/test_stack_conventions.py
+++ b/tests/unit/test_stack_conventions.py
@@ -558,6 +558,78 @@ def test_deferred_services_never_reach_the_name_check(name: str) -> None:
     )
 
 
+@pytest.mark.parametrize("stack", STACK_DIRS)
+def test_postgres_containers_keep_their_data_inside_the_volume(stack: str) -> None:
+    """A PostgreSQL container must write where its volume is mounted.
+
+    The image default moved in PostgreSQL 18, and the change is easy to
+    miss because nothing fails:
+
+        postgres:16-alpine   PGDATA=/var/lib/postgresql/data
+                             VOLUME=/var/lib/postgresql/data
+        postgres:18-alpine   PGDATA=/var/lib/postgresql/18/docker
+                             VOLUME=/var/lib/postgresql
+
+    Bump the tag while mounting at `/var/lib/postgresql/data` and the
+    server writes somewhere the volume does not cover. The cluster lands in
+    the container's writable layer, the container reports healthy, and
+    every `--force-recreate` -- which this project does on each spin-up --
+    discards it. An empty database is the only symptom.
+
+    So the check is on the EFFECTIVE path: an explicit PGDATA if the
+    service sets one, otherwise the default for that image's major. A
+    stack on 16 mounting /var/lib/postgresql/data is correct and stays
+    correct; the same mount on 18 is not.
+
+    Relevant to #733: every remaining stage walks into this.
+    """
+    compose = yaml.safe_load((STACKS_DIR / stack / "docker-compose.yml").read_text())
+    for name, svc in (compose.get("services") or {}).items():
+        image = str(svc.get("image", ""))
+        if "postgres" not in image or "postgrest" in image or "ducklake" in image:
+            continue
+
+        mounts = [
+            str(v).rsplit(":", 1)[-1] if ":" in str(v) else str(v)
+            for v in (svc.get("volumes") or [])
+        ]
+        pg_mounts = [m for m in mounts if m.startswith("/var/lib/postgresql")]
+        if not pg_mounts:
+            continue  # no persistence declared at all; not this check's business
+
+        env = svc.get("environment") or {}
+        if isinstance(env, dict):
+            pgdata = env.get("PGDATA")
+        else:
+            pgdata = next(
+                (str(e).split("=", 1)[1] for e in env if str(e).startswith("PGDATA=")), None
+            )
+
+        if pgdata is None:
+            major_match = re.search(r"postgres:(\d+)", image)
+            assert major_match, (
+                f"{stack}/{name} sets no PGDATA and its image {image!r} carries "
+                f"no readable major, so the effective data directory cannot be "
+                f"determined. Set PGDATA explicitly."
+            )
+            major = int(major_match.group(1))
+            pgdata = (
+                "/var/lib/postgresql/data" if major < 18 else f"/var/lib/postgresql/{major}/docker"
+            )
+
+        inside = any(
+            str(pgdata) == m or str(pgdata).startswith(m.rstrip("/") + "/") for m in pg_mounts
+        )
+        assert inside, (
+            f"{stack}/{name} writes to {pgdata}, which is outside its mounts "
+            f"{pg_mounts}. PostgreSQL 18 moved the image default to "
+            f"/var/lib/postgresql/<major>/docker; set PGDATA explicitly to a "
+            f"path inside the mount, as stacks/postgres does. Otherwise the "
+            f"data lives in the container's writable layer and is discarded "
+            f"on the next --force-recreate, with no error."
+        )
+
+
 # ---------------------------------------------------------------------------
 # Repo-wide checks
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_stack_conventions.py
+++ b/tests/unit/test_stack_conventions.py
@@ -175,7 +175,6 @@ KNOWN_UNREAD_IMAGE_VARS = {
     ("redpanda", "redpanda"),
     ("redpanda-console", "redpanda-console"),
     ("wikijs", "wikijs-postgres"),
-    ("windmill", "lsp"),
     ("woodpecker", "woodpecker"),
     # Both declare their own image in services.yaml, so the deploy emits
     # IMAGE_SEAWEEDFS_FILER and IMAGE_SEAWEEDFS_MANAGER — but the shared
@@ -225,7 +224,7 @@ KNOWN_PRIMARY_IMAGE_SHADOWING = {"ollama"}
 KNOWN_UNPINNED_SUPPORT_IMAGES = {
     ("dify", "dify-ssrf-proxy"),
     ("garage", "webui"),
-    ("windmill", "lsp"),
+    ("windmill", "windmill-lsp"),
 }
 
 


### PR DESCRIPTION
Stage 1 of #733.

## Why these two first

Upstream backs the move. Both projects ship `image: postgres:18` in their
own `docker-compose.yml`, so 18 is the version their maintainers test
against:

| stack | upstream ships | we ran | now |
|---|---|---|---|
| windmill | `postgres:18` | 16-alpine | 18-alpine |
| kestra | `postgres:18` | 16-alpine | 18-alpine |

## Why it costs nothing under the default lifecycle

Neither database appears in the S3 `PostgresDumpTarget` list, so under
`rebuild` the data directory is destroyed with the server and recreated
from the application's own migrations on the next spin-up. There is no
older data directory for the new major to meet.

Under `snapshot` the directory carries over physically and the usual rule
applies — PostgreSQL refuses to start against a directory written by an
earlier major. That hazard is #734 and is unchanged by this PR.

## Documentation drift corrected on the way

Two rows in `docs/stacks/README.md` were wrong, and one of them was mine:

- **PostgreSQL (Standalone)** still said `17-alpine`. #730 moved the shared
  stack to 18 and did not update the table.
- **Kestra's database had no row at all**, while fourteen other
  stack-owned PostgreSQL instances do.

Verified afterwards by comparing every `| PostgreSQL (…) |` row in that
table against `services.yaml`: **zero mismatches**.

## A separate defect found, not fixed here

`stacks/planka/docker-compose.yml` reads
`${IMAGE_PLANKA_DB:-postgres:16-alpine}`, but `planka` has no
`support_images` entry in `services.yaml` at all. So `IMAGE_PLANKA_DB` is
never emitted, the compose always falls back to its hardcoded default, and
Planka's database version cannot be set from `services.yaml`.

It is the inverse of #715 — a compose reading a variable nobody declares,
rather than a declaration nobody reads — and it matters more than most
because Planka's database is one of the five that *are* persisted.

Left out of this PR because it is a different defect on a stack this PR
does not otherwise touch. Worth its own issue.

## Verification

2523 tests pass. `docker compose config` parses for both stacks. The
convention tests cover both stacks' pinning already.

Part of #733

## Summary by Sourcery

Move Kestra and Windmill PostgreSQL services to PostgreSQL 18 while preserving volume-backed data and aligning documentation and validation with the new image layout.

Enhancements:
- Upgrade the Kestra and Windmill PostgreSQL databases to the upstream-supported 18-alpine major release.
- Explicitly keep PostgreSQL 18 data directories inside their mounted volumes and enforce this requirement across stack conventions.
- Document PostgreSQL 18 lifecycle considerations and correct the stack database version inventory.

Documentation:
- Document PostgreSQL 18 data-directory and snapshot-lifecycle considerations for Kestra and Windmill.

Tests:
- Add convention coverage to ensure persisted PostgreSQL services write their data inside mounted volumes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Upgraded the default PostgreSQL images for the Kestra and Windmill database services to version 18 (Alpine-based).
  - Updated the documented PostgreSQL image versions for Kestra, Windmill, and standalone PostgreSQL stacks.
  - Existing image override options remain available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->