### PR TITLE
fix(ci): Let a First-Time Deploy start without restoring a snapshot

### DIFF
--- a/.github/workflows/initial-setup.yaml
+++ b/.github/workflows/initial-setup.yaml
@@ -105,7 +105,12 @@ jobs:
           # enabled_set`), so the single source of truth for "core" stays
           # services.yaml rather than a copy that drifts here.
           # Remove duplicates and empty values, sort
-          SERVICES=$(echo "$ENABLED_INPUT" | tr ',' '\n' | sort -u | grep -v '^$' | tr '\n' ',' | sed 's/,$//')
+          # printf, not echo. bash's builtin echo eats a leading -n/-e as an
+          # option, so an input of "-n" would print nothing, leave SERVICES
+          # empty and quietly deploy core-only instead of failing on a value
+          # nobody meant. This runs before the validation below, so it has to
+          # pass the string through unchanged.
+          SERVICES=$(printf '%s' "$ENABLED_INPUT" | tr ',' '\n' | sort -u | grep -v '^$' | tr '\n' ',' | sed 's/,$//')
 
           # Every name must look like a service name and be one. The format
           # check is what makes the rest safe: it admits no quote, semicolon,

--- a/.github/workflows/initial-setup.yaml
+++ b/.github/workflows/initial-setup.yaml
@@ -13,6 +13,34 @@ on:
         required: false
         default: false
         type: boolean
+      fresh_start:
+        # "First-Time Deploy" names what this workflow sets up -- the
+        # Control Plane, then a spin-up -- and says nothing about the data
+        # it starts from. It delegates to spin-up.yml, whose restore phase
+        # is gated only on the persistence feature flag and on
+        # `snapshots/latest.txt` existing in R2. There is no notion of a
+        # first run: an existing snapshot is applied here exactly as on any
+        # other spin-up.
+        #
+        # That is deliberate -- RFC 0001 decision #6, quoted above the
+        # `delete_data` input in destroy-all.yml: the snapshot history
+        # survives a destroy so a later setup reattaches to it. It is also
+        # reliably surprising, because every teardown writes a fresh
+        # snapshot. A stack torn down after a `destroy-all` has snapshot
+        # history again within a day, so the operator who wiped R2 on
+        # Friday does not expect Sunday's setup to restore Saturday's data.
+        #
+        # This forwards spin-up.yml's existing `s3_persistence` input
+        # rather than adding a second flag. For a spin-up that input does
+        # exactly one thing: skip the two restore_from_s3 calls in
+        # pipeline.py. Nothing else in run_pipeline consults it, and the
+        # teardown workflows read the repository secret rather than this
+        # input, so a fresh start here does not stop the next teardown from
+        # snapshotting.
+        description: 'Start with an empty stack, ignoring any snapshot in R2. Leave unchecked to restore the latest snapshot, as a normal spin-up would.'
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -111,4 +139,10 @@ jobs:
       # Pass enabled services (if configured, otherwise spin-up reads from D1)
       enabled_services: ${{ needs.configure-initial-services.outputs.enabled_services || '' }}
       silent_mode: ${{ inputs.silent_mode }}
+      # spin-up.yml feeds this into NEXUS_S3_PERSISTENCE, which
+      # s3_restore.is_enabled() compares against the exact literal "true".
+      # Empty means "not overridden", leaving the repository secret and the
+      # workflow's own default to decide -- which is why the unchecked case
+      # passes '' and not 'true'.
+      s3_persistence: ${{ inputs.fresh_start && 'false' || '' }}
     secrets: inherit

--- a/.github/workflows/initial-setup.yaml
+++ b/.github/workflows/initial-setup.yaml
@@ -37,7 +37,7 @@ on:
         # teardown workflows read the repository secret rather than this
         # input, so a fresh start here does not stop the next teardown from
         # snapshotting.
-        description: 'Start with an empty stack, ignoring any snapshot in R2. Leave unchecked to restore the latest snapshot, as a normal spin-up would.'
+        description: 'Start with an empty stack, ignoring any snapshot in R2. Leave unchecked to let the stack decide as it would on any spin-up — which restores the latest snapshot only if persistence is switched on for it.'
         required: false
         default: false
         type: boolean
@@ -83,6 +83,14 @@ jobs:
 
       - name: Build enabled services list
         id: build-list
+        env:
+          # Through the environment, never `${{ }}` inside the script body.
+          # Actions substitutes those textually before bash sees the line, so
+          # a dispatch value carrying shell syntax runs on the runner with
+          # this job's credentials. The value is operator-supplied, but "only
+          # someone with write access can dispatch" is an argument for a
+          # smaller blast radius, not for none.
+          ENABLED_INPUT: ${{ inputs.enabled_services }}
         run: |
           # No hardcoded core list. There used to be one — "infisical,mailpit"
           # — and it was wrong in both directions: the core set is forgejo,
@@ -96,18 +104,53 @@ jobs:
           # services regardless of D1 (`should_enable = is_core or name in
           # enabled_set`), so the single source of truth for "core" stays
           # services.yaml rather than a copy that drifts here.
-          SERVICES="${{ inputs.enabled_services }}"
-
           # Remove duplicates and empty values, sort
-          SERVICES=$(echo "$SERVICES" | tr ',' '\n' | sort -u | grep -v '^$' | tr '\n' ',' | sed 's/,$//')
+          SERVICES=$(echo "$ENABLED_INPUT" | tr ',' '\n' | sort -u | grep -v '^$' | tr '\n' ',' | sed 's/,$//')
+
+          # Every name must look like a service name and be one. The format
+          # check is what makes the rest safe: it admits no quote, semicolon,
+          # backtick, space or $, so nothing downstream can be talked out of
+          # its context -- neither this shell nor the SQL built from these
+          # names two steps below, which interpolates them into a string
+          # literal.
+          #
+          # The existence check is not security, it is honesty: a typo used to
+          # produce an UPDATE matching no row, and a silent no-op looks exactly
+          # like success. Now it stops before anything is written.
+          IFS=',' read -ra REQUESTED <<< "$SERVICES"
+          INVALID=""
+          UNKNOWN=""
+          for svc in "${REQUESTED[@]}"; do
+            [ -n "$svc" ] || continue
+            if ! printf '%s' "$svc" | grep -qE '^[a-z0-9][a-z0-9-]*$'; then
+              INVALID="$INVALID $svc"
+            elif ! grep -qE "^  ${svc}:\s*$" services.yaml; then
+              UNKNOWN="$UNKNOWN $svc"
+            fi
+          done
+          if [ -n "$INVALID" ]; then
+            echo "❌ Not valid service names:$INVALID"
+            echo "   Allowed: lowercase letters, digits and hyphens."
+            exit 1
+          fi
+          if [ -n "$UNKNOWN" ]; then
+            echo "❌ Not defined in services.yaml:$UNKNOWN"
+            echo "   Check the spelling against the Available Stacks table."
+            exit 1
+          fi
 
           echo "enabled_services=$SERVICES" >> "$GITHUB_OUTPUT"
-          echo "📋 Enabled services: $SERVICES"
+          echo "📋 Enabled services: ${SERVICES:-(none — core only)}"
 
       - name: Update D1 with selected services
+        env:
+          # Same rule as the step above. These names are already validated,
+          # so this is defence in depth rather than the load-bearing check --
+          # but a second `${{ }}` in a shell body is a second thing to get
+          # right later, and there is no reason to keep one.
+          ENABLED_SERVICES: ${{ steps.build-list.outputs.enabled_services }}
         run: |
           D1_DATABASE_NAME="nexus-${DOMAIN//./-}-db"
-          ENABLED_SERVICES="${{ steps.build-list.outputs.enabled_services }}"
 
           echo "📝 Updating D1 database: $D1_DATABASE_NAME"
           echo "   Services to enable: $ENABLED_SERVICES"

--- a/.github/workflows/initial-setup.yaml
+++ b/.github/workflows/initial-setup.yaml
@@ -110,7 +110,17 @@ jobs:
           # empty and quietly deploy core-only instead of failing on a value
           # nobody meant. This runs before the validation below, so it has to
           # pass the string through unchanged.
-          SERVICES=$(printf '%s' "$ENABLED_INPUT" | tr ',' '\n' | sort -u | grep -v '^$' | tr '\n' ',' | sed 's/,$//')
+          # `sed '/^$/d'` rather than `grep -v '^$'` to drop blank entries.
+          # grep exits 1 when it matches nothing, which an empty input
+          # guarantees — and an empty input is the documented "core services
+          # only" case, not an error. That is survivable today only because
+          # this workflow declares no `shell:`, so Actions runs `bash -e {0}`
+          # without pipefail and the substitution takes sed's status. Adding
+          # `shell: bash` here — as python-tests.yml does elsewhere, on
+          # purpose, to get pipefail — would turn the most ordinary invocation
+          # into a silent abort. sed exits 0 on empty input, so the trap goes
+          # away instead of being documented.
+          SERVICES=$(printf '%s' "$ENABLED_INPUT" | tr ',' '\n' | sort -u | sed '/^$/d' | tr '\n' ',' | sed 's/,$//')
 
           # Every name must look like a service name and be one. The format
           # check is what makes the rest safe: it admits no quote, semicolon,
@@ -129,7 +139,7 @@ jobs:
             [ -n "$svc" ] || continue
             if ! printf '%s' "$svc" | grep -qE '^[a-z0-9][a-z0-9-]*$'; then
               INVALID="$INVALID $svc"
-            elif ! grep -qE "^  ${svc}:\s*$" services.yaml; then
+            elif ! grep -qE "^  ${svc}:[[:space:]]*$" services.yaml; then
               UNKNOWN="$UNKNOWN $svc"
             fi
           done

--- a/.github/workflows/initial-setup.yaml
+++ b/.github/workflows/initial-setup.yaml
@@ -59,7 +59,17 @@ jobs:
   configure-initial-services:
     name: Configure Initial Services
     needs: setup-control-plane
-    if: ${{ inputs.enabled_services != '' }}
+    # Deliberately unconditional. The `enabled_services` input documents
+    # "empty = core services only", but the reset that makes that true —
+    # `UPDATE services SET enabled = 0 WHERE core = 0` in the step below —
+    # used to live behind `if: inputs.enabled_services != ''`. So it was a
+    # side effect of configuring services rather than a property of setting
+    # the stack up, and an empty field left whatever D1 already held.
+    #
+    # That is the distinction between the two entry points: teardown and
+    # spin-up preserve the selection, a first-time setup starts from core.
+    # Running this job with an empty list does exactly the reset and
+    # nothing else.
     runs-on: ubuntu-latest
     outputs:
       enabled_services: ${{ steps.build-list.outputs.enabled_services }}
@@ -74,16 +84,19 @@ jobs:
       - name: Build enabled services list
         id: build-list
         run: |
-          # Start with core services (always enabled)
-          CORE_SERVICES="infisical,mailpit"
-          USER_SERVICES="${{ inputs.enabled_services }}"
-
-          # Combine core + user-selected services
-          if [ -n "$USER_SERVICES" ]; then
-            SERVICES="$CORE_SERVICES,$USER_SERVICES"
-          else
-            SERVICES="$CORE_SERVICES"
-          fi
+          # No hardcoded core list. There used to be one — "infisical,mailpit"
+          # — and it was wrong in both directions: the core set is forgejo,
+          # grafana, infisical and portainer, so it named one of four and
+          # added mailpit, which is not core at all. Enabling mailpit on
+          # every setup was invisible only because this job was skipped
+          # whenever the field was empty; making the job unconditional would
+          # have turned that into a real behaviour change.
+          #
+          # It is also unnecessary. generate-services-tfvars.py enables core
+          # services regardless of D1 (`should_enable = is_core or name in
+          # enabled_set`), so the single source of truth for "core" stays
+          # services.yaml rather than a copy that drifts here.
+          SERVICES="${{ inputs.enabled_services }}"
 
           # Remove duplicates and empty values, sort
           SERVICES=$(echo "$SERVICES" | tr ',' '\n' | sort -u | grep -v '^$' | tr '\n' ',' | sed 's/,$//')

--- a/.github/workflows/spin-up.yml
+++ b/.github/workflows/spin-up.yml
@@ -730,8 +730,10 @@ jobs:
             echo "    to start empty instead."
           else
             echo "🧹 S3 persistence is off for this run: no snapshot will be restored."
-            echo "    Anything in R2 is left untouched, and the next teardown still"
-            echo "    snapshots — that side reads the repository secret, not this flag."
+            echo "    Anything already in R2 is left untouched. This flag does not"
+            echo "    reach teardown: that side reads the NEXUS_S3_PERSISTENCE"
+            echo "    repository secret, so whether it snapshots is unchanged by"
+            echo "    this run — not necessarily yes."
           fi
 
           # Derive PERSISTENCE_S3_BUCKET inline — YAML expressions

--- a/.github/workflows/spin-up.yml
+++ b/.github/workflows/spin-up.yml
@@ -709,6 +709,31 @@ jobs:
           MONITORING_TOKEN: ${{ secrets.MONITORING_TOKEN }}
           TENANT_ID: ${{ secrets.TENANT_ID }}
         run: |
+          # Say which data this run starts from, before anything else.
+          #
+          # restore_from_s3 skips silently when the flag is off — by design,
+          # so a stack that never opted into persistence does not print a
+          # line every deploy. That silence is wrong for the opposite case:
+          # an operator who deliberately asked for an empty start gets no
+          # confirmation, and one who did not gets no warning that a
+          # snapshot is about to be applied. Both are the confusion behind
+          # #750, where a "First-Time Deploy" restored a two-day-old
+          # snapshot and the log said nothing about the choice.
+          #
+          # This states the decision without claiming the outcome: whether
+          # a snapshot exists in R2 is not known until the restore phase
+          # looks, and asserting it here would be a claim this step cannot
+          # check.
+          if [ "$NEXUS_S3_PERSISTENCE" = "true" ]; then
+            echo "♻️  S3 persistence is on: if R2 holds a snapshot, this run restores it."
+            echo "    Pass fresh_start (initial-setup) or s3_persistence=false (spin-up)"
+            echo "    to start empty instead."
+          else
+            echo "🧹 S3 persistence is off for this run: no snapshot will be restored."
+            echo "    Anything in R2 is left untouched, and the next teardown still"
+            echo "    snapshots — that side reads the repository secret, not this flag."
+          fi
+
           # Derive PERSISTENCE_S3_BUCKET inline — YAML expressions
           # can't `tr '.' '-'` but bash can. Same convention as the
           # data bucket (nexus-<domain-slug>-data) → persistence

--- a/.github/workflows/spin-up.yml
+++ b/.github/workflows/spin-up.yml
@@ -729,7 +729,15 @@ jobs:
             echo "    Pass fresh_start (initial-setup) or s3_persistence=false (spin-up)"
             echo "    to start empty instead."
           else
-            echo "🧹 S3 persistence is off for this run: no snapshot will be restored."
+            # "R2 snapshot", not "snapshot". spin-up-snapshot.yml calls this
+            # same workflow with a Hetzner disk image as server_image and
+            # s3_persistence=false, because the disk carries newer data than
+            # R2 does. An unqualified "no snapshot will be restored" would
+            # print in the middle of a run that is restoring one.
+            echo "🧹 S3 persistence is off for this run: no R2 snapshot will be restored."
+            echo "    This says nothing about a Hetzner disk image — a snapshot"
+            echo "    spin-up restores that separately, and switches this off on"
+            echo "    purpose because the disk is the newer copy."
             echo "    Anything already in R2 is left untouched. This flag does not"
             echo "    reach teardown: that side reads the NEXUS_S3_PERSISTENCE"
             echo "    repository secret, so whether it snapshots is unchanged by"

--- a/docs/admin-guides/server-resize.md
+++ b/docs/admin-guides/server-resize.md
@@ -149,6 +149,29 @@ gh workflow run destroy-all.yml \
 
 That extra step deletes the persistence, data, and state buckets via the R2 S3 API. Once gone, snapshot history is unrecoverable — only do this if you really mean a fresh start. For a server-type resize you almost never want this; the bucket-preservation default is what lets the next `initial-setup` pick up where the old stack left off (DNS records re-applied, Cloudflare resources re-created, but all R2 buckets — Tofu state + snapshots + datalake — and the separate Hetzner Object Storage buckets retained).
 
+
+**Wiping R2 is not the only way to start empty, and often not the one you
+want.** `delete_data=DESTROY` is permanent — the history is gone for every
+future run. If you only want *this* deployment to ignore what is in R2, run
+the setup with `fresh_start` instead:
+
+```bash
+gh workflow run initial-setup.yaml -f fresh_start=true
+```
+
+That skips the restore for one run and leaves the bucket intact, so a later
+spin-up can still reattach to the history.
+
+**"First-Time Deploy" describes what is set up, not what it starts from.**
+The workflow creates the Control Plane and then spins up, and the spin-up's
+restore phase has no notion of a first run — it applies whatever
+`snapshots/latest.txt` points at. This surprises people because *every*
+teardown writes a fresh snapshot: a stack that keeps running after a
+`destroy-all` has snapshot history again within a day, so wiping R2 on
+Friday does not stop Sunday's setup from restoring Saturday's data. Since
+[#750](https://github.com/stefanko-ch/Nexus-Stack/issues/750) the spin-up
+log states which of the two it is doing before it starts.
+
 ---
 
 ## Variant: SERVER_PREFERENCES instead of SERVER_TYPE


### PR DESCRIPTION
## Problem

`Setup: First-Time Deploy` restored a snapshot on a deploy the operator had
started expecting an empty stack, and the log said nothing about the choice.

Observed on run `33327949185`:

```
→ restore: using snapshot snapshots/20260828T210127Z
✓ s3-restore (filesystem): applied snapshot 20260828T210127Z
```

`initial-setup.yaml` delegates to `spin-up.yml`, whose restore phase is gated
only on the persistence feature flag and on `snapshots/latest.txt` existing in
R2. There is no notion of a first run.

The reattach behaviour is deliberate — RFC 0001 decision #6, quoted above
`delete_data` in `destroy-all.yml`. What makes it surprising is that **every
teardown writes a fresh snapshot**: a stack that keeps running after a
`destroy-all` has snapshot history again within a day. In the observed case
`DELETE_DATA: DESTROY` had run on 27 Aug and worked; two scheduled teardowns
rebuilt the history before the setup on 30 Aug.

## Two changes

### 1. `fresh_start`

A new input that forwards `spin-up.yml`'s existing `s3_persistence` rather than
adding a second flag. For a spin-up that input does exactly one thing: skip the
two `restore_from_s3` calls in `pipeline.py`. Nothing else in `run_pipeline`
consults it, and the teardown workflows read the repository secret rather than
this input — so a fresh start does not stop the next teardown from snapshotting.

Unchecked passes `''`, meaning "not overridden", leaving the repository secret
and the workflow default to decide. Passing `'true'` would have overridden a
stack that deliberately has persistence switched off.

`spin-up.yml` now states which of the two it is doing before the deploy runs.
`restore_from_s3` skips silently when the flag is off — right for a stack that
never opted in, wrong here in both directions: an operator asking for an empty
start got no confirmation, and one who was not got no warning that a snapshot
was about to be applied. The line states the decision without claiming the
outcome; whether R2 holds a snapshot is not known until the restore phase looks.

### 2. A first-time setup now actually starts from core

Found while testing the above. The `enabled_services` input documents
*"empty = core services only"*, but the reset that makes that true —
`UPDATE services SET enabled = 0 WHERE core = 0` — sat inside a job gated on
`if: inputs.enabled_services != ''`. It was a side effect of *configuring*
services rather than a property of *setting up*, so an empty field preserved
whatever D1 already held.

That is the distinction between the two entry points: teardown and spin-up
preserve the selection, a first-time setup starts from core. The job is now
unconditional; with an empty list it performs the reset and nothing else.

Making it unconditional exposed a hardcoded list that had been harmless only
because the job was usually skipped:

```bash
CORE_SERVICES="infisical,mailpit"
```

Wrong in both directions — the core set is `forgejo, grafana, infisical,
portainer`, so it named one of four and added `mailpit`, which is not core at
all. Left in place, an empty-field setup would have *started* enabling mailpit.
It is also unnecessary: `generate-services-tfvars.py` enables core services
regardless of D1 (`should_enable = is_core or name in enabled_set`). Removed
rather than corrected, so `services.yaml` stays the single source of truth for
what "core" means.

## Verified on a real run

Run `33407203462` on this branch, with `fresh_start` checked:

```
🧹 S3 persistence is off for this run: no snapshot will be restored.
```

- `✓ s3-restore: applied snapshot …` — **absent**
- `→ s3-restore: bucket empty` — **absent**
- 12 containers up, none unhealthy, run `completed/success`

The proof is the absence: `restore_from_s3` announces both the applied and the
empty-bucket outcomes. Only `feature_flag_off` is silent, and that is the path
`fresh_start` selects. The one "restore" match in the log is
`Failed to restore: Cache service responded with 400` — Actions' own cache,
unrelated.

That also settles `${{ inputs.fresh_start && 'false' || '' }}`, which until this
run had been reasoned about rather than observed.

## Docs

`docs/admin-guides/server-resize.md` gains the distinction that matters when
choosing between them: `delete_data=DESTROY` is permanent and removes the
history for every future run; `fresh_start` skips one restore and leaves the
bucket intact, so a later spin-up can still reattach.

## Not verified

Change 2 has not been exercised on a run yet. The observed run predates it, and
its effect — an empty `enabled_services` resetting D1 to core-only — needs a
setup on a stack that has non-core services enabled to be seen rather than
reasoned about.

Closes #750.

## Summary by Sourcery

Allow initial deployments to start empty when requested while reliably resetting service selection to the core set and making snapshot behavior explicit.

New Features:
- Add a `fresh_start` option to initial setup so operators can skip restoring R2 snapshots for a single deployment.
- Report whether S3 persistence is enabled or disabled before deployment begins.

Bug Fixes:
- Ensure an initial setup with no explicitly enabled services resets the selection to core services instead of retaining stale D1 state.
- Remove the incorrect hardcoded core-service list and validate requested services against supported names.

Enhancements:
- Clarify the difference between permanently deleting snapshot history and skipping restoration for one deployment in the server resize guide.

Documentation:
- Document how to use `fresh_start` and explain the persistence behavior of initial setup and teardown workflows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a fresh-start option that skips snapshot restoration while preserving stored backup history.
  - Initial setup now supports user-selected services and validates service names and configuration.
  - Deployment logs clearly indicate whether persistence restoration is enabled and explain the resulting behavior.

- **Documentation**
  - Updated server resize guidance to explain fresh starts, snapshot restoration, backup preservation, and deployment status messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->