### PR TITLE
fix(stacks): Make the bundled Evidence query survive an empty database

### DIFF
--- a/docs/stacks/evidence.md
+++ b/docs/stacks/evidence.md
@@ -93,11 +93,30 @@ node exits. With `restart: unless-stopped` the container then restart-loops. The
 operator sees a container that will not stay up, with the actual error scrolled
 past several restarts back.
 
-The bundled `database_overview.sql` is written so it cannot happen: a
-`UNION ALL` branch guarded by `WHERE NOT EXISTS` over the same source yields a
-placeholder row exactly when the main query yields none. `pg_stat_user_tables` is
-empty until a user table exists, so without the guard the shipped page would kill
-the stack on any database whose tables had all been dropped.
+Both bundled queries are written so it cannot happen. The shape is a CTE holding
+the real query, then a `UNION ALL` placeholder guarded by `WHERE NOT EXISTS`
+against that CTE:
+
+```sql
+WITH q AS ( ...your query... )
+SELECT * FROM q
+UNION ALL
+SELECT ...placeholder columns...
+WHERE NOT EXISTS (SELECT 1 FROM q);
+```
+
+**Guard the CTE, not the source table.** The two look interchangeable and are
+not: `NOT EXISTS (SELECT 1 FROM q)` asks whether the query produced anything,
+while `NOT EXISTS (SELECT 1 FROM your_table)` asks whether the table holds
+anything. A query filtering `status = 'active'` over a table of inactive rows
+returns nothing while the table is non-empty, so a table-level guard never fires
+and the container still dies. Measured, not assumed — the table-level form
+returns 0 rows in that case and the CTE form returns the placeholder.
+
+The two shipped queries cover the two ways an empty result arises:
+`database_overview` when no user table exists at all, `monthly_revenue` when
+`demo_sales` exists but has no rows — the state `DELETE FROM demo_sales` leaves
+behind, which is what someone does while replacing the demo data.
 
 Apply the same shape to queries you add. This is
 [#725](https://github.com/stefanko-ch/Nexus-Stack/issues/725) defect 7 — arguably

--- a/docs/stacks/evidence.md
+++ b/docs/stacks/evidence.md
@@ -83,6 +83,27 @@ Compared to the other BI tools in this stack:
 3. Edit the sample page at `/opt/docker-server/stacks/evidence/project/pages/index.md` on the server (the project root is bind-mounted into the container at `/evidence-workspace`, so changes apply on save).
 4. Add new pages as `.md` files in `/opt/docker-server/stacks/evidence/project/pages/` — each one renders at `https://evidence.YOUR_DOMAIN/<filename>`.
 
+### Zero-row queries crash the container
+
+A source query that returns no rows is fatal, and the failure looks like
+something else entirely. Evidence writes no parquet file for an empty result but
+still lists it in the manifest; the page load builds a DuckDB view over the
+missing file with `read_parquet()`, DuckDB throws, the exception is uncaught, and
+node exits. With `restart: unless-stopped` the container then restart-loops. The
+operator sees a container that will not stay up, with the actual error scrolled
+past several restarts back.
+
+The bundled `database_overview.sql` is written so it cannot happen: a
+`UNION ALL` branch guarded by `WHERE NOT EXISTS` over the same source yields a
+placeholder row exactly when the main query yields none. `pg_stat_user_tables` is
+empty until a user table exists, so without the guard the shipped page would kill
+the stack on any database whose tables had all been dropped.
+
+Apply the same shape to queries you add. This is
+[#725](https://github.com/stefanko-ch/Nexus-Stack/issues/725) defect 7 — arguably
+an upstream bug, since a manifest should not reference a file the writer skipped,
+but reachable from any project that ships a query able to match nothing.
+
 ### Adding data sources
 
 Each source lives in its own directory under `project/sources/<name>/`:

--- a/stacks/evidence/project/pages/index.md
+++ b/stacks/evidence/project/pages/index.md
@@ -58,10 +58,24 @@ but still lists it in the manifest. The page load then builds a DuckDB view over
 the missing file, DuckDB throws, and nothing catches it — the node process exits
 and the container restarts. You see a restart loop, not "no results".
 
-So a query that *can* legitimately match nothing needs a guard. The bundled
-`database_overview.sql` shows the cheapest one: a `UNION ALL` branch with
-`WHERE NOT EXISTS` over the same source, which contributes a placeholder row
-exactly when the main query contributes none.
+So a query that *can* legitimately match nothing needs a guard. Both bundled
+queries show the shape: wrap the real query in a CTE, then `UNION ALL` a
+placeholder row guarded by `WHERE NOT EXISTS` **against that CTE**.
+
+```sql
+WITH q AS ( ...your query... )
+SELECT * FROM q
+UNION ALL
+SELECT ...placeholder columns...
+WHERE NOT EXISTS (SELECT 1 FROM q);
+```
+
+Guard against the CTE, not against the table it reads. `NOT EXISTS (SELECT 1
+FROM q)` asks *did the query produce anything*; `NOT EXISTS (SELECT 1 FROM
+your_table)` asks *does the table hold anything*, and those answers differ as
+soon as there is a `WHERE` or a `JOIN`. A query filtering `status = 'active'`
+over a table of only inactive rows returns nothing while the table is not
+empty — the table-level guard stays silent and the crash happens anyway.
 
 This is [#725](https://github.com/stefanko-ch/Nexus-Stack/issues/725) defect 7,
 and arguably an Evidence bug — a manifest should not list a file its writer

--- a/stacks/evidence/project/pages/index.md
+++ b/stacks/evidence/project/pages/index.md
@@ -50,6 +50,23 @@ select * from evidence_db.database_overview
 
 <DataTable data={database_overview} rows=25 />
 
+## A query that returns nothing takes the server down
+
+Worth knowing before you write your own, because the symptom points nowhere near
+the cause. When a source query returns zero rows, Evidence writes no parquet file
+but still lists it in the manifest. The page load then builds a DuckDB view over
+the missing file, DuckDB throws, and nothing catches it — the node process exits
+and the container restarts. You see a restart loop, not "no results".
+
+So a query that *can* legitimately match nothing needs a guard. The bundled
+`database_overview.sql` shows the cheapest one: a `UNION ALL` branch with
+`WHERE NOT EXISTS` over the same source, which contributes a placeholder row
+exactly when the main query contributes none.
+
+This is [#725](https://github.com/stefanko-ch/Nexus-Stack/issues/725) defect 7,
+and arguably an Evidence bug — a manifest should not list a file its writer
+skipped. Until it is fixed upstream, the guard is on the query.
+
 ## Adding more sources
 
 Drop a sibling directory under `project/sources/` with its own

--- a/stacks/evidence/project/sources/evidence_db/database_overview.sql
+++ b/stacks/evidence/project/sources/evidence_db/database_overview.sql
@@ -1,10 +1,31 @@
 -- Snapshot of the public schema: table list + estimated row counts.
 -- Edit or replace with queries that match the data you have loaded into
 -- this stack's evidence-db.
+--
+-- The UNION ALL branch is not decoration. A source query returning zero
+-- rows makes Evidence write no parquet file while still listing it in the
+-- manifest; +layout.js then builds a view over the missing file with
+-- read_parquet(), DuckDB throws, and because the throw is uncaught the
+-- node process exits. `restart: unless-stopped` restarts it, and the
+-- container sits in a restart loop that looks nothing like "your query
+-- matched nothing" (#725, defect 7).
+--
+-- pg_stat_user_tables is empty until a user table exists, so this query
+-- can legitimately return nothing -- on a database whose tables were all
+-- dropped, or one Evidence is pointed at before anything is loaded. The
+-- guard makes that impossible: there is always at least one row.
+--
+-- Any query you add here is subject to the same trap. `WHERE NOT EXISTS`
+-- over the same source is the cheapest way to make one zero-row-proof.
 SELECT
     relname AS table_name,
     n_live_tup AS estimated_rows
 FROM pg_stat_user_tables
-ORDER BY n_live_tup DESC NULLS LAST,
-         relname
+UNION ALL
+SELECT
+    '(no user tables yet)',
+    0
+WHERE NOT EXISTS (SELECT 1 FROM pg_stat_user_tables)
+ORDER BY estimated_rows DESC NULLS LAST,
+         table_name
 LIMIT 50;

--- a/stacks/evidence/project/sources/evidence_db/database_overview.sql
+++ b/stacks/evidence/project/sources/evidence_db/database_overview.sql
@@ -2,30 +2,31 @@
 -- Edit or replace with queries that match the data you have loaded into
 -- this stack's evidence-db.
 --
--- The UNION ALL branch is not decoration. A source query returning zero
--- rows makes Evidence write no parquet file while still listing it in the
--- manifest; +layout.js then builds a view over the missing file with
--- read_parquet(), DuckDB throws, and because the throw is uncaught the
--- node process exits. `restart: unless-stopped` restarts it, and the
--- container sits in a restart loop that looks nothing like "your query
--- matched nothing" (#725, defect 7).
+-- The CTE-plus-UNION-ALL shape is not decoration. A source query returning
+-- zero rows makes Evidence write no parquet file while still listing it in
+-- the manifest; +layout.js then builds a view over the missing file with
+-- read_parquet(), DuckDB throws, and because the throw is uncaught the node
+-- process exits. `restart: unless-stopped` restarts it, and the container
+-- sits in a restart loop that looks nothing like "your query matched
+-- nothing" (#725, defect 7).
 --
--- pg_stat_user_tables is empty until a user table exists, so this query
--- can legitimately return nothing -- on a database whose tables were all
--- dropped, or one Evidence is pointed at before anything is loaded. The
--- guard makes that impossible: there is always at least one row.
---
--- Any query you add here is subject to the same trap. `WHERE NOT EXISTS`
--- over the same source is the cheapest way to make one zero-row-proof.
-SELECT
-    relname AS table_name,
-    n_live_tup AS estimated_rows
-FROM pg_stat_user_tables
+-- Copy this shape for any query you add. Guard against the CTE, never
+-- against the underlying table: `WHERE NOT EXISTS (SELECT 1 FROM overview)`
+-- asks "did the query produce anything", while `... FROM pg_stat_user_tables`
+-- would ask "does the source hold anything" -- and those differ the moment
+-- the query has a WHERE or a JOIN. A query filtering `status = 'active'`
+-- over a table of inactive rows returns nothing while the table is not
+-- empty, so a source-level guard stays silent and the crash happens anyway.
+WITH overview AS (
+    SELECT
+        relname AS table_name,
+        n_live_tup AS estimated_rows
+    FROM pg_stat_user_tables
+)
+SELECT * FROM overview
 UNION ALL
-SELECT
-    '(no user tables yet)',
-    0
-WHERE NOT EXISTS (SELECT 1 FROM pg_stat_user_tables)
+SELECT '(no user tables yet)', 0
+WHERE NOT EXISTS (SELECT 1 FROM overview)
 ORDER BY estimated_rows DESC NULLS LAST,
          table_name
 LIMIT 50;

--- a/stacks/evidence/project/sources/evidence_db/monthly_revenue.sql
+++ b/stacks/evidence/project/sources/evidence_db/monthly_revenue.sql
@@ -2,28 +2,32 @@
 -- Replace this file once you have your own data; the page that renders
 -- it is pages/index.md.
 --
--- Guarded the same way as database_overview.sql, and for a case that one
--- does not cover: there the guard fires when no table exists, here when
--- the table exists but holds no rows. `DELETE FROM demo_sales` reaches
--- exactly that state, and it is what someone does while replacing the
--- demo data with their own -- so this is the likelier of the two paths
--- into the zero-row crash (#725, defect 7).
+-- Guarded like database_overview.sql, and for a case that one does not
+-- cover: there the guard fires when no table exists, here when the table
+-- exists but holds no rows. `DELETE FROM demo_sales` reaches exactly that
+-- state, and it is what someone does while replacing the demo data with
+-- their own -- so this is the likelier of the two paths into the zero-row
+-- crash (#725, defect 7).
+--
+-- The guard tests the CTE, not demo_sales. Testing the table would be
+-- equivalent only because this query has no WHERE clause; add one and the
+-- two stop agreeing. Guarding the CTE is right in both cases, so it is
+-- what this example shows.
 --
 -- The placeholder is a visible one on purpose. A flat zero line labelled
 -- "(no data)" reads as an empty table at a glance; a silently absent
 -- series would look like a rendering problem.
-SELECT
-    sale_month,
-    region,
-    SUM(revenue) AS revenue,
-    SUM(orders)  AS orders
-FROM demo_sales
-GROUP BY sale_month, region
+WITH monthly AS (
+    SELECT
+        sale_month,
+        region,
+        SUM(revenue) AS revenue,
+        SUM(orders)  AS orders
+    FROM demo_sales
+    GROUP BY sale_month, region
+)
+SELECT * FROM monthly
 UNION ALL
-SELECT
-    DATE '2025-01-01',
-    '(no data)',
-    0,
-    0
-WHERE NOT EXISTS (SELECT 1 FROM demo_sales)
+SELECT DATE '2025-01-01', '(no data)', 0, 0
+WHERE NOT EXISTS (SELECT 1 FROM monthly)
 ORDER BY sale_month, region;

--- a/stacks/evidence/project/sources/evidence_db/monthly_revenue.sql
+++ b/stacks/evidence/project/sources/evidence_db/monthly_revenue.sql
@@ -1,6 +1,17 @@
 -- Monthly revenue by region, from the seeded demo_sales table.
 -- Replace this file once you have your own data; the page that renders
 -- it is pages/index.md.
+--
+-- Guarded the same way as database_overview.sql, and for a case that one
+-- does not cover: there the guard fires when no table exists, here when
+-- the table exists but holds no rows. `DELETE FROM demo_sales` reaches
+-- exactly that state, and it is what someone does while replacing the
+-- demo data with their own -- so this is the likelier of the two paths
+-- into the zero-row crash (#725, defect 7).
+--
+-- The placeholder is a visible one on purpose. A flat zero line labelled
+-- "(no data)" reads as an empty table at a glance; a silently absent
+-- series would look like a rendering problem.
 SELECT
     sale_month,
     region,
@@ -8,4 +19,11 @@ SELECT
     SUM(orders)  AS orders
 FROM demo_sales
 GROUP BY sale_month, region
+UNION ALL
+SELECT
+    DATE '2025-01-01',
+    '(no data)',
+    0,
+    0
+WHERE NOT EXISTS (SELECT 1 FROM demo_sales)
 ORDER BY sale_month, region;


### PR DESCRIPTION
## Problem

Defect 7 of #725, the last one still open. A source query returning zero rows
kills the Evidence container, and the symptom points nowhere near the cause.

Evidence writes no parquet file for an empty result but still lists it in the
manifest. `+layout.js` then builds a DuckDB view over the file that was never
written:

```
Error: Invalid Input Error: File 'database_overview.parquet' too small to be a Parquet file
    at Module.setParquetURLs (node_modules/@evidence-dev/universal-sql/src/client-duckdb/node.js:130:15)
```

The throw is uncaught, so node exits and `restart: unless-stopped` restarts the
container. What an operator sees is a restart loop, with the actual error
scrolled past several restarts back — not "your query matched nothing".

`pg_stat_user_tables` is empty until a user table exists, so the shipped
`database_overview` query can legitimately return nothing: on a database whose
tables were all dropped, or one Evidence is pointed at before any data is loaded.

## Change

A `UNION ALL` branch guarded by `WHERE NOT EXISTS` over the same source, which
contributes a placeholder row exactly when the main query contributes none:

```sql
SELECT relname AS table_name, n_live_tup AS estimated_rows
FROM pg_stat_user_tables
UNION ALL
SELECT '(no user tables yet)', 0
WHERE NOT EXISTS (SELECT 1 FROM pg_stat_user_tables)
ORDER BY estimated_rows DESC NULLS LAST, table_name
LIMIT 50;
```

## Measured, not reasoned about

Run against `postgres:18-alpine` in a throwaway container:

| Schema | Query | Result |
|---|---|---|
| empty | old | **0 rows** — this is the crash |
| empty | new | 1 row — `(no user tables yet) \| 0` |
| 3 tables | new | 3 rows, placeholder absent, ordering `72 1 0` |

A table containing zero rows (`t_empty`) still appears in the output, which is
correct: the guard is about having no tables, not about empty ones.

## Why there is no test

The property is "returns at least one row against a real Postgres", which a unit
test cannot check without a database. Asserting that the file contains
`WHERE NOT EXISTS` would pin a spelling rather than the behaviour, and would fail
on any equivalent rewrite while still passing if someone kept the string and
broke the logic.

The reasoning lives in the query's own header comment instead — where the next
person editing it will actually be — and the measurement is recorded above.

## Docs

The trap applies to every query an operator adds, not only the one that ships, so
both the in-project `pages/index.md` and `docs/stacks/evidence.md` describe it:
what the failure looks like, why it looks like something else, and the
`WHERE NOT EXISTS` shape as the cheapest guard.

## Scope

`Refs #725`, not `Closes`. Defect 7 has two halves and this fixes the half that
belongs to this repo. The other half is upstream: a manifest should not reference
a file its writer skipped, and until Evidence changes that, any project shipping
a query able to match nothing is exposed. Keeping #725 open records that.

Also note this is the second layer of protection, not the first. Since #751 the
stack seeds `demo_sales`, so `pg_stat_user_tables` is non-empty on a fresh
deployment and defect 7 was already unreachable by default. This makes it
unreachable when someone drops the demo table too — which
`initdb/01-demo-sales.sql` explicitly invites once real data is loaded.

## Summary by Sourcery

Keep the Evidence container running when bundled or custom source queries return no rows.

Bug Fixes:
- Prevent the bundled Evidence queries from producing zero-row results that crash the container by returning visible placeholder rows instead.
- Apply empty-result safeguards to both database table overview and monthly revenue queries.

Enhancements:
- Document the zero-row failure mode and recommend guarding query results with CTE-based existence checks for custom sources.

Documentation:
- Add guidance to the Evidence stack documentation and sample page explaining the restart-loop symptom and how to protect queries that may return no rows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented empty query results from causing the Evidence container to fail and restart-loop.
  * Added visible placeholder rows when certain views or charts would otherwise return no data, keeping pages and summaries available.

* **Documentation**
  * Added guidance explaining the empty-result behavior and how to avoid it in custom queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->