### PR TITLE
docs: Record how to catch a commit Release Please dropped

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -896,6 +896,46 @@ WIP: still working on it        → Not descriptive
 Merge branch 'main' into feat   → Merge commits should not be PR titles
 ```
 
+### After merging, check that Release Please saw the commit
+
+**Release Please drops commits it cannot parse, silently, with a green
+workflow.** It logs one line and carries on:
+
+```
+❯ commit could not be parsed: 9e016e2 feat: Make a Nexus-Stack operable as …
+✔ Considering: 5 commits
+```
+
+Six commits existed since the last tag. The feature simply never reached
+`CHANGELOG.md`, and nothing failed — no red check, no warning on the
+release PR. It was found only because the entry was missing when someone
+read the release PR.
+
+So after merging a PR, confirm the commit arrived:
+
+```bash
+RID=$(gh run list --workflow=release-please.yml --limit 1 --json databaseId --jq '.[0].databaseId')
+gh run view "$RID" --log | grep -E "could not be parsed|Considering:"
+git log --oneline "$(git describe --tags --abbrev=0)"..main | wc -l
+```
+
+`Considering: N` must equal that commit count. If it does not, the
+changelog is already wrong and the fix has to land **before** the release
+PR is merged — the missing entry is added by hand to `CHANGELOG.md` on
+`release-please--branches--main` *and* to the release PR body, and any
+further commit to `main` regenerates that branch and discards the repair.
+
+What is *not* the cause, so nobody re-derives it: the subject was a valid
+`feat:`, the message was not the longest in the batch, it contained no
+carriage returns, and `conventional-commits-parser` parses it correctly on
+its own (returns `type='feat'`). The rejection happens inside Release
+Please's own wrapper and the trigger has not been isolated. The suspect is
+a squash-merge body carrying a fenced code block whose lines look like git
+trailers (`unset:`, `LABEL + accent:`) alongside a generated `Tests:`
+section — suspect, not finding. This is why the check is on the *count*
+rather than on a content rule: a rule guessed from an unproven cause would
+be worse than useless.
+
 ### Development Workflow
 
 1. Create a feature branch from `main`:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -906,23 +906,45 @@ workflow.** It logs one line and carries on:
 ✔ Considering: 5 commits
 ```
 
-Six commits existed since the last tag. The feature simply never reached
-`CHANGELOG.md`, and nothing failed — no red check, no warning on the
-release PR. It was found only because the entry was missing when someone
-read the release PR.
+Six commits existed since `v0.74.0`. The feature never reached
+`CHANGELOG.md`, and nothing failed — no red check, no warning on release
+PR #764. It was caught only because someone read that PR before merging
+it, which is not a control. The repair landed on
+`release-please--branches--main` as `93254c3`, minutes before the merge
+that cut `v0.75.0`.
 
-So after merging a PR, confirm the commit arrived:
+So after merging a PR, confirm the commit arrived. Pin every input —
+the run for *this* SHA, the tag reachable from *the remote* `main`:
 
 ```bash
-RID=$(gh run list --workflow=release-please.yml --limit 1 --json databaseId --jq '.[0].databaseId')
-gh run view "$RID" --log | grep -E "could not be parsed|Considering:"
-git log --oneline "$(git describe --tags --abbrev=0)"..main | wc -l
+git fetch --prune --tags origin
+SHA=$(git rev-parse origin/main)
+
+RID=$(gh run list --workflow=release-please.yml --branch main --commit "$SHA" \
+        --json databaseId,status --jq '[.[] | select(.status == "completed")][0].databaseId')
+
+if [ -z "$RID" ]; then
+  echo "Release Please has not finished for $SHA yet — try again in a minute."
+else
+  gh run view "$RID" --log | grep -E "could not be parsed|Considering:"
+  git log --oneline "$(git describe --tags --abbrev=0 origin/main)"..origin/main | wc -l
+fi
 ```
+
+None of that pinning is decoration. `--limit 1` returns the *previous*
+run in the seconds before GitHub creates the new one, and a local `main`
+or a local tag list that has not been fetched counts a different range
+than Release Please processed. Either produces a comparison of two
+unrelated numbers — a check that reports a mismatch that is not there, or
+agreement that is not either. An empty `RID` means "not finished", not
+"nothing to check", which is why it is a separate branch rather than an
+empty grep.
 
 `Considering: N` must equal that commit count. If it does not, the
 changelog is already wrong and the fix has to land **before** the release
 PR is merged — the missing entry is added by hand to `CHANGELOG.md` on
-`release-please--branches--main` *and* to the release PR body, and any
+`release-please--branches--main` *and* to the release PR body, since the
+GitHub release notes come from the PR rather than from the branch. Any
 further commit to `main` regenerates that branch and discards the repair.
 
 What is *not* the cause, so nobody re-derives it: the subject was a valid

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -917,11 +917,14 @@ So after merging a PR, confirm the commit arrived. Pin every input —
 the run for *this* SHA, the tag reachable from *the remote* `main`:
 
 ```bash
-git fetch --prune --tags origin
+# Fail closed: without a successful fetch, `origin/main` is whatever was
+# last seen, and every number below describes the wrong snapshot.
+git fetch --prune --tags origin || { echo "fetch failed — do not trust what follows"; return 2>/dev/null || exit 1; }
 SHA=$(git rev-parse origin/main)
 
 RID=$(gh run list --workflow=release-please.yml --branch main --commit "$SHA" \
-        --json databaseId,status --jq '[.[] | select(.status == "completed")][0].databaseId')
+        --json databaseId,status \
+        --jq '[.[] | select(.status == "completed")][0].databaseId // empty')
 
 if [ -z "$RID" ]; then
   echo "Release Please has not finished for $SHA yet — try again in a minute."
@@ -939,6 +942,12 @@ unrelated numbers — a check that reports a mismatch that is not there, or
 agreement that is not either. An empty `RID` means "not finished", not
 "nothing to check", which is why it is a separate branch rather than an
 empty grep.
+
+`// empty` is belt-and-braces rather than a fix for an observed failure:
+`gh --jq` prints nothing for a `null` result, verified both for a SHA with
+no runs and for one whose runs the filter excludes. A bare `jq` in a pipe
+*does* print `null`, so the guard would silently stop guarding the moment
+someone rewrote the call that way.
 
 `Considering: N` must equal that commit count. If it does not, the
 changelog is already wrong and the fix has to land **before** the release

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -917,20 +917,29 @@ So after merging a PR, confirm the commit arrived. Pin every input —
 the run for *this* SHA, the tag reachable from *the remote* `main`:
 
 ```bash
-# Fail closed: without a successful fetch, `origin/main` is whatever was
-# last seen, and every number below describes the wrong snapshot.
-git fetch --prune --tags origin || { echo "fetch failed — do not trust what follows"; return 2>/dev/null || exit 1; }
-SHA=$(git rev-parse origin/main)
-
-RID=$(gh run list --workflow=release-please.yml --branch main --commit "$SHA" \
-        --json databaseId,status \
-        --jq '[.[] | select(.status == "completed")][0].databaseId // empty')
-
-if [ -z "$RID" ]; then
-  echo "Release Please has not finished for $SHA yet — try again in a minute."
+# Everything hangs off a successful fetch: without one, `origin/main` is
+# whatever was last seen and every number below describes the wrong
+# snapshot. Written as one `if` so that a failure stops the check without
+# an `exit` — this is meant to be pasted into a terminal, and `exit` in an
+# interactive shell closes it.
+if ! git fetch --prune --tags origin; then
+  echo "fetch failed — do not trust what follows"
 else
-  gh run view "$RID" --log | grep -E "could not be parsed|Considering:"
-  git log --oneline "$(git describe --tags --abbrev=0 origin/main)"..origin/main | wc -l
+  SHA=$(git rev-parse origin/main)
+
+  # `.[0]` is the newest run for that SHA; requiring it to be completed
+  # means a rerun in progress reads as "not finished" rather than falling
+  # back to the older completed one.
+  RID=$(gh run list --workflow=release-please.yml --branch main --commit "$SHA" \
+          --json databaseId,status \
+          --jq '.[0] | select(.status == "completed") | .databaseId')
+
+  if [ -z "$RID" ]; then
+    echo "Release Please has not finished for $SHA yet — try again in a minute."
+  else
+    gh run view "$RID" --log | grep -E "could not be parsed|Considering:"
+    git log --oneline "$(git describe --tags --abbrev=0 origin/main)"..origin/main | wc -l
+  fi
 fi
 ```
 
@@ -943,11 +952,23 @@ agreement that is not either. An empty `RID` means "not finished", not
 "nothing to check", which is why it is a separate branch rather than an
 empty grep.
 
-`// empty` is belt-and-braces rather than a fix for an observed failure:
-`gh --jq` prints nothing for a `null` result, verified both for a SHA with
-no runs and for one whose runs the filter excludes. A bare `jq` in a pipe
-*does* print `null`, so the guard would silently stop guarding the moment
-someone rewrote the call that way.
+Taking `.[0]` and *then* testing its status is the part that is easy to
+get backwards. Filtering to completed runs first and taking the first
+match returns the previous run while a rerun is in flight, so the check
+reads a stale log and reports agreement about a run that has been
+superseded. Written this way, an unfinished newest run yields nothing and
+the guard fires. Exercised against all three shapes:
+
+```text
+[]                                                    -> ''  guard fires
+[{id:2,in_progress},{id:1,completed}]                 -> ''  guard fires
+[{id:9,completed}]                                    -> 9   proceeds
+```
+
+`gh --jq` also prints nothing for a `null` result, verified for a SHA with
+no runs and for one whose runs the filter excludes — so no `// empty` is
+needed here. A bare `jq` in a pipe *does* print `null`; if this call is
+ever rewritten that way, the guard needs it back.
 
 `Considering: N` must equal that commit count. If it does not, the
 changelog is already wrong and the fix has to land **before** the release


### PR DESCRIPTION
## What happened

Release Please could not parse the squash commit for #769 and left it out of the
0.75.0 changelog. The workflow stayed green — one log line, no failed check, no
warning on the release PR:

```
❯ commit could not be parsed: 9e016e2 feat: Make a Nexus-Stack operable as …
✔ Considering: 5 commits
```

Six commits existed since `v0.74.0`. The Conductor-Stack work — the largest change
in that release, closing #729 and #767 — simply was not in the changelog, and
nothing said so. It was noticed by reading the release PR before merging it, which
is not a control.

The entry was restored by hand on `release-please--branches--main` and in the
release PR body before #764 merged, so `v0.75.0` is correct. Had any commit reached
`main` in between, Release Please would have regenerated that branch and discarded
the repair silently.

## The rule

A count check after each merge, not a content restriction:

```bash
RID=$(gh run list --workflow=release-please.yml --limit 1 --json databaseId --jq '.[0].databaseId')
gh run view "$RID" --log | grep -E "could not be parsed|Considering:"
git log --oneline "$(git describe --tags --abbrev=0)"..main | wc -l
```

`Considering: N` must equal the commit count. If it does not, the changelog is
already wrong, and the repair has to land **before** the release PR is merged.

## Why there is no rule about commit-message content

Because the cause is not established, and a rule guessed from an unproven cause
would be worse than none. What was ruled out, recorded in the section so nobody
repeats the search:

- The subject was a valid `feat:` and `feat` is configured in
  `release-please-config.json`.
- Size was not it — 7147 characters, while the `fix(stacks)` commit at 6145
  parsed fine.
- No carriage returns.
- `conventional-commits-parser` parses the message correctly **on its own**,
  returning `type='feat'`. Checked directly:

  ```
  npx conventional-commits-parser < msg-769.txt
  → type = 'feat'  scope = None  subject = 'Make a Nexus-Stack operable as the Condu…'
  ```

So the rejection happens inside Release Please's own wrapper, not in the underlying
parser. The suspect is a squash-merge body carrying a fenced code block whose lines
read as git trailers (`unset:`, `LABEL + accent:`) next to a generated `Tests:`
section — suspect, not finding, and labelled as such in the text.

## Why this matters beyond one commit

The failure mode is the one this repository already documents elsewhere: something
that reports success while not having done the work. `CLAUDE.md` has rules against
success messages that outrun what a step verified, and against `|| true` hiding a
status. This is the same shape, in a tool rather than in our own bash — and the only
signal it gives is a number in a log nobody reads.

Docs-only change; no CI beyond the workflow linter applies.

## Summary by Sourcery

Document how to detect and repair commits silently omitted by Release Please before the release pull request is merged.

Enhancements:
- Document a post-merge Release Please verification procedure that matches the processed commit count with the commits since the latest remote tag.
- Document safeguards for checking the correct workflow run and remote repository state, plus the required pre-release repair process when commits are dropped.

Documentation:
- Record the silent Release Please commit-drop failure mode, its known investigation results, and the rationale for using a count check rather than a speculative commit-message rule.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added guidance for verifying that Release Please processes all commits after merging.
  - Documented how to compare processed commit counts with the workflow logs.
  - Added steps for identifying and restoring a missing changelog entry before the release pull request is merged.
  - Clarified that unparseable commits may be silently omitted even when the workflow reports success.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->