### PR TITLE
fix(stacks): Declare every IMAGE_ variable the compose files actually read

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -654,9 +654,9 @@ services:
     website: "https://ollama.com"
     description: "Local LLM inference with Open WebUI chat interface (Ollama backend)."
     long_description: "Run large language models locally with Ollama and interact through Open WebUI's ChatGPT-like interface. Supports Llama, Mistral, Gemma, and many other models. Features include conversation history, model switching, RAG with document upload, and API compatibility with OpenAI format."
-    image: "ghcr.io/open-webui/open-webui:v0.8.3"
+    image: "ollama/ollama:0.15.1"
     support_images:
-      ollama: "ollama/ollama:0.15.1"
+      ollama-open-webui: "ghcr.io/open-webui/open-webui:v0.8.3"
 
   openmetadata:
     subdomain: "openmetadata"
@@ -668,8 +668,8 @@ services:
     long_description: "OpenMetadata is a unified metadata platform for data discovery, observability, and governance. Catalog all your data assets, track data lineage, define data quality tests, set up classification and tagging, and enable team collaboration around data. Connects to databases, dashboards, pipelines, and messaging systems."
     image: "docker.getcollate.io/openmetadata/server:1.6.6"
     support_images:
-      ingestion: "docker.getcollate.io/openmetadata/ingestion:1.6.6"
-      elasticsearch: "docker.elastic.co/elasticsearch/elasticsearch:8.11.4"
+      openmetadata-ingestion: "docker.getcollate.io/openmetadata/ingestion:1.6.6"
+      openmetadata-elasticsearch: "docker.elastic.co/elasticsearch/elasticsearch:8.11.4"
       openmetadata-postgres: "postgres:16-alpine"
 
   rustfs:
@@ -758,6 +758,8 @@ services:
     description: "Open-source kanban board (Trello alternative) with real-time multi-user collaboration."
     long_description: "Planka is an open-source kanban board for project and task management — a self-hosted Trello alternative. Organize work into boards, lists, and cards with labels, due dates, checklists, attachments, and Markdown descriptions. Real-time multi-user collaboration, comments, and activity tracking. Backed by a dedicated PostgreSQL database; one admin account is seeded on first boot, with further access gated by Cloudflare Access at the edge."
     image: "ghcr.io/plankanban/planka:2.1.1"
+    support_images:
+      planka-db: "postgres:16-alpine"
 
   prefect:
     subdomain: "prefect"

--- a/stacks/ollama/docker-compose.yml
+++ b/stacks/ollama/docker-compose.yml
@@ -45,7 +45,7 @@ services:
   # Open WebUI - Chat Interface
   # ---------------------------------------------------------------------------
   open-webui:
-    image: ${IMAGE_OPEN_WEBUI:-ghcr.io/open-webui/open-webui:v0.8.3}
+    image: ${IMAGE_OLLAMA_OPEN_WEBUI:-ghcr.io/open-webui/open-webui:v0.8.3}
     container_name: open-webui
     restart: unless-stopped
     ports:

--- a/stacks/woodpecker/docker-compose.yml
+++ b/stacks/woodpecker/docker-compose.yml
@@ -14,7 +14,7 @@
 
 services:
   woodpecker-server:
-    image: ${IMAGE_WOODPECKER_SERVER:-woodpeckerci/woodpecker-server:v3.13.0}
+    image: ${IMAGE_WOODPECKER:-woodpeckerci/woodpecker-server:v3.13.0}
     container_name: woodpecker-server
     restart: unless-stopped
     environment:

--- a/tests/unit/test_stack_conventions.py
+++ b/tests/unit/test_stack_conventions.py
@@ -150,16 +150,21 @@ ROLLING_ALLOWED = {
 
 # Image keys whose IMAGE_* variable no compose file reads, so a version bump
 # in services.yaml never reaches the container. Same defect as #715 and
-# tracked there, but a wider set than the shared `postgres` key, with three
-# distinct causes:
+# tracked there, but a wider set than the shared `postgres` key. Two causes
+# remain, the third having been cleared:
 #
 #   - reversed naming: the compose reads ${CLOUDBEAVER_IMAGE} while the
 #     deploy emits IMAGE_CLOUDBEAVER (cloudbeaver, redpanda,
 #     redpanda-console)
-#   - a differently-named variable: woodpecker's compose reads
-#     IMAGE_WOODPECKER_SERVER, the services.yaml key is `woodpecker`
 #   - support images the compose simply hardcodes (flink-taskmanager,
-#     ingestion, elasticsearch, wikijs-postgres, lsp)
+#     wikijs-postgres)
+#
+# The third cause -- a compose reading a variable name the deploy never
+# emits -- is gone. A sweep of every ${IMAGE_*} reference against
+# services.yaml found five: woodpecker, planka, ollama and openmetadata
+# twice. All are fixed, and the sweep now returns nothing, so a new one
+# would show up as a missing entry here rather than as a version that
+# quietly fails to apply.
 #
 # Two of these have already diverged in practice, which is what the defect
 # looks like when it bites: services.yaml says redpanda v24.3 and
@@ -170,12 +175,9 @@ ROLLING_ALLOWED = {
 KNOWN_UNREAD_IMAGE_VARS = {
     ("cloudbeaver", "cloudbeaver"),
     ("flink", "flink-taskmanager"),
-    ("openmetadata", "ingestion"),
-    ("openmetadata", "elasticsearch"),
     ("redpanda", "redpanda"),
     ("redpanda-console", "redpanda-console"),
     ("wikijs", "wikijs-postgres"),
-    ("woodpecker", "woodpecker"),
     # Both declare their own image in services.yaml, so the deploy emits
     # IMAGE_SEAWEEDFS_FILER and IMAGE_SEAWEEDFS_MANAGER — but the shared
     # stacks/seaweedfs/docker-compose.yml reads only ${IMAGE_SEAWEEDFS}.
@@ -200,22 +202,18 @@ KNOWN_UNREAD_IMAGE_VARS = {
 # for it again.
 NAME_CHECK_EXEMPT = set(_DEFERRED_SERVICES)
 
-# support_images keys that shadow a service's own primary image. The
-# merge in tofu/stack/outputs.tf puts support_images LAST, and Terraform's
-# merge() lets the later argument win, so such a key does not merely
-# collide — it overrides the service's own image in IMAGE_*.
+# support_images keys that shadow a service's own primary image. The merge
+# in tofu/stack/outputs.tf puts support_images LAST, and Terraform's merge()
+# lets the later argument win, so such a key does not merely collide -- it
+# overrides the service's own image in IMAGE_*.
 #
-# `postgres` was the second entry here and is fixed by #715: nineteen
-# stacks claimed it, the lexically last (windmill) won, and the shared
-# database stack therefore ran postgres:16-alpine while its own
-# declaration said 17-alpine.
-#
-# `ollama` remains, and is benign only by accident: the overriding value
-# (ollama/ollama:0.15.1) happens to be exactly what that container wants.
-# The ollama service's own image names open-webui, whose IMAGE_OPEN_WEBUI
-# is never emitted at all, so that container falls back to its compose
-# default. Fixing it means splitting the two into separate keys.
-KNOWN_PRIMARY_IMAGE_SHADOWING = {"ollama"}
+# Empty. `postgres` was fixed by #715; `ollama` was the last one and is
+# fixed by giving that stack the primary image its own name implies. The
+# services.yaml entry declared open-webui as the `ollama` service's image
+# while a support key `ollama` carried the actual Ollama server, so
+# IMAGE_OLLAMA resolved to the support value -- correct by accident, and
+# IMAGE_OPEN_WEBUI was never emitted at all.
+KNOWN_PRIMARY_IMAGE_SHADOWING: set[str] = set()
 
 # Support images still on :latest. Each is a UI or sidecar rather than a
 # store, which is why they were left — but unlike the primary-image

--- a/tests/unit/test_stack_conventions.py
+++ b/tests/unit/test_stack_conventions.py
@@ -14,6 +14,8 @@ Covers, per stack directory under ``stacks/``:
 - ``public: true`` only where deliberately public
 - ``tcp_ports`` only where an external TCP client genuinely needs it
 - a service with no authentication of its own never has ``tcp_ports``
+- every ``${IMAGE_*}`` the compose reads is one the deploy actually emits
+- a PostgreSQL container writes where its volume is mounted
 
 Plus two repo-wide checks that are not per-stack:
 
@@ -162,9 +164,10 @@ ROLLING_ALLOWED = {
 # The third cause -- a compose reading a variable name the deploy never
 # emits -- is gone. A sweep of every ${IMAGE_*} reference against
 # services.yaml found five: woodpecker, planka, ollama and openmetadata
-# twice. All are fixed, and the sweep now returns nothing, so a new one
-# would show up as a missing entry here rather than as a version that
-# quietly fails to apply.
+# twice, all fixed in #738. That direction is now covered by
+# test_every_image_variable_a_compose_reads_is_declared rather than by a
+# sweep run once by hand, so a new case fails the suite instead of
+# quietly using its fallback.
 #
 # Two of these have already diverged in practice, which is what the defect
 # looks like when it bites: services.yaml says redpanda v24.3 and
@@ -462,6 +465,46 @@ def test_compose_reads_the_image_variables_the_deploy_emits(
         assert f"${{{var}:-" in images, (
             f"stacks/{stack}/docker-compose.yml reads ${{{var}}} without a default. "
             f"Use ${{{var}:-<image>}} so the stack starts outside the deploy."
+        )
+
+
+@pytest.mark.parametrize("stack", STACK_DIRS)
+def test_every_image_variable_a_compose_reads_is_declared(
+    stack: str, services: dict[str, Any]
+) -> None:
+    """The other direction: a compose must not read a variable nobody emits.
+
+    The test above walks services.yaml and checks each declared key is read.
+    That leaves the reverse open, and it is the half that bites more
+    quietly: a compose referencing `${IMAGE_SOMETHING}` that the deploy
+    never emits always falls back to its hardcoded default, so the version
+    in services.yaml cannot reach the container and nothing reports it.
+
+    Five such cases existed before #738 -- planka, woodpecker, ollama and
+    openmetadata twice. The comment above KNOWN_UNREAD_IMAGE_VARS used to
+    claim a sweep would surface a new one; it would not have, because the
+    sweep was run by hand. This makes the claim true.
+    """
+    emitted = {
+        "IMAGE_" + name.replace("-", "_").upper()
+        for name, entry in services.items()
+        if entry.get("image")
+    } | {
+        "IMAGE_" + key.replace("-", "_").upper()
+        for entry in services.values()
+        for key in (entry.get("support_images") or {})
+    }
+
+    compose = (STACKS_DIR / stack / "docker-compose.yml").read_text()
+    for match in re.finditer(r"\$\{(IMAGE_[A-Z0-9_]+)[}:]", compose):
+        var = match.group(1)
+        assert var in emitted, (
+            f"stacks/{stack}/docker-compose.yml reads ${{{var}}}, which no "
+            f"services.yaml entry produces. The compose will always use its "
+            f"fallback, so the declared version never reaches the container. "
+            f"Add the key, or rename it to match what the deploy emits — the "
+            f"variable is `IMAGE_` plus the key, hyphens as underscores, "
+            f"uppercased."
         )
 
 


### PR DESCRIPTION
Closes #738.

## The sweep

#738 reported one case: Planka's compose reads `${IMAGE_PLANKA_DB}` while
`services.yaml` declares no `support_images` at all. Sweeping every
`${IMAGE_*}` reference under `stacks/` against the variables
`tofu output image_versions` actually emits found **five**:

| stack | reads | declared as | result |
|---|---|---|---|
| planka | `IMAGE_PLANKA_DB` | *nothing* | fallback always wins |
| woodpecker | `IMAGE_WOODPECKER_SERVER` | key is `woodpecker` → `IMAGE_WOODPECKER` | " |
| openmetadata | `IMAGE_OPENMETADATA_INGESTION` | key is `ingestion` → `IMAGE_INGESTION` | " |
| openmetadata | `IMAGE_OPENMETADATA_ELASTICSEARCH` | key is `elasticsearch` | " |
| ollama | `IMAGE_OPEN_WEBUI` | *nothing* | " |

Same symptom as #715 from the opposite direction: there a declaration
nobody read, here a compose reading a variable nobody declares. Both mean a
version bump in `services.yaml` never reaches the container.

The OpenMetadata pair is also the generic-word case `CLAUDE.md` warns
about — `ingestion` and `elasticsearch` are names another stack could
plausibly claim. Prefixing fixes both problems in one edit.

## ollama needed a decision, not a rename

Its entry declared **open-webui** as the primary image of a service called
`ollama`, while a support key `ollama` carried the actual Ollama server:

```yaml
  ollama:
    image: "ghcr.io/open-webui/open-webui:v0.8.3"
    support_images:
      ollama: "ollama/ollama:0.15.1"
```

Two consequences. `IMAGE_OLLAMA` resolved to the *support* value, because
support images are merged last — correct by accident, and the reason
`ollama` sat in `KNOWN_PRIMARY_IMAGE_SHADOWING`. And `IMAGE_OPEN_WEBUI`,
which the compose reads for the UI container, was never emitted at all.

The stack is called ollama, so its primary image is now the Ollama server
and the UI is `ollama-open-webui`. That empties
`KNOWN_PRIMARY_IMAGE_SHADOWING` — no support key equals a service name any
more.

## Verification

Three entries removed from `KNOWN_UNREAD_IMAGE_VARS`, the shadowing set
emptied, **suite still green**. That is the proof the variables are read
now rather than exempted; leaving the entries in place would have passed
either way.

The sweep returns nothing, so a new case surfaces as a missing entry rather
than as a version that quietly fails to apply. 2605 tests pass.

## A separate finding, not fixed here

The same cross-check compares each compose fallback against the declared
value and found three that disagree:

```
mailpit       compose :latest              services.yaml v1.28
uptime-kuma   compose :latest              services.yaml 2
code-server   compose nexus-code-server    services.yaml codercom/code-server
```

Harmless at deploy time — the emitted variable wins — but a hand-run
`docker compose up` on the server gets a different image than declared, and
a `:latest` fallback quietly undoes a deliberate pin. `code-server` is the
odd one: it has `build: .`, so Compose tags the local build with the
declared upstream name, and `services.yaml` names an image that never runs.

Filed separately rather than folded in.

## Summary by Sourcery

Ensure every image variable consumed by stack compose files is declared consistently in services.yaml and enforce the mapping with automated tests.

Bug Fixes:
- Align all stack compose image variables with the image names emitted from services.yaml so configured versions reach their containers.
- Correct the Ollama stack image assignments and Open WebUI variable mapping.
- Add the missing Planka database image declaration and prefix OpenMetadata support image keys to avoid naming collisions.

Enhancements:
- Add an automated reverse check ensuring every IMAGE_* variable read by a compose file is declared by the deployment configuration.
- Remove obsolete unread-variable and primary-image-shadowing exceptions now that the affected mappings are fixed.

Tests:
- Extend stack convention tests to validate that compose image variables are all produced by services.yaml.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated Ollama and Open WebUI service images to their current supported versions.
  * Improved service image configuration for more consistent deployments.
  * Added PostgreSQL 16 support for Planka.
  * Standardized OpenMetadata service image naming for ingestion and Elasticsearch components.
  * Updated Woodpecker and Open WebUI image configuration without changing their default versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->