### PR TITLE
ci: Run the Python tests when services.yaml or a stack changes

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -6,8 +6,26 @@
 #   - typecheck:   mypy --strict (~1-2 min, depends on cache hit)
 #   - test:        pytest unit + integration with coverage gate (≥80%)
 #
-# Tests run only when Python or workflow files change — to keep CI cheap
-# during pure docs/stack PRs.
+# Tests run only when the files they actually read change — to keep CI
+# cheap during pure documentation PRs.
+#
+# That includes `services.yaml` and `stacks/**`, not just Python.
+# `test_stack_conventions.py` reads both and is where support_images
+# uniqueness, version pinning and compose/services.yaml agreement are
+# enforced. Two mutations confirm it, rather than the path list being
+# argued from the file names:
+#
+#   services.yaml: postgres:14-alpine -> postgres:latest
+#     -> test_support_images_are_pinned[infisical] and
+#        test_compose_fallbacks_match_the_declared_version[infisical]
+#   stacks/infisical/docker-compose.yml: fallback 14 -> 15
+#     -> test_compose_fallbacks_match_the_declared_version[infisical]
+#
+# Before this, neither PR ran a single test: a stack-only change matched
+# no path, so the assertions written for exactly that change fired only
+# when a PR happened to touch Python too.
+#
+# Docs stay excluded — no test reads them.
 # =============================================================================
 
 name: "CI: Python Tests"
@@ -17,6 +35,8 @@ on:
     paths:
       - "src/**"
       - "tests/**"
+      - "services.yaml"
+      - "stacks/**"
       - "pyproject.toml"
       - "uv.lock"
       - ".python-version"
@@ -27,6 +47,8 @@ on:
     paths:
       - "src/**"
       - "tests/**"
+      - "services.yaml"
+      - "stacks/**"
       - "pyproject.toml"
       - "uv.lock"
       - ".python-version"


### PR DESCRIPTION
## Problem

`python-tests.yml` filters on `src/**`, `tests/**` and a few config files. A PR
touching only `services.yaml` or `stacks/**` matches none of them and runs **no
tests at all** — while `tests/unit/test_stack_conventions.py` exists to check
exactly those two files.

Found while preparing the Infisical PostgreSQL bump for #731. That diff is
`services.yaml`, one compose file and two docs; it would have reached review
with zero test runs, and the assertions written for that class of change would
have been the ones not to run.

## Verified by mutation, not by reading the path list

```
services.yaml:  postgres:14-alpine -> postgres:latest
  FAILED test_support_images_are_pinned[infisical]
  FAILED test_compose_fallbacks_match_the_declared_version[infisical]

stacks/infisical/docker-compose.yml:  fallback 14 -> 15
  FAILED test_compose_fallbacks_match_the_declared_version[infisical]
```

Worth recording: the first attempt at the `services.yaml` mutation **silently
did not apply**. It targeted a value that exists on the feature branch but not
on `main`, so the suite came back green — which would have read as "no test
covers this". The `assert count == 1` around the replacement caught it. This is
the failure mode CLAUDE.md describes: a mutation that does not reach the code
looks exactly like a passing test with a gap.

## Scope

`tofu/**` deliberately stays out. It appears in tests only inside comments and
path-equality assertions (`runner.tofu_dir == Path("tofu/stack")`) — no test
reads those files. Docs stay out for the same reason.

The header comment claimed tests are skipped for "pure docs/stack PRs".
Skipping stack PRs *was* the defect, so the comment is rewritten rather than
left describing behaviour that no longer holds.

## Effect on CI cost

Documentation-only PRs still skip the suite. Stack and `services.yaml` PRs now
run it — roughly 90 s, and they are the PRs whose assertions are most specific
to what changed.

## Note on this PR itself

It touches `.github/workflows/python-tests.yml`, which was already in the path
list, so this PR does run the suite.

Follow-up: #731 (`fix/infisical-postgres-18`) is waiting on this one — it gets
rebased afterwards so its CI actually runs.

## Summary by Sourcery

Ensure changes to service definitions and stack configurations trigger the Python test suite in CI.

Bug Fixes:
- Run Python tests for pull requests that modify services.yaml or stacks/** so stack-specific validation is no longer skipped.

Enhancements:
- Update the workflow documentation to reflect that test execution follows files read by the test suite while continuing to exclude documentation-only changes.

CI:
- Expand pull-request and push path filters in the Python test workflow to include services.yaml and stacks/**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Automated tests now run when changes affect `services.yaml` or files under `stacks/`, in addition to Python files.
  * Updated workflow guidance and validation examples clarify coverage for these configuration changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->