### PR TITLE
test(deploy): Pin the secret-sync collision precedence

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -129,6 +129,20 @@ jobs:
       - name: Sync deps
         run: uv sync --frozen --group dev
 
+      # tests/unit/test_secret_sync_collisions.py runs the rendered
+      # secret-sync script for real, and that script uses jq to turn the
+      # Infisical response into TSV. jq cannot be shimmed the way curl and
+      # docker are without reimplementing it.
+      #
+      # Installed rather than assumed present: five workflows in this repo
+      # use jq without installing it and one installs it explicitly, so its
+      # availability on the runner image is a habit rather than a
+      # guarantee. Those tests skip when jq is missing, which on a
+      # developer machine is the right outcome and in CI would mean a green
+      # run that never exercised what the suite claims to pin.
+      - name: Install jq (needed by the secret-sync script tests)
+        run: sudo apt-get update && sudo apt-get install -y jq
+
       - name: pytest unit
         # Runs the full test suite under pyproject.toml's testpaths (today
         # only tests/unit/; an `integration` marker is registered for

--- a/tests/unit/test_secret_sync_collisions.py
+++ b/tests/unit/test_secret_sync_collisions.py
@@ -1,0 +1,210 @@
+"""Which folder wins when the same secret key appears twice.
+
+`secret_sync` keeps the first occurrence of a key and discards the rest.
+Nothing states which folder should be "first" — it falls out of the
+`LC_ALL=C sort` at the top of the rendered script, and out of the root
+folder being appended after that sorted list. Issue #756.
+
+These tests exist because that is a side effect rather than a decision.
+A change that dropped the sort, switched to a locale-aware one, or
+reordered the root append would silently hand every deployment a
+different value for a colliding key, with no runtime signal: a notebook
+reads `API_KEY` and gets the wrong one. Pinning it makes the behaviour a
+contract, so such a change fails here rather than in production.
+
+The rendered script runs for real, with `curl` and `docker` replaced by
+shims — the same approach as tests/unit/test_repo_secret_script.py. One
+harness liberty: `compose_dir` is the hardcoded `/opt/docker-server/...`,
+so the script's copy is rewritten to point at a tmpdir. That path is
+orthogonal to precedence; everything the tests assert on runs unmodified.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from nexus_deploy.secret_sync import StackTarget, render_remote_script
+
+# A curl that answers from fixture files instead of Infisical. The folder
+# listing and the per-folder secret fetch differ by `secretPath` appearing
+# in argv, which is how the two are told apart.
+CURL_SHIM = """#!/bin/bash
+path=""
+for a in "$@"; do
+  case "$a" in secretPath=*) path="${a#secretPath=}" ;; esac
+done
+if [ -n "$path" ]; then
+  label="$path"
+  if [ "$label" = "/" ]; then label="root"; else label="${label#/}"; fi
+  cat "$FIXTURES/secrets_${label}.json" 2>/dev/null || echo '{"secrets":[]}'
+else
+  cat "$FIXTURES/folders.json"
+fi
+"""
+
+DOCKER_SHIM = "#!/bin/bash\nexit 0\n"
+
+
+def _run_sync(tmp_path: Path, folders: dict[str, dict[str, str]]) -> tuple[str, str]:
+    """Run the real rendered script over a fake Infisical.
+
+    `folders` maps folder label -> {key: value}; use "root" for the
+    unnamed root folder. Returns (stdout+stderr, env-file contents).
+    """
+    target = StackTarget(name="jupyter")
+    script = render_remote_script(
+        target=target,
+        project_id="proj-1",
+        infisical_token="tok-1",
+        infisical_env="prod",
+    )
+
+    stack_dir = tmp_path / "stack"
+    stack_dir.mkdir()
+    script = script.replace(target.compose_dir, str(stack_dir))
+
+    fixtures = tmp_path / "fixtures"
+    fixtures.mkdir()
+    named = [f for f in folders if f != "root"]
+    (fixtures / "folders.json").write_text(json.dumps({"folders": [{"name": n} for n in named]}))
+    for label, pairs in folders.items():
+        (fixtures / f"secrets_{label}.json").write_text(
+            json.dumps({"secrets": [{"secretKey": k, "secretValue": v} for k, v in pairs.items()]})
+        )
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    (bin_dir / "curl").write_text(CURL_SHIM)
+    (bin_dir / "docker").write_text(DOCKER_SHIM)
+    for name in ("curl", "docker"):
+        (bin_dir / name).chmod(0o755)
+
+    proc = subprocess.run(
+        ["bash", "-c", script],
+        capture_output=True,
+        text=True,
+        env={
+            "PATH": f"{bin_dir}:{os.environ['PATH']}",
+            "FIXTURES": str(fixtures),
+            "HOME": str(tmp_path),
+        },
+        check=False,
+    )
+    env_file = stack_dir / Path(target.env_file).name
+    return proc.stdout + proc.stderr, env_file.read_text() if env_file.exists() else ""
+
+
+def test_the_alphabetically_first_folder_wins(tmp_path: Path) -> None:
+    """Precedence follows `LC_ALL=C sort` over folder names.
+
+    `clickhouse` sorts before `postgres`, so its value survives. Nothing
+    declares this; it is what the sort produces, which is exactly why it
+    is asserted here.
+    """
+    out, env = _run_sync(
+        tmp_path,
+        {
+            "postgres": {"SHARED_KEY": "from-postgres"},
+            "clickhouse": {"SHARED_KEY": "from-clickhouse"},
+        },
+    )
+
+    assert "from-clickhouse" in env
+    assert "from-postgres" not in env
+    assert "collisions=1" in out
+
+
+def test_the_losing_folder_is_named_in_the_log(tmp_path: Path) -> None:
+    """The discard is announced, and names both sides.
+
+    This is the only signal an operator gets: after the deploy the stack
+    simply holds one of the two values, with nothing at runtime marking
+    which. The message has to carry the shadowed folder and the winner.
+    """
+    out, _ = _run_sync(
+        tmp_path,
+        {
+            "postgres": {"SHARED_KEY": "from-postgres"},
+            "clickhouse": {"SHARED_KEY": "from-clickhouse"},
+        },
+    )
+
+    assert "Key collision" in out
+    assert "SHARED_KEY" in out
+    assert "postgres" in out
+    assert "clickhouse" in out
+    assert "first-wins" in out
+
+
+def test_sorting_is_byte_order_not_locale(tmp_path: Path) -> None:
+    """`LC_ALL=C` is not alphabetical: uppercase sorts before lowercase.
+
+    A folder named `Analytics` beats `analytics` and beats every
+    lowercase name, which is not what "alphabetically first" suggests to
+    a reader. Pinned separately so a switch to a locale-aware sort fails
+    loudly rather than quietly reversing this pair.
+    """
+    out, env = _run_sync(
+        tmp_path,
+        {
+            "analytics": {"SHARED_KEY": "from-lowercase"},
+            "Analytics": {"SHARED_KEY": "from-uppercase"},
+        },
+    )
+
+    assert "from-uppercase" in env
+    assert "from-lowercase" not in env
+    assert "collisions=1" in out
+
+
+def test_the_root_folder_loses_to_every_named_folder(tmp_path: Path) -> None:
+    """Root is appended after the sorted list, so it is processed last.
+
+    That makes it lose every collision regardless of name — a second
+    ordering rule layered on the sort, and the one most likely to be
+    overlooked when the loop is touched.
+    """
+    out, env = _run_sync(
+        tmp_path,
+        {
+            "root": {"SHARED_KEY": "from-root"},
+            "zzz": {"SHARED_KEY": "from-zzz"},
+        },
+    )
+
+    assert "from-zzz" in env
+    assert "from-root" not in env
+    assert "collisions=1" in out
+
+
+def test_distinct_keys_across_folders_are_all_kept(tmp_path: Path) -> None:
+    """The guard rails: only equal keys collide.
+
+    Without this a change that deduplicated too eagerly — by value, or
+    per-folder-prefix — would still satisfy the tests above.
+    """
+    out, env = _run_sync(
+        tmp_path,
+        {
+            "alpha": {"KEY_A": "value-a"},
+            "beta": {"KEY_B": "value-b"},
+        },
+    )
+
+    assert "value-a" in env
+    assert "value-b" in env
+    assert "collisions=0" in out
+
+
+@pytest.mark.parametrize("label", ["clickhouse", "postgres"])
+def test_a_key_present_in_only_one_folder_is_never_a_collision(tmp_path: Path, label: str) -> None:
+    """A single occurrence is not shadowed, whichever folder holds it."""
+    out, env = _run_sync(tmp_path, {label: {"ONLY_KEY": "only-value"}})
+
+    assert "only-value" in env
+    assert "collisions=0" in out

--- a/tests/unit/test_secret_sync_collisions.py
+++ b/tests/unit/test_secret_sync_collisions.py
@@ -31,6 +31,7 @@ import pytest
 
 from nexus_deploy.secret_sync import StackTarget, render_remote_script
 
+
 # jq does real work in the rendered script — JSON to TSV — so it cannot be
 # shimmed the way curl and docker are without reimplementing it. Without it
 # the script takes its intentional missing-jq early exit, writes no env
@@ -41,6 +42,28 @@ from nexus_deploy.secret_sync import StackTarget, render_remote_script
 # without installing it and one installs it explicitly, so "the runner has
 # jq" is a habit here rather than a guarantee. If these ever skip in CI,
 # that is the signal to add an install step rather than to weaken them.
+def test_ci_actually_has_jq() -> None:
+    """In CI a skip is indistinguishable from a pass, and this file is the
+    thing that pins the precedence contract. A green run that silently
+    skipped every test in it would defeat the purpose of having it.
+
+    So the dependency is enforced where it can be: locally jq is a
+    convenience and its absence skips, in CI its absence fails here with a
+    message naming the fix, rather than seven skips nobody reads.
+
+    .github/workflows/python-tests.yml installs it. This test is what
+    notices if that step is ever dropped.
+    """
+    if os.environ.get("CI") != "true":
+        pytest.skip("only enforced in CI; locally jq is optional")
+
+    assert shutil.which("jq") is not None, (
+        "jq is missing in CI, so the secret-sync collision tests would skip "
+        "and the precedence contract would go unchecked. Restore the "
+        "'Install jq' step in .github/workflows/python-tests.yml."
+    )
+
+
 requires_jq = pytest.mark.skipif(
     shutil.which("jq") is None,
     reason="the rendered secret-sync script needs jq; install it to run these",

--- a/tests/unit/test_secret_sync_collisions.py
+++ b/tests/unit/test_secret_sync_collisions.py
@@ -23,12 +23,28 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import subprocess
 from pathlib import Path
 
 import pytest
 
 from nexus_deploy.secret_sync import StackTarget, render_remote_script
+
+# jq does real work in the rendered script — JSON to TSV — so it cannot be
+# shimmed the way curl and docker are without reimplementing it. Without it
+# the script takes its intentional missing-jq early exit, writes no env
+# file, and every test below fails on an assertion that says nothing about
+# the cause. A skip names the cause instead.
+#
+# Not asserted as always-present: five workflows in this repo use jq
+# without installing it and one installs it explicitly, so "the runner has
+# jq" is a habit here rather than a guarantee. If these ever skip in CI,
+# that is the signal to add an install step rather than to weaken them.
+requires_jq = pytest.mark.skipif(
+    shutil.which("jq") is None,
+    reason="the rendered secret-sync script needs jq; install it to run these",
+)
 
 # A curl that answers from fixture files instead of Infisical. The folder
 # listing and the per-folder secret fetch differ by `secretPath` appearing
@@ -95,10 +111,17 @@ def _run_sync(tmp_path: Path, folders: dict[str, dict[str, str]]) -> tuple[str, 
         },
         check=False,
     )
+    # The exit status is part of what is under test. Without this a failure
+    # anywhere after the env file is written -- cleanup, the compose
+    # recreate -- still satisfies every content assertion below, and the
+    # tests would report a sync that succeeded when it did not.
+    assert proc.returncode == 0, f"sync script exited {proc.returncode}\n{proc.stdout}{proc.stderr}"
+
     env_file = stack_dir / Path(target.env_file).name
     return proc.stdout + proc.stderr, env_file.read_text() if env_file.exists() else ""
 
 
+@requires_jq
 def test_the_alphabetically_first_folder_wins(tmp_path: Path) -> None:
     """Precedence follows `LC_ALL=C sort` over folder names.
 
@@ -119,6 +142,7 @@ def test_the_alphabetically_first_folder_wins(tmp_path: Path) -> None:
     assert "collisions=1" in out
 
 
+@requires_jq
 def test_the_losing_folder_is_named_in_the_log(tmp_path: Path) -> None:
     """The discard is announced, and names both sides.
 
@@ -141,6 +165,7 @@ def test_the_losing_folder_is_named_in_the_log(tmp_path: Path) -> None:
     assert "first-wins" in out
 
 
+@requires_jq
 def test_sorting_is_byte_order_not_locale(tmp_path: Path) -> None:
     """`LC_ALL=C` is not alphabetical: uppercase sorts before lowercase.
 
@@ -162,6 +187,7 @@ def test_sorting_is_byte_order_not_locale(tmp_path: Path) -> None:
     assert "collisions=1" in out
 
 
+@requires_jq
 def test_the_root_folder_loses_to_every_named_folder(tmp_path: Path) -> None:
     """Root is appended after the sorted list, so it is processed last.
 
@@ -182,6 +208,7 @@ def test_the_root_folder_loses_to_every_named_folder(tmp_path: Path) -> None:
     assert "collisions=1" in out
 
 
+@requires_jq
 def test_distinct_keys_across_folders_are_all_kept(tmp_path: Path) -> None:
     """The guard rails: only equal keys collide.
 
@@ -201,6 +228,7 @@ def test_distinct_keys_across_folders_are_all_kept(tmp_path: Path) -> None:
     assert "collisions=0" in out
 
 
+@requires_jq
 @pytest.mark.parametrize("label", ["clickhouse", "postgres"])
 def test_a_key_present_in_only_one_folder_is_never_a_collision(tmp_path: Path, label: str) -> None:
     """A single occurrence is not shadowed, whichever folder holds it."""


### PR DESCRIPTION
Option 1 from #756: pin the behaviour so it stops being an accident.

## What is unpinned today

When the same key appears in two Infisical folders, `secret-sync` keeps the
first and discards the rest. Which folder is "first" comes out of two
mechanisms, neither stated as a rule:

- `secret_sync.py:315` — `jq -r '.folders[]?.name' | LC_ALL=C sort`
- `:316` — the root folder is appended *after* that sorted list, so it is
  processed last and loses every collision

Nothing declared that alphabetically-earlier folders should win, and no test
held it in place. Dropping the sort, switching to a locale-aware one, or
reordering the root append would hand every deployment a different value for a
colliding key. The damage is silent where it matters: the collision is logged
during the deploy, and afterwards a notebook reads `API_KEY` and gets the
`clickhouse` one when `openai` was meant, with nothing at runtime marking the
difference.

## What this adds

Seven tests that run the **real rendered script** with `curl` and `docker`
replaced by shims — the approach `tests/unit/test_repo_secret_script.py` already
uses in this repo.

They cover both ordering rules, the log line that names shadowed folder and
winner, and two guard rails so an over-eager dedup cannot pass:

| Test | Pins |
|---|---|
| alphabetically first folder wins | `clickhouse` beats `postgres` |
| byte order, not locale | `Analytics` beats `analytics` — `LC_ALL=C` is not alphabetical |
| root loses to every named folder | the append-after-sort rule |
| the losing folder is named in the log | shadowed, winner and `first-wins` all present |
| distinct keys are all kept | only equal keys collide |
| a single occurrence is never a collision | parametrised over two folders |

## Mutation-tested, not assumed green

Seven passing tests on a first run is a claim, not evidence, so both rules were
broken deliberately:

| Mutation | Result |
|---|---|
| `LC_ALL=C sort` → `sort -r` | `test_the_alphabetically_first_folder_wins` fails |
| root appended first instead of last | `test_the_root_folder_loses_to_every_named_folder` fails |

Both restored; `git diff` on `secret_sync.py` is empty and the full suite is
`2805 passed`.

Worth recording that my first attempt at the second mutation reported "not
caught" — the replacement string had not matched, so nothing was mutated. The
gap was in the harness, not the test.

## One harness liberty

`compose_dir` is the hardcoded `/opt/docker-server/stacks/<name>`, which a unit
test cannot write to, so the script's copy is rewritten to a tmpdir. That path is
orthogonal to precedence; everything the tests assert on runs unmodified. Stated
in the module docstring rather than only here.

## Scope

`Refs #756`, not `Closes`. This pins the current behaviour; it does not endorse
it. Whether precedence should be explicit — a declared order, a folder prefix, or
failing the phase on collision — is the open question, and the issue is where it
should stay until someone decides. What changes now is that a future change to
the ordering fails here instead of in production.

Also unchanged: whether any current deployment actually has a colliding key. That
would show as `collisions=` on the secret-sync `RESULT` line in a spin-up log; I
have not seen one with a non-zero count.

## Summary by Sourcery

Pin the existing secret-sync collision precedence with end-to-end unit tests so ordering changes fail before reaching deployments.

Enhancements:
- Pin secret-sync collision precedence by testing the real rendered script’s folder ordering, root-folder behavior, collision logging, and key-retention rules.

CI:
- Install jq in the Python test workflow so secret-sync collision tests cannot silently skip in CI.

Tests:
- Add rendered-script tests covering byte-order precedence, root-folder collisions, collision diagnostics, distinct keys, and single-occurrence keys.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded integration-style test coverage for secret synchronization collisions.
  - Verified deterministic first-wins behavior based on folder ordering.
  - Confirmed collision logs identify the losing folder.
  - Added coverage for byte-order sorting and root-folder precedence.
  - Confirmed distinct keys are preserved and keys found in only one folder are not treated as collisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->