### PR TITLE
feat(deploy): Preflight the PostgreSQL data-directory major

### DIFF
--- a/docs/admin-guides/snapshot-lifecycle.md
+++ b/docs/admin-guides/snapshot-lifecycle.md
@@ -153,7 +153,8 @@ An image still in `creating` state cannot be deleted through the API. Purge name
 ### A database refuses to start after a PostgreSQL version bump
 
 The deploy now stops before this happens, with a message naming both
-versions and the volume. Before the preflight
+versions and, per database, the exact command that discards the data.
+Before the preflight
 ([#734](https://github.com/stefanko-ch/Nexus-Stack/issues/734)) it showed up
 as a restart loop and `compose up failed`, with the cause a `docker logs`
 away.
@@ -167,10 +168,11 @@ it.
 
 The message offers the two ways out. Migrating means starting the old
 major against the volume, `pg_dump`, then the new major against an empty
-volume and `pg_restore`. Discarding means `docker volume rm` (or clearing
-the bind-mounted directory under `/mnt/nexus-data`) and deploying again —
-fine for a stack that rebuilds its own schema, not for one holding data
-you want.
+volume and `pg_restore`. Discarding means `docker volume rm <volume>` for a
+named volume, or `find <dir> -mindepth 1 -delete` for one of the bind mounts
+under `/mnt/nexus-data` — emptied rather than removed, so the ownership
+`ensure_data_dirs` gave the directory survives. Then deploy again. Fine for a
+stack that rebuilds its own schema, not for one holding data you want.
 
 Re-running the deploy is the one thing that does not help: it reproduces
 the same state exactly.

--- a/docs/admin-guides/snapshot-lifecycle.md
+++ b/docs/admin-guides/snapshot-lifecycle.md
@@ -150,6 +150,31 @@ An image still in `creating` state cannot be deleted through the API. Purge name
 
 ## What can go wrong
 
+### A database refuses to start after a PostgreSQL version bump
+
+The deploy now stops before this happens, with a message naming both
+versions and the volume. Before the preflight
+([#734](https://github.com/stefanko-ch/Nexus-Stack/issues/734)) it showed up
+as a restart loop and `compose up failed`, with the cause a `docker logs`
+away.
+
+PostgreSQL will not start against a data directory written by an older
+major. On the **rebuild** lifecycle that never arises — the directory is
+destroyed with the server, and the database is recreated from the
+application's own migrations, so a major bump is free. On **snapshot** the
+directory comes back physically, and it outlives the image tag that wrote
+it.
+
+The message offers the two ways out. Migrating means starting the old
+major against the volume, `pg_dump`, then the new major against an empty
+volume and `pg_restore`. Discarding means `docker volume rm` (or clearing
+the bind-mounted directory under `/mnt/nexus-data`) and deploying again —
+fine for a stack that rebuilds its own schema, not for one holding data
+you want.
+
+Re-running the deploy is the one thing that does not help: it reproduces
+the same state exactly.
+
 ### The snapshot is refused and the stack rebuilds fresh
 
 This is the **designed** behaviour, not a fault. A snapshot is only used when it is genuinely usable. It is skipped when:

--- a/src/nexus_deploy/orchestrator.py
+++ b/src/nexus_deploy/orchestrator.py
@@ -1227,7 +1227,7 @@ class Orchestrator:
             return PhaseResult(
                 name="pg-preflight",
                 status="failed",
-                detail=f"{len(result.mismatches)} data directory/ies on a different major",
+                detail=f"{len(result.mismatches)} data directories on a different major",
             )
 
         detail = f"{result.checked} checked, {result.absent} not yet initialised"

--- a/src/nexus_deploy/orchestrator.py
+++ b/src/nexus_deploy/orchestrator.py
@@ -46,6 +46,7 @@ import re
 import shlex
 import socket
 import subprocess
+import sys
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -59,6 +60,7 @@ from nexus_deploy import forgejo as _forgejo
 from nexus_deploy import forgejo_runner as _forgejo_runner
 from nexus_deploy import infisical as _infisical
 from nexus_deploy import kestra as _kestra
+from nexus_deploy import pg_preflight as _pg_preflight
 from nexus_deploy import secret_sync as _secret_sync
 from nexus_deploy import seeder as _seeder
 from nexus_deploy import service_env as _service_env
@@ -1189,6 +1191,55 @@ class Orchestrator:
             status="ok",
             detail=(f"rendered={len(gen.compiled)} redpanda={'yes' if gen.redpanda else 'no'}"),
         )
+
+    def _phase_pg_preflight(self) -> PhaseResult:
+        """Refuse to start containers whose data directory is a different
+        PostgreSQL major (#734).
+
+        Placed before ``_phase_compose_up`` rather than inside it: once
+        `docker compose up` has run, the failure is already a restart loop
+        and the diagnosis is a log line away. The point is to fail with
+        the cause instead.
+
+        Only reachable under the snapshot lifecycle, where the data
+        directory outlives the image tag. On a rebuild it is destroyed
+        with the server, so this phase finds nothing and says so.
+        """
+        try:
+            result = _pg_preflight.run_preflight(
+                self.enabled_services,
+                stacks_dir=Path("stacks"),
+                host=self.ssh_host,
+            )
+        except Exception as exc:
+            # The probe failing is not a reason to stop a deploy that
+            # would otherwise proceed; it is a reason to say the check did
+            # not happen. type(exc).__name__ per CLAUDE.md — an exception
+            # string can carry a credential.
+            return PhaseResult(
+                name="pg-preflight",
+                status="partial",
+                detail=f"could not run ({type(exc).__name__})",
+            )
+
+        if not result.ok:
+            sys.stderr.write(_pg_preflight.format_failure(result.mismatches) + "\n")
+            return PhaseResult(
+                name="pg-preflight",
+                status="failed",
+                detail=f"{len(result.mismatches)} data directory/ies on a different major",
+            )
+
+        detail = f"{result.checked} checked, {result.absent} not yet initialised"
+        if result.unverified:
+            return PhaseResult(
+                name="pg-preflight",
+                status="partial",
+                detail=detail
+                + f", {len(result.unverified)} unverified: "
+                + ", ".join(result.unverified),
+            )
+        return PhaseResult(name="pg-preflight", status="ok", detail=detail)
 
     def _phase_compose_up(self) -> PhaseResult:
         """Start containers in parallel via
@@ -2423,6 +2474,7 @@ class Orchestrator:
             self._phase_stack_sync,
             self._phase_firewall_sync,  # NEW (4b1)
             self._phase_global_env,  # NEW (4b1)
+            self._phase_pg_preflight,
             self._phase_compose_up,
             self._phase_infisical_provision,
         ]

--- a/src/nexus_deploy/orchestrator.py
+++ b/src/nexus_deploy/orchestrator.py
@@ -1208,7 +1208,7 @@ class Orchestrator:
         try:
             result = _pg_preflight.run_preflight(
                 self.enabled_services,
-                stacks_dir=Path("stacks"),
+                stacks_dir=self.project_root / "stacks",
                 host=self.ssh_host,
             )
         except Exception as exc:

--- a/src/nexus_deploy/pg_preflight.py
+++ b/src/nexus_deploy/pg_preflight.py
@@ -1,0 +1,357 @@
+"""PostgreSQL major-version preflight for the stacks about to start.
+
+PostgreSQL refuses to start against a data directory written by an older
+major. The container then restart-loops and everything behind that
+database is down::
+
+    FATAL:  database files are incompatible with server
+    DETAIL: The data directory was initialized by PostgreSQL version 16,
+            which is not compatible with this version 18.
+
+Nothing is lost quietly — ``compose_runner`` counts the stack as failed
+and the smoke check marks it ``RESTARTING`` — but the operator sees
+"compose up failed" and has to go find the log line to learn that the
+cause is a major mismatch and the fix is a dump/restore rather than a
+retry. This closes that gap by checking before anything starts (#734).
+
+**Only the snapshot lifecycle can reach it.** A ``rebuild`` teardown
+destroys the data directory with the server, so the database is recreated
+from the application's own migrations and a major bump is free. A
+``snapshot`` teardown preserves it physically in the Hetzner disk image,
+where it outlives the image tag that wrote it. The six databases in
+``s3_restore``'s ``PostgresDumpTarget`` list are a third path again:
+``pg_dump``/``pg_restore`` is logical and crosses majors on its own.
+
+**Where PG_VERSION lives depends on the major**, which is why the scan
+looks in four places rather than one. Up to 17 the image mounts
+``/var/lib/postgresql/data`` and writes ``PG_VERSION`` at its root. From
+18 the recommended layout mounts ``/var/lib/postgresql`` one level up,
+with the cluster at ``<major>/docker`` inside it. A stack may also pin
+``PGDATA`` to a subdirectory. The volume is searched for whichever of
+these exists, exactly as the image's own entrypoint scans for a legacy
+cluster.
+"""
+
+from __future__ import annotations
+
+import re
+import shlex
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol
+
+import yaml
+
+# `postgres:<digits>` and nothing else. Deliberately strict: matching on
+# the substring "postgres" also catches `postgrest/postgrest:v14.12`,
+# which is an HTTP layer over a database rather than a database, has no
+# data directory, and would be reported as an unparseable major forever.
+_POSTGRES_IMAGE = re.compile(r"\bpostgres:(\d+)")
+
+# Candidate locations of PG_VERSION inside the mounted volume, relative to
+# its root. Order matters only for reporting; at most one exists.
+_PG_VERSION_CANDIDATES = (
+    "PG_VERSION",  # <=17, volume at /var/lib/postgresql/data
+    "pgdata/PG_VERSION",  # explicit PGDATA under the same mount
+    "data/PG_VERSION",  # volume one level up, pre-18 cluster inside
+    "*/docker/PG_VERSION",  # 18+, cluster at <major>/docker
+)
+
+
+@dataclass(frozen=True)
+class PgContainer:
+    """One PostgreSQL service the deploy is about to start."""
+
+    stack: str
+    """Directory under ``stacks/`` — also the compose project name, since
+    ``compose_runner`` runs ``cd stacks/<name> && docker compose up``."""
+
+    service: str
+    """Compose service name, for the message the operator reads."""
+
+    source: str
+    """Where the data directory lives: a named volume as written in the
+    compose file, or an absolute host path for a bind mount."""
+
+    is_bind: bool
+    """True for a host path. Both forms need checking under the snapshot
+    lifecycle — the disk image carries ``/mnt/nexus-data`` back exactly as
+    it carries a named volume, so a bind-mounted cluster meets the same
+    wall. The S3 ``PostgresDumpTarget`` list covers three of these on the
+    *rebuild* path, where the dump is logical and crosses majors, but that
+    path never sees this failure at all."""
+
+    expected_major: int
+    """Major from the image tag in the compose file.
+
+    The tag there is a fallback — ``${IMAGE_X:-postgres:18-alpine}`` — and
+    the deploy may override it from ``tofu output image_versions``. Using
+    the fallback is safe because all three agree by construction: the
+    override is derived from ``services.yaml``, and
+    ``test_compose_fallbacks_match_the_declared_version`` fails the suite
+    if a fallback ever drifts from it.
+    """
+
+    @property
+    def qualified_volume(self) -> str:
+        """What the operator has to name to remove it — a bind path as
+        given, a named volume with the Compose project prefix."""
+        return self.source if self.is_bind else f"{self.stack}_{self.source}"
+
+
+@dataclass(frozen=True)
+class Mismatch:
+    stack: str
+    service: str
+    volume: str
+    found_major: str
+    expected_major: int
+
+
+@dataclass(frozen=True)
+class PreflightResult:
+    checked: int
+    """Containers whose volume existed and held a cluster."""
+
+    absent: int
+    """Probed, and there is no cluster there yet — a first start."""
+
+    unverified: tuple[str, ...]
+    """Containers the probe reported nothing for, as ``stack/service``.
+
+    Kept apart from ``absent`` because they are a different statement:
+    "there is no data directory" is a finding, "the check did not run
+    there" is the lack of one. Folding them together would let a broken
+    probe read as a clean bill of health.
+    """
+
+    mismatches: tuple[Mismatch, ...]
+
+    @property
+    def ok(self) -> bool:
+        """No mismatch found. Deliberately not "and everything was
+        checked": an unverifiable container should not block a deploy that
+        would otherwise proceed — the caller reports it instead."""
+        return not self.mismatches
+
+
+class ScriptRunner(Protocol):
+    def __call__(self, script: str, *, host: str) -> str: ...
+
+
+def discover_pg_containers(stacks_dir: Path) -> list[PgContainer]:
+    """Every PostgreSQL service across the stack compose files.
+
+    Included when the image tag names a major and something is mounted
+    under ``/var/lib/postgresql`` — named volume or bind mount alike.
+
+    Bind mounts were excluded in the first draft, on the reasoning that
+    ``/mnt/nexus-data`` is covered by the S3 layer. That is true and
+    beside the point: the S3 dump is logical and only runs on the rebuild
+    path, which cannot reach this failure anyway. On the snapshot path the
+    disk image carries those directories back byte for byte, so
+    ``dify-db``, ``forgejo-db`` and ``gitea-db`` hit the same wall as any
+    named volume — and they were the three the exclusion dropped.
+    """
+    found: list[PgContainer] = []
+    for compose in sorted(stacks_dir.glob("*/docker-compose.yml")):
+        parsed = yaml.safe_load(compose.read_text()) or {}
+        for service, spec in (parsed.get("services") or {}).items():
+            if not isinstance(spec, dict):
+                continue
+            match = _POSTGRES_IMAGE.search(str(spec.get("image", "")))
+            if match is None:
+                continue
+            mount = _data_mount_for(spec)
+            if mount is None:
+                continue
+            source, is_bind = mount
+            found.append(
+                PgContainer(
+                    stack=compose.parent.name,
+                    service=str(service),
+                    source=source,
+                    is_bind=is_bind,
+                    expected_major=int(match.group(1)),
+                )
+            )
+    return found
+
+
+def _data_mount_for(spec: dict[str, object]) -> tuple[str, bool] | None:
+    """``(source, is_bind)`` for the data directory, or None.
+
+    Matches on the container-side path rather than the source, since the
+    source is arbitrary — `postgres-data`, `evidence-db-data`,
+    `/mnt/nexus-data/gitea/db` — while the target is always under
+    /var/lib/postgresql.
+    """
+    volumes = spec.get("volumes")
+    if not isinstance(volumes, list):
+        return None
+    for entry in volumes:
+        if not isinstance(entry, str) or ":" not in entry:
+            continue
+        source, target = entry.split(":")[:2]
+        if not target.startswith("/var/lib/postgresql"):
+            continue
+        return source, source.startswith((".", "/"))
+    return None
+
+
+def render_preflight_script(containers: list[PgContainer]) -> str:
+    """Bash that reads each volume's PG_VERSION and reports one line each.
+
+    Reads the host path from ``docker volume inspect`` rather than
+    guessing ``/var/lib/docker/volumes/...``: the docker root is
+    configurable, and inspect is the only thing that knows where it is.
+
+    Emits ``PGCHECK <stack> <service> <found> <expected>`` per container,
+    with ``found`` set to ``-`` when the volume or the cluster is absent.
+    Comparing here rather than in bash keeps the decision, the message and
+    its tests in one language.
+    """
+    lines = [
+        "set -uo pipefail",
+        "",
+    ]
+    for c in containers:
+        lines.append(
+            f"STACK={shlex.quote(c.stack)}; SVC={shlex.quote(c.service)}; WANT={c.expected_major}"
+        )
+        if c.is_bind:
+            lines.append(f"MP={shlex.quote(c.source)}")
+        else:
+            lines.append(f"VOL={shlex.quote(c.qualified_volume)}")
+            lines.append(
+                'MP=$(docker volume inspect "$VOL" '
+                "--format '{{.Mountpoint}}' 2>/dev/null || true)"
+            )
+        lines.append('FOUND="-"')
+        lines.append('if [ -n "$MP" ] && [ -d "$MP" ]; then')
+        lines.append(
+            "  for rel in " + " ".join(shlex.quote(p) for p in _PG_VERSION_CANDIDATES) + "; do"
+        )
+        lines.append('    for f in "$MP"/$rel; do')
+        lines.append('      if [ -s "$f" ]; then FOUND=$(tr -d "[:space:]" < "$f"); break 2; fi')
+        lines.append("    done")
+        lines.append("  done")
+        lines.append("fi")
+        lines.append('echo "PGCHECK $STACK $SVC $FOUND $WANT"')
+        lines.append("")
+    return "\n".join(lines)
+
+
+def parse_result(stdout: str, containers: list[PgContainer]) -> PreflightResult:
+    """Turn the ``PGCHECK`` lines into a verdict.
+
+    The script emits one line per container unconditionally, so a missing
+    line means the probe did not run there. Those are listed separately
+    rather than counted as absent — see ``PreflightResult.unverified``.
+    """
+    by_key = {(c.stack, c.service): c for c in containers}
+    checked = 0
+    absent = 0
+    mismatches: list[Mismatch] = []
+    seen: set[tuple[str, str]] = set()
+
+    for line in stdout.splitlines():
+        parts = line.split()
+        if len(parts) != 5 or parts[0] != "PGCHECK":
+            continue
+        _, stack, service, found, want = parts
+        seen.add((stack, service))
+        if found == "-":
+            absent += 1
+            continue
+        checked += 1
+        if found != want:
+            container = by_key.get((stack, service))
+            mismatches.append(
+                Mismatch(
+                    stack=stack,
+                    service=service,
+                    volume=container.qualified_volume if container else "",
+                    found_major=found,
+                    expected_major=int(want),
+                )
+            )
+
+    unverified = tuple(
+        f"{c.stack}/{c.service}" for c in containers if (c.stack, c.service) not in seen
+    )
+    return PreflightResult(
+        checked=checked, absent=absent, unverified=unverified, mismatches=tuple(mismatches)
+    )
+
+
+def format_failure(mismatches: tuple[Mismatch, ...]) -> str:
+    """The message an operator reads instead of hunting through logs.
+
+    Names both versions and both ways out, because the wrong instinct
+    here is to re-run the deploy — which reproduces the restart loop
+    exactly.
+    """
+    out = [
+        "❌ PostgreSQL data directory was written by a different major version.",
+        "",
+        "   Starting these containers would fail with 'database files are",
+        "   incompatible with server' and leave them restart-looping:",
+        "",
+    ]
+    for m in mismatches:
+        out.append(
+            f"     {m.stack}/{m.service}: data is PostgreSQL {m.found_major}, "
+            f"image is {m.expected_major}  (volume {m.volume})"
+        )
+    out += [
+        "",
+        "   Re-running the deploy will not help — it reproduces the same loop.",
+        "   Two ways out, per database:",
+        "",
+        "     1. Migrate the data. Start the OLD major against the volume,",
+        "        `pg_dump` it, start the new one against an empty volume and",
+        "        `pg_restore` into it.",
+        "     2. Discard the data, if the stack can rebuild it:",
+        "        `docker volume rm <volume>` and deploy again.",
+        "",
+        "   Reached only under the snapshot lifecycle — a rebuild teardown",
+        "   drops the volume with the server, so the same bump is free there.",
+        "   See docs/admin-guides/snapshot-lifecycle.md.",
+    ]
+    return "\n".join(out)
+
+
+def run_preflight(
+    enabled: list[str],
+    *,
+    stacks_dir: Path,
+    host: str = "nexus",
+    script_runner: ScriptRunner | None = None,
+) -> PreflightResult:
+    """Render → exec → parse, for the enabled stacks only.
+
+    Restricting to ``enabled`` is not an optimisation: a disabled stack's
+    volume may well hold an old cluster, and reporting it would block a
+    deploy over a database nothing is about to start. The check has to
+    describe the run that is happening.
+    """
+    containers = [c for c in discover_pg_containers(stacks_dir) if c.stack in set(enabled)]
+    if not containers:
+        return PreflightResult(checked=0, absent=0, unverified=(), mismatches=())
+
+    runner = script_runner or _default_runner
+    stdout = runner(render_preflight_script(containers), host=host)
+    return parse_result(stdout, containers)
+
+
+def _default_runner(script: str, *, host: str) -> str:
+    from nexus_deploy import _remote
+
+    # check=False: a non-zero status means the probe itself could not run.
+    # Raising here would turn "could not look" into "must not deploy",
+    # which is the wrong trade for a check that only ever prevents a
+    # restart loop. Containers with no PGCHECK line land in
+    # `PreflightResult.unverified`, which the caller reports — so the gap
+    # is visible without being fatal.
+    return _remote.ssh_run_script(script, host=host, check=False).stdout

--- a/src/nexus_deploy/pg_preflight.py
+++ b/src/nexus_deploy/pg_preflight.py
@@ -44,16 +44,17 @@ from typing import Protocol
 
 import yaml
 
+# Where the compose files live on the server. Mirrors compose_runner's
+# constant rather than importing it, the way compose_restart already does.
+# A relative bind source is resolved against the stack's directory below,
+# because Compose resolves it against the directory holding the compose
+# file — which on the server is this.
+_REMOTE_STACKS_DIR = "/opt/docker-server/stacks"
+
 # `postgres:<digits>` and nothing else. Deliberately strict: matching on
 # the substring "postgres" also catches `postgrest/postgrest:v14.12`,
 # which is an HTTP layer over a database rather than a database, has no
 # data directory, and would be reported as an unparseable major forever.
-# Mirrors compose_runner's constant rather than importing it, the way
-# compose_restart already does. A relative bind source is resolved against
-# the stack's directory here, because Compose resolves it against the
-# directory holding the compose file — which on the server is this.
-_REMOTE_STACKS_DIR = "/opt/docker-server/stacks"
-
 _POSTGRES_IMAGE = re.compile(r"\bpostgres:(\d+)")
 
 # Candidate locations of PG_VERSION inside the mounted volume, relative to
@@ -172,12 +173,16 @@ def discover_pg_containers(stacks_dir: Path) -> list[PgContainer]:
     for compose in sorted(stacks_dir.glob("*/docker-compose.yml")):
         try:
             parsed = yaml.safe_load(compose.read_text())
-        except (OSError, yaml.YAMLError) as exc:
+        except (OSError, UnicodeDecodeError, yaml.YAMLError) as exc:
             # Named, not swallowed. The file may well belong to a stack
             # this deploy never starts — a *disabled* stack's compose file
             # is never fed to compose-up, so "it fails loudly later" is
             # not true of it, and letting the exception out would take the
             # check down for every enabled stack instead.
+            #
+            # UnicodeDecodeError is named separately because it is a
+            # ValueError, not an OSError — `read_text` raises it before
+            # yaml sees the file, so the other two do not cover it.
             sys.stderr.write(
                 f"⚠️  pg-preflight: skipping {compose} ({type(exc).__name__}); "
                 "the databases it defines go unchecked\n"

--- a/src/nexus_deploy/pg_preflight.py
+++ b/src/nexus_deploy/pg_preflight.py
@@ -34,8 +34,10 @@ cluster.
 
 from __future__ import annotations
 
+import posixpath
 import re
 import shlex
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Protocol
@@ -46,6 +48,12 @@ import yaml
 # the substring "postgres" also catches `postgrest/postgrest:v14.12`,
 # which is an HTTP layer over a database rather than a database, has no
 # data directory, and would be reported as an unparseable major forever.
+# Mirrors compose_runner's constant rather than importing it, the way
+# compose_restart already does. A relative bind source is resolved against
+# the stack's directory here, because Compose resolves it against the
+# directory holding the compose file — which on the server is this.
+_REMOTE_STACKS_DIR = "/opt/docker-server/stacks"
+
 _POSTGRES_IMAGE = re.compile(r"\bpostgres:(\d+)")
 
 # Candidate locations of PG_VERSION inside the mounted volume, relative to
@@ -162,7 +170,19 @@ def discover_pg_containers(stacks_dir: Path) -> list[PgContainer]:
     """
     found: list[PgContainer] = []
     for compose in sorted(stacks_dir.glob("*/docker-compose.yml")):
-        parsed = yaml.safe_load(compose.read_text())
+        try:
+            parsed = yaml.safe_load(compose.read_text())
+        except (OSError, yaml.YAMLError) as exc:
+            # Named, not swallowed. The file may well belong to a stack
+            # this deploy never starts — a *disabled* stack's compose file
+            # is never fed to compose-up, so "it fails loudly later" is
+            # not true of it, and letting the exception out would take the
+            # check down for every enabled stack instead.
+            sys.stderr.write(
+                f"⚠️  pg-preflight: skipping {compose} ({type(exc).__name__}); "
+                "the databases it defines go unchecked\n"
+            )
+            continue
         # One odd file must cost only itself. Without these two guards a
         # compose file parsing to a list makes `.get` raise, the phase
         # catches it and reports "partial", and every *other* stack goes
@@ -184,6 +204,14 @@ def discover_pg_containers(stacks_dir: Path) -> list[PgContainer]:
             if mount is None:
                 continue
             source, is_bind = mount
+            if is_bind and not source.startswith("/"):
+                # Compose resolves "./db" against the compose file's own
+                # directory; the probe runs from the SSH login directory.
+                # Left relative it would name a path that does not exist,
+                # report absent, and pass the phase on a directory nobody
+                # looked at — and the printed recovery command would point
+                # somewhere else again.
+                source = posixpath.normpath(f"{_REMOTE_STACKS_DIR}/{compose.parent.name}/{source}")
             found.append(
                 PgContainer(
                     stack=compose.parent.name,

--- a/src/nexus_deploy/pg_preflight.py
+++ b/src/nexus_deploy/pg_preflight.py
@@ -106,6 +106,9 @@ class Mismatch:
     volume: str
     found_major: str
     expected_major: int
+    is_bind: bool = False
+    """`volume` is a host path, not a named volume — which changes both
+    what it is called and how it is discarded."""
 
 
 @dataclass(frozen=True)
@@ -189,17 +192,45 @@ def _data_mount_for(spec: dict[str, object]) -> tuple[str, bool] | None:
     source is arbitrary — `postgres-data`, `evidence-db-data`,
     `/mnt/nexus-data/gitea/db` — while the target is always under
     /var/lib/postgresql.
+
+    Both Compose volume syntaxes are read. Every stack uses the short
+    string form today, but a long-form mapping would otherwise be skipped
+    *silently*: the service drops out of the probe, and the mismatch this
+    module exists to catch reaches `compose up` unannounced.
     """
     volumes = spec.get("volumes")
     if not isinstance(volumes, list):
         return None
     for entry in volumes:
-        if not isinstance(entry, str) or ":" not in entry:
+        parsed = _parse_volume_entry(entry)
+        if parsed is None:
             continue
-        source, target = entry.split(":")[:2]
+        source, target, is_bind = parsed
         if not target.startswith("/var/lib/postgresql"):
             continue
-        return source, source.startswith((".", "/"))
+        return source, is_bind
+    return None
+
+
+def _parse_volume_entry(entry: object) -> tuple[str, str, bool] | None:
+    """``(source, target, is_bind)`` for one Compose ``volumes`` entry."""
+    if isinstance(entry, str):
+        if ":" not in entry:
+            return None
+        source, target = entry.split(":")[:2]
+        return source, target, source.startswith((".", "/"))
+    if isinstance(entry, dict):
+        src = entry.get("source")
+        tgt = entry.get("target")
+        if not isinstance(src, str) or not isinstance(tgt, str):
+            # `type: tmpfs` carries a target and no source; nothing to probe.
+            return None
+        # `type` is authoritative where present. A long-form bind may name
+        # a relative source ("./initdb"), which the leading-character test
+        # would read as a named volume.
+        kind = entry.get("type")
+        is_bind = kind == "bind" if isinstance(kind, str) else src.startswith((".", "/"))
+        return src, tgt, is_bind
     return None
 
 
@@ -243,7 +274,7 @@ def render_preflight_script(containers: list[PgContainer]) -> str:
                 "--format '{{.Mountpoint}}' 2>/dev/null || true)"
             )
         lines.append('FOUND="-"')
-        lines.append('if [ -n "$MP" ] && [ -d "$MP" ]; then')
+        lines.append('if [ -d "$MP" ]; then')
         lines.append(
             "  for rel in " + " ".join(shlex.quote(p) for p in _PG_VERSION_CANDIDATES) + "; do"
         )
@@ -251,6 +282,22 @@ def render_preflight_script(containers: list[PgContainer]) -> str:
         lines.append('      if [ -s "$f" ]; then FOUND=$(tr -d "[:space:]" < "$f"); break 2; fi')
         lines.append("    done")
         lines.append("  done")
+        # `-` has to keep meaning "no cluster here", because that is what
+        # lets the phase pass. A directory that cannot be listed, or one
+        # holding files this probe does not recognise, establishes no such
+        # thing — report it as undetermined and let the phase say so.
+        lines.append('  if [ "$FOUND" = "-" ]; then')
+        lines.append('    if ENTRIES=$(ls -A "$MP" 2>/dev/null); then')
+        lines.append('      [ -n "$ENTRIES" ] && FOUND="?"')
+        lines.append("    else")
+        lines.append('      FOUND="?"')
+        lines.append("    fi")
+        lines.append("  fi")
+        if not c.is_bind:
+            # inspect named a mountpoint, so the volume exists; a bind
+            # source that is simply not there is a genuine `-`.
+            lines.append('elif [ -n "$MP" ]; then')
+            lines.append('  FOUND="?"')
         lines.append("fi")
         lines.append('echo "PGCHECK $STACK $SVC $FOUND $WANT"')
         lines.append("")
@@ -289,6 +336,9 @@ def parse_result(stdout: str, containers: list[PgContainer]) -> PreflightResult:
         if found == "-":
             absent += 1
             continue
+        if found == "?":
+            unreadable.append(f"{stack}/{service} (data directory could not be read)")
+            continue
         if not found.isdigit():
             # A PG_VERSION holding something other than a major is a
             # damaged directory, not a version. Comparing it would report
@@ -306,6 +356,7 @@ def parse_result(stdout: str, containers: list[PgContainer]) -> PreflightResult:
                     volume=container.qualified_volume if container else "",
                     found_major=found,
                     expected_major=int(want),
+                    is_bind=container.is_bind if container else False,
                 )
             )
 
@@ -333,9 +384,10 @@ def format_failure(mismatches: tuple[Mismatch, ...]) -> str:
         "",
     ]
     for m in mismatches:
+        where = "bind mount" if m.is_bind else "volume"
         out.append(
             f"     {m.stack}/{m.service}: data is PostgreSQL {m.found_major}, "
-            f"image is {m.expected_major}  (volume {m.volume})"
+            f"image is {m.expected_major}  ({where} {m.volume})"
         )
     out += [
         "",
@@ -345,8 +397,20 @@ def format_failure(mismatches: tuple[Mismatch, ...]) -> str:
         "     1. Migrate the data. Start the OLD major against the volume,",
         "        `pg_dump` it, start the new one against an empty volume and",
         "        `pg_restore` into it.",
-        "     2. Discard the data, if the stack can rebuild it:",
-        "        `docker volume rm <volume>` and deploy again.",
+        "     2. Discard the data, if the stack can rebuild it, then deploy",
+        "        again. A bind mount is emptied rather than removed, so that",
+        "        the ownership `setup` gave the directory survives:",
+        "",
+    ]
+    for m in mismatches:
+        # `find -mindepth 1 -delete` over `rm -rf <dir>/*`: it takes
+        # dotfiles too, and leaves the directory itself in place.
+        out.append(
+            f"        find {m.volume} -mindepth 1 -delete"
+            if m.is_bind
+            else f"        docker volume rm {m.volume}"
+        )
+    out += [
         "",
         "   Reached only under the snapshot lifecycle — a rebuild teardown",
         "   drops the volume with the server, so the same bump is free there.",

--- a/src/nexus_deploy/pg_preflight.py
+++ b/src/nexus_deploy/pg_preflight.py
@@ -279,9 +279,18 @@ def render_preflight_script(containers: list[PgContainer]) -> str:
             "  for rel in " + " ".join(shlex.quote(p) for p in _PG_VERSION_CANDIDATES) + "; do"
         )
         lines.append('    for f in "$MP"/$rel; do')
-        lines.append('      if [ -s "$f" ]; then FOUND=$(tr -d "[:space:]" < "$f"); break 2; fi')
+        lines.append(
+            '      if [ -s "$f" ]; then FOUND=$(tr -d "[:space:]" < "$f" 2>/dev/null); break 2; fi'
+        )
         lines.append("    done")
         lines.append("  done")
+        # A PG_VERSION that stat says is non-empty but yields nothing —
+        # unreadable, or whitespace only. Left empty it emits a
+        # four-field PGCHECK line, and `parse_result` drops malformed
+        # lines, so the container reaches `unverified` by way of its own
+        # answer going missing. That works, and it is the shape this repo
+        # calls out: the indicator must be the answer, not a by-product.
+        lines.append('  if [ -z "$FOUND" ]; then FOUND="?"; fi')
         # `-` has to keep meaning "no cluster here", because that is what
         # lets the phase pass. A directory that cannot be listed, or one
         # holding files this probe does not recognise, establishes no such
@@ -405,10 +414,14 @@ def format_failure(mismatches: tuple[Mismatch, ...]) -> str:
     for m in mismatches:
         # `find -mindepth 1 -delete` over `rm -rf <dir>/*`: it takes
         # dotfiles too, and leaves the directory itself in place.
+        # Quoted because the line is meant to be copy-pasted. `shlex.quote`
+        # leaves an ordinary /mnt/nexus-data path untouched, so this costs
+        # nothing in the common case and keeps the odd one executable.
+        target = shlex.quote(m.volume)
         out.append(
-            f"        find {m.volume} -mindepth 1 -delete"
+            f"        find {target} -mindepth 1 -delete"
             if m.is_bind
-            else f"        docker volume rm {m.volume}"
+            else f"        docker volume rm {target}"
         )
     out += [
         "",

--- a/src/nexus_deploy/pg_preflight.py
+++ b/src/nexus_deploy/pg_preflight.py
@@ -117,12 +117,16 @@ class PreflightResult:
     """Probed, and there is no cluster there yet — a first start."""
 
     unverified: tuple[str, ...]
-    """Containers the probe reported nothing for, as ``stack/service``.
+    """Containers nothing could be established for, as ``stack/service``.
 
-    Kept apart from ``absent`` because they are a different statement:
-    "there is no data directory" is a finding, "the check did not run
-    there" is the lack of one. Folding them together would let a broken
-    probe read as a clean bill of health.
+    Kept apart from ``absent`` because they are different statements:
+    "there is no data directory" is a finding, "the check could not look"
+    is the lack of one. Folding them together would let a broken probe
+    read as a clean bill of health.
+
+    Three ways in: the probe emitted no line at all, the docker daemon was
+    down so a named volume's location was unknowable, or PG_VERSION held
+    something that is not a major.
     """
 
     mismatches: tuple[Mismatch, ...]
@@ -211,8 +215,19 @@ def render_preflight_script(containers: list[PgContainer]) -> str:
     Comparing here rather than in bash keeps the decision, the message and
     its tests in one language.
     """
+    # One `docker info` up front, rather than reading each volume's
+    # inspect failure as an answer. Both a stopped daemon and a
+    # not-yet-created volume make `docker volume inspect` exit 1, and the
+    # second is the normal case on a first deploy — so per-volume failure
+    # cannot distinguish them. Asking once can: with docker up, a missing
+    # volume genuinely means no cluster; with docker down, nothing about
+    # named volumes is knowable and saying "absent" would be a finding
+    # nobody established.
     lines = [
         "set -uo pipefail",
+        "",
+        "if docker info >/dev/null 2>&1; then DOCKER=ok; else DOCKER=unavailable; fi",
+        'echo "PGPROBE docker $DOCKER"',
         "",
     ]
     for c in containers:
@@ -253,16 +268,33 @@ def parse_result(stdout: str, containers: list[PgContainer]) -> PreflightResult:
     checked = 0
     absent = 0
     mismatches: list[Mismatch] = []
+    unreadable: list[str] = []
     seen: set[tuple[str, str]] = set()
+
+    # A stopped daemon makes every named volume unknowable. Bind mounts
+    # are unaffected — those paths are read straight off the filesystem,
+    # so their answers stand on their own.
+    docker_down = "PGPROBE docker unavailable" in stdout
+    blind = {(c.stack, c.service) for c in containers if docker_down and not c.is_bind}
 
     for line in stdout.splitlines():
         parts = line.split()
         if len(parts) != 5 or parts[0] != "PGCHECK":
             continue
         _, stack, service, found, want = parts
+        if (stack, service) in blind:
+            # Leave it out of `seen`, so it lands in `unverified` below.
+            continue
         seen.add((stack, service))
         if found == "-":
             absent += 1
+            continue
+        if not found.isdigit():
+            # A PG_VERSION holding something other than a major is a
+            # damaged directory, not a version. Comparing it would report
+            # a mismatch naming a PostgreSQL release that does not exist,
+            # which sends the operator looking for the wrong problem.
+            unreadable.append(f"{stack}/{service} (PG_VERSION reads {found!r})")
             continue
         checked += 1
         if found != want:
@@ -278,7 +310,8 @@ def parse_result(stdout: str, containers: list[PgContainer]) -> PreflightResult:
             )
 
     unverified = tuple(
-        f"{c.stack}/{c.service}" for c in containers if (c.stack, c.service) not in seen
+        [f"{c.stack}/{c.service}" for c in containers if (c.stack, c.service) not in seen]
+        + unreadable
     )
     return PreflightResult(
         checked=checked, absent=absent, unverified=unverified, mismatches=tuple(mismatches)

--- a/src/nexus_deploy/pg_preflight.py
+++ b/src/nexus_deploy/pg_preflight.py
@@ -162,8 +162,19 @@ def discover_pg_containers(stacks_dir: Path) -> list[PgContainer]:
     """
     found: list[PgContainer] = []
     for compose in sorted(stacks_dir.glob("*/docker-compose.yml")):
-        parsed = yaml.safe_load(compose.read_text()) or {}
-        for service, spec in (parsed.get("services") or {}).items():
+        parsed = yaml.safe_load(compose.read_text())
+        # One odd file must cost only itself. Without these two guards a
+        # compose file parsing to a list makes `.get` raise, the phase
+        # catches it and reports "partial", and every *other* stack goes
+        # unchecked — the check disabled by a file it was not asked about.
+        # The per-service guard below already worked this way; these are
+        # the two levels above it.
+        if not isinstance(parsed, dict):
+            continue
+        services = parsed.get("services")
+        if not isinstance(services, dict):
+            continue
+        for service, spec in services.items():
             if not isinstance(spec, dict):
                 continue
             match = _POSTGRES_IMAGE.search(str(spec.get("image", "")))
@@ -446,7 +457,8 @@ def run_preflight(
     deploy over a database nothing is about to start. The check has to
     describe the run that is happening.
     """
-    containers = [c for c in discover_pg_containers(stacks_dir) if c.stack in set(enabled)]
+    wanted = set(enabled)
+    containers = [c for c in discover_pg_containers(stacks_dir) if c.stack in wanted]
     if not containers:
         return PreflightResult(checked=0, absent=0, unverified=(), mismatches=())
 

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -2216,9 +2216,9 @@ def test_run_pre_bootstrap_runs_phases_in_order(
     orchestrator: Orchestrator,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """All 8 pre-bootstrap phases run in deterministic order:
+    """All 9 pre-bootstrap phases run in deterministic order:
     workspace-coords (first), service-env, firewall-configure,
-    stack-sync, firewall-sync, global-env, compose-up,
+    stack-sync, firewall-sync, global-env, pg-preflight, compose-up,
     infisical-provision."""
     invocation_order: list[str] = []
 
@@ -2239,6 +2239,7 @@ def test_run_pre_bootstrap_runs_phases_in_order(
     monkeypatch.setattr(Orchestrator, "_phase_stack_sync", _make_phase("stack-sync"))
     monkeypatch.setattr(Orchestrator, "_phase_firewall_sync", _make_phase("firewall-sync"))
     monkeypatch.setattr(Orchestrator, "_phase_global_env", _make_phase("global-env"))
+    monkeypatch.setattr(Orchestrator, "_phase_pg_preflight", _make_phase("pg-preflight"))
     monkeypatch.setattr(Orchestrator, "_phase_compose_up", _make_phase("compose-up"))
     monkeypatch.setattr(
         Orchestrator,
@@ -2248,7 +2249,11 @@ def test_run_pre_bootstrap_runs_phases_in_order(
     result = orchestrator.run_pre_bootstrap()
     # workspace-coords first (downstream phases gate on REPO_NAME etc.);
     # firewall-configure before stack-sync (rsync picks up overrides);
-    # firewall-sync + global-env after stack-sync (use the synced state).
+    # firewall-sync + global-env after stack-sync (use the synced state);
+    # pg-preflight immediately before compose-up — after stack-sync so it
+    # reads the compose files the run will actually use, and before
+    # compose-up because once a container has started on a mismatched data
+    # directory the failure is a restart loop rather than a diagnosis.
     assert invocation_order == [
         "workspace-coords",
         "service-env",
@@ -2256,6 +2261,7 @@ def test_run_pre_bootstrap_runs_phases_in_order(
         "stack-sync",
         "firewall-sync",
         "global-env",
+        "pg-preflight",
         "compose-up",
         "infisical-provision",
     ]

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -4000,6 +4000,33 @@ def test_pg_preflight_fails_the_run_on_a_mismatch(
     assert "PostgreSQL 16" in capsys.readouterr().err
 
 
+def test_pg_preflight_looks_under_the_configured_checkout_root(
+    orchestrator: Orchestrator, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A relative "stacks" would resolve against the process cwd instead.
+
+    The failure is silent and points the wrong way: discovery finds no
+    compose files, `run_preflight` returns a clean result with nothing
+    checked, and the phase reports success — so a mismatched data
+    directory reaches compose-up with the guard reporting green. Every
+    neighbouring phase already derives its path from `project_root`.
+    """
+    from nexus_deploy import pg_preflight
+
+    orchestrator.project_root = tmp_path
+    seen: dict[str, object] = {}
+
+    def _capture(services: object, *, stacks_dir: Path, host: str) -> object:
+        seen["stacks_dir"] = stacks_dir
+        return _preflight()
+
+    monkeypatch.setattr(pg_preflight, "run_preflight", _capture)
+
+    orchestrator._phase_pg_preflight()
+
+    assert seen["stacks_dir"] == tmp_path / "stacks"
+
+
 def test_pg_preflight_reports_a_clean_run_with_counts(
     orchestrator: Orchestrator, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -3952,3 +3952,104 @@ def test_forgejo_runner_register_skipped_when_only_the_forge_is_enabled() -> Non
 
     assert result.status == "skipped"
     assert "forgejo-runner" in result.detail
+
+
+# ---------------------------------------------------------------------------
+# pg-preflight phase (#734)
+# ---------------------------------------------------------------------------
+
+
+def _preflight(**kw: Any) -> Any:
+    from nexus_deploy.pg_preflight import PreflightResult
+
+    return PreflightResult(
+        checked=kw.get("checked", 0),
+        absent=kw.get("absent", 0),
+        unverified=kw.get("unverified", ()),
+        mismatches=kw.get("mismatches", ()),
+    )
+
+
+def test_pg_preflight_fails_the_run_on_a_mismatch(
+    orchestrator: Orchestrator, monkeypatch: pytest.MonkeyPatch, capsys: Any
+) -> None:
+    """A mismatch stops the deploy before compose-up.
+
+    Letting it through would start a container that cannot start, and the
+    operator would read a restart loop instead of the cause.
+    """
+    from nexus_deploy import pg_preflight
+
+    mismatch = pg_preflight.Mismatch(
+        stack="shared",
+        service="postgres",
+        volume="postgres_postgres-data",
+        found_major="16",
+        expected_major=18,
+    )
+    monkeypatch.setattr(
+        pg_preflight, "run_preflight", lambda *a, **k: _preflight(mismatches=(mismatch,))
+    )
+
+    result = orchestrator._phase_pg_preflight()
+
+    assert result.status == "failed"
+    assert "1 data directories" in result.detail
+    # The actionable message goes to stderr, not into the phase detail —
+    # the detail is one line in a summary table.
+    assert "PostgreSQL 16" in capsys.readouterr().err
+
+
+def test_pg_preflight_reports_a_clean_run_with_counts(
+    orchestrator: Orchestrator, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from nexus_deploy import pg_preflight
+
+    monkeypatch.setattr(
+        pg_preflight, "run_preflight", lambda *a, **k: _preflight(checked=3, absent=2)
+    )
+
+    result = orchestrator._phase_pg_preflight()
+
+    assert result.status == "ok"
+    assert "3 checked" in result.detail
+    assert "2 not yet initialised" in result.detail
+
+
+def test_pg_preflight_is_partial_when_something_could_not_be_checked(
+    orchestrator: Orchestrator, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Partial rather than ok: nothing was found wrong, but neither was
+    everything looked at, and the two must not read alike."""
+    from nexus_deploy import pg_preflight
+
+    monkeypatch.setattr(
+        pg_preflight,
+        "run_preflight",
+        lambda *a, **k: _preflight(checked=1, unverified=("evidence/evidence-db",)),
+    )
+
+    result = orchestrator._phase_pg_preflight()
+
+    assert result.status == "partial"
+    assert "evidence/evidence-db" in result.detail
+
+
+def test_pg_preflight_survives_the_probe_raising(
+    orchestrator: Orchestrator, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A probe that cannot run is not a reason to stop a deploy that would
+    otherwise proceed — and the detail names the exception type, never
+    str(exc), which can carry a credential (CLAUDE.md)."""
+    from nexus_deploy import pg_preflight
+
+    def _raise(*a: Any, **k: Any) -> Any:
+        raise ConnectionResetError("ssh://user:hunter2@host went away")
+
+    monkeypatch.setattr(pg_preflight, "run_preflight", _raise)
+
+    result = orchestrator._phase_pg_preflight()
+
+    assert result.status == "partial"
+    assert "ConnectionResetError" in result.detail
+    assert "hunter2" not in result.detail

--- a/tests/unit/test_pg_preflight.py
+++ b/tests/unit/test_pg_preflight.py
@@ -489,7 +489,9 @@ def test_a_compose_file_with_no_services_is_skipped(tmp_path: Path) -> None:
         ),
         (
             {"type": "bind", "source": "./db", "target": "/var/lib/postgresql/data"},
-            "./db",
+            # Resolved against the remote stack dir at discovery time; see
+            # test_a_relative_bind_source_is_resolved_against_the_remote_stack_dir.
+            "/opt/docker-server/stacks/lf/db",
             True,
             "relative bind — only `type` says it is one",
         ),
@@ -704,3 +706,102 @@ def test_a_malformed_compose_file_does_not_disable_the_whole_check(
     found = discover_pg_containers(tmp_path)
 
     assert [c.stack for c in found] == ["good"], f"sibling lost to: {why}"
+
+
+def test_an_unparseable_compose_file_is_named_and_skipped(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A *disabled* stack's file can hold this shape and never reach compose-up.
+
+    So "it fails loudly later" is not true of it: nothing else would ever
+    read it, while letting the exception out takes discovery down for
+    every enabled stack. Skipped, but named — the databases it defines go
+    unchecked, and that is a fact about the run.
+    """
+    bad = tmp_path / "bad"
+    bad.mkdir()
+    (bad / "docker-compose.yml").write_text("services:\n  db:\n   image: [unclosed\n")
+    good = tmp_path / "good"
+    good.mkdir()
+    (good / "docker-compose.yml").write_text(
+        "services:\n"
+        "  good-db:\n"
+        "    image: postgres:18-alpine\n"
+        '    volumes: ["good-data:/var/lib/postgresql"]\n'
+    )
+
+    found = discover_pg_containers(tmp_path)
+
+    assert [c.stack for c in found] == ["good"]
+    err = capsys.readouterr().err
+    assert "bad/docker-compose.yml" in err
+    assert "go unchecked" in err
+
+
+def test_an_unreadable_compose_file_is_skipped_not_fatal(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Same contract for an OSError as for a parse error."""
+    bad = tmp_path / "bad"
+    bad.mkdir()
+    locked = bad / "docker-compose.yml"
+    locked.write_text("services: {}\n")
+    locked.chmod(0o000)
+    good = tmp_path / "good"
+    good.mkdir()
+    (good / "docker-compose.yml").write_text(
+        "services:\n"
+        "  good-db:\n"
+        "    image: postgres:18-alpine\n"
+        '    volumes: ["good-data:/var/lib/postgresql"]\n'
+    )
+    try:
+        found = discover_pg_containers(tmp_path)
+    finally:
+        locked.chmod(0o644)
+
+    assert [c.stack for c in found] == ["good"]
+    assert "PermissionError" in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# A relative bind source means nothing where the probe runs
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("entry", "expected"),
+    [
+        (
+            '["./db:/var/lib/postgresql/data"]',
+            "/opt/docker-server/stacks/rel/db",
+        ),
+        (
+            '[{"type": "bind", "source": "./data/db", "target": "/var/lib/postgresql"}]',
+            "/opt/docker-server/stacks/rel/data/db",
+        ),
+    ],
+)
+def test_a_relative_bind_source_is_resolved_against_the_remote_stack_dir(
+    tmp_path: Path, entry: str, expected: str
+) -> None:
+    """Compose resolves it against the compose file; the probe does not.
+
+    `ssh nexus '...'` starts in the login directory, so an unresolved
+    `./db` names a path that does not exist — the probe reports absent,
+    the phase passes, and it passed on a directory nobody looked at. The
+    printed recovery command would point somewhere else again.
+    """
+    stack = tmp_path / "rel"
+    stack.mkdir()
+    (stack / "docker-compose.yml").write_text(
+        f"services:\n  rel-db:\n    image: postgres:18-alpine\n    volumes: {entry}\n"
+    )
+
+    (found,) = discover_pg_containers(tmp_path)
+
+    assert found.is_bind
+    assert found.source == expected
+    # Both the probe and the operator-facing name follow from `source`.
+    assert found.qualified_volume == expected
+    assert f"MP={expected}" in render_preflight_script([found])

--- a/tests/unit/test_pg_preflight.py
+++ b/tests/unit/test_pg_preflight.py
@@ -805,3 +805,31 @@ def test_a_relative_bind_source_is_resolved_against_the_remote_stack_dir(
     # Both the probe and the operator-facing name follow from `source`.
     assert found.qualified_volume == expected
     assert f"MP={expected}" in render_preflight_script([found])
+
+
+def test_a_binary_compose_file_is_skipped_like_any_other_bad_one(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """`UnicodeDecodeError` is a ValueError, so OSError does not cover it.
+
+    `read_text` raises it before yaml ever sees the file, which put it
+    outside the guard the previous commit added — the same "one bad file
+    takes the enabled stacks with it" failure, reached by a different
+    exception.
+    """
+    bad = tmp_path / "bad"
+    bad.mkdir()
+    (bad / "docker-compose.yml").write_bytes(b"\xff\xfe\x00\x00binary")
+    good = tmp_path / "good"
+    good.mkdir()
+    (good / "docker-compose.yml").write_text(
+        "services:\n"
+        "  good-db:\n"
+        "    image: postgres:18-alpine\n"
+        '    volumes: ["good-data:/var/lib/postgresql"]\n'
+    )
+
+    found = discover_pg_containers(tmp_path)
+
+    assert [c.stack for c in found] == ["good"]
+    assert "UnicodeDecodeError" in capsys.readouterr().err

--- a/tests/unit/test_pg_preflight.py
+++ b/tests/unit/test_pg_preflight.py
@@ -661,3 +661,46 @@ def test_the_discard_command_stays_a_valid_shell_command(tmp_path: Path) -> None
     assert subprocess.run(["bash", "-c", command], check=False).returncode == 0
     assert list(odd.iterdir()) == []
     assert odd.is_dir(), "the directory itself must survive, ownership with it"
+
+
+# ---------------------------------------------------------------------------
+# One malformed compose file must cost only itself
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("content", "why"),
+    [
+        ("- eine\n- liste\n", "root parses to a list, not a mapping"),
+        ("just a string\n", "root parses to a scalar"),
+        ("", "empty file — yaml.safe_load returns None"),
+        ("services:\n  - db\n", "`services` is a list, so .items() would raise"),
+        ("services:\n", "`services` present but null"),
+    ],
+)
+def test_a_malformed_compose_file_does_not_disable_the_whole_check(
+    tmp_path: Path, content: str, why: str
+) -> None:
+    """The failure is disproportionate, and it fails in the passing direction.
+
+    `.get` on a list raises, `_phase_pg_preflight` catches it and reports
+    "partial", and the deploy proceeds with *every* stack unchecked — the
+    guard switched off by a file it was not asked about. `sorted()` makes
+    it likelier still: a stack named earlier in the alphabet takes the
+    rest down with it.
+    """
+    bad = tmp_path / "bad"
+    bad.mkdir()
+    (bad / "docker-compose.yml").write_text(content)
+    good = tmp_path / "good"
+    good.mkdir()
+    (good / "docker-compose.yml").write_text(
+        "services:\n"
+        "  good-db:\n"
+        "    image: postgres:18-alpine\n"
+        '    volumes: ["good-data:/var/lib/postgresql"]\n'
+    )
+
+    found = discover_pg_containers(tmp_path)
+
+    assert [c.stack for c in found] == ["good"], f"sibling lost to: {why}"

--- a/tests/unit/test_pg_preflight.py
+++ b/tests/unit/test_pg_preflight.py
@@ -1,0 +1,347 @@
+"""The PostgreSQL major-version preflight (#734).
+
+The rendered bash runs for real against fixture directories — the same
+approach as tests/unit/test_repo_secret_script.py — because the part worth
+testing is whether it finds a PG_VERSION wherever the image happens to put
+it, and that is a filesystem question rather than a string question.
+
+Bind mounts are used throughout for the probe tests: a named volume needs
+`docker volume inspect` to resolve, and shimming that would test the shim.
+The bind path and the volume path differ only in how the mountpoint is
+obtained, which `test_named_volumes_are_resolved_through_docker` covers on
+its own.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from nexus_deploy.pg_preflight import (
+    _POSTGRES_IMAGE,
+    PgContainer,
+    discover_pg_containers,
+    format_failure,
+    parse_result,
+    render_preflight_script,
+    run_preflight,
+)
+
+
+def _bind(stack: str, path: Path, major: int) -> PgContainer:
+    return PgContainer(
+        stack=stack, service=f"{stack}-db", source=str(path), is_bind=True, expected_major=major
+    )
+
+
+def _probe(containers: list[PgContainer]) -> str:
+    proc = subprocess.run(
+        ["bash", "-c", render_preflight_script(containers)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr
+    return proc.stdout
+
+
+# ---------------------------------------------------------------------------
+# Finding PG_VERSION where the image actually puts it
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("relative", "label"),
+    [
+        ("PG_VERSION", "<=17: volume at /var/lib/postgresql/data"),
+        ("pgdata/PG_VERSION", "explicit PGDATA under the same mount"),
+        ("data/PG_VERSION", "volume one level up, pre-18 cluster inside"),
+        ("18/docker/PG_VERSION", "18+: cluster at <major>/docker"),
+    ],
+)
+def test_a_cluster_is_found_in_every_supported_layout(
+    tmp_path: Path, relative: str, label: str
+) -> None:
+    """All four layouts exist in this repo simultaneously.
+
+    Nineteen stacks still mount `/var/lib/postgresql/data`, five use the
+    18 layout one level up, and the shared `postgres` stack pins PGDATA to
+    a subdirectory. A check that knew only one of them would pass by
+    finding nothing, which is the failure mode worth guarding: absent and
+    fine are the same output.
+    """
+    target = tmp_path / relative
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("16\n")
+
+    out = _probe([_bind("s", tmp_path, 18)])
+
+    assert "PGCHECK s s-db 16 18" in out, f"not found for {label}"
+
+
+def test_a_mismatch_is_reported_with_both_versions(tmp_path: Path) -> None:
+    (tmp_path / "PG_VERSION").write_text("16\n")
+    containers = [_bind("shared", tmp_path, 18)]
+
+    result = parse_result(_probe(containers), containers)
+
+    assert not result.ok
+    assert result.checked == 1
+    (mismatch,) = result.mismatches
+    assert mismatch.found_major == "16"
+    assert mismatch.expected_major == 18
+
+
+def test_a_matching_major_is_silent(tmp_path: Path) -> None:
+    (tmp_path / "18" / "docker").mkdir(parents=True)
+    (tmp_path / "18" / "docker" / "PG_VERSION").write_text("18\n")
+    containers = [_bind("evidence", tmp_path, 18)]
+
+    result = parse_result(_probe(containers), containers)
+
+    assert result.ok
+    assert result.checked == 1
+    assert result.absent == 0
+
+
+def test_an_empty_directory_is_absent_not_a_mismatch(tmp_path: Path) -> None:
+    """A first start, and the common case on the rebuild lifecycle.
+
+    Reporting it would block every deploy that creates a database.
+    """
+    containers = [_bind("fresh", tmp_path, 18)]
+
+    result = parse_result(_probe(containers), containers)
+
+    assert result.ok
+    assert result.absent == 1
+    assert result.checked == 0
+
+
+def test_a_missing_directory_is_absent(tmp_path: Path) -> None:
+    containers = [_bind("gone", tmp_path / "never-created", 18)]
+
+    result = parse_result(_probe(containers), containers)
+
+    assert result.ok
+    assert result.absent == 1
+
+
+def test_an_empty_pg_version_file_is_not_read_as_a_version(tmp_path: Path) -> None:
+    """A zero-byte PG_VERSION is a half-written directory, not a cluster.
+
+    Treating it as a version would compare "" against the major and report
+    a mismatch naming a version nobody has.
+    """
+    (tmp_path / "PG_VERSION").write_text("")
+
+    result = parse_result(_probe([_bind("half", tmp_path, 18)]), [_bind("half", tmp_path, 18)])
+
+    assert result.ok
+    assert result.absent == 1
+
+
+# ---------------------------------------------------------------------------
+# Result semantics
+# ---------------------------------------------------------------------------
+
+
+def test_a_container_the_probe_said_nothing_about_is_unverified(tmp_path: Path) -> None:
+    """Not folded into `absent`, which would read as "checked, nothing there".
+
+    A probe that could not run is the absence of a finding, and letting it
+    look like a clean result is the silent outcome this module removes.
+    """
+    containers = [_bind("a", tmp_path, 18), _bind("b", tmp_path, 18)]
+
+    result = parse_result("PGCHECK a a-db - 18\n", containers)
+
+    assert result.unverified == ("b/b-db",)
+    assert result.absent == 1
+    assert result.ok, "an unverifiable container must not block a deploy on its own"
+
+
+def test_unparseable_lines_are_ignored_rather_than_guessed_at(tmp_path: Path) -> None:
+    """The probe's stdout carries whatever the remote shell also wrote."""
+    containers = [_bind("a", tmp_path, 18)]
+
+    result = parse_result(
+        "Warning: something unrelated\nPGCHECK a a-db 16 18\ndebug noise\n", containers
+    )
+
+    assert len(result.mismatches) == 1
+    assert result.unverified == ()
+
+
+# ---------------------------------------------------------------------------
+# Discovery over the real compose files
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("image", "expected"),
+    [
+        ("postgres:18-alpine", "18"),
+        ("${IMAGE_EVIDENCE_DB:-postgres:18-alpine}", "18"),
+        ("postgres:14-alpine", "14"),
+        ("postgrest/postgrest:v14.12", None),
+        ("postgres-exporter:latest", None),
+        ("timescale/timescaledb:2.14.2-pg16", None),
+    ],
+)
+def test_the_image_pattern_matches_a_server_and_nothing_adjacent(
+    image: str, expected: str | None
+) -> None:
+    """`postgres:<digits>` and nothing else.
+
+    Pinned directly rather than through discovery, because discovery does
+    not actually depend on it: `postgrest` has no mount under
+    /var/lib/postgresql, so it drops out on that check whatever the
+    pattern does. Loosening the regex to a lazy substring match leaves the
+    end-to-end assertion green — verified by trying it — so without this
+    test the pattern is unpinned and the guard is accidental.
+
+    timescaledb is the one that would actually slip through a loose
+    pattern: it *is* a PostgreSQL server with a data directory, but its
+    tag names the PG major as a suffix, and reading `2` from `2.14.2` as
+    the major would report a mismatch against every real cluster.
+    """
+    match = _POSTGRES_IMAGE.search(image)
+
+    assert (match.group(1) if match else None) == expected
+
+
+def test_postgrest_is_not_discovered_as_a_database() -> None:
+    """The end-to-end half of the above: whatever excludes it, it is out."""
+    stacks = {c.stack for c in discover_pg_containers(Path("stacks"))}
+
+    assert "postgrest" not in stacks
+
+
+def test_bind_mounted_databases_are_checked_too() -> None:
+    """dify, forgejo and gitea keep their clusters under /mnt/nexus-data.
+
+    They were excluded in the first draft because the S3 layer covers
+    them — true, and irrelevant: that dump is logical and only runs on the
+    rebuild path, which never meets this failure. The snapshot path
+    restores those directories physically, so they hit the same wall.
+    """
+    by_stack = {c.stack: c for c in discover_pg_containers(Path("stacks"))}
+
+    for stack in ("dify", "forgejo", "gitea"):
+        assert stack in by_stack, f"{stack} must be checked"
+        assert by_stack[stack].is_bind
+        assert by_stack[stack].qualified_volume.startswith("/mnt/nexus-data/")
+
+
+def test_named_volumes_are_resolved_through_docker() -> None:
+    """The compose project name prefixes the volume, and the mountpoint
+    comes from `docker volume inspect` rather than a guess at
+    /var/lib/docker — the docker root is configurable."""
+    containers = discover_pg_containers(Path("stacks"))
+    evidence = next(c for c in containers if c.stack == "evidence")
+
+    assert evidence.qualified_volume == "evidence_evidence-db-data"
+    assert "docker volume inspect" in render_preflight_script([evidence])
+
+
+def test_every_discovered_container_declares_a_known_major() -> None:
+    """A tag the regex cannot parse would silently drop that database from
+    the check, which looks identical to having no databases."""
+    containers = discover_pg_containers(Path("stacks"))
+
+    assert containers, "discovery found nothing — the glob or the regex is wrong"
+    assert all(9 <= c.expected_major <= 99 for c in containers)
+
+
+def test_only_enabled_stacks_are_probed(tmp_path: Path) -> None:
+    """A disabled stack's volume may hold an old cluster, and blocking a
+    deploy over a database nothing is about to start would describe a run
+    that is not happening."""
+    seen: list[str] = []
+
+    def runner(script: str, *, host: str) -> str:
+        seen.append(script)
+        return ""
+
+    run_preflight(["evidence"], stacks_dir=Path("stacks"), script_runner=runner)
+
+    (script,) = seen
+    assert "evidence" in script
+    assert "hedgedoc" not in script
+
+
+def test_no_enabled_postgres_means_no_remote_call() -> None:
+    called = False
+
+    def runner(script: str, *, host: str) -> str:
+        nonlocal called
+        called = True
+        return ""
+
+    result = run_preflight(["grafana"], stacks_dir=Path("stacks"), script_runner=runner)
+
+    assert not called
+    assert result.ok
+
+
+# ---------------------------------------------------------------------------
+# The message
+# ---------------------------------------------------------------------------
+
+
+def test_the_failure_message_carries_what_the_operator_needs(tmp_path: Path) -> None:
+    """Both versions, the volume to act on, and that a retry is not it.
+
+    The wrong instinct here is to re-run the deploy, which reproduces the
+    restart loop exactly — so the message has to say so rather than only
+    describe the state.
+    """
+    (tmp_path / "PG_VERSION").write_text("16\n")
+    containers = [_bind("shared", tmp_path, 18)]
+
+    message = format_failure(parse_result(_probe(containers), containers).mismatches)
+
+    assert "PostgreSQL 16" in message
+    assert "image is 18" in message
+    assert str(tmp_path) in message
+    assert "Re-running the deploy will not help" in message
+    assert "pg_dump" in message
+    assert "docker volume rm" in message
+    assert "snapshot lifecycle" in message
+
+
+def test_the_rendered_script_is_valid_bash() -> None:
+    script = render_preflight_script(discover_pg_containers(Path("stacks")))
+
+    proc = subprocess.run(["bash", "-n", "-c", script], capture_output=True, text=True)
+
+    assert proc.returncode == 0, proc.stderr
+
+
+def test_paths_with_spaces_survive_the_shell(tmp_path: Path) -> None:
+    """Every value reaching bash is shlex-quoted. Nothing in this repo has
+    a space today, which is exactly why an unquoted expansion would go
+    unnoticed until someone's path did."""
+    awkward = tmp_path / "a dir with spaces"
+    awkward.mkdir()
+    (awkward / "PG_VERSION").write_text("16\n")
+    containers = [_bind("odd", awkward, 18)]
+
+    result = parse_result(_probe(containers), containers)
+
+    assert len(result.mismatches) == 1
+
+
+def test_module_docstring_names_the_lifecycle_that_can_reach_this() -> None:
+    """The check is unreachable on the rebuild path, and someone reading
+    the module should learn that before wondering why it never fires."""
+    from nexus_deploy import pg_preflight
+
+    assert pg_preflight.__doc__ is not None
+    doc = textwrap.dedent(pg_preflight.__doc__)
+    assert "snapshot" in doc
+    assert "rebuild" in doc

--- a/tests/unit/test_pg_preflight.py
+++ b/tests/unit/test_pg_preflight.py
@@ -345,3 +345,115 @@ def test_module_docstring_names_the_lifecycle_that_can_reach_this() -> None:
     doc = textwrap.dedent(pg_preflight.__doc__)
     assert "snapshot" in doc
     assert "rebuild" in doc
+
+
+# ---------------------------------------------------------------------------
+# When the probe itself cannot answer
+# ---------------------------------------------------------------------------
+
+
+def test_a_stopped_docker_daemon_makes_named_volumes_unverified(tmp_path: Path) -> None:
+    """Not `absent`, which would read as "checked, no cluster there".
+
+    The distinction needs a separate question, because `docker volume
+    inspect` exits 1 both when the daemon is down and when the volume has
+    simply not been created — and the second is the normal case on a first
+    deploy. Reading per-volume failure as "unknowable" would flag every
+    first deploy; reading it as "absent" hides a dead daemon. The script
+    asks `docker info` once instead.
+    """
+    named = PgContainer(
+        stack="evidence", service="evidence-db", source="db-data", is_bind=False, expected_major=18
+    )
+
+    result = parse_result(
+        "PGPROBE docker unavailable\nPGCHECK evidence evidence-db - 18\n", [named]
+    )
+
+    assert result.unverified == ("evidence/evidence-db",)
+    assert result.absent == 0
+    assert result.checked == 0
+
+
+def test_a_stopped_daemon_does_not_taint_bind_mounts(tmp_path: Path) -> None:
+    """Those paths are read off the filesystem, so their answers stand."""
+    (tmp_path / "PG_VERSION").write_text("16\n")
+    containers = [_bind("gitea", tmp_path, 17)]
+
+    result = parse_result("PGPROBE docker unavailable\n" + _probe(containers), containers)
+
+    assert result.unverified == ()
+    assert len(result.mismatches) == 1
+
+
+def test_the_script_reports_the_daemon_state_before_anything_else() -> None:
+    """Verified against a real stopped daemon rather than a stub: with
+    docker down on this machine the line reads `unavailable`, and with it
+    up the same script reads `ok`."""
+    script = render_preflight_script([])
+
+    assert "docker info" in script
+    assert 'echo "PGPROBE docker $DOCKER"' in script
+
+
+def test_a_pg_version_that_is_not_a_number_is_unverified(tmp_path: Path) -> None:
+    """A damaged directory, not a version.
+
+    Comparing it would report a mismatch naming a PostgreSQL release that
+    does not exist, sending the operator after the wrong problem.
+    """
+    containers = [_bind("odd", tmp_path, 18)]
+
+    result = parse_result("PGCHECK odd odd-db garbage 18\n", containers)
+
+    assert result.mismatches == ()
+    assert result.checked == 0
+    assert len(result.unverified) == 1
+    assert "garbage" in result.unverified[0]
+
+
+# ---------------------------------------------------------------------------
+# Malformed compose entries must not take the discovery down
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("volumes", "why"),
+    [
+        (None, "no volumes key at all"),
+        ([], "empty volumes list"),
+        ("postgres-data:/var/lib/postgresql/data", "a string where a list belongs"),
+        ([{"type": "volume", "source": "d"}], "long-form mount syntax"),
+        (["postgres-data"], "an anonymous volume, no colon"),
+        (["./conf:/etc/postgresql/postgresql.conf"], "a mount that is not the data dir"),
+    ],
+)
+def test_a_service_without_a_recognisable_data_mount_is_skipped(
+    tmp_path: Path, volumes: object, why: str
+) -> None:
+    """Discovery walks every stack, so one odd entry must not raise.
+
+    Long-form mount syntax is the interesting one: it is valid Compose and
+    this repo happens not to use it, so the parser would meet it for the
+    first time in production. Skipping is right — a service whose data
+    directory cannot be located cannot be checked — but it has to skip
+    rather than crash the deploy before compose-up.
+    """
+    stack = tmp_path / "odd"
+    stack.mkdir()
+    spec: dict[str, object] = {"image": "postgres:18-alpine"}
+    if volumes is not None:
+        spec["volumes"] = volumes
+    (stack / "docker-compose.yml").write_text(
+        __import__("yaml").safe_dump({"services": {"odd-db": spec}})
+    )
+
+    assert discover_pg_containers(tmp_path) == [], f"should skip: {why}"
+
+
+def test_a_compose_file_with_no_services_is_skipped(tmp_path: Path) -> None:
+    stack = tmp_path / "empty"
+    stack.mkdir()
+    (stack / "docker-compose.yml").write_text("services:\n")
+
+    assert discover_pg_containers(tmp_path) == []

--- a/tests/unit/test_pg_preflight.py
+++ b/tests/unit/test_pg_preflight.py
@@ -14,6 +14,7 @@ its own.
 
 from __future__ import annotations
 
+import shlex
 import subprocess
 import textwrap
 from pathlib import Path
@@ -597,3 +598,66 @@ def test_a_bind_mount_is_named_and_discarded_as_a_directory() -> None:
     # The named volume keeps the command that does work for it.
     assert "volume postgres_pg-data" in text
     assert "docker volume rm postgres_pg-data" in text
+
+
+# ---------------------------------------------------------------------------
+# The answer has to be the signal, never a side effect of a broken line
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("content", "mode", "why"),
+    [
+        ("17\n", 0o000, "exists and is non-empty, but cannot be read"),
+        ("   \n", 0o644, "readable, but holds nothing once whitespace is stripped"),
+    ],
+)
+def test_a_pg_version_that_yields_nothing_says_so_itself(
+    tmp_path: Path, content: str, mode: int, why: str
+) -> None:
+    """`[ -s ]` calls stat, which needs no read permission on the file.
+
+    So the guard passes and the read that follows produces an empty
+    string. Emitting that would make a four-field PGCHECK line, and
+    `parse_result` drops malformed lines — the container would still reach
+    `unverified`, but by way of its own answer going missing rather than
+    by giving one. CLAUDE.md names that shape: the indicator must not be a
+    by-product. Assert the field count, since that is what breaks.
+    """
+    (tmp_path / "PG_VERSION").write_text(content)
+    (tmp_path / "PG_VERSION").chmod(mode)
+    containers = [_bind("mute", tmp_path, 18)]
+    try:
+        out = _probe(containers)
+    finally:
+        (tmp_path / "PG_VERSION").chmod(0o644)
+
+    line = next(x for x in out.splitlines() if x.startswith("PGCHECK"))
+    assert len(line.split()) == 5, f"malformed line for: {why}"
+    assert line == "PGCHECK mute mute-db ? 18"
+
+    result = parse_result(out, containers)
+    assert result.absent == 0
+    assert result.unverified == ("mute/mute-db (data directory could not be read)",)
+
+
+def test_the_discard_command_stays_a_valid_shell_command(tmp_path: Path) -> None:
+    """The line exists to be copy-pasted, so it has to survive the paste.
+
+    An unquoted path with a space splits into two arguments: `find` reads
+    the first as its starting point and the second as an expression, and
+    the operator gets an error naming neither. Quoting is free for the
+    ordinary /mnt/nexus-data paths — `shlex.quote` leaves those alone.
+    """
+    odd = tmp_path / "with space"
+    odd.mkdir()
+    text = format_failure((Mismatch("odd", "db", str(odd), "16", 17, is_bind=True),))
+
+    command = next(x for x in text.splitlines() if "find" in x).strip()
+    assert command == f"find {shlex.quote(str(odd))} -mindepth 1 -delete"
+
+    # Executable as printed: run it and confirm it emptied the directory.
+    (odd / "PG_VERSION").write_text("16\n")
+    assert subprocess.run(["bash", "-c", command], check=False).returncode == 0
+    assert list(odd.iterdir()) == []
+    assert odd.is_dir(), "the directory itself must survive, ownership with it"

--- a/tests/unit/test_pg_preflight.py
+++ b/tests/unit/test_pg_preflight.py
@@ -22,6 +22,7 @@ import pytest
 
 from nexus_deploy.pg_preflight import (
     _POSTGRES_IMAGE,
+    Mismatch,
     PgContainer,
     discover_pg_containers,
     format_failure,
@@ -134,14 +135,18 @@ def test_an_empty_pg_version_file_is_not_read_as_a_version(tmp_path: Path) -> No
     """A zero-byte PG_VERSION is a half-written directory, not a cluster.
 
     Treating it as a version would compare "" against the major and report
-    a mismatch naming a version nobody has.
+    a mismatch naming a version nobody has. Nor is it `absent`: the
+    directory is not empty, so something is there and this probe could not
+    say what — the deploy proceeds, but the phase reports partial.
     """
     (tmp_path / "PG_VERSION").write_text("")
+    containers = [_bind("half", tmp_path, 18)]
 
-    result = parse_result(_probe([_bind("half", tmp_path, 18)]), [_bind("half", tmp_path, 18)])
+    result = parse_result(_probe(containers), containers)
 
     assert result.ok
-    assert result.absent == 1
+    assert result.absent == 0
+    assert result.unverified == ("half/half-db (data directory could not be read)",)
 
 
 # ---------------------------------------------------------------------------
@@ -310,7 +315,9 @@ def test_the_failure_message_carries_what_the_operator_needs(tmp_path: Path) -> 
     assert str(tmp_path) in message
     assert "Re-running the deploy will not help" in message
     assert "pg_dump" in message
-    assert "docker volume rm" in message
+    # A bind mount, so the discard command has to be the one that works
+    # on a directory — see the dedicated test below.
+    assert f"find {tmp_path} -mindepth 1 -delete" in message
     assert "snapshot lifecycle" in message
 
 
@@ -423,8 +430,9 @@ def test_a_pg_version_that_is_not_a_number_is_unverified(tmp_path: Path) -> None
         (None, "no volumes key at all"),
         ([], "empty volumes list"),
         ("postgres-data:/var/lib/postgresql/data", "a string where a list belongs"),
-        ([{"type": "volume", "source": "d"}], "long-form mount syntax"),
+        ([{"type": "volume", "source": "d"}], "long-form mount with no target"),
         (["postgres-data"], "an anonymous volume, no colon"),
+        ([42], "an entry that is neither a string nor a mapping"),
         (["./conf:/etc/postgresql/postgresql.conf"], "a mount that is not the data dir"),
     ],
 )
@@ -433,11 +441,10 @@ def test_a_service_without_a_recognisable_data_mount_is_skipped(
 ) -> None:
     """Discovery walks every stack, so one odd entry must not raise.
 
-    Long-form mount syntax is the interesting one: it is valid Compose and
-    this repo happens not to use it, so the parser would meet it for the
-    first time in production. Skipping is right — a service whose data
-    directory cannot be located cannot be checked — but it has to skip
-    rather than crash the deploy before compose-up.
+    Skipping is right where the data directory genuinely cannot be located
+    — but it has to skip rather than crash the deploy before compose-up.
+    A long-form mount naming a target is *not* in this list; see
+    `test_a_long_form_data_mount_is_discovered`.
     """
     stack = tmp_path / "odd"
     stack.mkdir()
@@ -457,3 +464,136 @@ def test_a_compose_file_with_no_services_is_skipped(tmp_path: Path) -> None:
     (stack / "docker-compose.yml").write_text("services:\n")
 
     assert discover_pg_containers(tmp_path) == []
+
+
+# ---------------------------------------------------------------------------
+# Long-form compose mounts are read, not silently skipped
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("entry", "source", "is_bind", "why"),
+    [
+        (
+            {"type": "volume", "source": "db-data", "target": "/var/lib/postgresql"},
+            "db-data",
+            False,
+            "long-form named volume",
+        ),
+        (
+            {"type": "bind", "source": "/mnt/nexus-data/x/db", "target": "/var/lib/postgresql"},
+            "/mnt/nexus-data/x/db",
+            True,
+            "long-form bind by absolute path",
+        ),
+        (
+            {"type": "bind", "source": "./db", "target": "/var/lib/postgresql/data"},
+            "./db",
+            True,
+            "relative bind — only `type` says it is one",
+        ),
+    ],
+)
+def test_a_long_form_data_mount_is_discovered(
+    tmp_path: Path, entry: dict[str, str], source: str, is_bind: bool, why: str
+) -> None:
+    """Skipping one would be silent, and silence here reads as success.
+
+    A service that drops out of discovery is not reported as unverified —
+    nothing knows it existed. The mismatch this module exists to catch
+    would reach compose-up unannounced, which is the one outcome the phase
+    must never produce.
+    """
+    stack = tmp_path / "lf"
+    stack.mkdir()
+    (stack / "docker-compose.yml").write_text(
+        __import__("yaml").safe_dump(
+            {"services": {"lf-db": {"image": "postgres:18-alpine", "volumes": [entry]}}}
+        )
+    )
+
+    found = discover_pg_containers(tmp_path)
+
+    assert len(found) == 1, f"not discovered: {why}"
+    assert found[0].source == source
+    assert found[0].is_bind is is_bind
+
+
+# ---------------------------------------------------------------------------
+# `absent` has to mean "verified empty", because it is what lets the deploy run
+# ---------------------------------------------------------------------------
+
+
+def test_a_directory_that_cannot_be_listed_is_unverified_not_absent(tmp_path: Path) -> None:
+    """The dangerous reading: unreadable looks exactly like uninitialised.
+
+    Both leave the probe with no PG_VERSION. Counting the first as absent
+    lets the phase pass on a directory whose major nobody established —
+    here one holding PostgreSQL 17 under an image asking for 18.
+    """
+    data = tmp_path / "locked"
+    data.mkdir()
+    (data / "PG_VERSION").write_text("17\n")
+    data.chmod(0o000)
+    containers = [_bind("locked", data, 18)]
+    try:
+        result = parse_result(_probe(containers), containers)
+    finally:
+        data.chmod(0o755)
+
+    assert result.absent == 0
+    assert len(result.unverified) == 1
+    assert "locked/locked-db" in result.unverified[0]
+
+
+def test_a_non_empty_directory_with_no_cluster_is_unverified(tmp_path: Path) -> None:
+    """A layout none of the four candidates match must not read as empty.
+
+    An uninitialised volume is empty. Files this probe does not recognise
+    mean it looked in the wrong place, not that there is nothing there.
+    """
+    (tmp_path / "something").write_text("x")
+    containers = [_bind("odd", tmp_path, 18)]
+
+    result = parse_result(_probe(containers), containers)
+
+    assert result.absent == 0
+    assert result.unverified == ("odd/odd-db (data directory could not be read)",)
+
+
+def test_a_genuinely_empty_directory_is_still_absent(tmp_path: Path) -> None:
+    """The counterpart — first deploy has to stay quiet, not go partial."""
+    containers = [_bind("fresh", tmp_path, 18)]
+
+    result = parse_result(_probe(containers), containers)
+
+    assert result.absent == 1
+    assert result.unverified == ()
+    assert result.ok
+
+
+# ---------------------------------------------------------------------------
+# The recovery command has to exist for the thing it names
+# ---------------------------------------------------------------------------
+
+
+def test_a_bind_mount_is_named_and_discarded_as_a_directory() -> None:
+    """`docker volume rm /mnt/nexus-data/gitea/db` removes nothing.
+
+    Three of the six persisted databases are bind mounts, so the wrong
+    command is the likely one. It fails with 'no such volume' and sends
+    the operator looking for a volume that was never there.
+    """
+    text = format_failure(
+        (
+            Mismatch("gitea", "gitea-db", "/mnt/nexus-data/gitea/db", "16", 17, is_bind=True),
+            Mismatch("shared", "postgres", "postgres_pg-data", "17", 18, is_bind=False),
+        )
+    )
+
+    assert "bind mount /mnt/nexus-data/gitea/db" in text
+    assert "find /mnt/nexus-data/gitea/db -mindepth 1 -delete" in text
+    assert "docker volume rm /mnt/nexus-data/gitea/db" not in text
+    # The named volume keeps the command that does work for it.
+    assert "volume postgres_pg-data" in text
+    assert "docker volume rm postgres_pg-data" in text


### PR DESCRIPTION
## Problem

PostgreSQL refuses to start against a data directory written by an older major.
The container restart-loops, everything behind that database is down, and what
the operator sees is `compose up failed` — with the cause a `docker logs` away:

```
FATAL:  database files are incompatible with server
DETAIL: The data directory was initialized by PostgreSQL version 16,
        which is not compatible with this version 18.
```

Nothing is lost quietly, as #734 notes: `compose_runner` counts the stack failed
and the smoke check marks it `RESTARTING`. What is missing is the *connection*
between symptom and cause, and that a retry is not the fix.

## Change

A `pg-preflight` phase between `stack-sync` and `compose-up` — after the compose
files the run will use are on the server, before a container can enter the loop.
It reads `PG_VERSION` from each database's volume, compares it to the major in
the image, and fails with both versions, the volume to act on, and the two ways
out. Plus the one that does not work: re-running the deploy reproduces the state
exactly.

Reachable only on the **snapshot** lifecycle, where the directory outlives the
image tag. A rebuild teardown destroys it with the server, so the phase finds
nothing there and says so.

## Two things the survey corrected

Neither was assumed — both came out of checking against the 84 compose files.

**Bind mounts belong in the check.** The first draft excluded them, reasoning
that `/mnt/nexus-data` is covered by the S3 layer. True, and beside the point:
that dump is *logical* and runs on the rebuild path, which never meets this
failure. The snapshot image restores those directories byte for byte, so
`dify-db`, `forgejo-db` and `gitea-db` hit the same wall as any named volume —
and they were precisely the three the exclusion dropped.

**`PG_VERSION` lives in four places, not one.** All four exist in this repo right
now:

| Layout | Where | Stacks |
|---|---|---|
| ≤17 | volume root | 16 |
| explicit `PGDATA` | `pgdata/` | the shared `postgres` stack |
| volume one level up, old cluster | `data/` | — (a migration in progress) |
| 18+ | `<major>/docker/` | 4 |

A check knowing one layout would pass by finding nothing — and *absent* looks
identical to *fine*.

## `unverified` is not `absent`

A probe that could not run is the lack of a finding, not the finding that there
is no cluster. Folding them together would let a broken probe read as a clean
bill of health. It reports `partial` rather than blocking a deploy that would
otherwise proceed — the check only ever prevents a restart loop, so "could not
look" must not become "must not deploy".

## Tests

27, running the rendered bash against fixture directories — the approach
`test_repo_secret_script.py` already uses here.

**Mutation-tested rather than assumed green**, and one mutation is the reason a
test exists:

| Mutation | Caught by |
|---|---|
| drop the 18 layout from the candidates | `test_a_cluster_is_found_in_every_supported_layout` |
| re-exclude bind mounts | `test_bind_mounted_databases_are_checked_too` |
| loosen the image regex to a substring match | `test_the_image_pattern_matches_a_server_and_nothing_adjacent` |

The third initially caught nothing. `postgrest` is excluded by the mount check
whatever the pattern does, so the end-to-end assertion was green for the wrong
reason and the pattern was unpinned. Hence a direct test — which also covers
`timescale/timescaledb:2.14.2-pg16`, a real PostgreSQL server whose tag would
give a loose pattern the major `2`.

## Not verified

No deploy test. The failure needs a snapshot restore across a major bump, which
means tearing down under the snapshot lifecycle, changing a tag, and spinning up
— destructive on the running stack for a check that fires before anything
starts. The probe itself is exercised against real directories in all four
layouts; what remains untested end to end is `docker volume inspect` returning a
mountpoint on the server, which no fixture can stand in for.

Closes #734.

## Summary by Sourcery

Add a snapshot-deployment preflight that identifies PostgreSQL data directories written by an incompatible major before compose startup and explains how to recover.

New Features:
- Add PostgreSQL data-directory major-version preflight checks for enabled snapshot deployments before containers start.
- Provide actionable mismatch diagnostics covering affected databases, versions, recovery options, and non-working retries.

Bug Fixes:
- Prevent PostgreSQL major-version mismatches from reaching container restart loops without an upfront explanation.
- Detect PostgreSQL clusters across legacy, explicit-PGDATA, intermediate, and PostgreSQL 18+ layouts, including named volumes and bind mounts.
- Distinguish verified empty directories from unverified probe results so failed checks are not reported as clean.

Enhancements:
- Integrate the preflight as a deployment phase after stack synchronization and before compose startup, while allowing probe failures to produce a partial result rather than blocking deployment.
- Harden compose discovery and remote probing against malformed configurations, unavailable Docker, unreadable data, relative bind paths, and adjacent non-PostgreSQL images.

Documentation:
- Document PostgreSQL major-version failures, snapshot versus rebuild behavior, and migration or data-discard recovery procedures.

Tests:
- Add comprehensive unit coverage for discovery, all supported data-directory layouts, bind mounts, named volumes, probe outcomes, failure formatting, shell safety, and phase ordering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a pre-deployment check for PostgreSQL data directories created by an incompatible major version.
  * Reports detected version mismatches with actionable recovery guidance before containers start.
  * Reports unverified checks for review without blocking deployment.

* **Documentation**
  * Added troubleshooting guidance for PostgreSQL startup failures after major version changes, including rebuild, migration, and data-discard recovery options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->