### PR TITLE
docs: Explain the two secret stores and what actually gates access

### DIFF
--- a/docs/admin-guides/setup-guide.md
+++ b/docs/admin-guides/setup-guide.md
@@ -117,10 +117,17 @@ Add these secrets to your GitHub repository:
 
 **Settings → Secrets and variables → Actions → New repository secret**
 
-### Two separate secret stores
+### Where credentials live
 
-Nexus-Stack keeps credentials in two places that never mix. Knowing which is
-which answers most access questions before they are asked.
+Nexus-Stack keeps credentials in two stores, plus one credential that belongs to
+neither. Knowing which is which answers most access questions before they are
+asked.
+
+The two stores are below; the exception is the Cloudflare **tunnel token**,
+which lives in the `cloudflared` systemd unit on the server rather than in
+either. It is described under *What actually controls access*, and it is the
+reason the table's boundary is about API tokens rather than about Cloudflare in
+general.
 
 | | Repository secrets (this section) | Infisical (on the server) |
 |---|---|---|
@@ -169,12 +176,24 @@ on every target. A multi-line value — a PEM, a certificate — is skipped for
 Jupyter, Marimo and code-server, which receive plain env files; Kestra takes it,
 because its values transit base64-encoded and are decoded server-side.
 
-The two are not equally easy to notice, which matters when a key is missing and
-you are looking for the reason. A skipped multi-line value is named in the
-deploy log (`Skipping multi-line secret '<KEY>'`). An invalid key name is not:
-it only raises the `skipped_name=` counter on the summary line, so the count
-tells you *that* something was dropped and you have to compare the folder
-against the env file to learn *what*. Neither ever prints a value.
+A third rule drops values without any of them being malformed: the same key in
+two folders is **first-wins**. The later folder's value is discarded, which
+matters because which folder wins depends on iteration order rather than on
+anything an operator chose.
+
+The three are not equally easy to notice, and that is what counts when a key is
+missing and you are looking for the reason:
+
+| Rule | In the deploy log |
+|---|---|
+| Multi-line value | named — `Skipping multi-line secret '<KEY>'` |
+| Key collision | named, with both folders — `Key collision: '<KEY>' in folder '<B>' shadowed by earlier value from '<A>' (first-wins)` |
+| Invalid key name | **not named** — only the `skipped_name=` count on the summary line |
+
+So two of the three can be found by searching the log for the key. For the
+third, the counter tells you *that* something was dropped and you have to
+compare the folder against the env file to learn *what*. None of them ever
+prints a value.
 
 What does arrive is readable by anything running in those four stacks. On a
 stack belonging to the person using it, that is the point. It also means

--- a/docs/admin-guides/setup-guide.md
+++ b/docs/admin-guides/setup-guide.md
@@ -126,18 +126,26 @@ which answers most access questions before they are asked.
 |---|---|---|
 | **Where** | The repository that runs the workflows — GitHub, or a Forgejo instance | The `infisical` core stack, on the deployed server |
 | **What** | Credentials that *build* infrastructure: Hetzner, Cloudflare, R2, the generated SSH key | Credentials that *services* use: database passwords, admin logins, one folder per stack (~50) |
-| **Who sets them** | The operator, before the first run | OpenTofu, on every spin-up |
+| **Who sets them** | The operator, before the first run | OpenTofu generates them on every spin-up; operators may add their own directly in Infisical |
 | **Who reads them** | Only the workflows | Anyone who can reach the Control Plane or the stacks on that server |
 
-Nothing crosses. **No Hetzner or Cloudflare token is ever written to Infisical
-or to the server**, and no service password is ever written back to the
-repository. The workflow stores exactly four values back as repository secrets
-— `SSH_PRIVATE_KEY`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY` and
+**No Hetzner or Cloudflare API token is ever written to Infisical or reachable
+from the application stacks**, and no service password is ever written back to
+the repository. The workflow stores exactly four values back as repository
+secrets — `SSH_PRIVATE_KEY`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY` and
 `R2_DATA_BUCKET` — and those are infrastructure credentials, not service ones.
 
+"API token" is the precise word, and the imprecise version would have been worth
+distrusting the rest of the page over. The server *does* hold one Cloudflare
+credential: `cloudflared service install` writes the **tunnel token** into the
+connector's systemd unit, because a tunnel cannot connect without one. It
+authorises that one tunnel and nothing else — it cannot read the account, create
+DNS records or reach any other zone — and it is not in Infisical, so the
+Control Plane never shows it.
+
 This matters most for teaching setups, where people work on a stack without
-being meant to hold the account credentials behind it. They cannot: the tokens
-are not on the machine they are using.
+being meant to hold the account credentials behind it. They do not: the tokens
+that could manage the Cloudflare or Hetzner account are not on that machine.
 
 #### What actually controls access
 
@@ -151,13 +159,20 @@ may push to the repository holding these secrets, not who may look at a
 settings page.
 
 Infisical is deliberately the opposite. Its secrets are *meant* to be read by
-the people using that stack — the Control Plane shows them, and
-`secret-sync` writes every one of them into **Kestra**, **Jupyter**,
-**Marimo** and **code-server** as environment variables so notebooks and flows
-can use them without copy-pasting. Anyone who can run code in those four stacks
-can read every credential of that stack. On a stack belonging to the person
-using it, that is the point. It also means Infisical is not a way to keep
-something from that person.
+the people using that stack — the Control Plane shows them, and `secret-sync`
+writes them into **Kestra**, **Jupyter**, **Marimo** and **code-server** as
+environment variables so notebooks and flows can use them without copy-pasting.
+
+Not quite all of them, and the exceptions are worth knowing before relying on a
+key being present. A name that is not a valid POSIX shell identifier is skipped
+on every target. A multi-line value — a PEM, a certificate — is skipped for
+Jupyter, Marimo and code-server, which receive plain env files; Kestra takes it,
+because its values transit base64-encoded and are decoded server-side. Skipped
+keys are logged by name, never by value.
+
+What does arrive is readable by anything running in those four stacks. On a
+stack belonging to the person using it, that is the point. It also means
+Infisical is not a way to keep something from that person.
 
 ### Required Secrets
 

--- a/docs/admin-guides/setup-guide.md
+++ b/docs/admin-guides/setup-guide.md
@@ -123,18 +123,24 @@ Nexus-Stack keeps credentials in two stores, plus one credential that belongs to
 neither. Knowing which is which answers most access questions before they are
 asked.
 
-The two stores are below; the exception is the Cloudflare **tunnel token**,
-which lives in the `cloudflared` systemd unit on the server rather than in
-either. It is described under *What actually controls access*, and it is the
-reason the table's boundary is about API tokens rather than about Cloudflare in
-general.
+The two stores are below. Two credentials sit outside both, and both are named
+where they matter rather than left for the reader to discover:
+
+- the Cloudflare **tunnel token**, in the `cloudflared` systemd unit on the
+  server — the reason the table's boundary is about API tokens rather than
+  Cloudflare in general
+- **`GH_SECRETS_TOKEN`**, which the setup also copies into the Cloudflare
+  scheduled-teardown Worker and the Control Plane Pages project, because both
+  need to dispatch workflows
+
+Both are described under *What actually controls access*.
 
 | | Repository secrets (this section) | Infisical (on the server) |
 |---|---|---|
 | **Where** | The repository that runs the workflows — GitHub, or a Forgejo instance | The `infisical` core stack, on the deployed server |
 | **What** | Credentials that *build* infrastructure: Hetzner, Cloudflare, R2, the generated SSH key | Credentials that *services* use: database passwords, admin logins, one folder per stack (~50) |
 | **Who sets them** | The operator, before the first run | OpenTofu generates them on every spin-up; operators may add their own directly in Infisical |
-| **Who reads them** | Only the workflows | Anyone who can reach the Control Plane or the stacks on that server |
+| **Who reads them** | The workflows — and, for `GH_SECRETS_TOKEN` alone, the Cloudflare Worker and Pages project it is copied into | Anyone who can reach the Control Plane or the stacks on that server |
 
 **No Hetzner or Cloudflare API token is ever written to Infisical or reachable
 from the application stacks**, and no service password is ever written back to
@@ -169,6 +175,17 @@ Infisical is deliberately the opposite. Its secrets are *meant* to be read by
 the people using that stack — the Control Plane shows them, and `secret-sync`
 writes them into **Kestra**, **Jupyter**, **Marimo** and **code-server** as
 environment variables so notebooks and flows can use them without copy-pasting.
+
+Only into the ones that are enabled, and only when the deploy could reach
+Infisical. Each target has its own phase, and a phase bails out twice: `skipped`
+when its stack is not enabled, and again when `PROJECT_ID` or `INFISICAL_TOKEN`
+is missing — as `partial` for the three plain targets, `skipped` for Kestra.
+Enabling one of the four later does not backfill; the next spin-up is what
+delivers the secrets.
+
+Worth checking the phase summary rather than assuming, then: a `partial`
+secret-sync means the env file was not written, and the stack starts without the
+credentials a notebook expects to find.
 
 Not quite all of them, and the exceptions are worth knowing before relying on a
 key being present. A name that is not a valid POSIX shell identifier is skipped

--- a/docs/admin-guides/setup-guide.md
+++ b/docs/admin-guides/setup-guide.md
@@ -117,6 +117,48 @@ Add these secrets to your GitHub repository:
 
 **Settings → Secrets and variables → Actions → New repository secret**
 
+### Two separate secret stores
+
+Nexus-Stack keeps credentials in two places that never mix. Knowing which is
+which answers most access questions before they are asked.
+
+| | Repository secrets (this section) | Infisical (on the server) |
+|---|---|---|
+| **Where** | The repository that runs the workflows — GitHub, or a Forgejo instance | The `infisical` core stack, on the deployed server |
+| **What** | Credentials that *build* infrastructure: Hetzner, Cloudflare, R2, the generated SSH key | Credentials that *services* use: database passwords, admin logins, one folder per stack (~50) |
+| **Who sets them** | The operator, before the first run | OpenTofu, on every spin-up |
+| **Who reads them** | Only the workflows | Anyone who can reach the Control Plane or the stacks on that server |
+
+Nothing crosses. **No Hetzner or Cloudflare token is ever written to Infisical
+or to the server**, and no service password is ever written back to the
+repository. The workflow stores exactly four values back as repository secrets
+— `SSH_PRIVATE_KEY`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY` and
+`R2_DATA_BUCKET` — and those are infrastructure credentials, not service ones.
+
+This matters most for teaching setups, where people work on a stack without
+being meant to hold the account credentials behind it. They cannot: the tokens
+are not on the machine they are using.
+
+#### What actually controls access
+
+Not the storage — the push rights.
+
+Repository secrets cannot be read back through the UI or the API, and the
+runner masks them in logs. That protects against accidents, not against intent:
+**anyone who can push a workflow to the repository can print its secrets**, by
+encoding or splitting them past the mask. So the boundary that matters is who
+may push to the repository holding these secrets, not who may look at a
+settings page.
+
+Infisical is deliberately the opposite. Its secrets are *meant* to be read by
+the people using that stack — the Control Plane shows them, and
+`secret-sync` writes every one of them into **Kestra**, **Jupyter**,
+**Marimo** and **code-server** as environment variables so notebooks and flows
+can use them without copy-pasting. Anyone who can run code in those four stacks
+can read every credential of that stack. On a stack belonging to the person
+using it, that is the point. It also means Infisical is not a way to keep
+something from that person.
+
 ### Required Secrets
 
 | Secret Name | Source | Description |

--- a/docs/admin-guides/setup-guide.md
+++ b/docs/admin-guides/setup-guide.md
@@ -177,9 +177,12 @@ Jupyter, Marimo and code-server, which receive plain env files; Kestra takes it,
 because its values transit base64-encoded and are decoded server-side.
 
 A third rule drops values without any of them being malformed: the same key in
-two folders is **first-wins**. The later folder's value is discarded, which
-matters because which folder wins depends on iteration order rather than on
-anything an operator chose.
+two folders is **first-wins**. Folders are processed in `LC_ALL=C` sorted order,
+so "first" means the one whose name sorts earliest by byte value — `clickhouse`
+beats `postgres`, and an uppercase name beats every lowercase one. That is
+deterministic and it is a lever: renaming a folder changes which value survives.
+It is not a precedence mechanism anyone designed, though, so relying on it is
+relying on a sort order rather than on a stated rule.
 
 The three are not equally easy to notice, and that is what counts when a key is
 missing and you are looking for the reason:

--- a/docs/admin-guides/setup-guide.md
+++ b/docs/admin-guides/setup-guide.md
@@ -167,8 +167,14 @@ Not quite all of them, and the exceptions are worth knowing before relying on a
 key being present. A name that is not a valid POSIX shell identifier is skipped
 on every target. A multi-line value — a PEM, a certificate — is skipped for
 Jupyter, Marimo and code-server, which receive plain env files; Kestra takes it,
-because its values transit base64-encoded and are decoded server-side. Skipped
-keys are logged by name, never by value.
+because its values transit base64-encoded and are decoded server-side.
+
+The two are not equally easy to notice, which matters when a key is missing and
+you are looking for the reason. A skipped multi-line value is named in the
+deploy log (`Skipping multi-line secret '<KEY>'`). An invalid key name is not:
+it only raises the `skipped_name=` counter on the summary line, so the count
+tells you *that* something was dropped and you have to compare the folder
+against the env file to learn *what*. Neither ever prints a value.
 
 What does arrive is readable by anything running in those four stacks. On a
 stack belonging to the person using it, that is the point. It also means

--- a/docs/user-guides/secrets.md
+++ b/docs/user-guides/secrets.md
@@ -39,8 +39,11 @@ stacks can read them. That is intended: they are your stack's own services.
 Two kinds do not make it across, so check before depending on one. A secret
 whose *name* is not a valid environment-variable name is skipped everywhere. A
 secret whose *value* spans several lines — a certificate, a private key — is
-skipped for Jupyter, Marimo and code-server; Kestra still receives it. Both
-cases are logged by name during the deploy.
+skipped for Jupyter, Marimo and code-server; Kestra still receives it.
+
+Only the second is easy to spot: the deploy log names that secret. An invalid
+name is counted but not named, so if a key is missing and the log says nothing
+about it, its name is the first thing to check.
 
 ## How it's organised
 

--- a/docs/user-guides/secrets.md
+++ b/docs/user-guides/secrets.md
@@ -12,6 +12,27 @@ The Secrets page shows every secret managed by your stack, pulled live from **In
 
 ![Secrets page overview listing folders grouped by service name, with each folder collapsible to reveal its keys](./assets/secrets-overview.png)
 
+## What is here, and what is not
+
+This page shows the credentials **your services** use: database passwords,
+admin logins, API keys the stacks generate for themselves. One folder per
+service.
+
+It is not everything that exists. The credentials used to *build* the server —
+the Hetzner and Cloudflare API tokens — live in the repository that runs the
+deployment workflows and are never written to your stack. You will not find
+them here because they are not on this machine at all. If you are looking for
+them to do something with the underlying account, this is the wrong place and
+the answer is to ask whoever operates the deployment.
+
+The other direction is worth knowing too: these secrets are **not** hidden from
+you. Besides this page, every one of them is written into **Kestra**,
+**Jupyter**, **Marimo** and **code-server** as environment variables, so flows
+and notebooks can use them without copy-pasting — see
+[Kestra flow editing](./kestra-flow-editing.md). Anything you can run in those
+stacks can read any credential on this page. That is intended: they are your
+stack's own services.
+
 ## How it's organised
 
 Secrets are grouped by service name (e.g. `clickhouse`, `appsmith`, `redpanda`). Click a folder row to expand it and reveal the keys it contains.

--- a/docs/user-guides/secrets.md
+++ b/docs/user-guides/secrets.md
@@ -42,7 +42,9 @@ Three kinds do not make it across, so check before depending on one:
   everywhere
 - a secret whose **value** spans several lines, such as a certificate or a
   private key — skipped for Jupyter, Marimo and code-server; Kestra still gets it
-- the **same key in two folders** — the first one wins and the second is dropped
+- the **same key in two folders** — one wins and the other is dropped. The
+  winner is the folder whose name comes first alphabetically, so if this bites
+  you, renaming a folder changes the outcome
 
 The last two are named in the deploy log, so you can search it for the key. An
 invalid name is only counted, not named. If a key is missing and the log says

--- a/docs/user-guides/secrets.md
+++ b/docs/user-guides/secrets.md
@@ -19,19 +19,28 @@ admin logins, API keys the stacks generate for themselves. One folder per
 service.
 
 It is not everything that exists. The credentials used to *build* the server —
-the Hetzner and Cloudflare API tokens — live in the repository that runs the
-deployment workflows and are never written to your stack. You will not find
-them here because they are not on this machine at all. If you are looking for
-them to do something with the underlying account, this is the wrong place and
-the answer is to ask whoever operates the deployment.
+the Hetzner and Cloudflare **API** tokens — live in the repository that runs the
+deployment workflows, never in Infisical, and nothing on this stack can reach
+them. If you are looking for them to do something with the underlying account,
+this is the wrong place; ask whoever operates the deployment.
+
+One Cloudflare credential does live on the server: the **tunnel token**, held by
+the `cloudflared` service so the tunnel can connect at all. It authorises that
+one tunnel and nothing else — no account access, no DNS, no other zone — and it
+is not in Infisical, which is why it does not appear on this page.
 
 The other direction is worth knowing too: these secrets are **not** hidden from
-you. Besides this page, every one of them is written into **Kestra**,
-**Jupyter**, **Marimo** and **code-server** as environment variables, so flows
-and notebooks can use them without copy-pasting — see
+you. Besides this page, they are written into **Kestra**, **Jupyter**,
+**Marimo** and **code-server** as environment variables, so flows and notebooks
+can use them without copy-pasting — see
 [Kestra flow editing](./kestra-flow-editing.md). Anything you can run in those
-stacks can read any credential on this page. That is intended: they are your
-stack's own services.
+stacks can read them. That is intended: they are your stack's own services.
+
+Two kinds do not make it across, so check before depending on one. A secret
+whose *name* is not a valid environment-variable name is skipped everywhere. A
+secret whose *value* spans several lines — a certificate, a private key — is
+skipped for Jupyter, Marimo and code-server; Kestra still receives it. Both
+cases are logged by name during the deploy.
 
 ## How it's organised
 

--- a/docs/user-guides/secrets.md
+++ b/docs/user-guides/secrets.md
@@ -36,14 +36,17 @@ can use them without copy-pasting — see
 [Kestra flow editing](./kestra-flow-editing.md). Anything you can run in those
 stacks can read them. That is intended: they are your stack's own services.
 
-Two kinds do not make it across, so check before depending on one. A secret
-whose *name* is not a valid environment-variable name is skipped everywhere. A
-secret whose *value* spans several lines — a certificate, a private key — is
-skipped for Jupyter, Marimo and code-server; Kestra still receives it.
+Three kinds do not make it across, so check before depending on one:
 
-Only the second is easy to spot: the deploy log names that secret. An invalid
-name is counted but not named, so if a key is missing and the log says nothing
-about it, its name is the first thing to check.
+- a secret whose **name** is not a valid environment-variable name — skipped
+  everywhere
+- a secret whose **value** spans several lines, such as a certificate or a
+  private key — skipped for Jupyter, Marimo and code-server; Kestra still gets it
+- the **same key in two folders** — the first one wins and the second is dropped
+
+The last two are named in the deploy log, so you can search it for the key. An
+invalid name is only counted, not named. If a key is missing and the log says
+nothing about it, its name is the first thing to check.
 
 ## How it's organised
 

--- a/docs/user-guides/secrets.md
+++ b/docs/user-guides/secrets.md
@@ -36,6 +36,10 @@ can use them without copy-pasting — see
 [Kestra flow editing](./kestra-flow-editing.md). Anything you can run in those
 stacks can read them. That is intended: they are your stack's own services.
 
+Only the ones you have enabled, though. A stack that is switched off receives
+nothing, and switching it on later does not backfill — the secrets arrive with
+the next Spin Up.
+
 Three kinds do not make it across, so check before depending on one:
 
 - a secret whose **name** is not a valid environment-variable name — skipped


### PR DESCRIPTION
## Why

The question that prompted this: *do course participants get to see the Hetzner
and Cloudflare API tokens?*

The answer is no, and the separation that makes it no has been in place all
along — but it is written down nowhere. Answering required reading
`infisical.py`, `secret_sync.py` and the workflows. That is the wrong place for
a fact someone will eventually need under pressure, and the next person asking
may be an auditor rather than a maintainer.

## What the docs said before

Both layers were documented; the boundary between them was not.

- `docs/user-guides/secrets.md` told participants the page shows *"every secret
  managed by your stack"*. The whole distinction rides on **"your stack"**, and
  the page never unpacks it — a reader cannot tell whether they are seeing
  everything or a slice.
- `docs/admin-guides/setup-guide.md` listed the repository secrets and mentions
  Infisical five times, but never in contrast. No sentence said these never
  reach the server.
- `docs/stacks/infisical.md` describes the stack, nothing about the boundary.

## What this adds

**`setup-guide.md`** — a section above the Required Secrets table contrasting
the two stores: what lives where, who writes them, who reads them. Plus the
part that is easy to get backwards, that access is gated by **push rights, not
storage**: repository secrets cannot be read through the UI or the API and the
runner masks them, which stops accidents rather than intent — anyone who can
push a workflow can print them past the mask.

**`secrets.md`** — two short sections for participants: what is on the page,
what is deliberately not, and where the infrastructure credentials actually
live so nobody hunts for them on the wrong machine.

Both state the direction that is easy to assume wrongly: Infisical is **not** a
way to withhold anything from the person using the stack. `secret-sync` writes
every Infisical secret into **Kestra**, **Jupyter**, **Marimo** and
**code-server** as environment variables, so anything runnable in those four
stacks can read any credential on that page. That is intended — they are that
stack's own services — but "read-only view" in the UI could easily be read as a
containment boundary, and it is not one.

## Every claim checked against the code

| Claim | Verified by |
|---|---|
| ~50 Infisical folders | 50 `FolderSpec` names in `infisical.py` |
| Infisical is a core stack | `services.yaml` → `core: true` |
| Exactly four values written back | `repo-secret.sh set` sites: `SSH_PRIVATE_KEY`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, `R2_DATA_BUCKET` |
| No Hetzner/Cloudflare token reaches Infisical | zero matches for `hcloud` or `cloudflare_api_token` in `infisical.py` |
| Four sync targets | `_phase_kestra_secret_sync`, `_phase_secret_sync_{jupyter,marimo,code_server}` in `orchestrator.py` |

Docs only — no code changes, no behaviour change. Disjoint from #754, which
touches `.github/workflows/` alone.

## Summary by Sourcery

Clarify credential storage boundaries and access controls for repository secrets, Infisical, and deployed stack services.

Enhancements:
- Document the separation between repository infrastructure secrets and server-side Infisical service secrets, including where credentials live and who can access them.
- Clarify that repository push permissions—not secret storage visibility—are the effective control over workflow secrets, while Infisical secrets are intentionally available to enabled stack services and users.
- Document secret-sync scope and the conditions and limitations that can prevent secrets from reaching stack environments.

Documentation:
- Explain to administrators and participants which credentials are exposed through the Secrets page and which remain in the deployment repository or server services.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded the setup guide with details about repository secrets, Infisical, deployment credentials, and access boundaries.
  * Documented how secrets are synchronized across stack services, including handling of invalid names and multi-line values.
  * Added a Secrets page section clarifying which credentials are included, excluded, or managed separately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->