### PR TITLE
fix(stacks): Make every compose fallback match the version services.yaml declares

### DIFF
--- a/docs/stacks/README.md
+++ b/docs/stacks/README.md
@@ -22,7 +22,7 @@ Two stateful stacks do still follow a rolling tag — `pg_ducklake` (`18-main`) 
 | Chroma | `chromadb/chroma` | `1.5.9` | Exact ¹ |
 | CloudBeaver | `dbeaver/cloudbeaver` | `24` | Major |
 | ClickHouse | `clickhouse/clickhouse-server` | `25.8.16.34` | Exact ¹ |
-| code-server | `codercom/code-server` | `latest` | Latest ² |
+| code-server | `nexus-code-server` (custom build) | `latest` | Latest ² |
 | Crawl4AI | `unclecode/crawl4ai` | `0.8.6` | Exact ¹ |
 | CyberChef | `mpepping/cyberchef` | `v10.24.0` | Exact ¹ |
 | Dagster | dagster (custom build) | `1.12.21` | Exact ³ |

--- a/services.yaml
+++ b/services.yaml
@@ -141,7 +141,14 @@ services:
     website: "https://coder.com"
     description: "VS Code in the browser for remote development."
     long_description: "Code Server runs VS Code on a remote server, accessible through your browser. Full VS Code experience including extensions, terminal, Git integration, and IntelliSense. Access your development environment from any device with a consistent setup."
-    image: "codercom/code-server:latest"
+    # The built image, not its base. `stacks/code-server/Dockerfile` starts
+    # FROM codercom/code-server:latest and adds the nexus-venv, so the
+    # container never runs the upstream image. Declaring the base would put
+    # a name into IMAGE_CODE_SERVER that Compose then tags the local build
+    # with — masquerading, and it made services.yaml describe an image that
+    # is never pulled. Matches dagster, dinky, flink, marimo, sling and
+    # spark, which all declare their `nexus-` build.
+    image: "nexus-code-server:latest"
 
   crawl4ai:
     subdomain: "crawl4ai"

--- a/stacks/mailpit/docker-compose.yml
+++ b/stacks/mailpit/docker-compose.yml
@@ -11,7 +11,7 @@
 
 services:
   mailpit:
-    image: ${IMAGE_MAILPIT:-axllent/mailpit:latest}
+    image: ${IMAGE_MAILPIT:-axllent/mailpit:v1.28}
     container_name: mailpit
     restart: unless-stopped
     environment:

--- a/stacks/uptime-kuma/docker-compose.yml
+++ b/stacks/uptime-kuma/docker-compose.yml
@@ -8,7 +8,7 @@
 
 services:
   uptime-kuma:
-    image: ${IMAGE_UPTIME_KUMA:-louislam/uptime-kuma:latest}
+    image: ${IMAGE_UPTIME_KUMA:-louislam/uptime-kuma:2}
     container_name: uptime-kuma
     restart: unless-stopped
     ports:

--- a/tests/unit/test_stack_conventions.py
+++ b/tests/unit/test_stack_conventions.py
@@ -509,6 +509,46 @@ def test_every_image_variable_a_compose_reads_is_declared(
 
 
 @pytest.mark.parametrize("stack", STACK_DIRS)
+def test_compose_fallbacks_match_the_declared_version(stack: str, services: dict[str, Any]) -> None:
+    """The `:-default` must be the same image services.yaml declares.
+
+    The two checks above ask whether the variable is emitted and whether
+    the compose reads it. This asks whether the two agree on the value.
+
+    At deploy time the emitted variable wins, so a mismatch breaks
+    nothing — which is exactly why it survives. It shows up when the
+    variable is *not* set: a `docker compose up` run by hand on the server
+    while investigating one container, or a stack started outside the
+    pipeline. `mailpit` fell back to `:latest` while services.yaml pinned
+    `v1.28`, so a pin that reads as deliberate held on one code path only.
+
+    `code-server` was the sharper case. Its compose has `build: .` beside
+    the `image:` key, so Compose tags the local build with whatever that
+    resolves to — and services.yaml named the upstream base image, which
+    the container never runs.
+    """
+    compose = (STACKS_DIR / stack / "docker-compose.yml").read_text()
+
+    declared: dict[str, str] = {}
+    for name, entry in services.items():
+        if entry.get("image"):
+            declared["IMAGE_" + name.replace("-", "_").upper()] = str(entry["image"])
+        for key, value in (entry.get("support_images") or {}).items():
+            declared["IMAGE_" + key.replace("-", "_").upper()] = str(value)
+
+    for match in re.finditer(r"\$\{(IMAGE_[A-Z0-9_]+):-([^}]*)\}", compose):
+        var, fallback = match.group(1), match.group(2)
+        if var not in declared:
+            continue  # covered by test_every_image_variable_a_compose_reads_is_declared
+        assert fallback == declared[var], (
+            f"stacks/{stack}/docker-compose.yml falls back to {fallback!r} while "
+            f"services.yaml declares {declared[var]!r} for {var}. The deploy "
+            f"overrides it, so this only shows when the variable is unset — a "
+            f"hand-run `docker compose up` on the server gets the wrong image."
+        )
+
+
+@pytest.mark.parametrize("stack", STACK_DIRS)
 def test_a_container_is_named_after_the_service(stack: str, services: dict[str, Any]) -> None:
     """The deploy proves a stack started by looking for this exact name.
 


### PR DESCRIPTION
Closes #747.

## The gap

Every stack reads its image as `${IMAGE_X:-<fallback>}`. The fallback is
what runs when the variable is not set — a `docker compose up` run by hand
on the server while investigating one container, or a stack started outside
the pipeline. Three disagreed with the declaration:

| stack | compose fallback | services.yaml |
|---|---|---|
| `mailpit` | `axllent/mailpit:latest` | `axllent/mailpit:v1.28` |
| `uptime-kuma` | `louislam/uptime-kuma:latest` | `louislam/uptime-kuma:2` |
| `code-server` | `nexus-code-server:latest` | `codercom/code-server:latest` |

Nothing was broken at deploy time — the emitted variable wins — which is
precisely why it survived. The cost is that a pin reading as deliberate held
on **one code path only**, and investigating a container on the server gave a
different image than the project declares.

## code-server needed a decision, not an edit

```yaml
  code-server:
    build: .
    image: ${IMAGE_CODE_SERVER:-nexus-code-server:latest}
```

With `build:` beside `image:`, Compose builds the local Dockerfile and
**tags the result** with whatever `image:` resolves to. Since the deploy
emitted `codercom/code-server:latest`, a locally built image was being
tagged with the upstream name — and `services.yaml` declared an image the
container never pulls.

`stacks/code-server/Dockerfile` starts `FROM codercom/code-server:latest`
and adds the nexus-venv, so the upstream image is the base, not what runs.
It now declares `nexus-code-server:latest`, matching **dagster, dinky,
flink, marimo, sling and spark** — all six name their build rather than its
base. The docs table follows the `(custom build)` convention those already
use.

## The check

`test_compose_fallbacks_match_the_declared_version` is the third corner of
the same square:

- **#715** — a declaration nobody reads
- **#738** — a compose reading a variable nobody declares
- **this** — both sides present, values disagreeing

Verified against a copy of the mailpit compose carrying the old fallback: it
fails and names both values.

## Verification

2769 tests pass (up from 2687), `ruff` and `mypy --strict` clean. The
cross-check that found these now returns zero mismatches across all 84
stacks.

## Summary by Sourcery

Ensure every stack’s fallback image matches the image declaration used when deployment variables are unavailable.

Bug Fixes:
- Align mailpit and uptime-kuma Compose fallbacks with the versions declared in services.yaml.
- Correct code-server’s declared image to represent the custom built image used at runtime.

Enhancements:
- Add a convention test that detects mismatches between Compose image fallbacks and services.yaml declarations across all stacks.

Documentation:
- Update the stack documentation to identify code-server as a custom build.

Tests:
- Extend stack convention coverage to validate fallback image consistency.