### PR TITLE
fix(stacks): Move Infisical's PostgreSQL from 14 to 18

### DIFF
--- a/docs/stacks/README.md
+++ b/docs/stacks/README.md
@@ -51,7 +51,7 @@ Two stateful stacks do still follow a rolling tag — `pg_ducklake` (`18-main`) 
 | Kestra | `kestra/kestra` | `v1.0` | Minor |
 | PostgreSQL (Kestra DB) | `postgres` | `18-alpine` | Major |
 | Infisical | `infisical/infisical` | `v0.155.5` | Exact ¹ |
-| PostgreSQL (Infisical DB) | `postgres` | `14-alpine` | Major |
+| PostgreSQL (Infisical DB) | `postgres` | `18-alpine` | Major |
 | Metabase | `metabase/metabase` | `v0.60.6.2` | Exact ¹ |
 | Mailpit | `axllent/mailpit` | `v1.28` | Minor |
 | IT-Tools | `corentinth/it-tools` | `latest` | Latest ² |

--- a/docs/stacks/infisical.md
+++ b/docs/stacks/infisical.md
@@ -75,10 +75,25 @@ versions:
      infisical/infisical-db: data is PostgreSQL 14, image is 18  (volume infisical_infisical-db-data)
 ```
 
-Take a dump first, so the decision stays reversible:
+At that point `infisical-db` is **not running** — the preflight stopped the
+deploy before compose-up — so `docker exec infisical-db pg_dump` has nothing
+to attach to. Start a temporary PostgreSQL 14 against the volume instead. It
+mounts at the *old* path, because that is the layout the volume still has:
 
 ```bash
-ssh nexus "docker exec infisical-db pg_dump -U nexus-infisical -Fc infisical" > infisical-pg14.dump
+ssh nexus "docker run --rm -u postgres \
+  -v infisical_infisical-db-data:/var/lib/postgresql/data \
+  --entrypoint sh postgres:14-alpine -c \
+  'pg_ctl -D /var/lib/postgresql/data -o \"-c listen_addresses=\" -w start >/dev/null \
+   && pg_dump -U nexus-infisical -Fc infisical'" > infisical-pg14.dump
+```
+
+`listen_addresses=` keeps the temporary server on its socket only, so nothing
+can reach it while it runs. Check the result before continuing — the file
+starts with `PGDMP`:
+
+```bash
+head -c 5 infisical-pg14.dump   # PGDMP
 ```
 
 Then discard the volume and deploy again:
@@ -90,8 +105,18 @@ ssh nexus "docker volume rm infisical_infisical-db-data"
 
 Everything Nexus-Stack manages returns on the next spin-up — the admin
 account and all generated service credentials are re-pushed. What does
-**not** return is anything added by hand in the Infisical UI: your own
-secrets, extra projects and users, and the audit log. If the stack holds
-any of that, restore it from the dump into the new cluster yourself before
-letting Infisical migrate the schema; this project does not automate that
-path and does not test it, so treat the dump as the thing you rely on.
+**not** return is anything you added by hand in the Infisical UI: your own
+secrets, extra projects and users, and the audit log.
+
+If the stack holds any of that, restore it once Infisical has started and
+created its schema, so the restore lands on a database that exists:
+
+```bash
+ssh nexus "docker exec -i infisical-db pg_restore -U nexus-infisical \
+  -d infisical --clean --if-exists" < infisical-pg14.dump
+ssh nexus "cd /opt/docker-server/stacks/infisical && docker compose restart infisical"
+```
+
+The `14 -> 18` round trip works — `pg_dump -Fc` is version-independent by
+design and `pg_restore` reads the older format. Restore into a **new**
+cluster, never over one Infisical has since written to.

--- a/docs/stacks/infisical.md
+++ b/docs/stacks/infisical.md
@@ -27,3 +27,71 @@ A modern, developer-friendly alternative to HashiCorp Vault:
 > ✅ **Auto-configured:** Admin account is automatically created during deployment. A "Nexus Stack" project is created with all generated passwords pre-loaded. Credentials are available in Infisical.
 
 > ℹ️ **Note:** Secrets are auto-generated on first deployment (encryption key, auth secret). These are stored in `stacks/infisical/.env`.
+
+### The bundled PostgreSQL
+
+Infisical brings its own database, `infisical-db`, on `postgres:18-alpine`.
+It is not the shared `postgres` stack — that one is optional and off by
+default, while Infisical is a core service that has to come up on every
+spin-up.
+
+Note the mount: **`/var/lib/postgresql`, not `/var/lib/postgresql/data`**.
+From 18 the image stores the cluster in a major-versioned subdirectory
+(`/var/lib/postgresql/18/docker`), so the mount goes one level up. With the
+pre-18 path the container exits 1 on start rather than writing somewhere
+unexpected — the failure is loud, but total. The four other stacks on 18
+mount the same way.
+
+**Why 18.** Infisical's own requirements page says it has "extensively
+tested" PostgreSQL 16 and recommends "versions 14 and up", and says nothing
+about anything newer — so this was checked directly instead. Running
+`infisical/infisical:v0.155.5` against 16, 17 and 18 produces the same 713
+migrated tables and a `200` from `/api/status` on all three; the only log
+error is an unrelated SMTP connection refusal. 18 is therefore not a
+gamble, it is where the rest of this project's databases already are, and
+it is supported until **2030-11-14**. The 14 it replaces reaches end of
+life on **2026-11-12**.
+
+### Changing the major version
+
+What it costs depends on which lifecycle the stack runs — see
+[snapshot-lifecycle.md](../admin-guides/snapshot-lifecycle.md).
+
+**Rebuild lifecycle: nothing to do.** The teardown destroys the server and
+the `infisical-db-data` volume with it. Postgres initialises an empty
+cluster, Infisical runs its own migrations against it, and the spin-up
+recreates the admin account and pushes every managed secret back. That is
+the normal state of affairs for this stack, not a special case for a
+version bump.
+
+**Snapshot lifecycle: the data directory comes back.** It holds a cluster
+written by the old major, and PostgreSQL refuses to start against it. The
+`pg-preflight` phase stops the deploy before that happens and names both
+versions:
+
+```text
+❌ PostgreSQL data directory was written by a different major version.
+
+     infisical/infisical-db: data is PostgreSQL 14, image is 18  (volume infisical_infisical-db-data)
+```
+
+Take a dump first, so the decision stays reversible:
+
+```bash
+ssh nexus "docker exec infisical-db pg_dump -U nexus-infisical -Fc infisical" > infisical-pg14.dump
+```
+
+Then discard the volume and deploy again:
+
+```bash
+ssh nexus "cd /opt/docker-server/stacks/infisical && docker compose down"
+ssh nexus "docker volume rm infisical_infisical-db-data"
+```
+
+Everything Nexus-Stack manages returns on the next spin-up — the admin
+account and all generated service credentials are re-pushed. What does
+**not** return is anything added by hand in the Infisical UI: your own
+secrets, extra projects and users, and the audit log. If the stack holds
+any of that, restore it from the dump into the new cluster yourself before
+letting Infisical migrate the schema; this project does not automate that
+path and does not test it, so treat the dump as the thing you rely on.

--- a/services.yaml
+++ b/services.yaml
@@ -428,7 +428,7 @@ services:
     long_description: "Infisical is an open-source secret management platform. Centralize secrets, environment variables, and API keys across your entire infrastructure. Features include versioning, audit logs, access controls, secret rotation, and integrations with Docker, Kubernetes, and CI/CD systems."
     image: "infisical/infisical:v0.155.5"
     support_images:
-      infisical-postgres: "postgres:14-alpine"
+      infisical-postgres: "postgres:18-alpine"
       infisical-redis: "redis:7-alpine"
 
   it-tools:

--- a/stacks/infisical/docker-compose.yml
+++ b/stacks/infisical/docker-compose.yml
@@ -48,7 +48,7 @@ services:
       - infisical-internal
 
   infisical-db:
-    image: ${IMAGE_INFISICAL_POSTGRES:-postgres:14-alpine}
+    image: ${IMAGE_INFISICAL_POSTGRES:-postgres:18-alpine}
     container_name: infisical-db
     restart: unless-stopped
     environment:
@@ -56,7 +56,10 @@ services:
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:?must be set in .env (rendered by service_env._render_infisical)}
       - POSTGRES_DB=infisical
     volumes:
-      - infisical-db-data:/var/lib/postgresql/data
+      # 18+ places the cluster in a major-versioned subdirectory, so the
+      # mount goes one level up. With the pre-18 path the image refuses to
+      # start (exit 1) rather than writing somewhere unexpected.
+      - infisical-db-data:/var/lib/postgresql
     networks:
       - infisical-internal
     healthcheck:

--- a/stacks/infisical/docker-compose.yml
+++ b/stacks/infisical/docker-compose.yml
@@ -55,6 +55,9 @@ services:
       - POSTGRES_USER=nexus-infisical
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:?must be set in .env (rendered by service_env._render_infisical)}
       - POSTGRES_DB=infisical
+    # 512m matches every other bundled Postgres in this repo (forgejo-db,
+    # evidence-db, hedgedoc-db, dagster-postgres, meltano-db).
+    mem_limit: 512m
     volumes:
       # 18+ places the cluster in a major-versioned subdirectory, so the
       # mount goes one level up. With the pre-18 path the image refuses to


### PR DESCRIPTION
## Problem

Infisical ran `postgres:14-alpine`. PostgreSQL 14 reaches end of life on
**2026-11-12** — 71 days out. It was the only stack still on 14, and it is the
one whose failure to start blocks every other stack, because it holds the
credentials the deploy pushes.

## Which major, and why not the newest

The issue asked to confirm what the pinned Infisical release supports rather than
assume. Upstream's own requirements page says it has "extensively tested"
PostgreSQL 16 and recommends "versions 14 and up", and says nothing about
anything newer; Infisical's `docker-compose.prod.yml` and `docker-compose.dev.yml`
both still ship `postgres:14-alpine`.

That is a statement about upstream, not about whether 17 or 18 work — so that got
tested directly. `infisical/infisical:v0.155.5` against all three:

| | server_version | `/api/status` | tables migrated |
|---|---|---|---|
| PG 16 | 16.15 | 200 | 713 |
| PG 17 | 17.11 | 200 | 713 |
| PG 18 | 18.6 | 200 | 713 |

Identical migrations, identical behaviour. The only log error is
`ECONNREFUSED 127.0.0.1:587` — SMTP, with no mail server in the test — and it
appears in all three runs.

So 18 is not a gamble. It is where this project's other databases already are
(five stacks), and it is supported until **2030-11-14**.

## The mount changes with it, and that part is not optional

From 18 the image keeps the cluster in a major-versioned subdirectory, so the
mount moves from `/var/lib/postgresql/data` to `/var/lib/postgresql`. With the old
path the container **exits 1 on start**, even on an empty volume:

```
Error: in 18+, these Docker images are configured to store database data in a
       format which is compatible with "pg_ctlcluster" ...
       The suggested container configuration for 18+ is to place a single mount
       at /var/lib/postgresql
```

Worth stating plainly because the opposite would be worse: it fails loudly, it
does not quietly write to the container layer. With the correct mount,
`data_directory` becomes `/var/lib/postgresql/18/docker` and the data survives a
container recreate — verified with a row written, container removed, container
recreated, row still there. The four other stacks on 18 mount the same way.

## Migration cost, per lifecycle

**Rebuild: none.** The teardown destroys the server and the `infisical-db-data`
volume with it. Postgres initialises an empty cluster, Infisical runs its own
migrations, and the spin-up recreates the admin and pushes every managed secret
back. That is this stack's normal state, not a special case.

**Snapshot: the data directory returns**, written by the old major, and PostgreSQL
refuses it. Verified end to end: a volume holding a real PG14 cluster plus
`postgres:18` on the new mount exits 1; after discarding the volume, 18.6 comes up
clean.

## This is the first real exercise of #765

The `pg-preflight` phase catches exactly this before compose-up. Run against a
real Docker named volume rather than a fixture — which is the gap #765's own
description listed as untested, since `docker volume inspect` returning a
mountpoint is not something a fixture can stand in for:

```
PGPROBE docker ok
PGCHECK infisical infisical-db 14 18
```

A second, unplanned confirmation came from the same run. On macOS `docker volume
inspect` returns a path inside the Docker VM that does not exist on the host. The
preflight did **not** report that as `absent` — it reported
`unverified: data directory could not be read`, which is precisely the branch
added in that PR's round 2 to stop a probe that cannot look from reading as a
clean bill of health. First time it fired under real conditions.

## Also verified rather than derived

- `infisical-db` is **not** a `PostgresDumpTarget`, so the S3 layer does not carry
  this database across a rebuild — which is why the bump is free there.
- The volume compose derives is `infisical_infisical-db-data`: `compose_runner`
  runs `cd $STACKS_DIR/$svc && docker compose up` with no `-p`, so the project
  name is the directory name. That matches what the preflight prints, so the
  recovery command it shows is copy-pasteable.
- EOL dates from endoflife.date: 14 → 2026-11-12, 16 → 2028-11-09,
  18 → 2030-11-14.

## Docs

`docs/stacks/infisical.md` gains a section on the bundled database, the mount, and
the per-lifecycle migration including the dump to take first. It deliberately does
**not** promise a restore recipe: this project neither automates nor tests
restoring into a migrated Infisical schema, so the dump is presented as the thing
you rely on, and the discard path as the one that is actually supported.

## Not verified

No deploy test. Everything above was exercised against real containers locally,
including the failure path and the preflight, but the stack itself has not been
spun up on this change.

Closes #731.

## Summary by Sourcery

Upgrade Infisical’s bundled PostgreSQL to 18 while preserving safe handling of rebuild and snapshot lifecycles.

Bug Fixes:
- Update Infisical’s bundled PostgreSQL from 14 to 18 and align its data volume mount with PostgreSQL 18’s storage layout.

Enhancements:
- Add resource limits and document PostgreSQL version compatibility, lifecycle-specific data migration, and recovery guidance for Infisical.

Documentation:
- Document the bundled database configuration, PostgreSQL 14-to-18 migration implications, and snapshot recovery procedure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Infisical’s bundled PostgreSQL database is now based on PostgreSQL 18.
  * Persistent database storage now uses PostgreSQL 18’s versioned cluster layout.
* **Documentation**
  * Added compatibility and support lifecycle details for PostgreSQL 18.
  * Added upgrade guidance covering rebuilds, snapshots, preflight checks, database dumps, volume handling, and data restoration.
  * Documented the updated database image and storage configuration in the available stacks reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->