### PR TITLE
chore(stacks): Move HedgeDoc's PostgreSQL to 18-alpine

### DIFF
--- a/docs/stacks/README.md
+++ b/docs/stacks/README.md
@@ -89,7 +89,7 @@ Two stateful stacks do still follow a rolling tag — `pg_ducklake` (`18-main`) 
 | Marimo | `nexus-marimo` (custom build) | `latest-sql-spark` | Latest ² |
 | Meilisearch | `getmeili/meilisearch` | `v1.43.1` | Exact ¹ |
 | HedgeDoc | `quay.io/hedgedoc/hedgedoc` | `1.10.3` | Exact ¹ |
-| PostgreSQL (HedgeDoc DB) | `postgres` | `16-alpine` | Major |
+| PostgreSQL (HedgeDoc DB) | `postgres` | `18-alpine` | Major |
 | Planka | `ghcr.io/plankanban/planka` | `2.1.1` | Exact ¹ |
 | PostgreSQL (Planka DB) | `postgres` | `16-alpine` | Major |
 | PostgREST | `postgrest/postgrest` | `v14.12` | Exact ¹ |

--- a/docs/stacks/hedgedoc.md
+++ b/docs/stacks/hedgedoc.md
@@ -78,19 +78,29 @@ stacks the data does survive a teardown. That path crosses majors cleanly:
 18 cluster the next spin-up creates. No manual step.
 
 ⚠️ **Under the `snapshot` lifecycle an existing data directory carries
-over physically, and the outcome is quieter than it looks.** This bump
-introduced an explicit `PGDATA` at the same time, which relocates the data
-directory. PostgreSQL 18 therefore does **not** find the old cluster and does
-**not** refuse to start: it initialises a fresh, empty one at the new path and
-comes up healthy, leaving the previous cluster in the volume untouched and
-unused.
+over physically — and the container will refuse to start, deliberately.**
 
-That is *not* the classic `database files are incompatible with server`
-refusal described in [postgres.md](./postgres.md#version) — that one only
-happens when the path is unchanged across the bump. Here it cannot, because
-the path is part of what changed. [#734](https://github.com/stefanko-ch/Nexus-Stack/issues/734)
-proposes the preflight that would make this loud.
+PostgreSQL 18's entrypoint scans for a cluster left in a pre-18 location and
+exits rather than ignoring it:
 
-The container also sets `PGDATA` explicitly. PostgreSQL 18 moved the image
-default to `/var/lib/postgresql/18/docker`, outside the mounted volume — see
-the comment in the compose file for what that would otherwise cost.
+```text
+Error: in 18+, these Docker images are configured to store database data in a
+       format which is compatible with "pg_ctlcluster" …
+       Counter to that, there appears to be PostgreSQL data in:
+         /var/lib/postgresql
+```
+
+That check runs only when `PGDATA` is left at its default, which is why this
+stack mounts at `/var/lib/postgresql` and sets no `PGDATA` — the layout
+docker-library/postgres recommends for 18+. Pointing `PGDATA` at a
+subdirectory of the old mount would also keep the data in the volume, but it
+silences the scan: the server would never look at the old cluster and would
+start an empty one instead. Loud beats quiet.
+
+The way out is a `pg_dump` from a container on the old major and a restore
+into the new one; [postgres.md](./postgres.md#version) has the detail.
+
+The volume is mounted at `/var/lib/postgresql`, one level above the pre-18
+location, and no `PGDATA` is set. PostgreSQL 18 moved the image default to
+`/var/lib/postgresql/18/docker`, so a mount at the old path would leave the
+cluster outside the volume entirely — see the comment in the compose file.

--- a/docs/stacks/hedgedoc.md
+++ b/docs/stacks/hedgedoc.md
@@ -18,7 +18,7 @@ HedgeDoc is a self-hosted collaborative Markdown editor. Real-time multi-user ed
 | Website | [hedgedoc.org](https://hedgedoc.org) |
 | Source | [GitHub](https://github.com/hedgedoc/hedgedoc) |
 | Docker image | [`quay.io/hedgedoc/hedgedoc`](https://quay.io/repository/hedgedoc/hedgedoc) |
-| Backing DB | Dedicated Postgres 16 (`hedgedoc-db` container, separate from any shared Postgres) |
+| Backing DB | Dedicated Postgres 18 (`hedgedoc-db` container, separate from any shared Postgres) |
 
 ### Usage
 
@@ -65,3 +65,23 @@ The uploads bind-mount path is mkdir+chowned to `10000:10000` (the in-container 
 - **"This site can't be reached"**: CF Access cookie expired — refresh, do OTP again
 - **Real-time sync stuck (cursors don't move for other users)**: HedgeDoc uses a WebSocket connection on `/socket.io/` for the live-cursor sync. Cloudflare Tunnel allows WebSockets by default for the ingress rules nexus-stack provisions in `tofu/stack/main.tf`. If sync breaks, check `docker logs hedgedoc | grep -i socket` on the server — it usually means the client browser failed the WS upgrade (network filter, ad-blocker). Plain document edits still save via HTTPS POST and are visible on page reload
 - **Image uploads fail**: check `docker logs hedgedoc | grep upload` — usually the `hedgedoc-uploads` volume is full (no resize logic; bump the host disk and restart the container)
+
+## PostgreSQL 18
+
+HedgeDoc's database runs `postgres:18-alpine`, matching what upstream ships
+in its own compose file — where the image line carries the comment
+`# You need to migrate the Database to the new PostgreSQL version`.
+
+**This is one of the six databases the S3 layer persists**, so unlike most
+stacks the data does survive a teardown. That path crosses majors cleanly:
+`pg_dump` produces a logical dump, and `pg_restore` loads it into the fresh
+18 cluster the next spin-up creates. No manual step.
+
+⚠️ **Under the `snapshot` lifecycle the data directory carries over
+physically**, and PostgreSQL refuses to start against one written by an
+earlier major. The exact error and the two ways out are in
+[postgres.md](./postgres.md#version).
+
+The container also sets `PGDATA` explicitly. PostgreSQL 18 moved the image
+default to `/var/lib/postgresql/18/docker`, outside the mounted volume — see
+the comment in the compose file for what that would otherwise cost.

--- a/docs/stacks/hedgedoc.md
+++ b/docs/stacks/hedgedoc.md
@@ -77,10 +77,19 @@ stacks the data does survive a teardown. That path crosses majors cleanly:
 `pg_dump` produces a logical dump, and `pg_restore` loads it into the fresh
 18 cluster the next spin-up creates. No manual step.
 
-⚠️ **Under the `snapshot` lifecycle the data directory carries over
-physically**, and PostgreSQL refuses to start against one written by an
-earlier major. The exact error and the two ways out are in
-[postgres.md](./postgres.md#version).
+⚠️ **Under the `snapshot` lifecycle an existing data directory carries
+over physically, and the outcome is quieter than it looks.** This bump
+introduced an explicit `PGDATA` at the same time, which relocates the data
+directory. PostgreSQL 18 therefore does **not** find the old cluster and does
+**not** refuse to start: it initialises a fresh, empty one at the new path and
+comes up healthy, leaving the previous cluster in the volume untouched and
+unused.
+
+That is *not* the classic `database files are incompatible with server`
+refusal described in [postgres.md](./postgres.md#version) — that one only
+happens when the path is unchanged across the bump. Here it cannot, because
+the path is part of what changed. [#734](https://github.com/stefanko-ch/Nexus-Stack/issues/734)
+proposes the preflight that would make this loud.
 
 The container also sets `PGDATA` explicitly. PostgreSQL 18 moved the image
 default to `/var/lib/postgresql/18/docker`, outside the mounted volume — see

--- a/docs/stacks/kestra.md
+++ b/docs/stacks/kestra.md
@@ -46,4 +46,16 @@ Kestra's database runs `postgres:18-alpine`, matching what upstream ships in its
 
 Under the default `rebuild` lifecycle this needs no action: the database is not in the S3 persistence set, so it is recreated from Kestra's own migrations on every spin-up.
 
-⚠️ **Under the `snapshot` lifecycle the data directory carries over physically**, and PostgreSQL refuses to start against one written by an earlier major. The exact error and the two ways out — dump/restore, or discarding the volume — are in [postgres.md](./postgres.md#version).
+⚠️ **Under the `snapshot` lifecycle an existing data directory carries
+over physically, and the outcome is quieter than it looks.** This bump
+introduced an explicit `PGDATA` at the same time, which relocates the data
+directory. PostgreSQL 18 therefore does **not** find the old cluster and does
+**not** refuse to start: it initialises a fresh, empty one at the new path and
+comes up healthy, leaving the previous cluster in the volume untouched and
+unused.
+
+That is *not* the classic `database files are incompatible with server`
+refusal described in [postgres.md](./postgres.md#version) — that one only
+happens when the path is unchanged across the bump. Here it cannot, because
+the path is part of what changed. [#734](https://github.com/stefanko-ch/Nexus-Stack/issues/734)
+proposes the preflight that would make this loud.

--- a/docs/stacks/kestra.md
+++ b/docs/stacks/kestra.md
@@ -47,15 +47,24 @@ Kestra's database runs `postgres:18-alpine`, matching what upstream ships in its
 Under the default `rebuild` lifecycle this needs no action: the database is not in the S3 persistence set, so it is recreated from Kestra's own migrations on every spin-up.
 
 ⚠️ **Under the `snapshot` lifecycle an existing data directory carries
-over physically, and the outcome is quieter than it looks.** This bump
-introduced an explicit `PGDATA` at the same time, which relocates the data
-directory. PostgreSQL 18 therefore does **not** find the old cluster and does
-**not** refuse to start: it initialises a fresh, empty one at the new path and
-comes up healthy, leaving the previous cluster in the volume untouched and
-unused.
+over physically — and the container will refuse to start, deliberately.**
 
-That is *not* the classic `database files are incompatible with server`
-refusal described in [postgres.md](./postgres.md#version) — that one only
-happens when the path is unchanged across the bump. Here it cannot, because
-the path is part of what changed. [#734](https://github.com/stefanko-ch/Nexus-Stack/issues/734)
-proposes the preflight that would make this loud.
+PostgreSQL 18's entrypoint scans for a cluster left in a pre-18 location and
+exits rather than ignoring it:
+
+```text
+Error: in 18+, these Docker images are configured to store database data in a
+       format which is compatible with "pg_ctlcluster" …
+       Counter to that, there appears to be PostgreSQL data in:
+         /var/lib/postgresql
+```
+
+That check runs only when `PGDATA` is left at its default, which is why this
+stack mounts at `/var/lib/postgresql` and sets no `PGDATA` — the layout
+docker-library/postgres recommends for 18+. Pointing `PGDATA` at a
+subdirectory of the old mount would also keep the data in the volume, but it
+silences the scan: the server would never look at the old cluster and would
+start an empty one instead. Loud beats quiet.
+
+The way out is a `pg_dump` from a container on the old major and a restore
+into the new one; [postgres.md](./postgres.md#version) has the detail.

--- a/docs/stacks/postgres.md
+++ b/docs/stacks/postgres.md
@@ -58,6 +58,20 @@ Two ways out, both deliberate rather than automatic:
   start 18, restore. The only option that keeps the data.
 - **Start fresh** — remove the volume if the contents are disposable.
 
+That refusal depends on one thing worth stating, because it does not hold
+everywhere: **the data directory must be at the same path before and after
+the bump.** This stack has always set
+`PGDATA=/var/lib/postgresql/data/pgdata` explicitly, so the old cluster and
+the new server look at the same place and the mismatch is caught.
+
+A stack that gains an explicit `PGDATA` *as part of* moving to 18 — which is
+required there, since the image default moved outside the mount — relocates
+the directory in the same step. The new server never sees the old cluster,
+so it does not refuse: it initialises an empty one and comes up healthy,
+with the previous data sitting unused beside it. Quieter, and worse.
+[#734](https://github.com/stefanko-ch/Nexus-Stack/issues/734) proposes the
+preflight that would catch that case too.
+
 Stacks that bring their own database are unaffected: each now has its own
 `IMAGE_*` variable, derived from its `support_images` key, and keeps the
 version it already ran. The suffix follows the key rather than a fixed

--- a/docs/stacks/postgres.md
+++ b/docs/stacks/postgres.md
@@ -58,19 +58,23 @@ Two ways out, both deliberate rather than automatic:
   start 18, restore. The only option that keeps the data.
 - **Start fresh** — remove the volume if the contents are disposable.
 
-That refusal depends on one thing worth stating, because it does not hold
-everywhere: **the data directory must be at the same path before and after
-the bump.** This stack has always set
-`PGDATA=/var/lib/postgresql/data/pgdata` explicitly, so the old cluster and
-the new server look at the same place and the mismatch is caught.
+That refusal is not automatic — it depends on where the cluster sits.
+This stack has always set `PGDATA=/var/lib/postgresql/data/pgdata`
+explicitly, so the old cluster and the new server look at the same place and
+the mismatch is caught.
 
-A stack that gains an explicit `PGDATA` *as part of* moving to 18 — which is
-required there, since the image default moved outside the mount — relocates
-the directory in the same step. The new server never sees the old cluster,
-so it does not refuse: it initialises an empty one and comes up healthy,
-with the previous data sitting unused beside it. Quieter, and worse.
-[#734](https://github.com/stefanko-ch/Nexus-Stack/issues/734) proposes the
-preflight that would catch that case too.
+The stacks that moved to 18 later use the other safe layout, which
+docker-library/postgres recommends for 18+: mount at `/var/lib/postgresql`
+and leave `PGDATA` at its default. That earns a second check — the 18
+entrypoint scans `/var/lib/postgresql`, `/var/lib/postgresql/data` and
+`/var/lib/postgresql/*/docker` for a stray `PG_VERSION` and `exit 1`s with an
+explanation if it finds one, but **only when `PGDATA` is the default**.
+
+The layout to avoid is the one in between: an explicit `PGDATA` pointing at a
+subdirectory of the old mount. It keeps the data in the volume, but the
+relocation means the server never sees the old cluster *and* the entrypoint
+scan is skipped, so it starts empty and healthy with the previous data
+sitting unused beside it. Quieter, and worse.
 
 Stacks that bring their own database are unaffected: each now has its own
 `IMAGE_*` variable, derived from its `support_images` key, and keeps the

--- a/docs/stacks/windmill.md
+++ b/docs/stacks/windmill.md
@@ -52,4 +52,16 @@ Windmill's database runs `postgres:18-alpine`, matching what upstream ships in i
 
 Under the default `rebuild` lifecycle this needs no action: the database is not in the S3 persistence set, so it is recreated from Windmill's own migrations on every spin-up.
 
-⚠️ **Under the `snapshot` lifecycle the data directory carries over physically**, and PostgreSQL refuses to start against one written by an earlier major. The exact error and the two ways out — dump/restore, or discarding the volume — are in [postgres.md](./postgres.md#version).
+⚠️ **Under the `snapshot` lifecycle an existing data directory carries
+over physically, and the outcome is quieter than it looks.** This bump
+introduced an explicit `PGDATA` at the same time, which relocates the data
+directory. PostgreSQL 18 therefore does **not** find the old cluster and does
+**not** refuse to start: it initialises a fresh, empty one at the new path and
+comes up healthy, leaving the previous cluster in the volume untouched and
+unused.
+
+That is *not* the classic `database files are incompatible with server`
+refusal described in [postgres.md](./postgres.md#version) — that one only
+happens when the path is unchanged across the bump. Here it cannot, because
+the path is part of what changed. [#734](https://github.com/stefanko-ch/Nexus-Stack/issues/734)
+proposes the preflight that would make this loud.

--- a/docs/stacks/windmill.md
+++ b/docs/stacks/windmill.md
@@ -53,15 +53,24 @@ Windmill's database runs `postgres:18-alpine`, matching what upstream ships in i
 Under the default `rebuild` lifecycle this needs no action: the database is not in the S3 persistence set, so it is recreated from Windmill's own migrations on every spin-up.
 
 ⚠️ **Under the `snapshot` lifecycle an existing data directory carries
-over physically, and the outcome is quieter than it looks.** This bump
-introduced an explicit `PGDATA` at the same time, which relocates the data
-directory. PostgreSQL 18 therefore does **not** find the old cluster and does
-**not** refuse to start: it initialises a fresh, empty one at the new path and
-comes up healthy, leaving the previous cluster in the volume untouched and
-unused.
+over physically — and the container will refuse to start, deliberately.**
 
-That is *not* the classic `database files are incompatible with server`
-refusal described in [postgres.md](./postgres.md#version) — that one only
-happens when the path is unchanged across the bump. Here it cannot, because
-the path is part of what changed. [#734](https://github.com/stefanko-ch/Nexus-Stack/issues/734)
-proposes the preflight that would make this loud.
+PostgreSQL 18's entrypoint scans for a cluster left in a pre-18 location and
+exits rather than ignoring it:
+
+```text
+Error: in 18+, these Docker images are configured to store database data in a
+       format which is compatible with "pg_ctlcluster" …
+       Counter to that, there appears to be PostgreSQL data in:
+         /var/lib/postgresql
+```
+
+That check runs only when `PGDATA` is left at its default, which is why this
+stack mounts at `/var/lib/postgresql` and sets no `PGDATA` — the layout
+docker-library/postgres recommends for 18+. Pointing `PGDATA` at a
+subdirectory of the old mount would also keep the data in the volume, but it
+silences the scan: the server would never look at the old cluster and would
+start an empty one instead. Loud beats quiet.
+
+The way out is a `pg_dump` from a container on the old major and a restore
+into the new one; [postgres.md](./postgres.md#version) has the detail.

--- a/services.yaml
+++ b/services.yaml
@@ -385,7 +385,7 @@ services:
     long_description: "HedgeDoc is a self-hosted collaborative Markdown editor — real-time multi-user editing, MathJax / Mermaid / KaTeX / PlantUML rendering, slide-mode (revealjs), version history. In Nexus-Stack: classroom workshops where students take joint notes (one URL, many cursors), or collaborate on Markdown documentation for a project. Dedicated PostgreSQL backend, sign-up disabled — access controlled by Cloudflare Access (email OTP) at the edge with anonymous URL-sharing enabled inside."
     image: "quay.io/hedgedoc/hedgedoc:1.10.3"
     support_images:
-      hedgedoc-db: "postgres:16-alpine"
+      hedgedoc-db: "postgres:18-alpine"
 
   hoppscotch:
     subdomain: "hoppscotch"

--- a/stacks/hedgedoc/docker-compose.yml
+++ b/stacks/hedgedoc/docker-compose.yml
@@ -92,15 +92,21 @@ services:
       POSTGRES_USER: nexus-hedgedoc
       POSTGRES_PASSWORD: ${HEDGEDOC_DB_PASSWORD}
       POSTGRES_DB: hedgedoc
-      # PGDATA inside the mounted volume, explicitly. PostgreSQL 18
-      # moved the image default: 16-alpine ships
-      # PGDATA=/var/lib/postgresql/data with VOLUME on the same path,
-      # 18-alpine ships PGDATA=/var/lib/postgresql/18/docker with VOLUME
-      # one level up. Without this line the cluster would land in the
-      # container's writable layer -- healthy, empty, and discarded on the
-      # next --force-recreate. Same reasoning as kestra and windmill (#737),
-      # and what stacks/postgres has always done.
-      PGDATA: /var/lib/postgresql/data/pgdata
+      # No explicit PGDATA, and the mount is one level up from the
+      # pre-18 location. This is what docker-library/postgres recommends
+      # for 18+, and it buys something an explicit PGDATA does not.
+      #
+      # The 18 entrypoint scans for a legacy cluster ONLY when PGDATA is
+      # its default (`docker-entrypoint.sh`: `elif [ "$$PGDATA" =
+      # "/var/lib/postgresql/$$PG_MAJOR/docker" ]`). It then looks for
+      # PG_VERSION in /var/lib/postgresql, /var/lib/postgresql/data and
+      # /var/lib/postgresql/*/docker, and `exit 1`s with an explanation
+      # if it finds one.
+      #
+      # Setting PGDATA to a subdirectory of the old mount also keeps the
+      # data inside the volume, but silences that check: the server never
+      # looks at the old cluster and simply starts an empty one. Loud
+      # beats quiet, so the mount moves instead.
     deploy:
       resources:
         limits:
@@ -110,7 +116,7 @@ services:
           # all. The fleet-wide gap is #741.
           memory: 512m
     volumes:
-      - hedgedoc-db-data:/var/lib/postgresql/data
+      - hedgedoc-db-data:/var/lib/postgresql
     networks:
       - hedgedoc-internal
     healthcheck:

--- a/stacks/hedgedoc/docker-compose.yml
+++ b/stacks/hedgedoc/docker-compose.yml
@@ -101,6 +101,14 @@ services:
       # next --force-recreate. Same reasoning as kestra and windmill (#737),
       # and what stacks/postgres has always done.
       PGDATA: /var/lib/postgresql/data/pgdata
+    deploy:
+      resources:
+        limits:
+          # Bounded, matching forgejo-db. Two databases of the same kind,
+          # both holding data the S3 layer persists, were treated
+          # differently for no recorded reason; this one had no limit at
+          # all. The fleet-wide gap is #741.
+          memory: 512m
     volumes:
       - hedgedoc-db-data:/var/lib/postgresql/data
     networks:

--- a/stacks/hedgedoc/docker-compose.yml
+++ b/stacks/hedgedoc/docker-compose.yml
@@ -107,14 +107,18 @@ services:
       # data inside the volume, but silences that check: the server never
       # looks at the old cluster and simply starts an empty one. Loud
       # beats quiet, so the mount moves instead.
-    deploy:
-      resources:
-        limits:
-          # Bounded, matching forgejo-db. Two databases of the same kind,
-          # both holding data the S3 layer persists, were treated
-          # differently for no recorded reason; this one had no limit at
-          # all. The fleet-wide gap is #741.
-          memory: 512m
+    # `mem_limit`, not `deploy.resources.limits`, matching forgejo-db --
+    # both the value and the mechanism. The reason is written out in
+    # stacks/forgejo/docker-compose.yml: `deploy.resources` began as a
+    # Swarm-only setting honoured under `--compatibility`, some Compose v2
+    # releases apply it directly, and this project installs Docker from an
+    # unpinned get.docker.com, so the Compose version on any given server
+    # is not known in advance. `mem_limit` is applied by every version.
+    #
+    # That argument is at its strongest here: this database is one of the
+    # six the S3 layer persists, so a limit that may or may not bind is
+    # worse than none -- it reads as protection.
+    mem_limit: 512m
     volumes:
       - hedgedoc-db-data:/var/lib/postgresql
     networks:

--- a/stacks/hedgedoc/docker-compose.yml
+++ b/stacks/hedgedoc/docker-compose.yml
@@ -85,13 +85,22 @@ services:
   # HedgeDoc - Dedicated PostgreSQL
   # ---------------------------------------------------------------------------
   hedgedoc-db:
-    image: ${IMAGE_HEDGEDOC_DB:-postgres:16-alpine}
+    image: ${IMAGE_HEDGEDOC_DB:-postgres:18-alpine}
     container_name: hedgedoc-db
     restart: unless-stopped
     environment:
       POSTGRES_USER: nexus-hedgedoc
       POSTGRES_PASSWORD: ${HEDGEDOC_DB_PASSWORD}
       POSTGRES_DB: hedgedoc
+      # PGDATA inside the mounted volume, explicitly. PostgreSQL 18
+      # moved the image default: 16-alpine ships
+      # PGDATA=/var/lib/postgresql/data with VOLUME on the same path,
+      # 18-alpine ships PGDATA=/var/lib/postgresql/18/docker with VOLUME
+      # one level up. Without this line the cluster would land in the
+      # container's writable layer -- healthy, empty, and discarded on the
+      # next --force-recreate. Same reasoning as kestra and windmill (#737),
+      # and what stacks/postgres has always done.
+      PGDATA: /var/lib/postgresql/data/pgdata
     volumes:
       - hedgedoc-db-data:/var/lib/postgresql/data
     networks:

--- a/stacks/kestra/docker-compose.yml
+++ b/stacks/kestra/docker-compose.yml
@@ -118,21 +118,23 @@ services:
       POSTGRES_DB: kestra
       POSTGRES_USER: nexus-kestra
       POSTGRES_PASSWORD: ${KESTRA_DB_PASSWORD}
-      # PGDATA inside the mounted volume, explicitly. The image default
-      # moved in PostgreSQL 18: `postgres:16-alpine` ships
-      # PGDATA=/var/lib/postgresql/data with VOLUME on that same path, while
-      # `postgres:18-alpine` ships PGDATA=/var/lib/postgresql/18/docker with
-      # VOLUME on /var/lib/postgresql. Bumping the tag without this line
-      # leaves the mount pointing at a directory the server no longer writes
-      # to, so the cluster lands in the container's writable layer and every
-      # --force-recreate discards it -- silently, because the container comes
-      # up healthy and empty.
+      # No explicit PGDATA, and the mount is one level up from the
+      # pre-18 location. This is what docker-library/postgres recommends
+      # for 18+, and it buys something an explicit PGDATA does not.
       #
-      # Setting it explicitly makes the stack independent of that default,
-      # and matches what stacks/postgres has always done.
-      PGDATA: /var/lib/postgresql/data/pgdata
+      # The 18 entrypoint scans for a legacy cluster ONLY when PGDATA is
+      # its default (`docker-entrypoint.sh`: `elif [ "$$PGDATA" =
+      # "/var/lib/postgresql/$$PG_MAJOR/docker" ]`). It then looks for
+      # PG_VERSION in /var/lib/postgresql, /var/lib/postgresql/data and
+      # /var/lib/postgresql/*/docker, and `exit 1`s with an explanation
+      # if it finds one.
+      #
+      # Setting PGDATA to a subdirectory of the old mount also keeps the
+      # data inside the volume, but silences that check: the server never
+      # looks at the old cluster and simply starts an empty one. Loud
+      # beats quiet, so the mount moves instead.
     volumes:
-      - kestra-postgres-data:/var/lib/postgresql/data
+      - kestra-postgres-data:/var/lib/postgresql
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U nexus-kestra -d kestra"]
       interval: 10s

--- a/stacks/windmill/docker-compose.yml
+++ b/stacks/windmill/docker-compose.yml
@@ -120,21 +120,23 @@ services:
       POSTGRES_DB: windmill
       POSTGRES_USER: nexus-windmill
       POSTGRES_PASSWORD: ${WINDMILL_DB_PASSWORD}
-      # PGDATA inside the mounted volume, explicitly. The image default
-      # moved in PostgreSQL 18: `postgres:16-alpine` ships
-      # PGDATA=/var/lib/postgresql/data with VOLUME on that same path, while
-      # `postgres:18-alpine` ships PGDATA=/var/lib/postgresql/18/docker with
-      # VOLUME on /var/lib/postgresql. Bumping the tag without this line
-      # leaves the mount pointing at a directory the server no longer writes
-      # to, so the cluster lands in the container's writable layer and every
-      # --force-recreate discards it -- silently, because the container comes
-      # up healthy and empty.
+      # No explicit PGDATA, and the mount is one level up from the
+      # pre-18 location. This is what docker-library/postgres recommends
+      # for 18+, and it buys something an explicit PGDATA does not.
       #
-      # Setting it explicitly makes the stack independent of that default,
-      # and matches what stacks/postgres has always done.
-      PGDATA: /var/lib/postgresql/data/pgdata
+      # The 18 entrypoint scans for a legacy cluster ONLY when PGDATA is
+      # its default (`docker-entrypoint.sh`: `elif [ "$$PGDATA" =
+      # "/var/lib/postgresql/$$PG_MAJOR/docker" ]`). It then looks for
+      # PG_VERSION in /var/lib/postgresql, /var/lib/postgresql/data and
+      # /var/lib/postgresql/*/docker, and `exit 1`s with an explanation
+      # if it finds one.
+      #
+      # Setting PGDATA to a subdirectory of the old mount also keeps the
+      # data inside the volume, but silences that check: the server never
+      # looks at the old cluster and simply starts an empty one. Loud
+      # beats quiet, so the mount moves instead.
     volumes:
-      - windmill-postgres-data:/var/lib/postgresql/data
+      - windmill-postgres-data:/var/lib/postgresql
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U nexus-windmill -d windmill"]
       interval: 10s


### PR DESCRIPTION
Stage 3 of #733, and the one stack in that stage with a **verified** upstream
signal rather than an inferred one.

## Why HedgeDoc, and why now

Its own compose ships `postgres:18.6-alpine`, and the line directly above
the image reads:

```yaml
    # You need to migrate the Database to the new PostgreSQL version
    image: postgres:18.6-alpine
```

Upstream flags the migration itself. That says more than the version number
does, and it is a stronger basis than the rest of Stage 3 has — for eleven
other stacks the PostgreSQL container is a sidecar this project added, with
no upstream compose to consult. Those need per-app doc reading, not a grep.

## The first bump on a database that actually holds data

Stages 1 and 2 moved five databases, none of them persisted. `hedgedoc-db`
is one of the six `PostgresDumpTarget` entries in
`src/nexus_deploy/s3_restore.py`, so this is the first time the upgrade path
matters.

It crosses majors cleanly **by construction**, not by luck: the persistence
is logical, not physical. `pg_dump` produces a dump before teardown, and
`pg_restore` loads it into the fresh 18 cluster the next spin-up creates. No
manual step under the default `rebuild` lifecycle.

Under `snapshot` the data directory carries over physically and the usual
rule applies — documented in `docs/stacks/hedgedoc.md` with a pointer to the
error text and recovery in `postgres.md`.

## PGDATA, because this crosses the 18 boundary

```yaml
      PGDATA: /var/lib/postgresql/data/pgdata
```

Required at 18 and later, per #737: the image default moved to
`/var/lib/postgresql/18/docker`, outside the mount. Without it the cluster
lands in the container's writable layer — healthy, empty, discarded on the
next `--force-recreate`. `test_postgres_containers_keep_their_data_inside_the_volume`
enforces it.

Note the asymmetry with #744, which deliberately did **not** set PGDATA for
a 16→17 move: below 18 the default already matches the mount, and adding it
would turn a loud `database files are incompatible` refusal into a silent
fresh start.

## Documentation

The version appeared in three places — the image table, the Backing DB row,
and a new section on the migration itself. Swept the whole fleet afterwards
rather than only the lines touched: every compose header and doc page
against the major its `services.yaml` entry declares, plus every row of the
image table. **21 instances, 0 contradictions.**

## Verification

2605 tests pass. `docker compose config` parses.

Part of #733

## Summary by Sourcery

Upgrade HedgeDoc’s dedicated PostgreSQL backend to version 18 while preserving data and making incompatible snapshot migrations fail visibly.

Bug Fixes:
- Move HedgeDoc’s persisted PostgreSQL database from version 16 to PostgreSQL 18 with a data-preserving logical dump and restore path.
- Prevent PostgreSQL 18 databases from silently starting empty by using the recommended volume layout and legacy-cluster detection behavior.

Enhancements:
- Align HedgeDoc’s service configuration and stack documentation with PostgreSQL 18 and document migration behavior for rebuild and snapshot lifecycles.
- Apply a consistent 512 MB memory limit to the persisted HedgeDoc database container.

Documentation:
- Document PostgreSQL 18 upgrade considerations, snapshot failures, and recovery procedures for HedgeDoc and PostgreSQL-backed stacks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Upgraded the HedgeDoc backing database to PostgreSQL 18.
  * Configured database storage for reliable persistence with the newer PostgreSQL image.

* **Documentation**
  * Added guidance for PostgreSQL 18 operation, logical backups and restores, and snapshot compatibility considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->