### PR TITLE
docs: Record two verification rules this session established

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -47,10 +47,11 @@ Flag any claim of this shape unless the surrounding code guarantees it:
 - **"the next run will take path Y"** without checking the condition that selects the path. In `setup-control-plane.yaml` that is `check_r2`, which requires *both* R2 secrets to be non-empty — so an incomplete pair takes the first-time path, not the recreate path.
 - **"nothing is left behind"** for a cleanup that does not verify its own result.
 - Documentation quoting an error string that the code does not print verbatim. An operator searching the log finds nothing. Prefer making the messages identical over documenting two variants.
+- **A success line naming state the step never read** — `✅ X is set / scoped / configured`. Applies to green output too, and there it is worse: a reassuring line is read less carefully than a red one. A status message may only name state the same step inspected. Seen twice in one PR on the same check — it reported a token's permission scope, which no workflow can read, and then a fallback secret it had never tested for.
 
 When a guarantee cannot be given, say so: *"this step cannot determine which"* is a better failure message than a confident wrong one, and it tells the operator to go look.
 
-Real examples, all from PR #687 review: a recovery message asserted deleted secrets that a `|| true` may have left in place; another said the next run takes a path it does not take; a documented error string matched only one of two code paths.
+Real examples, mostly from PR #687 review: a recovery message asserted deleted secrets that a `|| true` may have left in place; another said the next run takes a path it does not take; a documented error string matched only one of two code paths.
 
 ## 5. Error handling in critical operations
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -293,8 +293,8 @@ mutation that silently fails to apply, or that lands on a branch the test never
 executes, looks exactly like a passing test with a gap. Both happened here: one
 replacement string did not match after escaping, and one changed a `docker`
 invocation the rendered script never emits for that target, because
-`force_recreate` is false. Neither was a weak test; both would have been
-reported as one.
+`force_recreate` is false. Neither test was weak, but both would have been
+reported as missing coverage — and the first one was, before it was checked.
 
 **Never report an action as done before its tool call has returned.** Write the
 sentence after the result, not while planning the call — a wrong "I have

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -278,6 +278,23 @@ The recurring shapes, all observed in this repo:
 | "nothing is left behind" | Does the cleanup verify its own result, or only attempt it? |
 | A doc quoting an error string | Does the code print it verbatim? Two code paths with near-identical wording means a log search finds only one. Make the messages identical rather than documenting both. |
 | "this test / run covers X" | Trace it. A rebuild spin-up does not exercise a restored Postgres data directory, because `s3_restore` persists that database as a `pg_dump`, not as a filesystem tree. |
+| A **success** line: "X is set / scoped / configured" | Does this step read that? A status message may only name state the same step inspected. Twice in one PR a Cloudflare check reported a permission scope no workflow can read, then a fallback token it never tested for — both true-sounding, both unknowable there. |
+
+**The rule covers success messages, not only failures.** A green line is read
+less carefully than a red one, which makes a wrong one worse rather than
+better: `✅ scoped to what it needs` reassures about permissions the runner
+cannot see, and `falls back to X` names a secret the step never checked exists.
+Both survived review once and were caught the second time. If a status line
+mentions something the step did not read, either read it or drop the mention.
+
+**A mutation test proves nothing until the mutation reaches the code.** Break
+the behaviour deliberately, and confirm the test fails *for that reason* — a
+mutation that silently fails to apply, or that lands on a branch the test never
+executes, looks exactly like a passing test with a gap. Both happened here: one
+replacement string did not match after escaping, and one changed a `docker`
+invocation the rendered script never emits for that target, because
+`force_recreate` is false. Neither was a weak test; both would have been
+reported as one.
 
 **Never report an action as done before its tool call has returned.** Write the
 sentence after the result, not while planning the call — a wrong "I have


### PR DESCRIPTION
Two rules, both generalisations of mistakes made more than once in the
#751–#762 series rather than speculation about what could go wrong.

## 1. The verifiable-claims rule covers success lines

`CLAUDE.md` already says a claim about system behaviour must point at the code
that makes it true — but the section is titled *"especially in error messages"*
and every example is a failure path. That left the more dangerous half unstated:
green output is read less carefully than red, so a wrong reassurance survives
longer than a wrong error.

The same Cloudflare token check in #760 was flagged twice, in separate rounds,
for the same fault:

| Round | The line said | What the step had read |
|---|---|---|
| 1 | `scoped to what it needs` | nothing — a token's permissions are not visible to a workflow |
| 3 | `Cloudflare will be given GH_SECRETS_TOKEN instead` | only `GH_ACTIONS_TOKEN`; the fallback secret was never tested for |

Both read as reassurance, neither was knowable at that point, and the second was
wrong on precisely the failing run the step exists to help.

The rule: **a status message may only name state the same step inspected.** If it
mentions something the step did not read, either read it or drop the mention.

`.github/copilot-instructions.md` §4a gains the same shape as a bullet, since
this half is reviewable in a diff — it is a list of claim forms the reviewer
should flag, and this is another form.

## 2. A mutation test proves nothing until the mutation reaches the code

Twice in one afternoon a mutation looked like it had exposed a gap when it had
simply not applied:

- reversing the folder sort in `secret_sync.py` — the replacement string did not
  match after escaping, so nothing was mutated and the tests passed
- making the `docker` shim exit 1 — the rendered script emits **no** docker
  invocation for the `jupyter` target, because `force_recreate` is false, so the
  shim was never called

Neither was a weak test. Both would have been reported as missing coverage, and
in the first case I did report it before checking.

The rule: break the behaviour deliberately, then confirm the test fails **for
that reason**. A mutation that silently fails to apply, or lands on a branch the
test never executes, is indistinguishable from a passing test with a hole.

This one stays out of the Copilot instructions: it describes how to verify a
change, not something visible in a diff.

Docs only — no code, no behaviour change.

## Summary by Sourcery

Document two verification rules covering trustworthy success messages and mutation tests that demonstrably exercise the intended behavior.

Enhancements:
- Document that success messages must only claim state inspected by the reporting step.
- Document that mutation tests must verify the mutation applied and reached the exercised code path.

Documentation:
- Extend verification guidance in CLAUDE.md and Copilot instructions with rules for verifiable success claims and effective mutation testing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated runtime-behavior review guidance to prevent success messages from claiming unverified state.
  * Added mutation-testing guidance requiring mutations to apply successfully and reach the relevant test path.
  * Refined examples describing the source of the guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->