### PR TITLE
docs: Align the GH_ACTIONS_TOKEN wording and name both tokens

### DIFF
--- a/docs/admin-guides/setup-guide.md
+++ b/docs/admin-guides/setup-guide.md
@@ -265,11 +265,12 @@ this token is for.
 The token the **Cloudflare** side runs on: the scheduled-teardown Worker and the
 Control Plane's spin-up / teardown / status buttons. It never touches secrets.
 
-Optional, and only in the sense that setup still works without it — the workflow
-falls back to `GH_SECRETS_TOKEN` and says so in the log. Setting it is the point,
-though, because the fallback hands Cloudflare a token with `Secrets: Read and
-write` that it has no use for. Anyone who can read that binding can rewrite
-`HCLOUD_TOKEN` or `CLOUDFLARE_API_TOKEN`, and the next workflow run uses the
+Strongly recommended, and skippable only in the narrow sense that setup still
+completes without it — the workflow falls back to `GH_SECRETS_TOKEN` and says so
+in the log. Treat that as a transitional state: the fallback hands Cloudflare a
+token with `Secrets: Read and write` that it has no use for. Anyone who can read
+that binding can rewrite `HCLOUD_TOKEN` or `CLOUDFLARE_API_TOKEN`, and the next
+workflow run uses the
 replacement — a full takeover of the deployment from a credential parked in an
 edge runtime ([#757](https://github.com/stefanko-ch/Nexus-Stack/issues/757)).
 
@@ -278,6 +279,14 @@ edge runtime ([#757](https://github.com/stefanko-ch/Nexus-Stack/issues/757)).
 - **Actions** → **Read and write** — dispatch workflows, read run status
 - **Contents** → **Read** — the Control Plane reads `releases/latest` for its
   version banner
+
+Two names are involved and only one of them matters to the code. GitHub's
+**Token name** field is free text — it appears in your token list and nowhere
+else — so pick something that survives a year of not thinking about it, such as
+`nexus-stack-cloudflare-actions`. The **repository secret** must be called
+exactly `GH_ACTIONS_TOKEN`: the workflow reads `secrets.GH_ACTIONS_TOKEN`, and
+any other spelling silently takes the fallback, leaving the warning in the log
+with no hint that a typo caused it.
 
 Save it as `GH_ACTIONS_TOKEN`. Then narrow `GH_SECRETS_TOKEN` by removing
 **Actions** (and **Contents**, if you granted it) — and leave **Secrets → Read

--- a/docs/admin-guides/setup-guide.md
+++ b/docs/admin-guides/setup-guide.md
@@ -285,8 +285,11 @@ Two names are involved and only one of them matters to the code. GitHub's
 else — so pick something that survives a year of not thinking about it, such as
 `nexus-stack-cloudflare-actions`. The **repository secret** must be called
 exactly `GH_ACTIONS_TOKEN`: the workflow reads `secrets.GH_ACTIONS_TOKEN`, and
-any other spelling silently takes the fallback, leaving the warning in the log
-with no hint that a typo caused it.
+any other spelling falls back to `GH_SECRETS_TOKEN`, and the warning it logs
+reads *"GH_ACTIONS_TOKEN is not set"* — which is true, and identical to what you
+would see having never created the token at all. The fallback is not silent; the
+typo is. Check the spelling against this page before concluding the secret is
+missing.
 
 Save it as `GH_ACTIONS_TOKEN`. Then narrow `GH_SECRETS_TOKEN` by removing
 **Actions** (and **Contents**, if you granted it) — and leave **Secrets → Read


### PR DESCRIPTION
Two small gaps in the `GH_ACTIONS_TOKEN` documentation, both surfaced by
actually going through the token-creation flow rather than reading it.

## The section and the table disagreed on the first word

`#### GH_ACTIONS_TOKEN` opened with **"Optional"**. The Required Secrets row —
changed in #760 on review feedback — opens with **"Strongly recommended"**.

Both meant the same thing, technically skippable and practically not, but a
reader hitting the table first and the section second gets opposite headlines for
the same secret. That is drift I introduced last round by fixing one of the two
places.

The section now leads with the same judgement and calls an unset value a
transitional state, matching the row.

## Naming was documented by half

*"Save it as `GH_ACTIONS_TOKEN`"* covers the repository secret. Nothing said
anything about GitHub's **Token name** field, which the same flow also asks for.

Two names, and only one is dictated:

| Field | Constraint |
|---|---|
| GitHub **Token name** | free text, appears only in your token list |
| **Repository secret** | must be exactly `GH_ACTIONS_TOKEN` |

The guide now says which is which, suggests `nexus-stack-cloudflare-actions` for
the free one, and states the consequence of getting the fixed one wrong: any
other spelling silently takes the fallback, so the warning stays in the log with
nothing pointing at the typo as the cause.

That last part is the reason this is worth a PR rather than a shrug. The failure
mode of a misspelled secret name is indistinguishable from not having created the
token at all.

Docs only — no code, no behaviour change.

## Summary by Sourcery

Clarify GH_ACTIONS_TOKEN setup guidance and naming requirements in the administration documentation.

Enhancements:
- Align the GH_ACTIONS_TOKEN documentation to consistently describe it as strongly recommended and transitional when omitted.
- Clarify the distinction between GitHub’s token name and the required repository secret name, including the fallback behavior caused by misspelling the secret.

Documentation:
- Update the setup guide with consistent GH_ACTIONS_TOKEN guidance and explicit naming instructions for both token fields.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that configuring `GH_ACTIONS_TOKEN` is strongly recommended.
  - Explained that the GitHub token’s display name can be freely chosen.
  - Specified that the repository secret must be named exactly `GH_ACTIONS_TOKEN` to avoid silently using the fallback secret.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->