### PR TITLE
chore(stacks): Move Superset's and Lakekeeper's PostgreSQL to 17-alpine

### DIFF
--- a/docs/stacks/README.md
+++ b/docs/stacks/README.md
@@ -26,12 +26,14 @@ Two stateful stacks do still follow a rolling tag — `pg_ducklake` (`18-main`) 
 | Crawl4AI | `unclecode/crawl4ai` | `0.8.6` | Exact ¹ |
 | CyberChef | `mpepping/cyberchef` | `v10.24.0` | Exact ¹ |
 | Dagster | dagster (custom build) | `1.12.21` | Exact ³ |
+| PostgreSQL (Dagster DB) | `postgres` | `16-alpine` | Major |
 | Debezium | `quay.io/debezium/connect` | `3.5.0` | Exact ¹ |
 | Dinky | `dinkydocker/dinky-standalone-server` | `1.2.5-flink1.20` | Exact ¹ |
 | Dozzle | `amir20/dozzle` | `v10.5.3` | Exact ¹ |
 | Draw.io | `jgraph/drawio` | `latest` | Latest ² |
 | Grafana | `grafana/grafana` | `11.6` | Minor |
 | Hoppscotch | `hoppscotch/hoppscotch` | `2025.12.1` | Exact ¹ |
+| PostgreSQL (Hoppscotch DB) | `postgres` | `15-alpine` | Major |
 | Prometheus | `prom/prometheus` | `v3.9.1` | Exact ¹ |
 | Loki | `grafana/loki` | `3` | Major |
 | Promtail | `grafana/promtail` | `3` | Major |
@@ -49,6 +51,7 @@ Two stateful stacks do still follow a rolling tag — `pg_ducklake` (`18-main`) 
 | Kestra | `kestra/kestra` | `v1.0` | Minor |
 | PostgreSQL (Kestra DB) | `postgres` | `18-alpine` | Major |
 | Infisical | `infisical/infisical` | `v0.155.5` | Exact ¹ |
+| PostgreSQL (Infisical DB) | `postgres` | `14-alpine` | Major |
 | Metabase | `metabase/metabase` | `v0.60.6.2` | Exact ¹ |
 | Mailpit | `axllent/mailpit` | `v1.28` | Minor |
 | IT-Tools | `corentinth/it-tools` | `latest` | Latest ² |
@@ -68,6 +71,7 @@ Two stateful stacks do still follow a rolling tag — `pg_ducklake` (`18-main`) 
 | Gitea | `gitea/gitea` | `1.23` | Major |
 | PostgreSQL (Gitea DB) | `postgres` | `16-alpine` | Major |
 | LakeFS | `treeverse/lakefs` | `1.73.0` | Exact ¹ |
+| PostgreSQL (LakeFS DB) | `postgres` | `16-alpine` | Major |
 | Mage | `mageai/mageai` | `0.9.79` | Exact ¹ |
 | OpenSearch | `opensearchproject/opensearch` | `2.19.6` | Exact ¹ |
 | OpenSearch Dashboards | `opensearchproject/opensearch-dashboards` | `2.19.6` | Exact ¹ |
@@ -90,7 +94,7 @@ Two stateful stacks do still follow a rolling tag — `pg_ducklake` (`18-main`) 
 | PostgreSQL (Planka DB) | `postgres` | `16-alpine` | Major |
 | PostgREST | `postgrest/postgrest` | `v14.12` | Exact ¹ |
 | Lakekeeper | `quay.io/lakekeeper/catalog` | `v0.12.2` | Exact ¹ |
-| PostgreSQL (Lakekeeper DB) | `postgres` | `16-alpine` | Major |
+| PostgreSQL (Lakekeeper DB) | `postgres` | `17-alpine` | Major |
 | LiteLLM Proxy | `litellm/litellm-database` | `v1.85.1` | Exact ¹ |
 | PostgreSQL (LiteLLM DB) | `postgres` | `16-alpine` | Major |
 | Meltano | `meltano/meltano` | `v4.0` | Minor |
@@ -119,9 +123,11 @@ Two stateful stacks do still follow a rolling tag — `pg_ducklake` (`18-main`) 
 | SFTPGo | `drakkan/sftpgo` | `v2.7.1` | Exact ¹ |
 | Sling | `nexus-sling` (custom build) | `1.5.13` | Exact ³ |
 | Soda Core | `soda-core` | `3.3.7` | Exact ³ |
+| PostgreSQL (Soda DB) | `postgres` | `16-alpine` | Major |
 | Spark Master | `nexus-spark` | `4.1.1-python3.13` | Exact ³ |
 | Spark Worker | `nexus-spark` | `4.1.1-python3.13` | Exact ³ |
 | Superset | `apache/superset` | `6.0.0` | Exact ¹ |
+| PostgreSQL (Superset DB) | `postgres` | `17-alpine` | Major |
 | Telegraf | `telegraf` | `1.38.2` | Exact ¹ |
 | Trino | `trinodb/trino` | `479` | Exact ¹ |
 | Unity Catalog | `unitycatalog/unitycatalog` | `v0.6.0` | Exact ¹ |

--- a/docs/stacks/lakekeeper.md
+++ b/docs/stacks/lakekeeper.md
@@ -18,7 +18,7 @@ Lakekeeper is an open-source implementation of the [Apache Iceberg REST Catalog 
 | Website | [lakekeeper.io](https://lakekeeper.io) |
 | Source | [GitHub](https://github.com/lakekeeper/lakekeeper) |
 | Docker image | [`quay.io/lakekeeper/catalog`](https://quay.io/repository/lakekeeper/catalog) |
-| Backing DB | Dedicated Postgres 16 (`lakekeeper-db` container, separate from any shared Postgres) |
+| Backing DB | Dedicated Postgres 17 (`lakekeeper-db` container, separate from any shared Postgres) |
 
 ### Why this matters for the existing stack
 

--- a/services.yaml
+++ b/services.yaml
@@ -478,7 +478,7 @@ services:
     long_description: "Lakekeeper is an open-source implementation of the Apache Iceberg REST Catalog specification, written in Rust. It provides the catalog layer that turns the existing object storage (Garage / MinIO / SeaweedFS / RustFS / external R2) into a full lakehouse: register a table once via the REST API, query it from Spark, Trino, DuckDB, PyIceberg, or any other Iceberg-aware engine — no Hive Metastore, no per-engine catalog duplication. Dedicated PostgreSQL stores the catalog metadata; the actual Parquet data goes to whichever S3-compatible bucket the operator configures per warehouse."
     image: "quay.io/lakekeeper/catalog:v0.12.2"
     support_images:
-      lakekeeper-db: "postgres:16-alpine"
+      lakekeeper-db: "postgres:17-alpine"
 
   marquez:
     subdomain: "marquez"
@@ -609,7 +609,7 @@ services:
     long_description: "Apache Superset is a modern data exploration and visualization platform. Create interactive dashboards, explore datasets with SQL Lab, build rich visualizations with 40+ chart types, and share insights. Supports PostgreSQL, ClickHouse, Trino, and 30+ database engines with a no-code chart builder and role-based access control."
     image: "apache/superset:6.0.0"
     support_images:
-      superset-postgres: "postgres:16-alpine"
+      superset-postgres: "postgres:17-alpine"
       superset-redis: "redis:7-alpine"
 
   minio:

--- a/stacks/lakekeeper/docker-compose.yml
+++ b/stacks/lakekeeper/docker-compose.yml
@@ -102,7 +102,7 @@ services:
   # Lakekeeper - Dedicated PostgreSQL (catalog metadata)
   # ---------------------------------------------------------------------------
   lakekeeper-db:
-    image: ${IMAGE_LAKEKEEPER_DB:-postgres:16-alpine}
+    image: ${IMAGE_LAKEKEEPER_DB:-postgres:17-alpine}
     container_name: lakekeeper-db
     restart: unless-stopped
     environment:

--- a/stacks/lakekeeper/docker-compose.yml
+++ b/stacks/lakekeeper/docker-compose.yml
@@ -11,7 +11,7 @@
 #   - lakekeeper-bootstrap: one-shot `migrate` job that initialises
 #     the Postgres schema on first start, then exits
 #   - lakekeeper:           long-running `serve` process on :8181
-#   - lakekeeper-db:        dedicated Postgres 16, NOT shared with
+#   - lakekeeper-db:        dedicated Postgres 17, NOT shared with
 #                           any other stack (per project convention
 #                           for stateful services)
 #

--- a/stacks/superset/docker-compose.yml
+++ b/stacks/superset/docker-compose.yml
@@ -46,7 +46,7 @@ services:
       - superset-internal
 
   superset-db:
-    image: ${IMAGE_SUPERSET_POSTGRES:-postgres:16-alpine}
+    image: ${IMAGE_SUPERSET_POSTGRES:-postgres:17-alpine}
     container_name: superset-db
     restart: unless-stopped
     environment:


### PR DESCRIPTION
Stage 2 of #733.

## Why 17 and not 18

Upstream decides, not us. Both projects ship `image: postgres:17` in their
own compose files, so that is the version their maintainers test against:

| stack | upstream ships | we ran | now |
|---|---|---|---|
| superset | `postgres:17` | 16-alpine | 17-alpine |
| lakekeeper | `postgres:17` | 16-alpine | 17-alpine |

Neither database is in the S3 `PostgresDumpTarget` list, so under the
default `rebuild` lifecycle it is recreated from the application's own
migrations on the next spin-up. A tag change and nothing else.

## No explicit PGDATA here — reversing what I proposed

When planning this stage I suggested setting `PGDATA` anyway, to defuse the
trap #737 found. **That would have made things worse, not safer.**

The trap exists only at the 18 boundary. Read out of the registry:

```text
postgres:17-alpine   PGDATA=/var/lib/postgresql/data
                     VOLUME=/var/lib/postgresql/data
```

which already matches the existing mount. Against an existing 16 volume the
two options differ in exactly the way that matters:

| | behaviour |
|---|---|
| **without** PGDATA | 17 finds a 16 cluster and refuses to start: `FATAL: database files are incompatible with server` — **loud** |
| **with** `PGDATA=…/data/pgdata` | the subdirectory is empty, initdb creates a fresh 17 cluster beside the old data, container comes up healthy and **empty** — silent |

A loud failure traded for a silent one. So the rule stays scoped to where
it belongs, and the convention test already encodes that: it checks the
*effective* data path, which for 17 is inside the mount without any help.

## The image table was missing a third of the fleet

Six stacks with their own PostgreSQL had **no row at all** in
`docs/stacks/README.md` — `dagster`, `hoppscotch`, `infisical`, `lakefs`,
`soda`, `superset`. Added, each value derived from `services.yaml` rather
than typed.

The whole table now cross-checks clean: **21 declared instances, 22 rows,
0 mismatches.**

One of the new rows is worth looking at:

```
| PostgreSQL (Infisical DB) | `postgres` | `14-alpine` | Major |
```

That is the EOL-on-2026-11-12 case from #731, on the service holding every
generated credential. Making it visible in the table is the point.

## Verification

2605 tests pass. `docker compose config` parses for both stacks.

Part of #733

## Summary by Sourcery

Align Lakekeeper and Superset with PostgreSQL 17 and complete the stack PostgreSQL image inventory.

Enhancements:
- Align the Lakekeeper and Superset PostgreSQL images with their upstream-supported PostgreSQL 17 Alpine version.
- Expand the stack image inventory to include PostgreSQL instances for previously unlisted services.
- Update Lakekeeper documentation to reflect its PostgreSQL 17 backing database.

Documentation:
- Document the PostgreSQL versions used by Dagster, Hoppscotch, Infisical, LakeFS, Soda, and Superset in the stack image table.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated PostgreSQL support for Lakekeeper and Superset to version 17.
  * Added PostgreSQL version details for Dagster, Hoppscotch, Infisical, LakeFS, Soda, and Superset in the stack documentation.
  * Updated Lakekeeper’s documented PostgreSQL version from 16 to 17.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->