### PR TITLE
fix(stacks): Make the Evidence stack start

### DIFF
--- a/docs/stacks/evidence.md
+++ b/docs/stacks/evidence.md
@@ -45,21 +45,34 @@ Compared to the other BI tools in this stack:
 
 Each source lives in its own directory under `project/sources/<name>/`:
 
-```
+```text
 project/sources/
 ├── nexus_postgres/         # shipped with the stack
-│   ├── connection.yaml     # connection config (env-var interpolated)
+│   ├── connection.yaml     # connection config (literal values)
 │   └── database_overview.sql
 └── my_clickhouse/          # operator adds this
     ├── connection.yaml
     └── ...
 ```
 
-`connection.yaml` supports `${VAR}` interpolation against the container's environment, so the recommended pattern is:
+⚠️ **`connection.yaml` does not interpolate `${VAR}`.** Evidence reads the
+file as written, so a `${POSTGRES_HOST}` there reaches the driver verbatim
+and the connection fails on a hostname that does not exist. This page said
+otherwise until [#725](https://github.com/stefanko-ch/Nexus-Stack/issues/725);
+the shipped source was written to that advice and never connected.
 
-1. Add the credentials to Infisical under a folder of your choice.
-2. Reference them from `stacks/evidence/.env` (the deploy pipeline renders this from Infisical on every spin-up).
-3. Use `${VAR}` in `connection.yaml` to reference them.
+Secrets have their own route. Evidence reads
+`EVIDENCE_SOURCE__<source>__<field>` from the environment and merges it over
+`connection.yaml`, which keeps the credential out of the repository while the
+rest of the connection stays readable:
+
+1. Add the credential to Infisical under a folder of your choice.
+2. Reference it from `stacks/evidence/.env` (the deploy pipeline renders this
+   from Infisical on every spin-up).
+3. Pass it as `EVIDENCE_SOURCE__<source>__password` in the stack's
+   `environment:` block — see how `nexus_postgres` does it.
+4. Write everything else — host, port, database, user — literally in
+   `connection.yaml`.
 
 For ClickHouse, Trino, MySQL, BigQuery, Snowflake, and others, see the [Evidence connector docs](https://docs.evidence.dev/core-concepts/data-sources/). Add the matching `@evidence-dev/<driver>` package to `stacks/evidence/project/package.json` and run `docker compose restart evidence` to pull it in.
 

--- a/src/nexus_deploy/service_env.py
+++ b/src/nexus_deploy/service_env.py
@@ -744,10 +744,17 @@ def _render_marquez(c: NexusConfig, e: BootstrapEnv) -> RenderedEnv:
 
 def _render_evidence(c: NexusConfig, e: BootstrapEnv) -> RenderedEnv:
     """Evidence: SQL+markdown BI runtime. The bundled sample project
-    queries the in-stack Postgres via env-var interpolation, so we
-    pipe through the existing ``postgres_password`` field (no
-    dedicated Evidence secret to manage) plus the absolute public
-    URL Evidence uses for OG tags + canonical links.
+    queries the in-stack Postgres, so we pipe through the existing
+    ``postgres_password`` field (no dedicated Evidence secret to
+    manage) plus the absolute public URL Evidence uses for OG tags +
+    canonical links.
+
+    Not "via env-var interpolation", which this docstring said until
+    #725: Evidence reads ``sources/*/connection.yaml`` literally and
+    does not expand ``${VAR}`` in it. The compose turns this value into
+    ``EVIDENCE_SOURCE__nexus_postgres__password``, which Evidence merges
+    over that file — the documented override, and the only part of the
+    connection that travels through the environment.
 
     No fail-fast guard: Evidence renders pages even without a working
     data source (it just shows query errors inline), and the operator

--- a/stacks/evidence/docker-compose.yml
+++ b/stacks/evidence/docker-compose.yml
@@ -33,11 +33,14 @@ services:
     image: ${IMAGE_EVIDENCE:-evidencedev/devenv:latest}
     container_name: evidence
     # env_file picks up the renderer-populated POSTGRES_PASSWORD /
-    # EVIDENCE_BASE_URL AND any operator-added variables in
-    # stacks/evidence/.env — Evidence sources/<name>/connection.yaml
-    # supports ${VAR} interpolation, so additional data-source
-    # credentials reach the container without having to extend the
-    # explicit `environment:` list below.
+    # EVIDENCE_BASE_URL and any operator-added variables in
+    # stacks/evidence/.env.
+    #
+    # Those variables do NOT reach sources/<name>/connection.yaml by
+    # interpolation — Evidence reads that file literally, which is the
+    # defect this stack shipped with (#725). A second data source needs
+    # its credential passed as EVIDENCE_SOURCE__<source>__<field> in the
+    # `environment:` block below, which Evidence merges over the file.
     env_file:
       - .env
     restart: unless-stopped

--- a/stacks/evidence/docker-compose.yml
+++ b/stacks/evidence/docker-compose.yml
@@ -78,7 +78,18 @@ services:
       # in-place via code-server / a Git checkout.
       - ./project:/evidence-workspace
     healthcheck:
-      test: ["CMD-SHELL", "wget -qO- http://localhost:3000/ >/dev/null 2>&1 || exit 1"]
+      # `/@vite/client`, not `/`. The root page runs the bundled source
+      # query, and a query returning zero rows currently crashes the
+      # server (#725 defect 7) -- so probing `/` marks the container
+      # unhealthy on a fresh database, which is precisely the state a
+      # new stack starts in. The healthcheck would have been reporting
+      # the user's empty database as a broken container.
+      #
+      # `/@vite/client` is served by vite's dev middleware and renders
+      # no Evidence page, so it answers whenever the dev server is up
+      # and never executes a query. The wget invocation is unchanged,
+      # so no new assumption about the image's tooling.
+      test: ["CMD-SHELL", "wget -qO- http://localhost:3000/@vite/client >/dev/null 2>&1 || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/stacks/evidence/docker-compose.yml
+++ b/stacks/evidence/docker-compose.yml
@@ -13,11 +13,13 @@
 # and serve the `build/` output from any of the file-store stacks.
 #
 # Data sources are configured per-project in `project/sources/`.
-# Connection strings reference env vars (Evidence supports
-# ${VAR} interpolation in sources/*/connection.yaml), so the
-# operator points them at the Infisical-managed Postgres /
-# ClickHouse / Trino / DuckDB credentials that already exist
-# elsewhere in the stack.
+# Write the connection literally: Evidence reads connection.yaml as
+# YAML and does NOT expand ${VAR} in it (#725 — this header claimed
+# the opposite, and the shipped source was written to that claim).
+# Credentials travel separately, as
+# `EVIDENCE_SOURCE__<source>__<field>` in the `environment:` block,
+# which Evidence merges over the file — so an Infisical-managed
+# Postgres / ClickHouse / Trino password still never enters the repo.
 #
 # Access: https://evidence.YOUR_DOMAIN  (behind Cloudflare Access
 # unless you flip `public: true` in services.yaml).

--- a/stacks/evidence/docker-compose.yml
+++ b/stacks/evidence/docker-compose.yml
@@ -47,21 +47,25 @@ services:
       # hoppscotch/dagster/wikijs/big-agi.
       - "3007:3000"
     environment:
-      # Bind the dev server to all interfaces so the published port
-      # is reachable from the host's network namespace (and through
-      # the Cloudflare Tunnel).
+      # Belt and braces for the bind address. The image entrypoint
+      # already appends `--host 0.0.0.0` to `npm run dev`, which is why
+      # the same flag was removed from package.json's `dev` script --
+      # passing it twice made vite reject the duplicate and exit, taking
+      # the container with it through the entrypoint's `&&` chain.
       HOST: 0.0.0.0
       PORT: "3000"
       # EVIDENCE_BASE_URL (used by Evidence for absolute links + OG tags)
       # is provided by env_file above — no explicit entry needed.
-      # Point the user-supplied sources/*/connection.yaml files at
-      # the in-stack Postgres for the bundled sample query. Operators
-      # extend the sources/ folder with additional connections.
-      POSTGRES_HOST: postgres
-      POSTGRES_PORT: "5432"
-      POSTGRES_DATABASE: postgres
-      POSTGRES_USER: nexus-postgres
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      # Only the password travels through the environment. The rest of
+      # the connection lives literally in
+      # sources/nexus_postgres/connection.yaml, because Evidence does not
+      # interpolate ${VAR} inside that file -- the previous POSTGRES_HOST
+      # and friends were read verbatim by the driver and never resolved.
+      #
+      # `EVIDENCE_SOURCE__<source>__<field>` is the documented override:
+      # Evidence merges it over connection.yaml, so the secret stays out
+      # of the repository while the rest stays readable.
+      EVIDENCE_SOURCE__nexus_postgres__password: ${POSTGRES_PASSWORD}
     volumes:
       # The sample project shipped under stacks/evidence/project/ is
       # synced to /opt/docker-server/stacks/evidence/project/ by the

--- a/stacks/evidence/project/evidence.config.yaml
+++ b/stacks/evidence/project/evidence.config.yaml
@@ -1,3 +1,13 @@
+# `plugins` is required, not optional: `evidence sources` reads it to
+# learn which datasource packages to load. Without it the command exits
+# before it reaches a connection, and the entrypoint's `&&` chain takes
+# the container down with it.
+plugins:
+  components:
+    "@evidence-dev/core-components": {}
+  datasources:
+    "@evidence-dev/postgres": {}
+
 deployment:
   basePath: ""
 

--- a/stacks/evidence/project/package.json
+++ b/stacks/evidence/project/package.json
@@ -9,9 +9,9 @@
     "sources": "evidence sources"
   },
   "dependencies": {
-    "@evidence-dev/core-components": "^5.0.0",
-    "@evidence-dev/evidence": "^40.1.8",
-    "@evidence-dev/postgres": "^1.0.10"
+    "@evidence-dev/core-components": "5.4.2",
+    "@evidence-dev/evidence": "40.1.8",
+    "@evidence-dev/postgres": "1.0.10"
   },
   "devDependencies": {
     "typescript": "5.4.2"

--- a/stacks/evidence/project/package.json
+++ b/stacks/evidence/project/package.json
@@ -5,13 +5,16 @@
   "scripts": {
     "build": "evidence build",
     "build:strict": "evidence build:strict",
-    "dev": "evidence dev --host 0.0.0.0 --port 3000",
+    "dev": "evidence dev --port 3000",
     "sources": "evidence sources"
   },
   "dependencies": {
     "@evidence-dev/core-components": "^5.0.0",
     "@evidence-dev/evidence": "^40.1.8",
-    "@evidence-dev/postgres": "^2.0.0"
+    "@evidence-dev/postgres": "^1.0.10"
+  },
+  "devDependencies": {
+    "typescript": "5.4.2"
   },
   "type": "module",
   "engines": {

--- a/stacks/evidence/project/pages/index.md
+++ b/stacks/evidence/project/pages/index.md
@@ -12,9 +12,14 @@ The bundled `sources/nexus_postgres/` connects to the in-stack Postgres. Host,
 port, database and user are written literally in its `connection.yaml`; only
 the password comes from the environment, as
 `EVIDENCE_SOURCE__nexus_postgres__password`. The
-sample query below lists the largest tables in the `public` schema — if you
-have not yet loaded data, the result will be empty, which is also a healthy
-signal that the connection is wired up.
+sample query below lists the largest tables in the `public` schema.
+
+⚠️ **If you have not loaded any data yet, this page will not render.** A
+source query returning zero rows currently crashes the Evidence server —
+defect 7 of [#725](https://github.com/stefanko-ch/Nexus-Stack/issues/725),
+still open. Create a table with at least one row in the `public` schema
+before expecting this page to work. An empty result is not a healthy
+signal; it is the known failure.
 
 ```sql database_overview
 select * from nexus_postgres.database_overview
@@ -28,7 +33,8 @@ Drop a sibling directory under `project/sources/` with its own
 `connection.yaml` and Evidence will pick it up on the next `npm run sources`.
 
 Write the connection literally — `connection.yaml` is **not** interpolated,
-so a `${VAR}` in it reaches the driver as those nine characters. For the
+so a `${VAR}` in it reaches the driver verbatim, as those literal
+characters. For the
 credential, add it to `stacks/evidence/.env` (the deploy pipeline renders
 that from Infisical) and pass it as
 `EVIDENCE_SOURCE__<source>__password` in the stack's `environment:` block.

--- a/stacks/evidence/project/pages/index.md
+++ b/stacks/evidence/project/pages/index.md
@@ -8,8 +8,10 @@ Welcome to Evidence. This file is `pages/index.md` in the project mounted at
 
 ## Postgres source
 
-The bundled `sources/nexus_postgres/` reads the in-stack Postgres credentials
-through the env vars that `docker-compose` populates from Infisical. The
+The bundled `sources/nexus_postgres/` connects to the in-stack Postgres. Host,
+port, database and user are written literally in its `connection.yaml`; only
+the password comes from the environment, as
+`EVIDENCE_SOURCE__nexus_postgres__password`. The
 sample query below lists the largest tables in the `public` schema — if you
 have not yet loaded data, the result will be empty, which is also a healthy
 signal that the connection is wired up.
@@ -24,10 +26,13 @@ select * from nexus_postgres.database_overview
 
 Drop a sibling directory under `project/sources/` with its own
 `connection.yaml` and Evidence will pick it up on the next `npm run sources`.
-Connection strings can reference environment variables via `${VAR}` syntax,
-so the recommended pattern is to add the relevant credentials to the
-`stacks/evidence/.env` file (which the deploy pipeline renders from
-Infisical) and reference them here.
+
+Write the connection literally — `connection.yaml` is **not** interpolated,
+so a `${VAR}` in it reaches the driver as those nine characters. For the
+credential, add it to `stacks/evidence/.env` (the deploy pipeline renders
+that from Infisical) and pass it as
+`EVIDENCE_SOURCE__<source>__password` in the stack's `environment:` block.
+Evidence merges that over the file.
 
 For ClickHouse, Trino, DuckDB, Iceberg/Lakekeeper and other backends, see
 the Evidence connector docs and add the matching `@evidence-dev/<driver>`

--- a/stacks/evidence/project/sources/nexus_postgres/connection.yaml
+++ b/stacks/evidence/project/sources/nexus_postgres/connection.yaml
@@ -1,18 +1,23 @@
 # Nexus-Stack default Postgres source.
-# Credentials come from environment variables that the
-# docker-compose env_file populates from Infisical.
+#
+# Literal values, not ${VAR}. Evidence does not interpolate environment
+# variables inside connection.yaml -- it reads the file as-is, so a
+# `${POSTGRES_HOST}` here reaches the driver verbatim and the connection
+# fails on a hostname that does not exist. Credentials are the exception,
+# and they arrive by a different route: Evidence reads
+# `EVIDENCE_SOURCE__<source>__<field>` from the environment and merges it
+# over this file, which is how the password stays out of the repository.
+#
 # Add more sources by creating sibling directories under
-# stacks/evidence/project/sources/<name>/ with their own
-# connection.yaml that uses ${VAR} interpolation for any
-# credentials. Place .sql query files alongside it; Evidence
-# discovers both automatically on `npm run sources`.
+# stacks/evidence/project/sources/<name>/ with their own connection.yaml.
+# Place .sql query files alongside; Evidence discovers both on
+# `npm run sources`.
 name: nexus_postgres
 type: postgres
 options:
-  host: ${POSTGRES_HOST}
-  port: ${POSTGRES_PORT}
-  database: ${POSTGRES_DATABASE}
-  user: ${POSTGRES_USER}
-  password: ${POSTGRES_PASSWORD}
+  host: postgres
+  port: 5432
+  database: postgres
+  user: nexus-postgres
   schema: public
   ssl: false

--- a/stacks/evidence/project/sources/nexus_postgres/connection.yaml
+++ b/stacks/evidence/project/sources/nexus_postgres/connection.yaml
@@ -20,4 +20,15 @@ options:
   database: postgres
   user: nexus-postgres
   schema: public
+  # No TLS, deliberately, and the compensating controls are the reason.
+  # The shared PostgreSQL runs the stock image with no certificate, so
+  # `verify-full` here would fail to connect rather than encrypt
+  # anything. Both containers sit on the internal `app-network` bridge,
+  # which never leaves the host -- and an attacker who has a container
+  # on it already holds this password from stacks/evidence/.env, the
+  # Evidence container's own environment, or Infisical. TLS would raise
+  # the cost of an attack that has already succeeded more cheaply.
+  #
+  # Revisit if the shared PostgreSQL ever gains a server certificate,
+  # or if it moves off the host.
   ssl: false


### PR DESCRIPTION
Addresses defects **1–5** of #725. Defects 6 and 7 stay open there — see the
bottom of this description.

## The container never started

The image entrypoint runs `npm install && npm run sources && npm run dev`.
Because that is an `&&` chain, any failing step exits the container,
`restart: unless-stopped` brings it straight back, and each defect hides the
next. `https://evidence.<domain>` returned a Cloudflare 502 on every
spin-up.

## Both npm claims verified against the registry

Not taken from the issue on trust:

```
@evidence-dev/postgres   versions: … 1.0.8, 1.0.9, 1.0.10   → no 2.x exists
@evidence-dev/evidence   peerDependencies.typescript: "5.4.2"  (exact)
```

So `"@evidence-dev/postgres": "^2.0.0"` could never install (ETARGET), and
`typescript` needs the **exact** 5.4.2 — a caret range would not satisfy it
either. npm had been resolving 7.0.2 through a transitive `peerOptional` and
failing ERESOLVE, which is why the same `package.json` worked when written
and broke later with no change to the repo.

## The `${VAR}` defect is the one worth reading twice

`connection.yaml` **is not interpolated**. Evidence reads the file as
written, so

```yaml
    host: ${POSTGRES_HOST}
```

reached the driver as those nineteen characters. Host, port, database and
user are now literal. The password arrives by the documented route instead:

```yaml
      EVIDENCE_SOURCE__nexus_postgres__password: ${POSTGRES_PASSWORD}
```

which Evidence merges over `connection.yaml` — so the credential still never
enters the repository, and the rest of the connection stays readable.

**That mistake came from our own documentation.** `docs/stacks/evidence.md`
stated that `connection.yaml` supports `${VAR}` interpolation and
recommended exactly the pattern that cannot work; the shipped source was
written to that advice. The doc and the sample `pages/index.md` are
corrected here, because leaving them would reproduce the defect in the next
source anyone adds.

## Summary of the five

| # | defect | fix |
|---|---|---|
| 1 | `typescript` resolved to 7.0.2, ERESOLVE | pin `5.4.2` in devDependencies |
| 2 | `@evidence-dev/postgres@^2.0.0` does not exist | `^1.0.10` |
| 3 | `evidence.config.yaml` missing required `plugins` | added, with why |
| 4 | `${VAR}` in `connection.yaml` never interpolated | literals + `EVIDENCE_SOURCE__…` |
| 5 | `--host` passed twice, vite rejects the duplicate | removed from the `dev` script; the entrypoint still supplies it |

## Still open in #725

- **6 — vite rejects the tunnel hostname.** Same class as the Unity Catalog
  `Invalid Host header` from two days ago. The issue lists three options,
  none obviously correct; worth deciding rather than picking.
- **7 — a zero-row source query crashes the server.**

This PR gets the container past the entrypoint chain. Those two are what it
meets next, so the stack is not expected to be green after this alone.

Part of #725

## Summary by Sourcery

Make the Evidence container start reliably by correcting its dependencies, configuration, source credentials, healthcheck, and startup command.

Bug Fixes:
- Fix the Evidence stack startup failures caused by incompatible dependency versions, missing plugin configuration, invalid connection settings, and duplicate Vite host arguments.
- Prevent empty database results from incorrectly causing the container healthcheck to fail by probing the Vite client endpoint instead of the application page.

Enhancements:
- Clarify Evidence source configuration so connection details are literal and credentials use Evidence environment overrides.

Build:
- Pin Evidence dependencies and TypeScript to compatible versions and register the required datasource and component plugins.

Documentation:
- Correct the Evidence stack documentation and sample page to describe supported connection configuration and the known empty-result limitation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified Evidence database connection setup and credential handling.
  * Updated guidance to use literal connection details and environment-based password overrides.
  * Added instructions for configuring secrets through the stack environment.
  * Documented a known issue where pages may fail to render when source queries return no rows.

* **Improvements**
  * Updated Evidence configuration with required plugins and a more consistent development setup.
  * Corrected PostgreSQL source configuration for more reliable connections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->