### PR TITLE
fix(tofu): Rewrite the tunnel Host header for origins that check it

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -126,6 +126,7 @@ Convention background: [examples/README.md](../examples/README.md) carries the f
 - Absolute URLs for tutorial cross-links (see §6)
 - Missing screenshots in tutorials — deliberate, text is the primary medium, images are added later in separate PRs
 - The light-mode toggle on nexus-stack.ch being broken — this is a separate-repo issue tracked there, not relevant for PRs in this repo
+- `strict_host_check: true` in `services.yaml` (currently only `evidence`). It is a real field, consumed by `.github/scripts/generate-services-tfvars.py` and `tofu/stack/variables.tf`, and it makes the tunnel rewrite the `Host` header to `localhost:<port>` for origins that reject foreign hostnames. Don't suggest removing it or setting `server.allowedHosts` instead — Evidence regenerates its vite config on every start.
 - `services.yaml` not having an `enabled` field per service — `enabled` lives in Cloudflare D1 and is managed via the Control Plane, not the YAML. Don't suggest adding it.
 
 ## Verification commands reviewers should actually run

--- a/.github/scripts/generate-services-tfvars.py
+++ b/.github/scripts/generate-services-tfvars.py
@@ -93,6 +93,18 @@ def validate_services_yaml(data):
         if 'core' in config and not isinstance(config['core'], bool):
             errors.append(f"Service '{name}': 'core' must be a boolean")
 
+        if 'strict_host_check' in config:
+            if not isinstance(config['strict_host_check'], bool):
+                errors.append(f"Service '{name}': 'strict_host_check' must be a boolean")
+            elif config.get('internal_only', False):
+                # No subdomain means no ingress rule, so there is no Host
+                # header for the tunnel to rewrite. Silently ineffective is
+                # worse than rejected.
+                errors.append(
+                    f"Service '{name}': 'strict_host_check' has no effect on an "
+                    f"internal_only service (it gets no tunnel ingress rule)"
+                )
+
         if 'description' in config and not isinstance(config['description'], str):
             errors.append(f"Service '{name}': 'description' must be a string")
 
@@ -153,6 +165,8 @@ def main():
         output_lines.append(f'    public      = {public}')
         if core:
             output_lines.append(f'    core        = true')
+        if config.get('strict_host_check', False):
+            output_lines.append('    strict_host_check = true')
         output_lines.append(f'    description = "{description}"')
         output_lines.append(f'    image       = "{image}"')
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -425,6 +425,18 @@ When adding a new Docker stack, **all locations must be updated**:
 ```
 Find logos at [simpleicons.org](https://simpleicons.org/)
 
+**Dev servers that check the `Host` header.** A stack served by vite (or
+any origin that validates `Host`) answers `Blocked request. This host is
+not allowed.` through the tunnel, because the header carries the public
+hostname rather than the origin's own. Set `strict_host_check: true` on
+the service in `services.yaml`; `tofu/stack/main.tf` then gives its
+ingress rule an `origin_request` block rewriting the header to
+`localhost:<port>`. Reach for this only when the origin offers no way to
+allow the hostname directly — for Evidence it does not, because it
+regenerates its vite config on every start. The flag is meaningless on an
+`internal_only` service, which gets no ingress rule; the tfvars generator
+and `tests/unit/test_stack_conventions.py` both reject that pairing.
+
 **Example service entry (services.yaml):**
 ```yaml
 portainer:

--- a/docs/stacks/evidence.md
+++ b/docs/stacks/evidence.md
@@ -21,7 +21,38 @@ This stack ships the Evidence `devenv` runtime preloaded with a sample project, 
 | Source | [GitHub](https://github.com/evidence-dev/evidence) |
 | Docker image | [`evidencedev/devenv`](https://hub.docker.com/r/evidencedev/devenv) |
 | Database | `postgres:18-alpine` as `evidence-db`, on the stack-private `evidence-internal` bridge |
+| Host header | Rewritten by the tunnel to `localhost:3007` — see below |
 | Project root | `/opt/docker-server/stacks/evidence/project/` on the server (mounted at `/evidence-workspace` inside the container) |
+
+### Why the tunnel rewrites the Host header
+
+Evidence serves through vite's dev server. Since the 5.4.12 DNS-rebinding fix,
+vite rejects any request whose `Host` header is not listed in
+`server.allowedHosts`, answering:
+
+```
+Blocked request. This host ("evidence.YOUR_DOMAIN") is not allowed.
+To allow this host, add "evidence.YOUR_DOMAIN" to `server.allowedHosts` in vite.config.js.
+```
+
+Following that advice is not possible here. Evidence regenerates
+`.evidence/template/vite.config.js` on every start and exposes no hook to inject
+into it, and the vite it pins (5.4.21) has no environment escape — the
+`__VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS` variable is Vite 6 and later.
+
+So `services.yaml` marks the service `strict_host_check: true`, and
+`tofu/stack/main.tf` gives its tunnel ingress rule an `origin_request` block
+setting `http_host_header` to `localhost:<port>`. Cloudflare rewrites the header
+before the request reaches the origin; vite allows localhost, and the page
+loads. Cloudflare Access is unaffected — it runs at the edge, before the tunnel.
+
+This does not change Evidence's own links: canonical URLs and OG tags come from
+`EVIDENCE_BASE_URL`, which is set from the public domain.
+
+Set the same flag on any other stack whose dev server refuses foreign Host
+headers. It has no effect on an `internal_only` service, which gets no ingress
+rule at all, and both the tfvars generator and the unit tests reject that
+combination rather than letting it sit there silently.
 
 ### Why Evidence
 

--- a/docs/stacks/evidence.md
+++ b/docs/stacks/evidence.md
@@ -30,7 +30,7 @@ Evidence serves through vite's dev server. Since the 5.4.12 DNS-rebinding fix,
 vite rejects any request whose `Host` header is not listed in
 `server.allowedHosts`, answering:
 
-```
+```text
 Blocked request. This host ("evidence.YOUR_DOMAIN") is not allowed.
 To allow this host, add "evidence.YOUR_DOMAIN" to `server.allowedHosts` in vite.config.js.
 ```
@@ -48,6 +48,16 @@ loads. Cloudflare Access is unaffected — it runs at the edge, before the tunne
 
 This does not change Evidence's own links: canonical URLs and OG tags come from
 `EVIDENCE_BASE_URL`, which is set from the public domain.
+
+It does give up what vite's check was there for. That check is DNS-rebinding
+protection: it stops a browser that has been tricked into resolving an attacker's
+hostname to `127.0.0.1` from reaching a dev server bound to loopback. That threat
+needs a path to the origin which does not exist here — the server has no open
+ports, every request arrives through the Cloudflare Tunnel, and Cloudflare Access
+authenticates before the tunnel forwards anything. The check is redundant against
+this deployment's only reachable path, which is why disabling it costs nothing.
+It would matter again the moment the port were published directly, so a
+`tcp_ports` entry for a stack carrying this flag deserves a second look.
 
 Set the same flag on any other stack whose dev server refuses foreign Host
 headers. It has no effect on an `internal_only` service, which gets no ingress

--- a/services.yaml
+++ b/services.yaml
@@ -260,6 +260,14 @@ services:
     description: "SQL + markdown BI framework — write queries inside Markdown, render charts inline."
     long_description: "Evidence is an open-source 'BI as code' framework: each page is a Markdown file containing SQL blocks that render into charts, tables, and value components. Projects live in plain text — version them in Git, edit with your normal tools, and reload on save. This stack ships the devenv runtime preloaded with a sample project, plus its own Postgres seeded with demo data so the sample page renders immediately; extend the sources/ directory to connect the shared Postgres, ClickHouse, Trino, DuckDB, Iceberg/Lakekeeper, and more."
     image: "evidencedev/devenv:latest"
+    # Evidence serves through vite's dev server, which since the 5.4.12
+    # DNS-rebinding fix rejects any Host header not in
+    # `server.allowedHosts` -- answering "Blocked request. This host is
+    # not allowed." instead of the page. Evidence regenerates
+    # .evidence/template/vite.config.js on every start and offers no hook
+    # to set that option, and its pinned vite (5.4.21) has no environment
+    # escape either, so the header is rewritten at the tunnel instead.
+    strict_host_check: true
     support_images:
       evidence-db: "postgres:18-alpine"
 

--- a/tests/unit/test_stack_conventions.py
+++ b/tests/unit/test_stack_conventions.py
@@ -884,3 +884,29 @@ def test_evidence_sources_only_name_hosts_its_own_compose_defines(
         f"stacks/evidence/docker-compose.yml, or -- if it really is external and "
         f"always reachable -- add it to EVIDENCE_EXTERNAL_SOURCE_HOSTS with a reason."
     )
+
+
+def test_strict_host_check_only_where_a_tunnel_rule_exists(services: dict[str, Any]) -> None:
+    """`strict_host_check` rewrites the Host header on a tunnel ingress
+    rule, so it needs a rule to act on.
+
+    An `internal_only` service has no subdomain and therefore gets no
+    ingress rule (main.tf iterates `enabled_services_with_subdomain`), so
+    the flag would sit in services.yaml doing nothing -- the failure mode
+    where someone sets it, sees no change, and looks for the cause
+    elsewhere.
+
+    .github/scripts/generate-services-tfvars.py rejects the same
+    combination, but only when a deploy runs it. This catches it on the
+    commit instead.
+    """
+    offenders = sorted(
+        name
+        for name, entry in services.items()
+        if entry.get("strict_host_check")
+        and (entry.get("internal_only") or not entry.get("subdomain"))
+    )
+    assert not offenders, (
+        f"strict_host_check set on services with no tunnel ingress rule: {offenders}. "
+        f"The flag only has an effect on a service with a subdomain."
+    )

--- a/tofu/stack/main.tf
+++ b/tofu/stack/main.tf
@@ -964,6 +964,23 @@ resource "cloudflare_zero_trust_tunnel_cloudflared_config" "main" {
       content {
         hostname = "${ingress_rule.value.subdomain}.${var.domain}"
         service  = "http://localhost:${ingress_rule.value.port}"
+
+        # Some dev servers refuse a Host header that is not their own
+        # origin — vite does since the 5.4.12 DNS-rebinding fix, and it
+        # answers with "Blocked request. This host is not allowed."
+        # rather than the page. Evidence is the case that surfaced it:
+        # its vite is 5.4.21, which supports `server.allowedHosts`, but
+        # Evidence regenerates .evidence/template/vite.config.js on every
+        # start and exposes no hook to inject into it, and that vite build
+        # carries no environment escape (__VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS
+        # is Vite 6+). Rewriting the header upstream is the only fix that
+        # does not depend on the internals of an unpinned image.
+        dynamic "origin_request" {
+          for_each = try(ingress_rule.value.strict_host_check, false) ? [1] : []
+          content {
+            http_host_header = "localhost:${ingress_rule.value.port}"
+          }
+        }
       }
     }
 

--- a/tofu/stack/variables.tf
+++ b/tofu/stack/variables.tf
@@ -185,6 +185,23 @@ variable "services" {
     strict_host_check = optional(bool, false)
   }))
   default = {}
+
+  # `port` is interpolated into the tunnel origin and, for
+  # strict_host_check services, into http_host_header. HCL's `number`
+  # accepts 0, 65536 and 3000.5 alike, and a bad value there produces an
+  # invalid tunnel configuration rather than an error.
+  #
+  # .github/scripts/generate-services-tfvars.py already rejects the same
+  # values, so on the deploy path this is a second net. It is the only
+  # net on the documented local path, where an operator writes
+  # config.tfvars by hand and runs `tofu plan -var-file=config.tfvars`.
+  validation {
+    condition = alltrue([
+      for name, svc in var.services :
+      svc.port == floor(svc.port) && svc.port >= 1 && svc.port <= 65535
+    ])
+    error_message = "Every service port must be a whole number between 1 and 65535."
+  }
 }
 
 # =============================================================================

--- a/tofu/stack/variables.tf
+++ b/tofu/stack/variables.tf
@@ -177,6 +177,12 @@ variable "services" {
     core           = optional(bool, false)
     image          = optional(string, "")
     support_images = optional(map(string), {})
+    # Origins that reject a Host header naming anything but themselves.
+    # Sets the tunnel to present "localhost:<port>" instead of the public
+    # hostname. Boolean rather than a free-form header so it cannot drift
+    # from `port` above; if a service ever needs a different value, this
+    # becomes a string then.
+    strict_host_check = optional(bool, false)
   }))
   default = {}
 }


### PR DESCRIPTION
## Problem

Opening `https://evidence.<domain>` returns vite's block page instead of
Evidence, on a stack where the container is otherwise healthy:

```
Blocked request. This host ("evidence.nexus-stack.ch") is not allowed.
To allow this host, add "evidence.nexus-stack.ch" to `server.allowedHosts` in vite.config.js.
```

vite has rejected foreign `Host` headers since the 5.4.12 DNS-rebinding fix. The
tunnel forwards the public hostname, the origin only expects its own.

This is defect 6 of #725.

## Why vite's own advice cannot be followed

Checked against the running container, not assumed:

| Question | Answer |
|---|---|
| vite version | `5.4.21` |
| Does it support `server.allowedHosts`? | **Yes** — present in the dist |
| Environment escape? | **No** — `__VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS` occurs 0 times; that variable is Vite 6+ |
| Can we set it in Evidence's vite config? | **No** — `.evidence/template/vite.config.js` is regenerated on every start (root-owned, timestamped at container start), carries no `allowedHosts`, and `@evidence-dev/` contains no occurrence of the option and no user-config merge |

Patching the generated file after Evidence writes it would be undone by the next
`evidence dev`, and `evidencedev/devenv` is an unpinned `:latest` (a documented
exception — Evidence publishes no versioned devenv tags), so the internals can
change without notice.

## Change

Rewrite the header upstream, where nothing depends on the image's internals.

`services.yaml` gains an optional per-service flag:

```yaml
evidence:
  strict_host_check: true
```

and the tunnel's ingress rule gains a nested block:

```hcl
dynamic "origin_request" {
  for_each = try(ingress_rule.value.strict_host_check, false) ? [1] : []
  content {
    http_host_header = "localhost:${ingress_rule.value.port}"
  }
}
```

The pinned provider (`cloudflare/cloudflare 4.52.7`, constraint `~> 4.49`)
carries both `origin_request` and `http_host_header`.

**A boolean, not a header string.** The port is already declared two lines above
in `services.yaml`; a literal `"localhost:3007"` could drift from it. If a
service ever needs a different host, this becomes a string then.

**Cloudflare Access is unaffected** — it runs at the edge, ahead of the tunnel.
Evidence's canonical links and OG tags come from `EVIDENCE_BASE_URL` and do not
derive from the `Host` header.

## The silently-ineffective case

An `internal_only` service has no subdomain and so gets no ingress rule
(`main.tf` iterates `enabled_services_with_subdomain`). The flag would sit in
`services.yaml` doing nothing — the failure mode where someone sets it, sees no
change, and looks elsewhere for the cause.

Both `.github/scripts/generate-services-tfvars.py` and a new unit test reject
that pairing. The generator catches it at deploy time; the test catches it on the
commit.

Verified in both directions:

- generator emits `strict_host_check = true` for `evidence`
- generator exits 1 with `Service 'postgres': 'strict_host_check' has no effect
  on an internal_only service (it gets no tunnel ingress rule)` when the flag is
  moved onto internal-only postgres

## Docs

- `docs/stacks/evidence.md` — a section quoting the actual error and explaining
  why the suggested fix is unavailable, so the next person does not spend the
  same hour on it
- `CLAUDE.md` — a note at the services.yaml registration step, including that
  the flag is a last resort for origins offering no way to allow the hostname
- `.github/copilot-instructions.md` — added to the "do not flag this" list, so
  the reviewer stops proposing `server.allowedHosts` on every future PR

## Gates

`2772 passed, 1 skipped` · `tofu validate` · `ruff` · `mypy --strict` ·
pre-commit across all 8 files.

## Not verified

Whether anything downstream builds a redirect from the rewritten `Host` and
sends the browser to `localhost:3007`. That is the one residual risk of this
approach and only a deploy can show it — watch the address bar while navigating
between pages.

## How to test

```bash
gh workflow run spin-up.yml --ref fix/tunnel-host-header
```

No `initial-setup` needed: the tunnel configuration is applied by `tofu apply`
during a normal spin-up.

1. Open `https://evidence.YOUR_DOMAIN` → the page renders, with the seeded
   `demo_sales` line chart.
2. Navigate between pages and watch the address bar for any `localhost:3007`.
3. Confirm Cloudflare Access still challenges on first visit.

Refs #725 (defect 6). Not closing #725 — defect 7, the zero-row source query
crash, is unrelated and still open.

## Summary by Sourcery

Allow tunneled services that reject foreign Host headers to receive requests under their local origin hostname.

New Features:
- Add an optional per-service strict host-check setting that rewrites tunnel requests to the origin's localhost host and port.

Bug Fixes:
- Fix Evidence pages being blocked by Vite when accessed through the public tunnel hostname.

Enhancements:
- Reject strict host checking on services without tunnel ingress rules and validate service ports consistently.

Deployment:
- Configure Cloudflare tunnel ingress rules to rewrite the Host header for services that require it.

Documentation:
- Document the Evidence Host-header issue, the tunnel-based resolution, its security implications, and when to use the service flag.

Tests:
- Add unit coverage ensuring strict host checking is only configured for services with tunnel ingress rules.

Chores:
- Clarify the intended use of strict host checking in contributor and reviewer guidance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for rewriting tunnel request host headers for services requiring strict host validation.
  * Evidence stack access through its tunnel now avoids host validation errors.

* **Bug Fixes**
  * Fixed “Blocked request. This host is not allowed.” responses for supported development servers.

* **Documentation**
  * Documented configuration, behavior, and usage limitations for strict host checking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->