### PR TITLE
docs: Record the upstream status of the Evidence zero-row crash

### DIFF
--- a/docs/stacks/evidence.md
+++ b/docs/stacks/evidence.md
@@ -119,9 +119,23 @@ The two shipped queries cover the two ways an empty result arises:
 behind, which is what someone does while replacing the demo data.
 
 Apply the same shape to queries you add. This is
-[#725](https://github.com/stefanko-ch/Nexus-Stack/issues/725) defect 7 — arguably
-an upstream bug, since a manifest should not reference a file the writer skipped,
-but reachable from any project that ships a query able to match nothing.
+[#725](https://github.com/stefanko-ch/Nexus-Stack/issues/725) defect 7.
+
+**Do not expect an upstream fix.** The behaviour is Evidence's — a manifest
+should not reference a parquet file its writer skipped — and it is reported at
+[evidence-dev/evidence#2466](https://github.com/evidence-dev/evidence/issues/2466),
+with the same error text and the same trigger, labelled `bug` by the maintainers
+and independently reproduced by a third party. It was closed on 2026-08-25 not by
+a fix but with *"Closing along with the release of the new Evidence Core … Feel
+free to open a new issue if this is blocking you!"* — a sweep at a product
+boundary.
+
+That matters for how to treat the guard. `@evidence-dev/evidence@40.1.8`, which
+this stack pins, is still `dist-tags.latest` on npm (published 2026-02-06), so
+the version we run is the last of that line and carries the behaviour. The guard
+is not a stopgap until someone fixes this; for this stack it is permanent, and
+worth internalising when writing your own queries rather than working around
+once.
 
 ### Adding data sources
 

--- a/docs/stacks/evidence.md
+++ b/docs/stacks/evidence.md
@@ -121,21 +121,32 @@ behind, which is what someone does while replacing the demo data.
 Apply the same shape to queries you add. This is
 [#725](https://github.com/stefanko-ch/Nexus-Stack/issues/725) defect 7.
 
-**Do not expect an upstream fix.** The behaviour is Evidence's — a manifest
-should not reference a parquet file its writer skipped — and it is reported at
-[evidence-dev/evidence#2466](https://github.com/evidence-dev/evidence/issues/2466),
-with the same error text and the same trigger, labelled `bug` by the maintainers
-and independently reproduced by a third party. It was closed on 2026-08-25 not by
-a fix but with *"Closing along with the release of the new Evidence Core … Feel
-free to open a new issue if this is blocking you!"* — a sweep at a product
+**No fix is available for the version this stack pins.** The same crash is
+reported upstream at
+[evidence-dev/evidence#2466](https://github.com/evidence-dev/evidence/issues/2466)
+— same error text, same trigger — labelled `bug` by the maintainers and
+independently reproduced by a third party. It was closed on 2026-08-25 not by a
+fix but with *"Closing along with the release of the new Evidence Core … Feel
+free to open a new issue if this is blocking you!"*, a sweep at a product
 boundary.
 
-That matters for how to treat the guard. `@evidence-dev/evidence@40.1.8`, which
-this stack pins, is still `dist-tags.latest` on npm (published 2026-02-06), so
-the version we run is the last of that line and carries the behaviour. The guard
-is not a stopgap until someone fixes this; for this stack it is permanent, and
-worth internalising when writing your own queries rather than working around
-once.
+Two limits on what that establishes, because both invite a wrong conclusion:
+
+- **Which component owns the defect is inferred, not traced.** The failure
+  surfaces in `universal-sql` loading a file the manifest listed, so the natural
+  reading is that the manifest should not list a file its writer skipped — but
+  nobody here has followed that through `universal-sql`, DuckDB, or the
+  interaction between them. It is a bug *reported against* Evidence; treat the
+  component as a starting point for investigation, not a conclusion.
+- **"No fix" applies to the 40.1.8 line only.** `@evidence-dev/evidence@40.1.8`
+  is what this stack pins and is still `dist-tags.latest` on npm (published
+  2026-02-06), so the version we run carries the behaviour. Whether the new
+  Evidence Core fixes it is unknown and untested here, and a later release could
+  address it.
+
+For this stack, then, the guard is what stands between a query and a restart
+loop, and there is no pending change that would remove the need for it. Worth
+internalising when writing your own queries rather than working around once.
 
 ### Adding data sources
 


### PR DESCRIPTION
## Why

`docs/stacks/evidence.md` called the zero-row crash "arguably an upstream bug"
and stopped there. Anyone deciding how much to invest in the guard would have to
redo the search to find out whether a fix was on its way. It is not, and the
answer changes how the guard should be read.

## What the search found

[evidence-dev/evidence#2466](https://github.com/evidence-dev/evidence/issues/2466):

- same error text (`too small to be a Parquet file`) and same trigger (a source
  query returning zero rows)
- labelled `bug` by the maintainers, never disputed
- independently reproduced — a third party posted a pyarrow-based workaround in
  February 2025
- **closed 2026-08-25 without a fix**: *"Closing along with the release of the
  new Evidence Core … Feel free to open a new issue if this is blocking you!"*

A sweep at a product boundary, so nothing is pending upstream.

And the version matters: `@evidence-dev/evidence@40.1.8`, which this stack pins,
is still `dist-tags.latest` on npm (published 2026-02-06). The version we run is
the last of that line and carries the behaviour.

## What changes

Three sentences of prose. The guide now says not to expect an upstream fix,
links the issue, and states the consequence: the guard is permanent for this
stack rather than a stopgap, so it is worth internalising when writing queries
rather than working around once.

Docs only — no code, no behaviour change.

## Not verified

I did not run Evidence to reproduce the crash myself in this session. The claim
rests on three independent reports of the same signature — the reproduction
recorded in #725, the upstream issue, and the third-party comment on it — plus
the npm version check above. I also did not read `universal-sql`'s source: the
mechanism is inferred from the error and stack trace, not traced through the
code.

Filing a fresh upstream issue against "Evidence Core" is deliberately **not**
part of this. It would mean reporting behaviour on a product this repo does not
use, without a reproduction of my own.

## Summary by Sourcery

Documentation:
- Document the upstream status of Evidence’s zero-row crash, including the lack of a fix for the pinned 40.1.8 version and the resulting need to retain the guard.