### PR TITLE
refactor(ci): Give Cloudflare its own token instead of the secrets one

### DIFF
--- a/.github/workflows/setup-control-plane.yaml
+++ b/.github/workflows/setup-control-plane.yaml
@@ -1178,11 +1178,54 @@ jobs:
             echo "r2_data_bucket=$BUCKET_NAME"
           } >> "$GITHUB_OUTPUT"
 
+      - name: Check the Cloudflare token split
+        env:
+          HAS_ACTIONS_TOKEN: ${{ secrets.GH_ACTIONS_TOKEN != '' }}
+        run: |
+          # Not fatal. Splitting the token requires the operator to create a
+          # second one, and failing every existing deployment on upgrade
+          # would be a worse trade than running one more spin-up with the
+          # wider token. But it must not pass silently either: a fallback
+          # nobody is told about is how an over-scoped credential stays in
+          # place for a year.
+          if [ "$HAS_ACTIONS_TOKEN" = "true" ]; then
+            echo "✅ Cloudflare receives GH_ACTIONS_TOKEN — scoped to what it needs"
+          else
+            echo "⚠️  GH_ACTIONS_TOKEN is not set, so Cloudflare receives GH_SECRETS_TOKEN."
+            echo ""
+            echo "   That token carries Secrets: Read and write, which Cloudflare"
+            echo "   never uses — it only dispatches workflows, reads runs, and"
+            echo "   reads the latest release. Whoever can read the Worker's"
+            echo "   binding can therefore rewrite any repository secret,"
+            echo "   including HCLOUD_TOKEN and CLOUDFLARE_API_TOKEN, and the"
+            echo "   next workflow run would use the replacement."
+            echo ""
+            echo "   To split it (see docs/admin-guides/setup-guide.md):"
+            echo "     1. Create a second fine-grained token with"
+            echo "        Actions: Read and write, Contents: Read."
+            echo "     2. Save it as GH_ACTIONS_TOKEN."
+            echo "     3. Reduce GH_SECRETS_TOKEN to Secrets: Read and write."
+            echo "     4. Re-run this workflow."
+          fi
+
       - name: Set Scheduled Teardown Worker secrets
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          GITHUB_TOKEN: ${{ secrets.GH_SECRETS_TOKEN }}
+          # GH_ACTIONS_TOKEN, falling back to GH_SECRETS_TOKEN.
+          #
+          # Cloudflare needs Actions:RW (dispatch + read runs) and, for the
+          # version banner, Contents:Read. It never writes a repository
+          # secret. GH_SECRETS_TOKEN carries Secrets:RW because the setup
+          # workflow needs it — and parking that here means whoever reads
+          # this binding can rewrite HCLOUD_TOKEN or CLOUDFLARE_API_TOKEN,
+          # which the next workflow run would then use. See #757.
+          #
+          # The fallback keeps existing deployments working rather than
+          # breaking every stack on upgrade; the step below says so out
+          # loud, because a silent fallback would leave the wider token in
+          # place with nothing pointing at it.
+          GITHUB_TOKEN: ${{ secrets.GH_ACTIONS_TOKEN || secrets.GH_SECRETS_TOKEN }}
           RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
           DOMAIN: ${{ secrets.DOMAIN }}
         run: |
@@ -1217,7 +1260,9 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           DOMAIN: ${{ secrets.DOMAIN }}
-          WORKER_AUTH_TOKEN: ${{ secrets.GH_SECRETS_TOKEN }}
+          # Must match what the Worker received above, since the health
+          # endpoint compares the bearer against its own GITHUB_TOKEN.
+          WORKER_AUTH_TOKEN: ${{ secrets.GH_ACTIONS_TOKEN || secrets.GH_SECRETS_TOKEN }}
         run: |
           echo "🩺 Running Worker diagnostic health check..."
           WORKER_NAME="nexus-${DOMAIN//./-}-worker"
@@ -1318,7 +1363,20 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          GITHUB_TOKEN: ${{ secrets.GH_SECRETS_TOKEN }}
+          # GH_ACTIONS_TOKEN, falling back to GH_SECRETS_TOKEN.
+          #
+          # Cloudflare needs Actions:RW (dispatch + read runs) and, for the
+          # version banner, Contents:Read. It never writes a repository
+          # secret. GH_SECRETS_TOKEN carries Secrets:RW because the setup
+          # workflow needs it — and parking that here means whoever reads
+          # this binding can rewrite HCLOUD_TOKEN or CLOUDFLARE_API_TOKEN,
+          # which the next workflow run would then use. See #757.
+          #
+          # The fallback keeps existing deployments working rather than
+          # breaking every stack on upgrade; the step below says so out
+          # loud, because a silent fallback would leave the wider token in
+          # place with nothing pointing at it.
+          GITHUB_TOKEN: ${{ secrets.GH_ACTIONS_TOKEN || secrets.GH_SECRETS_TOKEN }}
           RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
           DOMAIN: ${{ secrets.DOMAIN }}
           BASE_DOMAIN: ${{ secrets.BASE_DOMAIN }}

--- a/.github/workflows/setup-control-plane.yaml
+++ b/.github/workflows/setup-control-plane.yaml
@@ -70,6 +70,44 @@ jobs:
       TF_VAR_external_s3_label: ${{ secrets.EXTERNAL_S3_LABEL }}
 
     steps:
+      - name: Check the Cloudflare token split
+        env:
+          HAS_ACTIONS_TOKEN: ${{ secrets.GH_ACTIONS_TOKEN != '' }}
+        run: |
+          # First step of the job on purpose. It used to sit next to the
+          # Cloudflare steps near the end, where any earlier failure — tofu,
+          # R2, secret storage — meant the warning never printed. A notice
+          # that only appears on fully successful runs is missing exactly
+          # when someone is already reading the log.
+          #
+          # This reports which secret NAME was found and nothing more. The
+          # workflow cannot read a token's permissions, so it cannot say
+          # whether GH_ACTIONS_TOKEN was actually created with the narrow
+          # scope, and claiming otherwise would be a reassurance nobody
+          # checked.
+          if [ "$HAS_ACTIONS_TOKEN" = "true" ]; then
+            echo "GH_ACTIONS_TOKEN is set — Cloudflare will be given that token."
+            echo "   Its permissions are not visible from here; the intended"
+            echo "   scope is Actions: Read and write plus Contents: Read."
+          else
+            echo "⚠️  GH_ACTIONS_TOKEN is not set, so Cloudflare will be given"
+            echo "   GH_SECRETS_TOKEN instead."
+            echo ""
+            echo "   That token carries Secrets: Read and write, which Cloudflare"
+            echo "   never uses — it only dispatches workflows, reads runs, and"
+            echo "   reads the latest release. Whoever can read the Worker's"
+            echo "   binding can therefore rewrite any repository secret,"
+            echo "   including HCLOUD_TOKEN and CLOUDFLARE_API_TOKEN, and the"
+            echo "   next workflow run would use the replacement."
+            echo ""
+            echo "   To split it (see docs/admin-guides/setup-guide.md):"
+            echo "     1. Create a second fine-grained token with"
+            echo "        Actions: Read and write, Contents: Read."
+            echo "     2. Save it as GH_ACTIONS_TOKEN."
+            echo "     3. Reduce GH_SECRETS_TOKEN to Secrets: Read and write."
+            echo "     4. Re-run this workflow."
+          fi
+
       - name: Checkout
         uses: actions/checkout@v5
 
@@ -1177,36 +1215,6 @@ jobs:
             echo "r2_data_secret_key=$R2_SECRET_ACCESS_KEY"
             echo "r2_data_bucket=$BUCKET_NAME"
           } >> "$GITHUB_OUTPUT"
-
-      - name: Check the Cloudflare token split
-        env:
-          HAS_ACTIONS_TOKEN: ${{ secrets.GH_ACTIONS_TOKEN != '' }}
-        run: |
-          # Not fatal. Splitting the token requires the operator to create a
-          # second one, and failing every existing deployment on upgrade
-          # would be a worse trade than running one more spin-up with the
-          # wider token. But it must not pass silently either: a fallback
-          # nobody is told about is how an over-scoped credential stays in
-          # place for a year.
-          if [ "$HAS_ACTIONS_TOKEN" = "true" ]; then
-            echo "✅ Cloudflare receives GH_ACTIONS_TOKEN — scoped to what it needs"
-          else
-            echo "⚠️  GH_ACTIONS_TOKEN is not set, so Cloudflare receives GH_SECRETS_TOKEN."
-            echo ""
-            echo "   That token carries Secrets: Read and write, which Cloudflare"
-            echo "   never uses — it only dispatches workflows, reads runs, and"
-            echo "   reads the latest release. Whoever can read the Worker's"
-            echo "   binding can therefore rewrite any repository secret,"
-            echo "   including HCLOUD_TOKEN and CLOUDFLARE_API_TOKEN, and the"
-            echo "   next workflow run would use the replacement."
-            echo ""
-            echo "   To split it (see docs/admin-guides/setup-guide.md):"
-            echo "     1. Create a second fine-grained token with"
-            echo "        Actions: Read and write, Contents: Read."
-            echo "     2. Save it as GH_ACTIONS_TOKEN."
-            echo "     3. Reduce GH_SECRETS_TOKEN to Secrets: Read and write."
-            echo "     4. Re-run this workflow."
-          fi
 
       - name: Set Scheduled Teardown Worker secrets
         env:

--- a/.github/workflows/setup-control-plane.yaml
+++ b/.github/workflows/setup-control-plane.yaml
@@ -73,6 +73,7 @@ jobs:
       - name: Check the Cloudflare token split
         env:
           HAS_ACTIONS_TOKEN: ${{ secrets.GH_ACTIONS_TOKEN != '' }}
+          HAS_SECRETS_TOKEN: ${{ secrets.GH_SECRETS_TOKEN != '' }}
         run: |
           # First step of the job on purpose. It used to sit next to the
           # Cloudflare steps near the end, where any earlier failure — tofu,
@@ -89,6 +90,21 @@ jobs:
             echo "GH_ACTIONS_TOKEN is set — Cloudflare will be given that token."
             echo "   Its permissions are not visible from here; the intended"
             echo "   scope is Actions: Read and write plus Contents: Read."
+          elif [ "$HAS_SECRETS_TOKEN" != "true" ]; then
+            # Neither is configured. Announcing the fallback here would be a
+            # false statement on exactly the run this step exists to help:
+            # there is nothing to fall back to. Not fatal here either —
+            # the SSH-key step below is where the missing prerequisite
+            # actually stops the run, with the instructions for fixing it.
+            echo "⚠️  Neither GH_ACTIONS_TOKEN nor GH_SECRETS_TOKEN is set."
+            echo ""
+            echo "   Cloudflare would receive no token at all, so the"
+            echo "   scheduled teardown and the Control Plane buttons could"
+            echo "   not dispatch anything."
+            echo ""
+            echo "   This run will not get that far: the SSH-key step below"
+            echo "   stops on the missing GH_SECRETS_TOKEN and explains how"
+            echo "   to create it. See docs/admin-guides/setup-guide.md."
           else
             echo "⚠️  GH_ACTIONS_TOKEN is not set, so Cloudflare will be given"
             echo "   GH_SECRETS_TOKEN instead."

--- a/docs/admin-guides/setup-guide.md
+++ b/docs/admin-guides/setup-guide.md
@@ -129,9 +129,9 @@ where they matter rather than left for the reader to discover:
 - the Cloudflare **tunnel token**, in the `cloudflared` systemd unit on the
   server — the reason the table's boundary is about API tokens rather than
   Cloudflare in general
-- **`GH_SECRETS_TOKEN`**, which the setup also copies into the Cloudflare
-  scheduled-teardown Worker and the Control Plane Pages project, because both
-  need to dispatch workflows
+- the **Cloudflare token** — `GH_ACTIONS_TOKEN`, or `GH_SECRETS_TOKEN` where the
+  two have not been split — which the setup copies into the scheduled-teardown
+  Worker and the Control Plane Pages project, because both dispatch workflows
 
 Both are described under *What actually controls access*.
 
@@ -140,7 +140,7 @@ Both are described under *What actually controls access*.
 | **Where** | The repository that runs the workflows — GitHub, or a Forgejo instance | The `infisical` core stack, on the deployed server |
 | **What** | Credentials that *build* infrastructure: Hetzner, Cloudflare, R2, the generated SSH key | Credentials that *services* use: database passwords, admin logins, one folder per stack (~50) |
 | **Who sets them** | The operator, before the first run | OpenTofu generates them on every spin-up; operators may add their own directly in Infisical |
-| **Who reads them** | The workflows — and, for `GH_SECRETS_TOKEN` alone, the Cloudflare Worker and Pages project it is copied into | Anyone who can reach the Control Plane or the stacks on that server |
+| **Who reads them** | The workflows — and, for the Cloudflare token alone, the Worker and Pages project it is copied into | Anyone who can reach the Control Plane or the stacks on that server |
 
 **No Hetzner or Cloudflare API token is ever written to Infisical or reachable
 from the application stacks**, and no service password is ever written back to
@@ -233,7 +233,7 @@ Infisical is not a way to keep something from that person.
 
 #### GH_SECRETS_TOKEN
 
-This token is what lets the setup workflow store the generated R2 credentials as repository secrets. It is also used as the runtime `GITHUB_TOKEN` in Cloudflare (for the scheduled teardown worker and Control Plane), so it must be able to dispatch workflows.
+This token is what lets the setup workflow store the generated R2 credentials as repository secrets. That is all it needs to do — see `GH_ACTIONS_TOKEN` below for the Cloudflare half, which used to share this token and should not.
 
 Without it the first run stops with an explanatory error, and Cloudflare-based automation that triggers GitHub Actions will not work. The workflow used to print the credentials to the log as a fallback; it no longer does, because Actions logs on a public repository are readable by anyone and these keys open the OpenTofu state bucket.
 
@@ -243,8 +243,37 @@ Without it the first run stops with an explanatory error, and Cloudflare-based a
 3. **Repository access**: Select your Nexus-Stack repository
 4. **Permissions** (Repository permissions):
    - **Secrets** → **Read and write**
-   - **Actions** → **Read and write** (required so Cloudflare workers can dispatch workflows)
 5. Copy the token and save it as `GH_SECRETS_TOKEN` in your repository secrets
+
+This used to also require **Actions → Read and write**, because the same token
+was handed to Cloudflare. Splitting that out is what `GH_ACTIONS_TOKEN` below is
+for; if you have an existing single token, reduce it to Secrets only once the
+second one is in place.
+
+#### GH_ACTIONS_TOKEN
+
+The token the **Cloudflare** side runs on: the scheduled-teardown Worker and the
+Control Plane's spin-up / teardown / status buttons. It never touches secrets.
+
+Optional, and only in the sense that setup still works without it — the workflow
+falls back to `GH_SECRETS_TOKEN` and says so in the log. Setting it is the point,
+though, because the fallback hands Cloudflare a token with `Secrets: Read and
+write` that it has no use for. Anyone who can read that binding can rewrite
+`HCLOUD_TOKEN` or `CLOUDFLARE_API_TOKEN`, and the next workflow run uses the
+replacement — a full takeover of the deployment from a credential parked in an
+edge runtime ([#757](https://github.com/stefanko-ch/Nexus-Stack/issues/757)).
+
+**How to create:** same fine-grained-token flow as above, with:
+
+- **Actions** → **Read and write** — dispatch workflows, read run status
+- **Contents** → **Read** — the Control Plane reads `releases/latest` for its
+  version banner
+
+Save it as `GH_ACTIONS_TOKEN`, then reduce `GH_SECRETS_TOKEN` to `Secrets` only.
+
+There is no narrower option. GitHub's fine-grained tokens scope by permission,
+not by workflow, so "may dispatch this one workflow" is not expressible — which
+is why the answer is a second token rather than a tighter first one.
 
 **Running the workflows under Forgejo Actions** (for example when the repository is a fork hosted on a Forgejo instance, as Nexus-Conductor does): the same secret is still called `GH_SECRETS_TOKEN`, but its value is a **Forgejo access token** — *Settings → Applications* on that forge, for an account that administers the repository, with the `write:repository` scope. The workflows detect the forge from `GITHUB_SERVER_URL` and store secrets through the forge's Actions API (`PUT /repos/{owner}/{repo}/actions/secrets/{name}`, see [`scripts/repo-secret.sh`](https://github.com/stefanko-ch/Nexus-Stack/blob/main/scripts/repo-secret.sh)) instead of the GitHub CLI. The Control Plane's own buttons (spin-up / teardown / status) still call the GitHub API and are not available on a Forgejo-hosted fork — Nexus-Conductor drives the lifecycle from its panel in that setup.
 

--- a/docs/admin-guides/setup-guide.md
+++ b/docs/admin-guides/setup-guide.md
@@ -230,7 +230,7 @@ Infisical is not a way to keep something from that person.
 | `DOMAIN` | Your domain | e.g. `example.com` |
 | `TF_VAR_admin_email` | Your email | Admin - full access including SSH |
 | `GH_SECRETS_TOKEN` | GitHub PAT, or a Forgejo access token | Stores the credentials the setup generates ([how to create](#gh_secrets_token)) |
-| `GH_ACTIONS_TOKEN` | GitHub PAT | What Cloudflare runs on. Setup works without it by falling back to `GH_SECRETS_TOKEN` — which hands Cloudflare secret-write rights it never uses, so treat an unset value as a transitional state rather than a choice ([how to create](#gh_actions_token)) |
+| `GH_ACTIONS_TOKEN` | GitHub PAT | **Strongly recommended, GitHub-hosted repositories only.** What Cloudflare runs on. Setup completes without it by falling back to `GH_SECRETS_TOKEN`, which hands Cloudflare secret-write rights it never uses — so an unset value is a transitional state, not a choice. Irrelevant on a Forgejo-hosted fork, where the Cloudflare buttons do not work anyway ([how to create](#gh_actions_token)) |
 
 #### GH_SECRETS_TOKEN
 
@@ -256,8 +256,9 @@ Without it the first run stops with an explanatory error, and Cloudflare-based a
 
 This used to also require **Actions → Read and write**, because the same token
 was handed to Cloudflare. Splitting that out is what `GH_ACTIONS_TOKEN` below is
-for; if you have an existing single token, reduce it to Secrets only once the
-second one is in place.
+for; if you have an existing single token, drop its **Actions** permission once
+the second one is in place — keeping **Secrets → Read and write**, which is what
+this token is for.
 
 #### GH_ACTIONS_TOKEN
 
@@ -278,7 +279,11 @@ edge runtime ([#757](https://github.com/stefanko-ch/Nexus-Stack/issues/757)).
 - **Contents** → **Read** — the Control Plane reads `releases/latest` for its
   version banner
 
-Save it as `GH_ACTIONS_TOKEN`, then reduce `GH_SECRETS_TOKEN` to `Secrets` only.
+Save it as `GH_ACTIONS_TOKEN`. Then narrow `GH_SECRETS_TOKEN` by removing
+**Actions** (and **Contents**, if you granted it) — and leave **Secrets → Read
+and write** in place. "Narrow" means fewer permissions, not a lower level on the
+one it keeps: without write access the setup cannot store anything and stops
+with an explanatory error.
 
 There is no narrower option. GitHub's fine-grained tokens scope by permission,
 not by workflow, so "may dispatch this one workflow" is not expressible — which

--- a/docs/admin-guides/setup-guide.md
+++ b/docs/admin-guides/setup-guide.md
@@ -229,11 +229,20 @@ Infisical is not a way to keep something from that person.
 | `HCLOUD_TOKEN` | Hetzner console | API token |
 | `DOMAIN` | Your domain | e.g. `example.com` |
 | `TF_VAR_admin_email` | Your email | Admin - full access including SSH |
-| `GH_SECRETS_TOKEN` | GitHub PAT, or a Forgejo access token | Stores the generated R2 credentials ([how to create](#gh_secrets_token)) |
+| `GH_SECRETS_TOKEN` | GitHub PAT, or a Forgejo access token | Stores the credentials the setup generates ([how to create](#gh_secrets_token)) |
+| `GH_ACTIONS_TOKEN` | GitHub PAT | What Cloudflare runs on. Setup works without it by falling back to `GH_SECRETS_TOKEN` — which hands Cloudflare secret-write rights it never uses, so treat an unset value as a transitional state rather than a choice ([how to create](#gh_actions_token)) |
 
 #### GH_SECRETS_TOKEN
 
-This token is what lets the setup workflow store the generated R2 credentials as repository secrets. That is all it needs to do — see `GH_ACTIONS_TOKEN` below for the Cloudflare half, which used to share this token and should not.
+This token is what lets the setup workflow store the credentials it generates as
+repository secrets. Four of them, not only the R2 pair: `SSH_PRIVATE_KEY`,
+`R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY` and `R2_DATA_BUCKET` all go through
+`repo-secret.sh` with this token. Worth knowing before scoping it down or
+removing it on the assumption that it is only about R2 — without it the SSH key
+exists for one run and the next standalone spin-up finds none.
+
+Storing those is all it needs to do; see `GH_ACTIONS_TOKEN` below for the
+Cloudflare half, which used to share this token and should not.
 
 Without it the first run stops with an explanatory error, and Cloudflare-based automation that triggers GitHub Actions will not work. The workflow used to print the credentials to the log as a fallback; it no longer does, because Actions logs on a public repository are readable by anyone and these keys open the OpenTofu state bucket.
 


### PR DESCRIPTION
## Problem

`GH_SECRETS_TOKEN` is copied into two Cloudflare services, where it stays:

| Line | Step | As |
|---|---|---|
| 1185 | Set Scheduled Teardown Worker secrets | `GITHUB_TOKEN` |
| 1220 | Verify Worker health | `WORKER_AUTH_TOKEN` |
| 1321 | Set Control Plane secrets | `GITHUB_TOKEN` |

It carries `Secrets: Read and write` because the setup workflow needs that.
Cloudflare does not — and a token that can write repository secrets can replace
`HCLOUD_TOKEN` or `CLOUDFLARE_API_TOKEN`, after which the next workflow run uses
the replacement. That is a takeover of the entire deployment path starting from a
credential parked in an edge runtime.

Under the Nexus-Conductor fork model it multiplies: one copy per stack.

## The narrower option was checked first, and does not exist

#757 offered "narrow what Cloudflare gets, if a token can be scoped to
dispatching a single workflow" as an alternative to splitting, and flagged that
I had not verified such a scope exists.

It does not. Fine-grained tokens scope by **permission**, not by workflow, so
"may dispatch this one workflow" is not expressible. Narrowing the Cloudflare
token *is* giving it a separate, smaller set of permissions — option 2 collapses
into option 1.

## What Cloudflare actually needs

Read off the code rather than assumed:

| Caller | Calls | Requires |
|---|---|---|
| Worker | `GET /actions/runs`, `POST /actions/workflows/<teardown>/dispatches` | Actions: RW |
| Control Plane | `GET /actions/runs` ×2, four `/dispatches`, authenticated `GET /releases/latest` | Actions: RW + Contents: Read |

No call writes a secret.

## Change

A new `GH_ACTIONS_TOKEN` for the Cloudflare side, with the three sites falling
back to `GH_SECRETS_TOKEN` when it is unset.

**On the fallback.** It keeps existing deployments working rather than failing
every stack on upgrade over a hardening change. But it hands Cloudflare the wider
token, so a new step reports which one was used — naming the consequence and the
four steps to split. A fallback nobody is told about is how an over-scoped
credential stays in place for a year; this one announces itself on every run
until it is fixed.

`docs/admin-guides/setup-guide.md` gains the `GH_ACTIONS_TOKEN` section with its
permissions and the reason, drops `Actions: Read and write` from the
`GH_SECRETS_TOKEN` instructions, and says to reduce an existing combined token
once the second is in place. The two-store section added in #755 now names "the
Cloudflare token" rather than `GH_SECRETS_TOKEN` specifically.

## Verified before recommending it

Reducing `GH_SECRETS_TOKEN` to `Secrets` only breaks nothing: no workflow uses it
to dispatch, and `setup-control-plane.yaml` contains no dispatch call at all —
all five of its `GH_TOKEN` sites feed `repo-secret.sh`.

## Not verified

- Whether `Contents: Read` is strictly required for `GET /releases/latest` on a
  **public** repository, or whether public read suffices. Documented as required,
  which is the safe direction: too much here costs a read permission, too little
  costs the version banner.
- Whether Cloudflare Worker secret bindings are readable by anyone below the
  Cloudflare account owner. The threat model above takes the account as the trust
  boundary; if that holds strictly, the exposure is smaller than described —
  though the argument for not parking `Secrets: write` there stands either way.
- No deploy test. The fallback path is what every existing stack takes, and it is
  the unchanged behaviour; the new path needs an operator to create the token.

Closes #757.

## Summary by Sourcery

Separate Cloudflare's workflow-dispatch credentials from the repository secret-management token while preserving existing deployments through an explicitly reported fallback.

New Features:
- Add support for a dedicated GH_ACTIONS_TOKEN for Cloudflare Workers and the Control Plane, with compatibility fallback to GH_SECRETS_TOKEN.

Bug Fixes:
- Prevent Cloudflare services from unnecessarily receiving the repository secret-management token and its Secrets: Read and write permission.

Enhancements:
- Report the active Cloudflare token configuration during setup and clearly warn when the broader fallback token is still being used.

Documentation:
- Document the separate Cloudflare token, its required permissions, migration steps, and the reduced permissions for GH_SECRETS_TOKEN.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Added validation and guidance for separating Cloudflare and GitHub token usage.
  * Reduced reliance on broadly privileged repository-secret tokens when configuring and verifying Workers.

* **Documentation**
  * Updated the setup guide with configuration details for the actions token, fallback behavior, required permissions, and security considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->