### PR TITLE
feat(control-plane): Show live step-by-step progress for spin-up and teardown

### DIFF
--- a/control-plane/functions/api/_utils/dispatch-marker.js
+++ b/control-plane/functions/api/_utils/dispatch-marker.js
@@ -1,0 +1,86 @@
+/**
+ * Remember that a workflow was just dispatched, so /api/status does not
+ * mistake the previous run for the new one.
+ *
+ * THE RACE THIS CLOSES. `POST …/dispatches` answers 204 with no run id,
+ * and for several seconds afterwards the new run is not in
+ * `GET /actions/runs` at all. The dashboard re-polls 2 s after the click,
+ * status.js picks the newest run of that workflow — the one that finished
+ * an hour ago — reports `deployed`, and the Spin Up button comes back.
+ * `spin-up.yml` carries no concurrency lock, so the second click starts a
+ * second run. Seen in the wild; this is the fix.
+ *
+ * Stored in D1 rather than the browser: a reload or a second tab must see
+ * the same picture, and the endpoints that dispatch already write to D1.
+ *
+ * TWO WINDOWS, deliberately different:
+ *   GRACE_MS   how long status.js keeps saying "dispatching" while no
+ *              matching run has appeared. GitHub usually lists the run
+ *              within ~10 s; 90 s is generous. After that the UI says the
+ *              run could not be found and points at GitHub.
+ *   TTL_MS     how long the marker influences run selection at all. It
+ *              hides runs older than the dispatch, which is right while the
+ *              new one is expected — and wrong forever if the dispatch
+ *              silently produced no run. After 15 min the marker is inert.
+ */
+
+export const DISPATCH_GRACE_MS = 90 * 1000;
+export const DISPATCH_MARKER_TTL_MS = 15 * 60 * 1000;
+
+/** Runs created this much before the marker still count as "the new one" — clock skew. */
+export const DISPATCH_SKEW_MS = 60 * 1000;
+
+const KEY_AT = 'dispatched_at';
+const KEY_WORKFLOW = 'dispatched_workflow';
+
+/** Families as status.js buckets them. Anything else is refused, not stored. */
+const FAMILIES = new Set(['initialSetup', 'setup', 'spinUp', 'teardown', 'destroy']);
+
+/**
+ * Record a dispatch. Best-effort like the logger — a failure here must not
+ * turn a successful dispatch into a reported failure — but it is logged,
+ * because a missing marker is exactly the race coming back.
+ */
+export async function markDispatched(db, family) {
+  if (!db) return;
+  if (!FAMILIES.has(family)) {
+    console.error(`dispatch-marker: refusing to store unknown family (${String(family).slice(0, 40)})`);
+    return;
+  }
+  try {
+    const now = new Date().toISOString();
+    await db.batch([
+      db.prepare('INSERT OR REPLACE INTO config (key, value, updated_at) VALUES (?, ?, datetime("now"))').bind(KEY_AT, now),
+      db.prepare('INSERT OR REPLACE INTO config (key, value, updated_at) VALUES (?, ?, datetime("now"))').bind(KEY_WORKFLOW, family),
+    ]);
+  } catch (error) {
+    console.error('dispatch-marker: failed to write to D1:', error);
+  }
+}
+
+/**
+ * @returns {Promise<{family: string, at: number, ageMs: number} | null>}
+ *   `at` is epoch ms. Null when there is no marker, it is malformed, or it
+ *   is older than TTL_MS — callers never see a stale marker.
+ */
+export async function readDispatchMarker(db, now = Date.now()) {
+  if (!db) return null;
+  let rows;
+  try {
+    const result = await db
+      .prepare('SELECT key, value FROM config WHERE key IN (?, ?)')
+      .bind(KEY_AT, KEY_WORKFLOW)
+      .all();
+    rows = result && Array.isArray(result.results) ? result.results : [];
+  } catch (error) {
+    console.error('dispatch-marker: failed to read from D1:', error);
+    return null;
+  }
+  const byKey = Object.fromEntries(rows.map((r) => [r.key, r.value]));
+  const family = byKey[KEY_WORKFLOW];
+  const at = Date.parse(byKey[KEY_AT] || '');
+  if (!FAMILIES.has(family) || !Number.isFinite(at)) return null;
+  const ageMs = now - at;
+  if (ageMs < 0 || ageMs > DISPATCH_MARKER_TTL_MS) return null;
+  return { family, at, ageMs };
+}

--- a/control-plane/functions/api/_utils/dispatch-marker.js
+++ b/control-plane/functions/api/_utils/dispatch-marker.js
@@ -13,6 +13,11 @@
  * Stored in D1 rather than the browser: a reload or a second tab must see
  * the same picture, and the endpoints that dispatch already write to D1.
  *
+ * ONE MARKER PER FAMILY, not one globally. A teardown dispatched while a
+ * setup was still waiting to be listed used to overwrite it, and the
+ * forgotten family fell straight back into the race this module exists to
+ * close. The families are independent, so their markers are too.
+ *
  * TWO WINDOWS, deliberately different:
  *   GRACE_MS   how long status.js keeps saying "dispatching" while no
  *              matching run has appeared. GitHub usually lists the run
@@ -22,6 +27,12 @@
  *              hides runs older than the dispatch, which is right while the
  *              new one is expected — and wrong forever if the dispatch
  *              silently produced no run. After 15 min the marker is inert.
+ *
+ * THE WRITE CAN FAIL, and the caller must know. D1 being unavailable is
+ * exactly when the duplicate-dispatch race returns, so `markDispatched`
+ * reports whether the marker landed instead of swallowing it. The
+ * endpoints pass that on as `tracked` and the browser holds its own latch
+ * when it is false — see window.NS.status.noteDispatch.
  */
 
 export const DISPATCH_GRACE_MS = 90 * 1000;
@@ -30,57 +41,67 @@ export const DISPATCH_MARKER_TTL_MS = 15 * 60 * 1000;
 /** Runs created this much before the marker still count as "the new one" — clock skew. */
 export const DISPATCH_SKEW_MS = 60 * 1000;
 
-const KEY_AT = 'dispatched_at';
-const KEY_WORKFLOW = 'dispatched_workflow';
-
 /** Families as status.js buckets them. Anything else is refused, not stored. */
-const FAMILIES = new Set(['initialSetup', 'setup', 'spinUp', 'teardown', 'destroy']);
+export const DISPATCH_FAMILIES = ['initialSetup', 'setup', 'spinUp', 'teardown', 'destroy'];
+const FAMILIES = new Set(DISPATCH_FAMILIES);
+
+const keyFor = (family) => `dispatched_at:${family}`;
 
 /**
- * Record a dispatch. Best-effort like the logger — a failure here must not
- * turn a successful dispatch into a reported failure — but it is logged,
- * because a missing marker is exactly the race coming back.
+ * Record a dispatch.
+ *
+ * @returns {Promise<boolean>} whether the marker is now stored. False means
+ *   status.js will not know about this dispatch — the caller must say so.
  */
 export async function markDispatched(db, family) {
-  if (!db) return;
   if (!FAMILIES.has(family)) {
     console.error(`dispatch-marker: refusing to store unknown family (${String(family).slice(0, 40)})`);
-    return;
+    return false;
   }
+  if (!db) return false;
   try {
-    const now = new Date().toISOString();
-    await db.batch([
-      db.prepare('INSERT OR REPLACE INTO config (key, value, updated_at) VALUES (?, ?, datetime("now"))').bind(KEY_AT, now),
-      db.prepare('INSERT OR REPLACE INTO config (key, value, updated_at) VALUES (?, ?, datetime("now"))').bind(KEY_WORKFLOW, family),
-    ]);
+    await db
+      .prepare('INSERT OR REPLACE INTO config (key, value, updated_at) VALUES (?, ?, datetime("now"))')
+      .bind(keyFor(family), new Date().toISOString())
+      .run();
+    return true;
   } catch (error) {
     console.error('dispatch-marker: failed to write to D1:', error);
+    return false;
   }
 }
 
 /**
- * @returns {Promise<{family: string, at: number, ageMs: number} | null>}
- *   `at` is epoch ms. Null when there is no marker, it is malformed, or it
- *   is older than TTL_MS — callers never see a stale marker.
+ * Every fresh marker, keyed by family.
+ *
+ * @returns {Promise<Record<string, {at: number, ageMs: number}>>}
+ *   `at` is epoch ms. Malformed values and anything older than TTL_MS are
+ *   dropped — callers never see a stale marker.
  */
-export async function readDispatchMarker(db, now = Date.now()) {
-  if (!db) return null;
+export async function readDispatchMarkers(db, now = Date.now()) {
+  if (!db) return {};
+  const keys = DISPATCH_FAMILIES.map(keyFor);
   let rows;
   try {
+    const placeholders = keys.map(() => '?').join(', ');
     const result = await db
-      .prepare('SELECT key, value FROM config WHERE key IN (?, ?)')
-      .bind(KEY_AT, KEY_WORKFLOW)
+      .prepare(`SELECT key, value FROM config WHERE key IN (${placeholders})`)
+      .bind(...keys)
       .all();
     rows = result && Array.isArray(result.results) ? result.results : [];
   } catch (error) {
     console.error('dispatch-marker: failed to read from D1:', error);
-    return null;
+    return {};
   }
-  const byKey = Object.fromEntries(rows.map((r) => [r.key, r.value]));
-  const family = byKey[KEY_WORKFLOW];
-  const at = Date.parse(byKey[KEY_AT] || '');
-  if (!FAMILIES.has(family) || !Number.isFinite(at)) return null;
-  const ageMs = now - at;
-  if (ageMs < 0 || ageMs > DISPATCH_MARKER_TTL_MS) return null;
-  return { family, at, ageMs };
+  const out = {};
+  for (const row of rows) {
+    const family = DISPATCH_FAMILIES.find((f) => keyFor(f) === row.key);
+    if (!family) continue;
+    const at = Date.parse(row.value || '');
+    if (!Number.isFinite(at)) continue;
+    const ageMs = now - at;
+    if (ageMs < 0 || ageMs > DISPATCH_MARKER_TTL_MS) continue;
+    out[family] = { at, ageMs };
+  }
+  return out;
 }

--- a/control-plane/functions/api/_utils/run-progress.js
+++ b/control-plane/functions/api/_utils/run-progress.js
@@ -1,0 +1,179 @@
+/**
+ * Turn a GitHub Actions run + its jobs into "Step N of M".
+ *
+ * Pure: no I/O, no clock, no globals. The Control Plane has no JavaScript
+ * test runner, so purity is the only testability this logic gets — every
+ * rule below can be exercised in a Node REPL against a saved
+ * `GET /actions/runs/{id}/jobs` payload, and was.
+ *
+ * WHAT THE JOBS API ACTUALLY RETURNS, since two of these surprised us:
+ *
+ *   - Housekeeping steps are in the list. `Set up job`, one `Post <name>`
+ *     per action with a post hook (checkout, setup-node, the caches…),
+ *     and `Complete job`. A workflow declaring 30 steps comes back as 37.
+ *     They stay in N and M so the numbers match what the operator sees on
+ *     "View in GitHub"; the UI dims them.
+ *   - `step.number` is NOT a 1..M index. The post-steps of a 37-step job
+ *     are numbered 61, 62, 63. `number` is what GitHub's step anchor
+ *     (`#step:<number>:1`) wants; `index` below is ours, contiguous across
+ *     jobs, and is what N/M is built from. Never mix them.
+ *   - A queued job has `steps: []` until a runner picks it up. In a
+ *     reusable-workflow run (spin-up-snapshot.yml) the second job does not
+ *     appear at all until the first finishes, so M can grow mid-run.
+ *
+ * FAILURE IS THE FAILURE POINT, NOT THE LAST STEP THAT RAN. `if: always()`
+ * steps — Close SSH port, Collect debug logs, every Post-step, Complete
+ * job — run after a failure. "Last step that ran" is therefore always the
+ * final one, and a failed run would fill the bar to 100%. The bar answers
+ * "how far did it get": the first `failure` step. What ran afterwards is
+ * visible, ticked, in the details list — that is where it is honest, not
+ * on the bar.
+ */
+
+const HOUSEKEEPING = /^(Set up job|Post |Complete job)/;
+
+/** Anything not started and not finished, whatever GitHub calls it today. */
+function isPending(status) {
+  return status !== 'in_progress' && status !== 'completed';
+}
+
+function durationBetween(startedAt, completedAt) {
+  if (!startedAt || !completedAt) return null;
+  const ms = Date.parse(completedAt) - Date.parse(startedAt);
+  return Number.isFinite(ms) ? Math.max(0, ms) : null;
+}
+
+/**
+ * @param {object|null} run   one item of `workflow_runs`, or the run object
+ * @param {object|null} jobs  the `/actions/runs/{id}/jobs` payload
+ */
+export function deriveProgress(run, jobs) {
+  const rawJobs = jobs && Array.isArray(jobs.jobs) ? jobs.jobs : [];
+
+  const flat = [];
+  const outJobs = [];
+  let index = 0;
+
+  for (const job of rawJobs) {
+    const rawSteps = Array.isArray(job.steps) ? job.steps : [];
+    const steps = [];
+    for (const s of rawSteps) {
+      index += 1;
+      const step = {
+        index,
+        number: typeof s.number === 'number' ? s.number : null,
+        name: typeof s.name === 'string' ? s.name : '',
+        jobName: typeof job.name === 'string' ? job.name : '',
+        status: typeof s.status === 'string' ? s.status : 'queued',
+        conclusion: typeof s.conclusion === 'string' ? s.conclusion : null,
+        startedAt: s.started_at || null,
+        completedAt: s.completed_at || null,
+        durationMs: durationBetween(s.started_at, s.completed_at),
+        housekeeping: HOUSEKEEPING.test(typeof s.name === 'string' ? s.name : ''),
+        htmlUrl: job.html_url && typeof s.number === 'number'
+          ? `${job.html_url}#step:${s.number}:1`
+          : null,
+      };
+      flat.push(step);
+      steps.push(step);
+    }
+    outJobs.push({
+      name: typeof job.name === 'string' ? job.name : '',
+      status: typeof job.status === 'string' ? job.status : 'queued',
+      conclusion: typeof job.conclusion === 'string' ? job.conclusion : null,
+      startedAt: job.started_at || null,
+      completedAt: job.completed_at || null,
+      htmlUrl: job.html_url || null,
+      steps,
+    });
+  }
+
+  const total = flat.length;
+  const completed = flat.filter((s) => s.status === 'completed').length;
+  const skipped = flat.filter((s) => s.conclusion === 'skipped').length;
+  const failed = flat.filter((s) => s.conclusion === 'failure').length;
+
+  const runStatus = run && typeof run.status === 'string' ? run.status : 'queued';
+  const runConclusion = run && typeof run.conclusion === 'string' ? run.conclusion : null;
+  const runDone = runStatus === 'completed';
+
+  // `current`: the step in progress, else the first one still to come
+  // (labelled "starting" so the UI does not claim it has begun).
+  const running = flat.find((s) => s.status === 'in_progress') || null;
+  const next = running ? null : flat.find((s) => isPending(s.status)) || null;
+  let current = null;
+  if (running) {
+    current = { index: running.index, name: running.name, jobName: running.jobName, startedAt: running.startedAt, starting: false };
+  } else if (next && !runDone) {
+    current = { index: next.index, name: next.name, jobName: next.jobName, startedAt: null, starting: true };
+  }
+
+  // Indeterminate: nothing to count yet. Either no job has steps (queued
+  // behind the concurrency group, or no runner yet), or the job about to
+  // run has not reported its steps — never render "0 of 0".
+  let indeterminate = false;
+  let waitingFor = null;
+  if (!runDone) {
+    if (total === 0) {
+      indeterminate = true;
+    } else if (!running) {
+      const waitingJob = outJobs.find((j) => isPending(j.status) && j.steps.length === 0);
+      if (waitingJob) {
+        indeterminate = true;
+        waitingFor = waitingJob.name || null;
+      }
+    }
+  }
+
+  const firstFailure = flat.find((s) => s.conclusion === 'failure') || null;
+  const firstCancelled = flat.find((s) => s.conclusion === 'cancelled') || null;
+  const failedAt = firstFailure
+    ? { index: firstFailure.index, name: firstFailure.name, jobName: firstFailure.jobName, htmlUrl: firstFailure.htmlUrl }
+    : null;
+  const cancelledAt = runConclusion === 'cancelled'
+    ? (firstCancelled
+      ? { index: firstCancelled.index, name: firstCancelled.name, jobName: firstCancelled.jobName }
+      : null)
+    : null;
+
+  let percent = 0;
+  if (total > 0) {
+    if (runDone && runConclusion === 'success') {
+      percent = 100;
+    } else if (runDone && failedAt) {
+      percent = Math.round((failedAt.index / total) * 100);
+    } else if (runDone && cancelledAt) {
+      percent = Math.round((cancelledAt.index / total) * 100);
+    } else if (runDone) {
+      // completed with a conclusion that named no step (timed_out, skipped
+      // job): show what finished, do not pretend it is 100.
+      percent = Math.round((completed / total) * 100);
+    } else {
+      percent = Math.round((completed / total) * 100);
+    }
+  }
+
+  // "Work began" is the earliest job start, not run.created_at — the run
+  // can sit behind `concurrency: group: infrastructure` for minutes and
+  // that wait is reported separately by the UI.
+  const jobStarts = outJobs.map((j) => j.startedAt).filter(Boolean).sort();
+  const startedAt = jobStarts.length > 0 ? jobStarts[0] : (run && run.run_started_at) || null;
+
+  return {
+    runId: run && typeof run.id === 'number' ? run.id : null,
+    runNumber: run && typeof run.run_number === 'number' ? run.run_number : null,
+    status: runStatus,
+    conclusion: runConclusion,
+    htmlUrl: (run && run.html_url) || null,
+    createdAt: (run && run.created_at) || null,
+    startedAt,
+    percent,
+    indeterminate,
+    waitingFor,
+    current,
+    failedAt,
+    cancelledAt,
+    totals: { steps: total, completed, skipped, failed },
+    jobs: outJobs,
+  };
+}

--- a/control-plane/functions/api/deploy.js
+++ b/control-plane/functions/api/deploy.js
@@ -59,9 +59,10 @@ export async function onRequestPost(context) {
 
     // GitHub returns 204 No Content on success
     if (response.status === 204) {
-      await markDispatched(env.NEXUS_DB, 'setup');
+      const tracked = await markDispatched(env.NEXUS_DB, 'setup');
       return new Response(JSON.stringify({
         success: true,
+        tracked,
         message: 'Deploy workflow triggered successfully'
       }), {
         status: 200,

--- a/control-plane/functions/api/deploy.js
+++ b/control-plane/functions/api/deploy.js
@@ -10,6 +10,7 @@ import { logApiCall, logError } from './_utils/logger.js';
 import { fetchWithTimeout } from './_utils/fetch-with-timeout.js';
 import { requireSameOrigin } from './_utils/require-same-origin.js';
 import { requireAdmin } from './_utils/require-admin.js';
+import { markDispatched } from './_utils/dispatch-marker.js';
 
 export async function onRequestPost(context) {
   const { env, request } = context;
@@ -58,6 +59,7 @@ export async function onRequestPost(context) {
 
     // GitHub returns 204 No Content on success
     if (response.status === 204) {
+      await markDispatched(env.NEXUS_DB, 'setup');
       return new Response(JSON.stringify({
         success: true,
         message: 'Deploy workflow triggered successfully'

--- a/control-plane/functions/api/destroy.js
+++ b/control-plane/functions/api/destroy.js
@@ -1,7 +1,7 @@
 /**
  * Trigger Destroy All workflow
  * POST /api/destroy
- * 
+ *
  * Triggers the GitHub Actions destroy-all.yml workflow.
  * Includes validation and error handling.
  */
@@ -9,6 +9,7 @@ import { fetchWithTimeout } from './_utils/fetch-with-timeout.js';
 import { logApiCall, logError } from './_utils/logger.js';
 import { requireAdmin } from './_utils/require-admin.js';
 import { requireSameOrigin } from './_utils/require-same-origin.js';
+import { markDispatched } from './_utils/dispatch-marker.js';
 
 export async function onRequestPost(context) {
   const { env, request } = context;
@@ -21,9 +22,9 @@ export async function onRequestPost(context) {
 
   // Validate environment variables
   if (!env.GITHUB_TOKEN || !env.GITHUB_OWNER || !env.GITHUB_REPO) {
-    return new Response(JSON.stringify({ 
-      success: false, 
-      error: 'Missing required environment variables' 
+    return new Response(JSON.stringify({
+      success: false,
+      error: 'Missing required environment variables'
     }), {
       status: 500,
       headers: { 'Content-Type': 'application/json' },
@@ -31,7 +32,7 @@ export async function onRequestPost(context) {
   }
 
   const url = `https://api.github.com/repos/${env.GITHUB_OWNER}/${env.GITHUB_REPO}/actions/workflows/destroy-all.yml/dispatches`;
-  
+
   try {
     const response = await fetchWithTimeout(url, {
       method: 'POST',
@@ -41,7 +42,7 @@ export async function onRequestPost(context) {
         'User-Agent': 'Nexus-Stack-Control-Plane',
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({ 
+      body: JSON.stringify({
         ref: 'main',
         inputs: {
           confirm: 'DESTROY'
@@ -50,6 +51,7 @@ export async function onRequestPost(context) {
     });
 
     if (response.status === 204) {
+      await markDispatched(env.NEXUS_DB, 'destroy');
       await logApiCall(env.NEXUS_DB, '/api/destroy', 'POST', {
         action: 'destroy_all_triggered',
       });
@@ -64,7 +66,7 @@ export async function onRequestPost(context) {
 
     const errorText = await response.text();
     let errorMessage = `Failed to trigger workflow: ${response.status}`;
-    
+
     try {
       const errorJson = JSON.parse(errorText);
       errorMessage = errorJson.message || errorMessage;
@@ -76,9 +78,9 @@ export async function onRequestPost(context) {
 
     console.error(`Destroy trigger failed: ${response.status} - ${errorMessage}`);
 
-    return new Response(JSON.stringify({ 
-      success: false, 
-      error: errorMessage 
+    return new Response(JSON.stringify({
+      success: false,
+      error: errorMessage
     }), {
       status: response.status,
       headers: { 'Content-Type': 'application/json' },

--- a/control-plane/functions/api/destroy.js
+++ b/control-plane/functions/api/destroy.js
@@ -51,12 +51,13 @@ export async function onRequestPost(context) {
     });
 
     if (response.status === 204) {
-      await markDispatched(env.NEXUS_DB, 'destroy');
+      const tracked = await markDispatched(env.NEXUS_DB, 'destroy');
       await logApiCall(env.NEXUS_DB, '/api/destroy', 'POST', {
         action: 'destroy_all_triggered',
       });
       return new Response(JSON.stringify({
         success: true,
+        tracked,
         message: 'Destroy workflow triggered successfully'
       }), {
         status: 200,

--- a/control-plane/functions/api/setup.js
+++ b/control-plane/functions/api/setup.js
@@ -1,7 +1,7 @@
 /**
  * Trigger Setup Control Plane workflow
  * POST /api/setup
- * 
+ *
  * Triggers the GitHub Actions setup-control-plane.yaml workflow.
  * Includes validation, error handling, and retry logic.
  */
@@ -9,6 +9,7 @@ import { fetchWithTimeout } from './_utils/fetch-with-timeout.js';
 import { logApiCall, logError } from './_utils/logger.js';
 import { requireAdmin } from './_utils/require-admin.js';
 import { requireSameOrigin } from './_utils/require-same-origin.js';
+import { markDispatched } from './_utils/dispatch-marker.js';
 
 export async function onRequestPost(context) {
   const { env, request } = context;
@@ -21,9 +22,9 @@ export async function onRequestPost(context) {
 
   // Validate environment variables
   if (!env.GITHUB_TOKEN || !env.GITHUB_OWNER || !env.GITHUB_REPO) {
-    return new Response(JSON.stringify({ 
-      success: false, 
-      error: 'Missing required environment variables' 
+    return new Response(JSON.stringify({
+      success: false,
+      error: 'Missing required environment variables'
     }), {
       status: 500,
       headers: { 'Content-Type': 'application/json' },
@@ -31,7 +32,7 @@ export async function onRequestPost(context) {
   }
 
   const url = `https://api.github.com/repos/${env.GITHUB_OWNER}/${env.GITHUB_REPO}/actions/workflows/setup-control-plane.yaml/dispatches`;
-  
+
   try {
     const response = await fetchWithTimeout(url, {
       method: 'POST',
@@ -45,6 +46,7 @@ export async function onRequestPost(context) {
     });
 
     if (response.status === 204) {
+      await markDispatched(env.NEXUS_DB, 'setup');
       await logApiCall(env.NEXUS_DB, '/api/setup', 'POST', {
         action: 'setup_control_plane_triggered',
       });
@@ -61,7 +63,7 @@ export async function onRequestPost(context) {
 
     const errorText = await response.text();
     let errorMessage = `Failed to trigger workflow: ${response.status}`;
-    
+
     try {
       const errorJson = JSON.parse(errorText);
       errorMessage = errorJson.message || errorMessage;
@@ -73,9 +75,9 @@ export async function onRequestPost(context) {
 
     console.error(`Setup trigger failed: ${response.status} - ${errorMessage}`);
 
-    return new Response(JSON.stringify({ 
-      success: false, 
-      error: errorMessage 
+    return new Response(JSON.stringify({
+      success: false,
+      error: errorMessage
     }), {
       status: response.status,
       headers: { 'Content-Type': 'application/json' },

--- a/control-plane/functions/api/setup.js
+++ b/control-plane/functions/api/setup.js
@@ -46,12 +46,13 @@ export async function onRequestPost(context) {
     });
 
     if (response.status === 204) {
-      await markDispatched(env.NEXUS_DB, 'setup');
+      const tracked = await markDispatched(env.NEXUS_DB, 'setup');
       await logApiCall(env.NEXUS_DB, '/api/setup', 'POST', {
         action: 'setup_control_plane_triggered',
       });
       return new Response(JSON.stringify({
         success: true,
+        tracked,
         message: 'Setup workflow triggered successfully'
       }), {
         status: 200,

--- a/control-plane/functions/api/spin-up.js
+++ b/control-plane/functions/api/spin-up.js
@@ -104,9 +104,15 @@ export async function onRequestPost(context) {
     if (response.status === 204) {
       // Before answering: the dashboard re-polls 2 s after this response,
       // and without the marker it would find last night's run instead.
-      await markDispatched(env.NEXUS_DB, 'spinUp');
+      //
+      // `tracked: false` means the marker did not land (D1 down), so
+      // /api/status cannot protect this window. GitHub has accepted the
+      // dispatch either way — this is not a failure to retry — so the
+      // client holds its own latch instead. See window.NS.status.noteDispatch.
+      const tracked = await markDispatched(env.NEXUS_DB, 'spinUp');
       return new Response(JSON.stringify({
         success: true,
+        tracked,
         message: 'Spin-up workflow triggered successfully',
         enabledServices: enabledServicesList
       }), {

--- a/control-plane/functions/api/spin-up.js
+++ b/control-plane/functions/api/spin-up.js
@@ -12,6 +12,7 @@ import { fetchWithTimeout } from './_utils/fetch-with-timeout.js';
 import { resolveLifecycle } from './_utils/workflow-selection.js';
 import { requireSameOrigin } from './_utils/require-same-origin.js';
 import { requireOperator } from './_utils/require-operator.js';
+import { markDispatched } from './_utils/dispatch-marker.js';
 
 /**
  * Get enabled services from D1
@@ -101,6 +102,9 @@ export async function onRequestPost(context) {
     });
 
     if (response.status === 204) {
+      // Before answering: the dashboard re-polls 2 s after this response,
+      // and without the marker it would find last night's run instead.
+      await markDispatched(env.NEXUS_DB, 'spinUp');
       return new Response(JSON.stringify({
         success: true,
         message: 'Spin-up workflow triggered successfully',

--- a/control-plane/functions/api/status.js
+++ b/control-plane/functions/api/status.js
@@ -1,12 +1,80 @@
 /**
  * Get workflow status
- * GET /api/status
+ * GET /api/status[?progress_for=<run id>]
  *
- * Returns the current infrastructure state based on GitHub Actions workflow runs.
- * More robust than before - uses workflow file paths instead of name matching.
+ * Returns the current infrastructure state based on GitHub Actions workflow
+ * runs, and — while a lifecycle run is in progress — its step-by-step
+ * progress ("Step N of M") from the jobs API.
+ *
+ * ONE endpoint on purpose. The GitHub rate limit (5000/h) is per account,
+ * shared by every token of it. A second browser request per poll would
+ * double the spend for the same picture; folding the jobs fetch in here
+ * means one request from the browser and at most two to GitHub, and only
+ * the second while something is actually running. It also means the
+ * browser never supplies a run id to fetch — see `progress_for` below for
+ * the one narrow exception.
+ *
+ * `progress_for` exists so the dashboard can render the FINAL state of a
+ * run that just finished (100% green, or red at the failed step) — the
+ * status alone would drop it the moment `inProgress` turns false. The id
+ * is accepted only if it is one this endpoint itself selected; anything
+ * else is ignored, not fetched.
+ *
+ * No `requireSameOrigin` here: that guard requires a JSON Content-Type,
+ * which a browser GET never sends, and it exists for state-changing
+ * endpoints. Reads are gated by Cloudflare Access like every other GET.
  */
 import { fetchWithTimeout } from './_utils/fetch-with-timeout.js';
 import { ALL_SPINUP_WORKFLOWS, ALL_TEARDOWN_WORKFLOWS } from './_utils/workflow-selection.js';
+import { deriveProgress } from './_utils/run-progress.js';
+import { readDispatchMarker, DISPATCH_GRACE_MS, DISPATCH_SKEW_MS } from './_utils/dispatch-marker.js';
+
+const FAMILY_ORDER = ['initialSetup', 'setup', 'spinUp', 'teardown', 'destroy'];
+
+function githubHeaders(token) {
+  return {
+    'Authorization': `Bearer ${token}`,
+    'Accept': 'application/vnd.github.v3+json',
+    'User-Agent': 'Nexus-Stack-Control-Plane',
+  };
+}
+
+/** The wire shape for one run. Only fields the UI needs; never the raw run. */
+function summarise(run) {
+  if (!run) return null;
+  return {
+    id: run.id,
+    runNumber: run.run_number,
+    status: run.status,
+    conclusion: run.conclusion,
+    createdAt: run.created_at,
+    updatedAt: run.updated_at,
+    event: run.event,
+    url: run.html_url,
+  };
+}
+
+/**
+ * Jobs for one run, derived into progress. Never throws: a failure to
+ * look is reported as `unavailable`, not as "no steps" — the UI then says
+ * the step list could not be read instead of showing an empty one.
+ */
+async function fetchProgress(env, run) {
+  const url = `https://api.github.com/repos/${env.GITHUB_OWNER}/${env.GITHUB_REPO}/actions/runs/${run.id}/jobs?per_page=100`;
+  try {
+    const response = await fetchWithTimeout(url, { headers: githubHeaders(env.GITHUB_TOKEN) });
+    if (!response.ok) {
+      // Status code only. The body is GitHub's, but this project does not
+      // forward API bodies it has not looked at.
+      console.error(`GitHub jobs API error: ${response.status}`);
+      return { ...deriveProgress(run, null), unavailable: true };
+    }
+    return deriveProgress(run, await response.json());
+  } catch (error) {
+    console.error('GitHub jobs fetch failed:', error && error.name);
+    return { ...deriveProgress(run, null), unavailable: true };
+  }
+}
 
 export async function onRequestGet(context) {
   const { env, request } = context;
@@ -43,16 +111,23 @@ export async function onRequestGet(context) {
   };
   const matchesPath = (path, candidates) => candidates.some((c) => path.includes(c));
 
+  // Which family a run belongs to: path first (most reliable), then name.
+  // Initial Setup includes spin-up, so it counts as a successful deployment.
+  const classify = (run) => {
+    const path = run.path || run.workflow_id || '';
+    const name = run.name || '';
+    if (matchesPath(path, WORKFLOW_PATHS.initialSetup) || name.includes('Initial Setup')) return 'initialSetup';
+    if (matchesPath(path, WORKFLOW_PATHS.setup) || (name.includes('Setup') && !name.includes('Initial'))) return 'setup';
+    if (matchesPath(path, WORKFLOW_PATHS.spinUp) || name.includes('Spin Up') || name.includes('Spin-Up')) return 'spinUp';
+    if (matchesPath(path, WORKFLOW_PATHS.teardown) || name.includes('Teardown')) return 'teardown';
+    if (matchesPath(path, WORKFLOW_PATHS.destroy) || name.includes('Destroy')) return 'destroy';
+    return null;
+  };
+
   try {
     const url = `https://api.github.com/repos/${env.GITHUB_OWNER}/${env.GITHUB_REPO}/actions/runs?per_page=100`;
 
-    const response = await fetchWithTimeout(url, {
-      headers: {
-        'Authorization': `Bearer ${env.GITHUB_TOKEN}`,
-        'Accept': 'application/vnd.github.v3+json',
-        'User-Agent': 'Nexus-Stack-Control-Plane',
-      },
-    });
+    const response = await fetchWithTimeout(url, { headers: githubHeaders(env.GITHUB_TOKEN) });
 
     if (!response.ok) {
       const errorText = await response.text();
@@ -67,6 +142,11 @@ export async function onRequestGet(context) {
       });
     }
 
+    // Surfaced so the client can slow down before the account runs dry —
+    // the limit is shared with every other token of this GitHub user.
+    const remainingHeader = Number(response.headers.get('x-ratelimit-remaining'));
+    const rateLimitRemaining = Number.isFinite(remainingHeader) ? remainingHeader : null;
+
     const data = await response.json();
 
     if (!data.workflow_runs || !Array.isArray(data.workflow_runs)) {
@@ -79,48 +159,49 @@ export async function onRequestGet(context) {
       });
     }
 
-    // Find the most recent run for each workflow type
-    // Use workflow path (more reliable) or fallback to name
-    const workflows = {
-      initialSetup: null,
-      setup: null,
-      spinUp: null,
-      teardown: null,
-      destroy: null,
-    };
+    // A dispatch that has not shown up as a run yet. Runs of that family
+    // created before the dispatch are ignored while the marker is fresh,
+    // so the previous run cannot be mistaken for the new one — the race
+    // dispatch-marker.js describes.
+    const now = Date.now();
+    const marker = await readDispatchMarker(env.NEXUS_DB, now);
+    const cutoff = marker ? marker.at - DISPATCH_SKEW_MS : null;
+    const predatesDispatch = (family, run) =>
+      marker !== null && family === marker.family && Date.parse(run.created_at) < cutoff;
 
+    // Newest run per family. The list is newest-first, so first match wins.
+    const workflows = { initialSetup: null, setup: null, spinUp: null, teardown: null, destroy: null };
     for (const run of data.workflow_runs) {
-      const workflowPath = run.path || run.workflow_id || '';
-      const workflowName = run.name || '';
+      const family = classify(run);
+      if (!family || workflows[family]) continue;
+      if (predatesDispatch(family, run)) continue;
+      workflows[family] = run;
+    }
 
-      // Match by path first (most reliable), then fallback to name
-      // Initial Setup includes spin-up, so count it as a successful deployment
-      if (!workflows.initialSetup && (
-        matchesPath(workflowPath, WORKFLOW_PATHS.initialSetup) ||
-        workflowName.includes('Initial Setup')
-      )) {
-        workflows.initialSetup = run;
-      } else if (!workflows.setup && (
-        matchesPath(workflowPath, WORKFLOW_PATHS.setup) ||
-        workflowName.includes('Setup') && !workflowName.includes('Initial')
-      )) {
-        workflows.setup = run;
-      } else if (!workflows.spinUp && (
-        matchesPath(workflowPath, WORKFLOW_PATHS.spinUp) ||
-        workflowName.includes('Spin Up') ||
-        workflowName.includes('Spin-Up')
-      )) {
-        workflows.spinUp = run;
-      } else if (!workflows.teardown && (
-        matchesPath(workflowPath, WORKFLOW_PATHS.teardown) ||
-        workflowName.includes('Teardown')
-      )) {
-        workflows.teardown = run;
-      } else if (!workflows.destroy && (
-        matchesPath(workflowPath, WORKFLOW_PATHS.destroy) ||
-        workflowName.includes('Destroy')
-      )) {
-        workflows.destroy = run;
+    // Is anything running?
+    let runningFamily = null;
+    for (const family of FAMILY_ORDER) {
+      const r = workflows[family];
+      if (r && (r.status === 'in_progress' || r.status === 'queued')) {
+        runningFamily = family;
+        break;
+      }
+    }
+    const runningWorkflow = runningFamily ? workflows[runningFamily] : null;
+
+    // Dispatched, but GitHub has not listed the run yet.
+    let dispatching = false;
+    let dispatchTimedOut = false;
+    let dispatchedAt = null;
+    let dispatchedWorkflow = null;
+    if (marker) {
+      const candidate = workflows[marker.family];
+      const appeared = candidate && Date.parse(candidate.created_at) >= cutoff;
+      if (!appeared) {
+        dispatchedAt = new Date(marker.at).toISOString();
+        dispatchedWorkflow = marker.family;
+        if (marker.ageMs <= DISPATCH_GRACE_MS) dispatching = true;
+        else dispatchTimedOut = true;
       }
     }
 
@@ -128,13 +209,7 @@ export async function onRequestGet(context) {
     let infraState = 'unknown';
     let inProgress = false;
 
-    // Check if any workflow is currently running
-    const allRuns = [workflows.initialSetup, workflows.setup, workflows.spinUp, workflows.teardown, workflows.destroy].filter(Boolean);
-    const runningWorkflow = allRuns.find(r =>
-      r && (r.status === 'in_progress' || r.status === 'queued')
-    );
-
-    if (runningWorkflow) {
+    if (runningWorkflow || dispatching) {
       inProgress = true;
       infraState = 'running';
     } else {
@@ -145,18 +220,33 @@ export async function onRequestGet(context) {
         .sort((a, b) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime());
 
       if (completedRuns.length > 0) {
-        const lastRun = completedRuns[0];
-        const lastPath = lastRun.path || lastRun.workflow_id || '';
-        const lastName = lastRun.name || '';
-
+        const lastFamily = classify(completedRuns[0]);
         // Initial Setup or Spin Up means infrastructure is deployed
-        if (matchesPath(lastPath, WORKFLOW_PATHS.initialSetup) || lastName.includes('Initial Setup') ||
-            matchesPath(lastPath, WORKFLOW_PATHS.spinUp) || lastName.includes('Spin Up') || lastName.includes('Spin-Up')) {
+        if (lastFamily === 'initialSetup' || lastFamily === 'spinUp') {
           infraState = 'deployed';
-        } else if (matchesPath(lastPath, WORKFLOW_PATHS.teardown) || lastName.includes('Teardown')) {
+        } else if (lastFamily === 'teardown') {
           infraState = 'torn-down';
-        } else if (matchesPath(lastPath, WORKFLOW_PATHS.destroy) || lastName.includes('Destroy')) {
+        } else if (lastFamily === 'destroy') {
           infraState = 'destroyed';
+        }
+      }
+    }
+
+    // Step progress: for the running run, or for the one just-finished run
+    // the client asked about — and only if that id is one we selected.
+    let progress = null;
+    let progressFamily = null;
+    if (runningWorkflow) {
+      progress = await fetchProgress(env, runningWorkflow);
+      progressFamily = runningFamily;
+    } else {
+      const requested = new URL(request.url).searchParams.get('progress_for');
+      if (requested && /^\d{1,15}$/.test(requested)) {
+        const wanted = Number(requested);
+        const family = FAMILY_ORDER.find((f) => workflows[f] && workflows[f].id === wanted) || null;
+        if (family) {
+          progress = await fetchProgress(env, workflows[family]);
+          progressFamily = family;
         }
       }
     }
@@ -165,37 +255,20 @@ export async function onRequestGet(context) {
       success: true,
       infraState,
       inProgress,
+      runningWorkflow: runningFamily,
+      dispatching,
+      dispatchTimedOut,
+      dispatchedAt,
+      dispatchedWorkflow,
+      progress,
+      progressFamily,
+      rateLimitRemaining,
       workflows: {
-        initialSetup: workflows.initialSetup ? {
-          status: workflows.initialSetup.status,
-          conclusion: workflows.initialSetup.conclusion,
-          updatedAt: workflows.initialSetup.updated_at,
-          url: workflows.initialSetup.html_url,
-        } : null,
-        setup: workflows.setup ? {
-          status: workflows.setup.status,
-          conclusion: workflows.setup.conclusion,
-          updatedAt: workflows.setup.updated_at,
-          url: workflows.setup.html_url,
-        } : null,
-        spinUp: workflows.spinUp ? {
-          status: workflows.spinUp.status,
-          conclusion: workflows.spinUp.conclusion,
-          updatedAt: workflows.spinUp.updated_at,
-          url: workflows.spinUp.html_url,
-        } : null,
-        teardown: workflows.teardown ? {
-          status: workflows.teardown.status,
-          conclusion: workflows.teardown.conclusion,
-          updatedAt: workflows.teardown.updated_at,
-          url: workflows.teardown.html_url,
-        } : null,
-        destroy: workflows.destroy ? {
-          status: workflows.destroy.status,
-          conclusion: workflows.destroy.conclusion,
-          updatedAt: workflows.destroy.updated_at,
-          url: workflows.destroy.html_url,
-        } : null,
+        initialSetup: summarise(workflows.initialSetup),
+        setup: summarise(workflows.setup),
+        spinUp: summarise(workflows.spinUp),
+        teardown: summarise(workflows.teardown),
+        destroy: summarise(workflows.destroy),
       },
     }), {
       headers: {
@@ -207,7 +280,7 @@ export async function onRequestGet(context) {
     console.error('Status endpoint error:', error);
     return new Response(JSON.stringify({
       success: false,
-      error: 'Internal server error'
+      error: 'Failed to fetch workflow status'
     }), {
       status: 500,
       headers: { 'Content-Type': 'application/json' },

--- a/control-plane/functions/api/status.js
+++ b/control-plane/functions/api/status.js
@@ -27,7 +27,7 @@
 import { fetchWithTimeout } from './_utils/fetch-with-timeout.js';
 import { ALL_SPINUP_WORKFLOWS, ALL_TEARDOWN_WORKFLOWS } from './_utils/workflow-selection.js';
 import { deriveProgress } from './_utils/run-progress.js';
-import { readDispatchMarker, DISPATCH_GRACE_MS, DISPATCH_SKEW_MS } from './_utils/dispatch-marker.js';
+import { readDispatchMarkers, DISPATCH_GRACE_MS, DISPATCH_SKEW_MS } from './_utils/dispatch-marker.js';
 
 const FAMILY_ORDER = ['initialSetup', 'setup', 'spinUp', 'teardown', 'destroy'];
 
@@ -114,8 +114,12 @@ export async function onRequestGet(context) {
   // Which family a run belongs to: path first (most reliable), then name.
   // Initial Setup includes spin-up, so it counts as a successful deployment.
   const classify = (run) => {
-    const path = run.path || run.workflow_id || '';
-    const name = run.name || '';
+    // Strictly a string. `workflow_id` used to be the fallback here, and
+    // it is a NUMBER — `path.includes(...)` on it throws a TypeError and
+    // takes the whole endpoint down. It could not have matched a filename
+    // substring anyway.
+    const path = typeof run.path === 'string' ? run.path : '';
+    const name = typeof run.name === 'string' ? run.name : '';
     if (matchesPath(path, WORKFLOW_PATHS.initialSetup) || name.includes('Initial Setup')) return 'initialSetup';
     if (matchesPath(path, WORKFLOW_PATHS.setup) || (name.includes('Setup') && !name.includes('Initial'))) return 'setup';
     if (matchesPath(path, WORKFLOW_PATHS.spinUp) || name.includes('Spin Up') || name.includes('Spin-Up')) return 'spinUp';
@@ -144,8 +148,13 @@ export async function onRequestGet(context) {
 
     // Surfaced so the client can slow down before the account runs dry —
     // the limit is shared with every other token of this GitHub user.
-    const remainingHeader = Number(response.headers.get('x-ratelimit-remaining'));
-    const rateLimitRemaining = Number.isFinite(remainingHeader) ? remainingHeader : null;
+    //
+    // The null check is not defensive noise: `Number(null)` is 0, and a
+    // finite 0 reads as "no budget left", so a missing header would slow
+    // every poll to the low-budget cadence — including mid-run.
+    const remainingHeader = response.headers.get('x-ratelimit-remaining');
+    const remainingValue = remainingHeader === null ? NaN : Number(remainingHeader);
+    const rateLimitRemaining = Number.isFinite(remainingValue) ? remainingValue : null;
 
     const data = await response.json();
 
@@ -159,15 +168,20 @@ export async function onRequestGet(context) {
       });
     }
 
-    // A dispatch that has not shown up as a run yet. Runs of that family
-    // created before the dispatch are ignored while the marker is fresh,
-    // so the previous run cannot be mistaken for the new one — the race
-    // dispatch-marker.js describes.
+    // Dispatches that have not shown up as runs yet. Runs of a marked
+    // family created before its dispatch are ignored while the marker is
+    // fresh, so the previous run cannot be mistaken for the new one — the
+    // race dispatch-marker.js describes. Markers are per family: a
+    // teardown dispatched while a setup is still pending must not erase
+    // the setup's protection.
     const now = Date.now();
-    const marker = await readDispatchMarker(env.NEXUS_DB, now);
-    const cutoff = marker ? marker.at - DISPATCH_SKEW_MS : null;
-    const predatesDispatch = (family, run) =>
-      marker !== null && family === marker.family && Date.parse(run.created_at) < cutoff;
+    const markers = await readDispatchMarkers(env.NEXUS_DB, now);
+    const cutoffFor = (family) =>
+      markers[family] ? markers[family].at - DISPATCH_SKEW_MS : null;
+    const predatesDispatch = (family, run) => {
+      const cutoff = cutoffFor(family);
+      return cutoff !== null && Date.parse(run.created_at) < cutoff;
+    };
 
     // Newest run per family. The list is newest-first, so first match wins.
     const workflows = { initialSetup: null, setup: null, spinUp: null, teardown: null, destroy: null };
@@ -189,20 +203,26 @@ export async function onRequestGet(context) {
     }
     const runningWorkflow = runningFamily ? workflows[runningFamily] : null;
 
-    // Dispatched, but GitHub has not listed the run yet.
+    // Dispatched, but GitHub has not listed the run yet. Reported for the
+    // oldest still-pending dispatch, so two in flight cannot hide one
+    // another.
     let dispatching = false;
     let dispatchTimedOut = false;
     let dispatchedAt = null;
     let dispatchedWorkflow = null;
-    if (marker) {
-      const candidate = workflows[marker.family];
-      const appeared = candidate && Date.parse(candidate.created_at) >= cutoff;
-      if (!appeared) {
-        dispatchedAt = new Date(marker.at).toISOString();
-        dispatchedWorkflow = marker.family;
-        if (marker.ageMs <= DISPATCH_GRACE_MS) dispatching = true;
-        else dispatchTimedOut = true;
-      }
+    const pending = FAMILY_ORDER
+      .filter((family) => {
+        if (!markers[family]) return false;
+        const candidate = workflows[family];
+        return !(candidate && Date.parse(candidate.created_at) >= cutoffFor(family));
+      })
+      .sort((a, b) => markers[a].at - markers[b].at);
+    if (pending.length > 0) {
+      const family = pending[0];
+      dispatchedAt = new Date(markers[family].at).toISOString();
+      dispatchedWorkflow = family;
+      if (markers[family].ageMs <= DISPATCH_GRACE_MS) dispatching = true;
+      else dispatchTimedOut = true;
     }
 
     // Determine infrastructure state based on recent runs

--- a/control-plane/functions/api/teardown.js
+++ b/control-plane/functions/api/teardown.js
@@ -12,6 +12,7 @@ import { fetchWithTimeout } from './_utils/fetch-with-timeout.js';
 import { requireOperator } from './_utils/require-operator.js';
 import { resolveLifecycle } from './_utils/workflow-selection.js';
 import { requireSameOrigin } from './_utils/require-same-origin.js';
+import { markDispatched } from './_utils/dispatch-marker.js';
 
 export async function onRequestPost(context) {
   const { env, request } = context;
@@ -79,6 +80,7 @@ export async function onRequestPost(context) {
     });
 
     if (response.status === 204) {
+      await markDispatched(env.NEXUS_DB, 'teardown');
       return new Response(JSON.stringify({
         success: true,
         message: 'Teardown workflow triggered successfully'

--- a/control-plane/functions/api/teardown.js
+++ b/control-plane/functions/api/teardown.js
@@ -80,9 +80,12 @@ export async function onRequestPost(context) {
     });
 
     if (response.status === 204) {
-      await markDispatched(env.NEXUS_DB, 'teardown');
+      // `tracked: false` — marker not stored, so the client keeps its own
+      // latch. See spin-up.js for the reasoning.
+      const tracked = await markDispatched(env.NEXUS_DB, 'teardown');
       return new Response(JSON.stringify({
         success: true,
+        tracked,
         message: 'Teardown workflow triggered successfully'
       }), {
         status: 200,

--- a/control-plane/src/components/PendingBar.astro
+++ b/control-plane/src/components/PendingBar.astro
@@ -214,6 +214,10 @@
         const contentType = r.headers.get('content-type') || '';
         if (!contentType.includes('application/json')) {
           // Cloudflare Access expired — Astro session bounced.
+          // Clear the flag before returning: leaving it set makes
+          // applyRunState a no-op forever, so the button would stay
+          // enabled through the next run.
+          triggerInFlight = false;
           showToast('Session expired - please refresh the page', 'error');
           btnSpinUp.innerHTML = originalHTML;
           btnSpinUp.disabled = false;

--- a/control-plane/src/components/PendingBar.astro
+++ b/control-plane/src/components/PendingBar.astro
@@ -205,6 +205,11 @@
       btnSpinUp.disabled = true;
       btnSpinUp.innerHTML = '<span aria-hidden="true">&#x26A1;</span> Triggering…';
       triggerInFlight = true;
+      // Latch before the request: until it is set, a service toggle on
+      // another tab or page is still accepted and can commit after the
+      // workflow has read the enabled list.
+      ensureStatusSubscription();
+      if (window.NS && window.NS.status) window.NS.status.beginDispatch('spinUp');
       try {
         const r = await fetch('/api/spin-up', {
           method: 'POST',
@@ -218,6 +223,7 @@
           // applyRunState a no-op forever, so the button would stay
           // enabled through the next run.
           triggerInFlight = false;
+          if (window.NS && window.NS.status) window.NS.status.cancelDispatch();
           showToast('Session expired - please refresh the page', 'error');
           btnSpinUp.innerHTML = originalHTML;
           btnSpinUp.disabled = false;
@@ -229,21 +235,22 @@
           btnSpinUp.innerHTML = '<span aria-hidden="true">&#x26A1;</span> Running…';
           runWasInProgress = true;
           triggerInFlight = false;
-          // Latch the controls and force a fresh poll: /api/status reports
-          // `dispatching` during the seconds before GitHub lists the run,
-          // and the latch covers the cases where even that cannot — a
-          // response already in flight, or the D1 marker not landing.
-          ensureStatusSubscription();
+          // Force a fresh poll: /api/status reports `dispatching` during
+          // the seconds before GitHub lists the run, and the latch covers
+          // the cases where even that cannot — a response already in
+          // flight, or the D1 marker not landing.
           if (window.NS && window.NS.status) window.NS.status.noteDispatch('spinUp');
           setTimeout(refresh, 2000);
         } else {
           triggerInFlight = false;
+          if (window.NS && window.NS.status) window.NS.status.cancelDispatch();
           showToast(data.error || 'Failed to trigger Spin Up', 'error');
           btnSpinUp.innerHTML = originalHTML;
           btnSpinUp.disabled = false;
         }
       } catch (_) {
         triggerInFlight = false;
+        if (window.NS && window.NS.status) window.NS.status.cancelDispatch();
         showToast('Network error - please try again', 'error');
         btnSpinUp.innerHTML = originalHTML;
         btnSpinUp.disabled = false;

--- a/control-plane/src/components/PendingBar.astro
+++ b/control-plane/src/components/PendingBar.astro
@@ -163,6 +163,7 @@
         text.textContent = formatBreakdown(stackCount, fwCount);
         view.setAttribute('href', pickViewHref(stackCount, fwCount));
         bar.hidden = false;
+        ensureStatusSubscription();
       } else {
         bar.hidden = true;
       }
@@ -171,9 +172,29 @@
     // Issue #476: Spin Up button POSTs /api/spin-up directly, same
     // contract as the Dashboard button. Disable while the request is
     // in flight so a panicky double-click can't trigger two workflow
-    // runs. After a successful trigger, re-enables after a 30s safety
-    // timeout (the workflow itself takes minutes, but the operator
-    // might want to retry if our API call silently failed).
+    // runs.
+    //
+    // The button's state after that comes from window.NS.status, not from
+    // a timer. It used to re-enable itself after a blind 30s while the
+    // workflow was still running for another five minutes — so a second
+    // click was not just possible, it looked invited. Now it stays
+    // "Running…" until a poll says the run is over.
+    let runWasInProgress = false;
+
+    function applyRunState(data) {
+      if (!data || !data.success) return;
+      if (data.inProgress) {
+        runWasInProgress = true;
+        btnSpinUp.disabled = true;
+        btnSpinUp.innerHTML = '<span aria-hidden="true">&#x26A1;</span> Running…';
+      } else {
+        btnSpinUp.disabled = false;
+        btnSpinUp.innerHTML = '<span aria-hidden="true">&#x26A1;</span> Spin Up Now';
+        // A finished run changes what is deployed — recount.
+        if (runWasInProgress) { runWasInProgress = false; refresh(); }
+      }
+    }
+
     async function triggerSpinUp() {
       const originalHTML = btnSpinUp.innerHTML;
       btnSpinUp.disabled = true;
@@ -195,18 +216,13 @@
         const data = await r.json();
         if (data.success) {
           showToast('Spin Up triggered!');
-          // Re-fetch state — pending count usually stays the same until
-          // the workflow finishes + the deployed-state sync runs, but
-          // refreshing keeps us honest if anything else changed.
-          setTimeout(refresh, 2000);
           btnSpinUp.innerHTML = '<span aria-hidden="true">&#x26A1;</span> Running…';
-          // Re-enable after 30s — the workflow takes minutes but the
-          // operator might want to retry if our API call itself failed
-          // silently somewhere.
-          setTimeout(function() {
-            btnSpinUp.innerHTML = originalHTML;
-            btnSpinUp.disabled = false;
-          }, 30000);
+          // Ask the shared poller straight away. /api/status now reports
+          // `dispatching` during the seconds before GitHub lists the run,
+          // so this no longer sees the PREVIOUS run and concludes the
+          // stack is idle.
+          if (window.NS && window.NS.status) window.NS.status.refreshNow();
+          setTimeout(refresh, 2000);
         } else {
           showToast(data.error || 'Failed to trigger Spin Up', 'error');
           btnSpinUp.innerHTML = originalHTML;
@@ -230,6 +246,17 @@
     }
 
     btnSpinUp.addEventListener('click', triggerSpinUp);
+
+    // Only subscribe where the banner is actually shown — the dashboard
+    // subscribes anyway, and on other pages this starts the poller only
+    // once there is something pending to act on.
+    let unsubscribeStatus = null;
+    function ensureStatusSubscription() {
+      if (unsubscribeStatus || !window.NS || !window.NS.status) return;
+      unsubscribeStatus = window.NS.status.subscribe(function(data, err) {
+        if (!err) applyRunState(data);
+      });
+    }
 
     refresh();
     document.addEventListener('visibilitychange', function() {

--- a/control-plane/src/components/PendingBar.astro
+++ b/control-plane/src/components/PendingBar.astro
@@ -180,8 +180,13 @@
     // click was not just possible, it looked invited. Now it stays
     // "Running…" until a poll says the run is over.
     let runWasInProgress = false;
+    // Set for the duration of the POST. A scheduled poll landing in that
+    // window would otherwise overwrite "Triggering…" and clear `disabled`
+    // before the dispatch has even been accepted.
+    let triggerInFlight = false;
 
     function applyRunState(data) {
+      if (triggerInFlight) return;
       if (!data || !data.success) return;
       if (data.inProgress) {
         runWasInProgress = true;
@@ -199,6 +204,7 @@
       const originalHTML = btnSpinUp.innerHTML;
       btnSpinUp.disabled = true;
       btnSpinUp.innerHTML = '<span aria-hidden="true">&#x26A1;</span> Triggering…';
+      triggerInFlight = true;
       try {
         const r = await fetch('/api/spin-up', {
           method: 'POST',
@@ -217,18 +223,23 @@
         if (data.success) {
           showToast('Spin Up triggered!');
           btnSpinUp.innerHTML = '<span aria-hidden="true">&#x26A1;</span> Running…';
-          // Ask the shared poller straight away. /api/status now reports
+          runWasInProgress = true;
+          triggerInFlight = false;
+          // Latch the controls and force a fresh poll: /api/status reports
           // `dispatching` during the seconds before GitHub lists the run,
-          // so this no longer sees the PREVIOUS run and concludes the
-          // stack is idle.
-          if (window.NS && window.NS.status) window.NS.status.refreshNow();
+          // and the latch covers the cases where even that cannot — a
+          // response already in flight, or the D1 marker not landing.
+          ensureStatusSubscription();
+          if (window.NS && window.NS.status) window.NS.status.noteDispatch('spinUp');
           setTimeout(refresh, 2000);
         } else {
+          triggerInFlight = false;
           showToast(data.error || 'Failed to trigger Spin Up', 'error');
           btnSpinUp.innerHTML = originalHTML;
           btnSpinUp.disabled = false;
         }
       } catch (_) {
+        triggerInFlight = false;
         showToast('Network error - please try again', 'error');
         btnSpinUp.innerHTML = originalHTML;
         btnSpinUp.disabled = false;

--- a/control-plane/src/components/RunProgress.astro
+++ b/control-plane/src/components/RunProgress.astro
@@ -176,6 +176,9 @@
     // Expanded state is the operator's choice and must survive polls. It
     // is only forced open once, when a run fails.
     let expanded = false;
+    // What the operator last chose, so a dispatching phase in between can
+    // collapse the list without forgetting they had it open.
+    let expandedPreference = false;
     let autoExpandedFor = null;
     let dismissedRun = null;
     let renderedSignature = null;
@@ -270,8 +273,9 @@
       el.steps.innerHTML = html;
     }
 
-    function setExpanded(next) {
+    function setExpanded(next, remember) {
       expanded = next;
+      if (remember !== false) expandedPreference = next;
       el.toggle.setAttribute('aria-expanded', next ? 'true' : 'false');
       el.steps.hidden = !next;
     }
@@ -301,11 +305,14 @@
         el.bar.removeAttribute('aria-valuenow');
         el.bar.setAttribute('aria-valuetext', el.step.textContent);
         el.fill.style.width = data.dispatchTimedOut ? '0%' : '';
-        el.link.href = 'https://github.com';
         el.link.hidden = true;
         el.dismiss.hidden = true;
         el.toggle.hidden = true;
-        el.steps.hidden = true;
+        // Through setExpanded, not by setting `hidden` directly: hiding
+        // the list while `aria-expanded` still says "true" leaves the
+        // toggle lying, and the operator's next click is swallowed
+        // restoring a state that was never visible.
+        setExpanded(false, false);
         startElapsed(data.dispatchedAt);
         return;
       }
@@ -321,6 +328,9 @@
       root.hidden = false;
       el.toggle.hidden = false;
       el.link.hidden = false;
+      // Restore what the operator had chosen, in case a dispatching phase
+      // collapsed the list in between.
+      if (expandedPreference !== expanded) setExpanded(expandedPreference, false);
       root.className = 'run-progress'
         + (done && p.conclusion === 'success' ? ' is-success' : '')
         + (done && p.conclusion === 'failure' ? ' is-failure' : '')

--- a/control-plane/src/components/RunProgress.astro
+++ b/control-plane/src/components/RunProgress.astro
@@ -239,9 +239,14 @@
       // Rebuild only when something changed — the list is re-derived from
       // the API on every poll (so a newly added step shows up on its own),
       // but re-writing identical HTML would fight the operator's scroll.
-      const sig = progress.jobs.map(function(j) {
+      // `runId` leads the signature. Without it, two runs of the same
+      // workflow at the same step compare equal — the list would keep the
+      // PREVIOUS run's names, durations and step links while the header
+      // counts the new one. Durations are in too, since a step that is
+      // still running changes its duration without changing its status.
+      const sig = progress.runId + '#' + progress.jobs.map(function(j) {
         return j.name + ':' + j.steps.map(function(s) {
-          return s.index + s.status + (s.conclusion || '');
+          return [s.index, s.number, s.status, s.conclusion || '', s.durationMs == null ? '' : s.durationMs].join('~');
         }).join(',');
       }).join('|');
       if (sig === renderedSignature) return;

--- a/control-plane/src/components/RunProgress.astro
+++ b/control-plane/src/components/RunProgress.astro
@@ -1,0 +1,421 @@
+---
+// Live progress for the running lifecycle workflow.
+//
+// Replaces a banner that said "Workflow is running… This usually takes
+// 5-10 minutes" and left the operator to open GitHub to learn anything
+// else. Now: a bar, "Step N of M", the name of the step actually running,
+// and — behind Details — the full step list as GitHub shows it.
+//
+// The step list is NOT hardcoded anywhere. M is counted from
+// /actions/runs/{id}/jobs on every poll, so a step added to a workflow
+// later appears here with no change to the Control Plane, and M can grow
+// mid-run (the snapshot lifecycle's second job only reports its steps
+// once the first job finishes).
+//
+// Subscribes to window.NS.status — the single poller in StacksShared —
+// rather than fetching on its own.
+---
+
+<section id="run-progress" class="run-progress" hidden>
+  <div class="rp-head">
+    <span id="rp-glyph" class="rp-glyph" aria-hidden="true"></span>
+    <div class="rp-headline">
+      <strong id="rp-title">Workflow</strong>
+      <span id="rp-step" class="rp-step" aria-live="polite"></span>
+    </div>
+    <span id="rp-elapsed" class="rp-elapsed"></span>
+    <a id="rp-link" class="rp-link" href="#" target="_blank" rel="noopener noreferrer">View in GitHub</a>
+    <button id="rp-dismiss" class="rp-link rp-dismiss" type="button" hidden>Dismiss</button>
+  </div>
+
+  <div id="rp-bar" class="rp-bar" role="progressbar" aria-valuemin="0" aria-valuemax="100">
+    <div id="rp-fill" class="rp-fill"></div>
+  </div>
+
+  <button id="rp-toggle" class="rp-toggle" type="button" aria-expanded="false" aria-controls="rp-steps">
+    <span class="rp-caret" aria-hidden="true">&#9656;</span> Details
+  </button>
+  <ol id="rp-steps" class="rp-steps" hidden></ol>
+</section>
+
+<style>
+  .run-progress {
+    background: rgba(0, 170, 255, 0.06);
+    border: 1px solid rgba(0, 170, 255, 0.3);
+    border-left-width: 3px;
+    padding: 0.8rem 1.2rem;
+    margin-bottom: 1.5rem;
+    border-radius: 3px;
+  }
+  .run-progress[hidden] { display: none; }
+  .run-progress.is-success { background: rgba(0, 255, 136, 0.06); border-color: rgba(0, 255, 136, 0.35); }
+  .run-progress.is-failure { background: rgba(255, 68, 68, 0.06); border-color: rgba(255, 68, 68, 0.35); }
+  .run-progress.is-cancelled { background: rgba(102, 102, 102, 0.08); border-color: var(--border); }
+
+  .rp-head { display: flex; align-items: center; gap: 0.7rem; flex-wrap: wrap; }
+  .rp-glyph { font-family: 'JetBrains Mono', monospace; color: var(--info); }
+  .is-success .rp-glyph { color: var(--accent); }
+  .is-failure .rp-glyph { color: var(--error); }
+  .rp-glyph.is-spinning { animation: pulse 1.6s infinite; }
+
+  .rp-headline { flex: 1; min-width: 12rem; }
+  .rp-headline strong { display: block; font-size: 0.9rem; }
+  .rp-step { font-size: 0.8rem; color: var(--text-secondary); }
+  .rp-elapsed { font-size: 0.78rem; color: var(--text-muted); font-variant-numeric: tabular-nums; }
+
+  .rp-link {
+    color: var(--info); text-decoration: none; font-size: 0.78rem;
+    background: transparent; border: 1px solid rgba(0, 170, 255, 0.3);
+    border-radius: 3px; padding: 0.2rem 0.6rem; cursor: pointer; font-family: inherit;
+  }
+  .rp-link:hover { background: rgba(0, 170, 255, 0.1); }
+
+  .rp-bar {
+    position: relative; height: 6px; margin: 0.7rem 0 0.5rem;
+    background: rgba(255, 255, 255, 0.07); border-radius: 3px; overflow: hidden;
+  }
+  .rp-fill {
+    height: 100%; width: 0%; background: var(--info);
+    transition: width 0.4s ease;
+  }
+  .is-success .rp-fill { background: var(--accent); }
+  .is-failure .rp-fill { background: var(--error); }
+  .is-cancelled .rp-fill { background: var(--text-muted); }
+
+  /* Nothing to count yet: a run that is queued, or a job that has not
+     reported its steps. A sliding sliver rather than a fake percentage. */
+  .rp-bar.is-indeterminate .rp-fill {
+    width: 35%; background: var(--info);
+    animation: rp-slide 1.4s ease-in-out infinite;
+  }
+  @keyframes rp-slide {
+    0%   { transform: translateX(-100%); }
+    100% { transform: translateX(300%); }
+  }
+
+  .rp-toggle {
+    background: none; border: none; color: var(--text-secondary);
+    font-family: inherit; font-size: 0.78rem; cursor: pointer; padding: 0.2rem 0;
+  }
+  .rp-toggle:hover { color: var(--accent); }
+  .rp-caret { display: inline-block; transition: transform 0.2s; }
+  .rp-toggle[aria-expanded="true"] .rp-caret { transform: rotate(90deg); }
+
+  .rp-steps {
+    list-style: none; margin: 0.5rem 0 0; padding: 0;
+    max-height: 22rem; overflow-y: auto;
+    border-top: 1px solid var(--border);
+  }
+  .rp-steps[hidden] { display: none; }
+  .rp-steps li {
+    display: flex; align-items: baseline; gap: 0.6rem;
+    padding: 0.25rem 0; font-size: 0.8rem;
+    border-bottom: 1px solid rgba(42, 42, 62, 0.5);
+  }
+  .rp-job-head {
+    font-size: 0.75rem; color: var(--text-muted); text-transform: uppercase;
+    letter-spacing: 0.08em; padding-top: 0.6rem;
+  }
+  .rp-i { color: var(--text-muted); font-variant-numeric: tabular-nums; min-width: 2.2rem; }
+  .rp-mark { font-family: 'JetBrains Mono', monospace; min-width: 1rem; }
+  .rp-name { flex: 1; }
+  .rp-name a { color: inherit; text-decoration: none; }
+  .rp-name a:hover { text-decoration: underline; }
+  .rp-dur { color: var(--text-muted); font-variant-numeric: tabular-nums; }
+
+  .rp-done .rp-mark { color: var(--accent); }
+  .rp-running .rp-mark { color: var(--info); animation: pulse 1.6s infinite; }
+  .rp-running .rp-name { color: var(--text-primary); font-weight: 700; }
+  .rp-pending { opacity: 0.55; }
+  .rp-skipped { opacity: 0.45; }
+  .rp-failed .rp-mark, .rp-failed .rp-name { color: var(--error); }
+  /* Runner bookkeeping — kept in N/M so the numbers match GitHub's own
+     view, dimmed because nobody is waiting on "Post Checkout". */
+  .rp-housekeeping .rp-name { color: var(--text-muted); }
+
+  .rp-sr {
+    position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;
+    overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .rp-fill { transition: none; }
+    .rp-bar.is-indeterminate .rp-fill { animation: none; width: 100%; opacity: 0.4; }
+    .rp-glyph.is-spinning, .rp-running .rp-mark { animation: none; }
+  }
+</style>
+
+<script is:inline>
+  (function() {
+    const root = document.getElementById('run-progress');
+    if (!root || !window.NS || !window.NS.status) return;
+
+    const el = {
+      glyph: document.getElementById('rp-glyph'),
+      title: document.getElementById('rp-title'),
+      step: document.getElementById('rp-step'),
+      elapsed: document.getElementById('rp-elapsed'),
+      link: document.getElementById('rp-link'),
+      dismiss: document.getElementById('rp-dismiss'),
+      bar: document.getElementById('rp-bar'),
+      fill: document.getElementById('rp-fill'),
+      toggle: document.getElementById('rp-toggle'),
+      steps: document.getElementById('rp-steps'),
+    };
+
+    const LABELS = {
+      initialSetup: 'Initial Setup', setup: 'Control Plane Setup',
+      spinUp: 'Spin Up', teardown: 'Teardown', destroy: 'Destroy',
+    };
+
+    const esc = (s) => (typeof window.escapeHtml === 'function'
+      ? window.escapeHtml(s)
+      : String(s == null ? '' : s).replace(/[&<>"']/g, (c) => (
+        { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c])));
+
+    // Expanded state is the operator's choice and must survive polls. It
+    // is only forced open once, when a run fails.
+    let expanded = false;
+    let autoExpandedFor = null;
+    let dismissedRun = null;
+    let renderedSignature = null;
+    let elapsedTimer = null;
+    let elapsedFrom = null;
+
+    try {
+      const stored = sessionStorage.getItem('rp-dismissed');
+      if (stored) dismissedRun = Number(stored);
+    } catch (_) { /* private mode */ }
+
+    function fmtDuration(ms) {
+      if (!Number.isFinite(ms) || ms < 0) return '';
+      const s = Math.floor(ms / 1000);
+      if (s < 60) return s + 's';
+      const m = Math.floor(s / 60);
+      const rem = s % 60;
+      if (m < 60) return m + 'm ' + String(rem).padStart(2, '0') + 's';
+      return Math.floor(m / 60) + 'h ' + String(m % 60).padStart(2, '0') + 'm';
+    }
+
+    // Ticks locally once a second. Polling every second just to move a
+    // clock would spend rate limit on arithmetic the browser can do.
+    function startElapsed(from) {
+      elapsedFrom = from ? Date.parse(from) : null;
+      if (elapsedTimer) clearInterval(elapsedTimer);
+      if (!elapsedFrom) { el.elapsed.textContent = ''; return; }
+      const tick = function() {
+        el.elapsed.textContent = fmtDuration(Date.now() - elapsedFrom);
+      };
+      tick();
+      elapsedTimer = setInterval(tick, 1000);
+    }
+
+    function stopElapsed(finalMs) {
+      if (elapsedTimer) { clearInterval(elapsedTimer); elapsedTimer = null; }
+      el.elapsed.textContent = Number.isFinite(finalMs) ? fmtDuration(finalMs) : '';
+    }
+
+    function stepClass(s, failedIndex) {
+      if (s.conclusion === 'failure') return 'rp-failed';
+      if (s.conclusion === 'skipped') return 'rp-skipped';
+      if (s.status === 'in_progress') return 'rp-running';
+      if (s.status === 'completed') return 'rp-done';
+      return 'rp-pending';
+    }
+
+    function stepMark(s) {
+      if (s.conclusion === 'failure') return ['✗', 'failed'];
+      if (s.conclusion === 'skipped') return ['⊘', 'skipped'];
+      if (s.conclusion === 'cancelled') return ['⊘', 'cancelled'];
+      if (s.status === 'in_progress') return ['●', 'running'];
+      if (s.status === 'completed') return ['✓', 'done'];
+      return ['○', 'pending'];
+    }
+
+    function renderSteps(progress) {
+      // Rebuild only when something changed — the list is re-derived from
+      // the API on every poll (so a newly added step shows up on its own),
+      // but re-writing identical HTML would fight the operator's scroll.
+      const sig = progress.jobs.map(function(j) {
+        return j.name + ':' + j.steps.map(function(s) {
+          return s.index + s.status + (s.conclusion || '');
+        }).join(',');
+      }).join('|');
+      if (sig === renderedSignature) return;
+      renderedSignature = sig;
+
+      const failedIndex = progress.failedAt ? progress.failedAt.index : null;
+      const multiJob = progress.jobs.length > 1;
+      let html = '';
+      progress.jobs.forEach(function(job) {
+        if (multiJob) {
+          html += '<li class="rp-job-head">' + esc(job.name) + '</li>';
+        }
+        job.steps.forEach(function(s) {
+          const mark = stepMark(s);
+          const cls = stepClass(s, failedIndex) + (s.housekeeping ? ' rp-housekeeping' : '');
+          const dur = s.durationMs != null ? fmtDuration(s.durationMs) : '';
+          const name = s.htmlUrl
+            ? '<a href="' + esc(s.htmlUrl) + '" target="_blank" rel="noopener noreferrer">' + esc(s.name) + '</a>'
+            : esc(s.name);
+          html += '<li class="' + cls + '">'
+            + '<span class="rp-i">' + s.index + '</span>'
+            + '<span class="rp-mark" aria-hidden="true">' + mark[0] + '</span>'
+            + '<span class="rp-sr">' + mark[1] + '</span>'
+            + '<span class="rp-name">' + name + '</span>'
+            + '<span class="rp-dur">' + dur + '</span>'
+            + '</li>';
+        });
+      });
+      el.steps.innerHTML = html;
+    }
+
+    function setExpanded(next) {
+      expanded = next;
+      el.toggle.setAttribute('aria-expanded', next ? 'true' : 'false');
+      el.steps.hidden = !next;
+    }
+
+    function hide() {
+      root.hidden = true;
+      stopElapsed(null);
+      renderedSignature = null;
+    }
+
+    function render(data) {
+      if (!data || !data.success) { hide(); return; }
+
+      // Dispatched, but GitHub has not listed the run yet. Without this the
+      // dashboard would show the PREVIOUS run as if nothing had happened.
+      if (data.dispatching || data.dispatchTimedOut) {
+        const label = LABELS[data.dispatchedWorkflow] || 'Workflow';
+        root.hidden = false;
+        root.className = 'run-progress';
+        el.glyph.textContent = data.dispatchTimedOut ? '⚠' : '◐';
+        el.glyph.classList.toggle('is-spinning', !data.dispatchTimedOut);
+        el.title.textContent = label;
+        el.step.textContent = data.dispatchTimedOut
+          ? 'Could not find the run — open GitHub to check'
+          : 'Dispatched — waiting for GitHub to start the run';
+        el.bar.classList.toggle('is-indeterminate', !data.dispatchTimedOut);
+        el.bar.removeAttribute('aria-valuenow');
+        el.bar.setAttribute('aria-valuetext', el.step.textContent);
+        el.fill.style.width = data.dispatchTimedOut ? '0%' : '';
+        el.link.href = 'https://github.com';
+        el.link.hidden = true;
+        el.dismiss.hidden = true;
+        el.toggle.hidden = true;
+        el.steps.hidden = true;
+        startElapsed(data.dispatchedAt);
+        return;
+      }
+
+      const p = data.progress;
+      if (!p || !p.runId) { hide(); return; }
+      if (dismissedRun === p.runId && p.status === 'completed') { hide(); return; }
+
+      const label = LABELS[data.progressFamily] || 'Workflow';
+      const done = p.status === 'completed';
+      const total = p.totals.steps;
+
+      root.hidden = false;
+      el.toggle.hidden = false;
+      el.link.hidden = false;
+      root.className = 'run-progress'
+        + (done && p.conclusion === 'success' ? ' is-success' : '')
+        + (done && p.conclusion === 'failure' ? ' is-failure' : '')
+        + (done && p.conclusion === 'cancelled' ? ' is-cancelled' : '');
+
+      // Headline
+      if (done) {
+        el.glyph.classList.remove('is-spinning');
+        if (p.conclusion === 'success') {
+          el.glyph.textContent = '✓';
+          el.title.textContent = label + ' finished';
+          el.step.textContent = total + ' step' + (total === 1 ? '' : 's') + ' completed';
+        } else if (p.conclusion === 'failure') {
+          el.glyph.textContent = '✗';
+          el.title.textContent = label + ' failed';
+          el.step.textContent = p.failedAt
+            ? 'Failed at step ' + p.failedAt.index + ' of ' + total + ': ' + p.failedAt.name
+            : 'Failed — see the step list';
+        } else {
+          el.glyph.textContent = '⊘';
+          el.title.textContent = label + ' ' + (p.conclusion || 'ended');
+          el.step.textContent = p.cancelledAt
+            ? 'Cancelled at step ' + p.cancelledAt.index + ' of ' + total
+            : '';
+        }
+      } else {
+        el.glyph.textContent = '◐';
+        el.glyph.classList.add('is-spinning');
+        el.title.textContent = label + ' is running';
+        if (p.unavailable) {
+          el.step.textContent = 'Running — step details are unavailable right now';
+        } else if (p.indeterminate) {
+          el.step.textContent = p.waitingFor
+            ? 'Waiting for job "' + p.waitingFor + '"'
+            : 'Queued — waiting for a runner';
+        } else if (p.current) {
+          el.step.textContent = 'Step ' + p.current.index + ' of ' + total + ': '
+            + (p.current.starting ? 'starting ' : '') + p.current.name;
+        } else {
+          el.step.textContent = p.totals.completed + ' of ' + total + ' steps';
+        }
+      }
+
+      // Bar
+      const indeterminate = !done && (p.indeterminate || p.unavailable);
+      el.bar.classList.toggle('is-indeterminate', indeterminate);
+      if (indeterminate) {
+        el.bar.removeAttribute('aria-valuenow');
+        el.fill.style.width = '';
+      } else {
+        el.fill.style.width = p.percent + '%';
+        el.bar.setAttribute('aria-valuenow', String(p.percent));
+      }
+      el.bar.setAttribute('aria-valuetext', el.step.textContent);
+
+      el.link.href = p.htmlUrl || '#';
+      el.dismiss.hidden = !done;
+
+      // Elapsed: from the first job's start, so time spent queued behind
+      // the concurrency group is not counted as work.
+      if (done) {
+        const started = p.startedAt ? Date.parse(p.startedAt) : null;
+        const ended = data.workflows && data.workflows[data.progressFamily]
+          ? Date.parse(data.workflows[data.progressFamily].updatedAt) : null;
+        stopElapsed(started && ended ? ended - started : null);
+      } else if (p.startedAt) {
+        if (elapsedFrom !== Date.parse(p.startedAt)) startElapsed(p.startedAt);
+      } else {
+        startElapsed(p.createdAt);
+      }
+
+      if (total > 0) renderSteps(p);
+
+      // Open the list once on failure — that is when the detail is the
+      // point. Never collapse what the operator opened.
+      if (done && p.conclusion === 'failure' && autoExpandedFor !== p.runId) {
+        autoExpandedFor = p.runId;
+        setExpanded(true);
+      }
+    }
+
+    el.toggle.addEventListener('click', function() { setExpanded(!expanded); });
+    el.dismiss.addEventListener('click', function() {
+      const cur = window.NS.status.current();
+      const id = cur && cur.progress ? cur.progress.runId : null;
+      if (id) {
+        dismissedRun = id;
+        try { sessionStorage.setItem('rp-dismissed', String(id)); } catch (_) {}
+      }
+      hide();
+    });
+
+    window.NS.status.subscribe(function(data, err) {
+      if (err) return;      // keep the last good picture; the poller backs off
+      render(data);
+    });
+  })();
+</script>

--- a/control-plane/src/components/StacksShared.astro
+++ b/control-plane/src/components/StacksShared.astro
@@ -231,10 +231,15 @@ import { CATEGORIES, CATEGORY_ORDER } from '../lib/categories.ts';
     const generation = statusGeneration;
     const isCurrent = function() { return generation === statusGeneration; };
 
-    // Ask for the pinned run's steps only once it is no longer the running
-    // one; while it runs the server returns its progress anyway.
+    // Sent whenever a run is pinned, not only once we believe it stopped.
+    // The poll that DISCOVERS the run has finished is decided by the state
+    // of the previous poll, which still said "running" — so it would omit
+    // the parameter, the server would return no progress, and the final
+    // bar would blink out and reappear one cadence later. The server
+    // ignores the parameter while a run is active (it returns the running
+    // run's progress regardless), so sending it always costs nothing.
     let url = '/api/status';
-    if (statusPinnedRun && (!statusLast || !statusLast.inProgress)) {
+    if (statusPinnedRun) {
       url += '?progress_for=' + encodeURIComponent(statusPinnedRun);
     }
     const request = fetch(url, { credentials: 'same-origin' })
@@ -339,8 +344,26 @@ import { CATEGORIES, CATEGORY_ORDER } from '../lib/categories.ts';
     /** Fetch now. Pass {force:true} to bypass an in-flight request. */
     refreshNow: function(opts) { return statusFetch(opts); },
     /**
-     * Call right after a dispatch returns 200. Holds the controls locked
-     * locally until a poll proves the server is tracking the run — see
+     * Call BEFORE issuing the dispatch request, not after it returns.
+     *
+     * The POST takes a moment, and until the latch is set `runLocked()` is
+     * false — so a service toggle in that window is accepted, commits to
+     * D1, and may land after the workflow has already read the enabled
+     * list. The run then uses the old configuration while the UI shows the
+     * new one, which is the desync this lock exists to prevent.
+     */
+    beginDispatch: function(family) {
+      dispatchLatch = { family: family || null, at: Date.now() };
+      statusDeliver(decorate(statusLast || { success: true }), null);
+    },
+    /** The dispatch failed — release the controls. */
+    cancelDispatch: function() {
+      dispatchLatch = null;
+      statusDeliver(decorate(statusLast || { success: true }), null);
+    },
+    /**
+     * Call once a dispatch has returned 200. Keeps the controls locked
+     * until a poll proves the server is tracking the run — see
      * `dispatchLatch` above for the four ways that would otherwise fail.
      */
     noteDispatch: function(family) {

--- a/control-plane/src/components/StacksShared.astro
+++ b/control-plane/src/components/StacksShared.astro
@@ -117,6 +117,9 @@ import { CATEGORIES, CATEGORY_ORDER } from '../lib/categories.ts';
   const STATUS_LOW_BUDGET_MS = 15000;
   const STATUS_MAX_MS = 60000;
   const RATE_LIMIT_FLOOR = 500;
+  // Matches DISPATCH_GRACE_MS on the server. Only a give-up bound — the
+  // latch normally clears as soon as a poll shows the server knows.
+  const DISPATCH_LATCH_MS = 90000;
 
   let statusSubscribers = [];
   let statusLast = null;
@@ -127,6 +130,59 @@ import { CATEGORIES, CATEGORY_ORDER } from '../lib/categories.ts';
   // progress", so the finished bar (100% green, or red at the failed step)
   // survives instead of vanishing the moment the run ends.
   let statusPinnedRun = null;
+  let statusFinalProgress = null;
+  let statusFinalProgressFamily = null;
+
+  // LOCAL LATCH. Between clicking Spin Up and a poll that can see the new
+  // run there are several ways to be told "nothing is running", and each
+  // one re-enables the button on a stack that is mid-provision:
+  //
+  //   - a poll already in flight when the click happened answers with data
+  //     computed before the dispatch;
+  //   - a scheduled poll lands while the POST is still open;
+  //   - the D1 marker did not store (`tracked: false`), so the server has
+  //     no way to know either;
+  //   - the poll itself fails, and the error path used to fall back to
+  //     "not in progress".
+  //
+  // `spin-up.yml` has no concurrency lock, so a second click is a second
+  // provisioning run. The latch says "a dispatch is outstanding" from the
+  // click until a poll proves the server has taken over — nothing else
+  // clears it except the give-up bound.
+  let dispatchLatch = null;   // { family, at }
+
+  function latchActive(now) {
+    if (!dispatchLatch) return false;
+    if ((now || Date.now()) - dispatchLatch.at > DISPATCH_LATCH_MS) {
+      dispatchLatch = null;
+      return false;
+    }
+    return true;
+  }
+
+  // The server has taken over once it reports the run running, or reports
+  // the dispatch itself as pending. Either way it will keep the controls
+  // locked without our help.
+  function serverKnows(data) {
+    if (!data || !data.success) return false;
+    if (data.dispatching || data.dispatchTimedOut) return true;
+    return data.inProgress === true;
+  }
+
+  /** What subscribers see: the payload, with the latch folded in. */
+  function decorate(data) {
+    if (!latchActive()) return data;
+    if (serverKnows(data)) { dispatchLatch = null; return data; }
+    if (!data || !data.success) return data;
+    return Object.assign({}, data, {
+      inProgress: true,
+      dispatching: true,
+      dispatchedWorkflow: data.dispatchedWorkflow || dispatchLatch.family,
+      dispatchedAt: data.dispatchedAt || new Date(dispatchLatch.at).toISOString(),
+      infraState: 'running',
+      latched: true,
+    });
+  }
 
   function statusInterval() {
     if (statusErrors > 0) {
@@ -136,6 +192,9 @@ import { CATEGORIES, CATEGORY_ORDER } from '../lib/categories.ts';
         && statusLast.rateLimitRemaining < RATE_LIMIT_FLOOR) {
       return STATUS_LOW_BUDGET_MS;
     }
+    // Latched counts as running: this is exactly the window in which the
+    // next poll matters most.
+    if (latchActive()) return STATUS_FAST_MS;
     return (statusLast && statusLast.inProgress) ? STATUS_FAST_MS : STATUS_IDLE_MS;
   }
 
@@ -146,48 +205,96 @@ import { CATEGORIES, CATEGORY_ORDER } from '../lib/categories.ts';
     statusTimer = setTimeout(function() { statusFetch(); }, statusInterval());
   }
 
-  function statusFetch() {
-    if (statusInflight) return statusInflight;
+  function statusDeliver(data, err) {
+    statusSubscribers.forEach(function(fn) {
+      try { fn(data, err); } catch (e) { console.error('status subscriber failed:', e); }
+    });
+  }
+
+  function statusFetch(opts) {
+    // `force` skips the in-flight share. After a dispatch the request
+    // already open was computed BEFORE it, and reusing it would report the
+    // stack as idle milliseconds after the click.
+    const force = opts && opts.force;
+    if (statusInflight && !force) return statusInflight;
+
     // Ask for the pinned run's steps only once it is no longer the running
     // one; while it runs the server returns its progress anyway.
     let url = '/api/status';
     if (statusPinnedRun && (!statusLast || !statusLast.inProgress)) {
       url += '?progress_for=' + encodeURIComponent(statusPinnedRun);
     }
-    statusInflight = fetch(url, { credentials: 'same-origin' })
+    const request = fetch(url, { credentials: 'same-origin' })
       .then(function(r) {
         const ct = r.headers.get('content-type') || '';
         if (!ct.includes('application/json')) throw new Error('non-json');
         return r.json();
       })
       .then(function(data) {
-        statusInflight = null;
+        if (statusInflight === request) statusInflight = null;
+        // `success: false` is a JSON body, not a success — /api/status
+        // answers that way for a 500, an unusable GitHub response, and a
+        // GitHub non-2xx (rate limiting included). Counting it as a good
+        // poll kept the cadence at 10s against a failing upstream.
+        if (!data || !data.success) {
+          statusErrors += 1;
+          statusDeliver(decorate(data), new Error((data && data.error) || 'status failed'));
+          statusSchedule();
+          return data;
+        }
         statusErrors = 0;
+
+        // Keep the finished run's steps on screen without asking GitHub
+        // for them again on every idle poll. The pin is dropped as soon as
+        // the run reports `completed`; the payload is kept so later polls,
+        // which carry no `progress`, still render the final bar.
+        //
+        // The augmented payload — not the raw one — becomes `statusLast`.
+        // Assigning first and augmenting after looks equivalent and is
+        // not: `current()` and the replay on subscribe would then hand out
+        // a payload with no progress and the finished bar would vanish on
+        // the next page interaction.
+        let finalFamily = statusFinalProgressFamily;
+        if (data.progress && data.progress.runId) {
+          if (data.progress.status === 'completed') {
+            statusFinalProgress = data.progress;
+            statusFinalProgressFamily = data.progressFamily || null;
+            statusPinnedRun = null;
+          } else {
+            statusFinalProgress = null;
+            statusFinalProgressFamily = null;
+            statusPinnedRun = data.progress.runId;
+          }
+        } else if (statusFinalProgress && !data.inProgress) {
+          data = Object.assign({}, data, {
+            progress: statusFinalProgress,
+            progressFamily: data.progressFamily || finalFamily || null,
+          });
+        }
+
         statusLast = data;
-        if (data && data.progress && data.progress.runId) statusPinnedRun = data.progress.runId;
-        statusSubscribers.forEach(function(fn) {
-          try { fn(data); } catch (e) { console.error('status subscriber failed:', e); }
-        });
+        statusDeliver(decorate(data), null);
         statusSchedule();
         return data;
       })
       .catch(function(err) {
-        statusInflight = null;
+        if (statusInflight === request) statusInflight = null;
         statusErrors += 1;
-        statusSubscribers.forEach(function(fn) {
-          try { fn(null, err); } catch (e) { console.error('status subscriber failed:', e); }
-        });
+        // Deliver the latch even on failure — a transient network error
+        // must not be read as "the run finished".
+        statusDeliver(latchActive() ? decorate({ success: true }) : null, err);
         statusSchedule();
         return null;
       });
-    return statusInflight;
+    statusInflight = request;
+    return request;
   }
 
   window.NS.status = {
     /** Call fn(data, err) on every poll. Returns an unsubscribe function. */
     subscribe: function(fn) {
       statusSubscribers.push(fn);
-      if (statusLast) { try { fn(statusLast); } catch (e) {} }
+      if (statusLast) { try { fn(decorate(statusLast)); } catch (e) {} }
       if (statusSubscribers.length === 1) statusFetch();
       else statusSchedule();
       return function() {
@@ -198,19 +305,29 @@ import { CATEGORIES, CATEGORY_ORDER } from '../lib/categories.ts';
         }
       };
     },
-    /** Fetch now — after a dispatch, or when the tab becomes visible. */
-    refreshNow: function() { return statusFetch(); },
+    /** Fetch now. Pass {force:true} to bypass an in-flight request. */
+    refreshNow: function(opts) { return statusFetch(opts); },
+    /**
+     * Call right after a dispatch returns 200. Holds the controls locked
+     * locally until a poll proves the server is tracking the run — see
+     * `dispatchLatch` above for the four ways that would otherwise fail.
+     */
+    noteDispatch: function(family) {
+      dispatchLatch = { family: family || null, at: Date.now() };
+      statusDeliver(decorate(statusLast || { success: true }), null);
+      return statusFetch({ force: true });
+    },
     /** Last payload, or null before the first response. */
-    current: function() { return statusLast; },
-    /** Keep showing this run's steps after it finishes. */
-    pinRun: function(id) { statusPinnedRun = id || null; },
+    current: function() { return statusLast ? decorate(statusLast) : null; },
+    /** Is a dispatch outstanding that no poll has confirmed yet? */
+    isLatched: function() { return latchActive(); },
   };
 
   document.addEventListener('visibilitychange', function() {
     if (document.hidden) {
       if (statusTimer) { clearTimeout(statusTimer); statusTimer = null; }
     } else if (statusSubscribers.length > 0) {
-      statusFetch();
+      statusFetch({ force: true });
     }
   });
 

--- a/control-plane/src/components/StacksShared.astro
+++ b/control-plane/src/components/StacksShared.astro
@@ -150,6 +150,7 @@ import { CATEGORIES, CATEGORY_ORDER } from '../lib/categories.ts';
   // click until a poll proves the server has taken over — nothing else
   // clears it except the give-up bound.
   let dispatchLatch = null;   // { family, at }
+  let runLockStarted = false;
 
   function latchActive(now) {
     if (!dispatchLatch) return false;
@@ -321,6 +322,27 @@ import { CATEGORIES, CATEGORY_ORDER } from '../lib/categories.ts';
     current: function() { return statusLast ? decorate(statusLast) : null; },
     /** Is a dispatch outstanding that no poll has confirmed yet? */
     isLatched: function() { return latchActive(); },
+    /** Should service toggles be refused right now? */
+    runLocked: function() {
+      if (latchActive()) return true;
+      return !!(statusLast && statusLast.success && statusLast.inProgress);
+    },
+  };
+
+  /**
+   * Start polling and mark <body> while a run is in progress, so pages
+   * that render toggles can grey them out. Call from those pages only —
+   * this is what makes them poll at all, and pages without toggles have
+   * no reason to spend GitHub rate limit.
+   */
+  window.NS.lockControlsDuringRuns = function() {
+    if (runLockStarted) return;
+    runLockStarted = true;
+    const apply = function() {
+      document.body.classList.toggle('run-locked', window.NS.status.runLocked());
+    };
+    window.NS.status.subscribe(apply);
+    apply();
   };
 
   document.addEventListener('visibilitychange', function() {
@@ -364,6 +386,17 @@ import { CATEGORIES, CATEGORY_ORDER } from '../lib/categories.ts';
 
   window.NS.toggleService = async function(name, enabled) {
     const action = enabled ? 'enable' : 'disable';
+    // A toggle made during a run is silently ignored by that run: the
+    // enabled-services list was read from D1 when the workflow started.
+    // The UI would then show one configuration and the stack would be
+    // running another, with nothing to tell the operator which. Refuse
+    // here rather than in each page — click, keyboard shortcut and all
+    // three pages that render toggles funnel through this function.
+    if (window.NS.status && window.NS.status.runLocked()) {
+      const msg = 'A workflow is running — changes now would not be picked up. Wait for it to finish.';
+      if (typeof showToast === 'function') showToast(msg, 'error');
+      return { success: false, error: msg };
+    }
     try {
       const response = await fetch('/api/services', {
         method: 'POST',

--- a/control-plane/src/components/StacksShared.astro
+++ b/control-plane/src/components/StacksShared.astro
@@ -95,6 +95,125 @@ import { CATEGORIES, CATEGORY_ORDER } from '../lib/categories.ts';
     servicesCacheTime = 0;
   };
 
+  // ---- Workflow status subscription ---------------------------------------
+  // ONE poller for the whole page. The dashboard renders the progress bar,
+  // PendingBar drives its "Spin Up Now" button from it, and both used to
+  // guess independently — PendingBar with a 30s timer that re-enabled the
+  // button whether or not the run had finished.
+  //
+  // Cadence is deliberate, because /api/status costs GitHub rate limit and
+  // that limit is per ACCOUNT, shared with every other token of this user:
+  //   5s   a run is in progress and the tab is visible  (near-realtime)
+  //   10s  idle
+  //   ---  hidden tab: nothing at all, and an immediate fetch on return
+  // Under 500 remaining calls it backs off to 15s. Errors back off
+  // exponentially to 60s, as the dashboard's own poller did before.
+  //
+  // Starts LAZILY: nothing polls until someone subscribes, so /stacks and
+  // /settings add no GitHub load just by mounting PendingBar.
+
+  const STATUS_FAST_MS = 5000;
+  const STATUS_IDLE_MS = 10000;
+  const STATUS_LOW_BUDGET_MS = 15000;
+  const STATUS_MAX_MS = 60000;
+  const RATE_LIMIT_FLOOR = 500;
+
+  let statusSubscribers = [];
+  let statusLast = null;
+  let statusTimer = null;
+  let statusErrors = 0;
+  let statusInflight = null;
+  // The run whose progress we still want after it stops being "in
+  // progress", so the finished bar (100% green, or red at the failed step)
+  // survives instead of vanishing the moment the run ends.
+  let statusPinnedRun = null;
+
+  function statusInterval() {
+    if (statusErrors > 0) {
+      return Math.min(STATUS_IDLE_MS * Math.pow(2, Math.min(statusErrors, 6)), STATUS_MAX_MS);
+    }
+    if (statusLast && typeof statusLast.rateLimitRemaining === 'number'
+        && statusLast.rateLimitRemaining < RATE_LIMIT_FLOOR) {
+      return STATUS_LOW_BUDGET_MS;
+    }
+    return (statusLast && statusLast.inProgress) ? STATUS_FAST_MS : STATUS_IDLE_MS;
+  }
+
+  function statusSchedule() {
+    if (statusTimer) clearTimeout(statusTimer);
+    if (statusSubscribers.length === 0) return;
+    if (document.hidden) return;   // resumed by visibilitychange
+    statusTimer = setTimeout(function() { statusFetch(); }, statusInterval());
+  }
+
+  function statusFetch() {
+    if (statusInflight) return statusInflight;
+    // Ask for the pinned run's steps only once it is no longer the running
+    // one; while it runs the server returns its progress anyway.
+    let url = '/api/status';
+    if (statusPinnedRun && (!statusLast || !statusLast.inProgress)) {
+      url += '?progress_for=' + encodeURIComponent(statusPinnedRun);
+    }
+    statusInflight = fetch(url, { credentials: 'same-origin' })
+      .then(function(r) {
+        const ct = r.headers.get('content-type') || '';
+        if (!ct.includes('application/json')) throw new Error('non-json');
+        return r.json();
+      })
+      .then(function(data) {
+        statusInflight = null;
+        statusErrors = 0;
+        statusLast = data;
+        if (data && data.progress && data.progress.runId) statusPinnedRun = data.progress.runId;
+        statusSubscribers.forEach(function(fn) {
+          try { fn(data); } catch (e) { console.error('status subscriber failed:', e); }
+        });
+        statusSchedule();
+        return data;
+      })
+      .catch(function(err) {
+        statusInflight = null;
+        statusErrors += 1;
+        statusSubscribers.forEach(function(fn) {
+          try { fn(null, err); } catch (e) { console.error('status subscriber failed:', e); }
+        });
+        statusSchedule();
+        return null;
+      });
+    return statusInflight;
+  }
+
+  window.NS.status = {
+    /** Call fn(data, err) on every poll. Returns an unsubscribe function. */
+    subscribe: function(fn) {
+      statusSubscribers.push(fn);
+      if (statusLast) { try { fn(statusLast); } catch (e) {} }
+      if (statusSubscribers.length === 1) statusFetch();
+      else statusSchedule();
+      return function() {
+        statusSubscribers = statusSubscribers.filter(function(x) { return x !== fn; });
+        if (statusSubscribers.length === 0 && statusTimer) {
+          clearTimeout(statusTimer);
+          statusTimer = null;
+        }
+      };
+    },
+    /** Fetch now — after a dispatch, or when the tab becomes visible. */
+    refreshNow: function() { return statusFetch(); },
+    /** Last payload, or null before the first response. */
+    current: function() { return statusLast; },
+    /** Keep showing this run's steps after it finishes. */
+    pinRun: function(id) { statusPinnedRun = id || null; },
+  };
+
+  document.addEventListener('visibilitychange', function() {
+    if (document.hidden) {
+      if (statusTimer) { clearTimeout(statusTimer); statusTimer = null; }
+    } else if (statusSubscribers.length > 0) {
+      statusFetch();
+    }
+  });
+
   // ---- Tri-state status ---------------------------------------------------
   // enabled + deployed -> running
   // enabled + !deployed -> pending-enable

--- a/control-plane/src/components/StacksShared.astro
+++ b/control-plane/src/components/StacksShared.astro
@@ -132,6 +132,8 @@ import { CATEGORIES, CATEGORY_ORDER } from '../lib/categories.ts';
   let statusPinnedRun = null;
   let statusFinalProgress = null;
   let statusFinalProgressFamily = null;
+  let statusFinalProgressRunId = null;
+  let statusGeneration = 0;
 
   // LOCAL LATCH. Between clicking Spin Up and a poll that can see the new
   // run there are several ways to be told "nothing is running", and each
@@ -219,6 +221,16 @@ import { CATEGORIES, CATEGORY_ORDER } from '../lib/categories.ts';
     const force = opts && opts.force;
     if (statusInflight && !force) return statusInflight;
 
+    // Every request carries a generation. Forcing leaves the earlier one
+    // running, and it answers with a picture from before the dispatch —
+    // so only the newest may touch shared state. Without this the stale
+    // response lands after the forced one, overwrites `statusLast` with
+    // "nothing is running", and PendingBar re-enables Spin Up on a stack
+    // that is provisioning.
+    statusGeneration += 1;
+    const generation = statusGeneration;
+    const isCurrent = function() { return generation === statusGeneration; };
+
     // Ask for the pinned run's steps only once it is no longer the running
     // one; while it runs the server returns its progress anyway.
     let url = '/api/status';
@@ -233,6 +245,7 @@ import { CATEGORIES, CATEGORY_ORDER } from '../lib/categories.ts';
       })
       .then(function(data) {
         if (statusInflight === request) statusInflight = null;
+        if (!isCurrent()) return data;   // superseded; do not publish
         // `success: false` is a JSON body, not a success — /api/status
         // answers that way for a 500, an unusable GitHub response, and a
         // GitHub non-2xx (rate limiting included). Counting it as a good
@@ -255,22 +268,38 @@ import { CATEGORIES, CATEGORY_ORDER } from '../lib/categories.ts';
         // not: `current()` and the replay on subscribe would then hand out
         // a payload with no progress and the finished bar would vanish on
         // the next page interaction.
-        let finalFamily = statusFinalProgressFamily;
+        const cachedFamily = statusFinalProgressFamily;
+        const cachedRunId = statusFinalProgressRunId;
         if (data.progress && data.progress.runId) {
           if (data.progress.status === 'completed') {
             statusFinalProgress = data.progress;
             statusFinalProgressFamily = data.progressFamily || null;
+            statusFinalProgressRunId = data.progress.runId;
             statusPinnedRun = null;
           } else {
             statusFinalProgress = null;
             statusFinalProgressFamily = null;
+            statusFinalProgressRunId = null;
             statusPinnedRun = data.progress.runId;
           }
         } else if (statusFinalProgress && !data.inProgress) {
-          data = Object.assign({}, data, {
-            progress: statusFinalProgress,
-            progressFamily: data.progressFamily || finalFamily || null,
-          });
+          // Only if the payload still describes the run the cache belongs
+          // to. A short run that starts and finishes between two polls
+          // arrives with no `progress` (nothing pinned it), and merging
+          // blindly would present the PREVIOUS run's steps as this run's
+          // result — the same bar, the same green tick, the wrong run.
+          const selected = cachedFamily ? data.workflows && data.workflows[cachedFamily] : null;
+          const stillTheSameRun = cachedRunId !== null && selected && selected.id === cachedRunId;
+          if (stillTheSameRun) {
+            data = Object.assign({}, data, {
+              progress: statusFinalProgress,
+              progressFamily: data.progressFamily || cachedFamily || null,
+            });
+          } else {
+            statusFinalProgress = null;
+            statusFinalProgressFamily = null;
+            statusFinalProgressRunId = null;
+          }
         }
 
         statusLast = data;
@@ -280,6 +309,7 @@ import { CATEGORIES, CATEGORY_ORDER } from '../lib/categories.ts';
       })
       .catch(function(err) {
         if (statusInflight === request) statusInflight = null;
+        if (!isCurrent()) return null;
         statusErrors += 1;
         // Deliver the latch even on failure — a transient network error
         // must not be read as "the run finished".

--- a/control-plane/src/pages/category.astro
+++ b/control-plane/src/pages/category.astro
@@ -1,8 +1,10 @@
 ---
 import Layout from '../layouts/Layout.astro';
+import RunProgress from '../components/RunProgress.astro';
 ---
 
 <Layout title="Category" activeNav="stacks">
+  <RunProgress />
   <div class="category-header">
     <button type="button" class="btn-back" onclick="document.referrer && document.referrer.startsWith(location.origin) ? history.back() : (location.href='/stacks')">&#8592; Back to Stacks</button>
     <h2 id="page-title">Loading...</h2>
@@ -210,6 +212,10 @@ import Layout from '../layouts/Layout.astro';
       toggleEl.classList.remove('disabled');
     }
   }
+
+  // Lock service toggles while a spin-up or teardown runs (#249) and
+  // show the progress bar, so the greyed toggles have a visible reason.
+  window.NS.lockControlsDuringRuns();
 
   window.NS.registerKeyboard({ searchInputId: null });
 

--- a/control-plane/src/pages/index.astro
+++ b/control-plane/src/pages/index.astro
@@ -1,5 +1,6 @@
 ---
 import Layout from '../layouts/Layout.astro';
+import RunProgress from '../components/RunProgress.astro';
 ---
 
 <Layout title="Nexus Stack" activeNav="dashboard">
@@ -35,17 +36,8 @@ import Layout from '../layouts/Layout.astro';
     </div>
   </div>
 
-  <!-- Workflow Progress Banner -->
-  <div id="workflow-progress-banner" style="display: none;" class="progress-banner">
-    <div class="progress-banner-content">
-      <span class="spinner"></span>
-      <div class="progress-banner-text">
-        <strong><span id="progress-workflow-name">Workflow</span> is running...</strong>
-        <span class="progress-hint">This usually takes 5-10 minutes</span>
-      </div>
-      <a id="progress-workflow-link" href="#" target="_blank" rel="noopener noreferrer" class="progress-link">View in GitHub</a>
-    </div>
-  </div>
+  <!-- Live step-by-step progress for the running workflow -->
+  <RunProgress />
 
   <!-- Active Stacks -->
   <div class="active-stacks-panel">
@@ -236,34 +228,7 @@ import Layout from '../layouts/Layout.astro';
     display: block;
   }
 
-  /* Progress Banner */
-  .progress-banner {
-    background: rgba(0, 170, 255, 0.08);
-    border: 1px solid rgba(0, 170, 255, 0.3);
-    padding: 0.8rem 1.2rem;
-    margin-bottom: 1.5rem;
-  }
-
-  .progress-banner-content {
-    display: flex;
-    align-items: center;
-    gap: 0.8rem;
-  }
-
-  .progress-hint {
-    font-size: 0.8rem;
-    color: var(--text-muted);
-    display: block;
-  }
-
-  .progress-link {
-    color: var(--info);
-    text-decoration: none;
-    font-size: 0.8rem;
-    margin-left: auto;
-  }
-
-  .progress-link:hover { text-decoration: underline; }
+  /* Progress banner styles moved to components/RunProgress.astro */
 
   /* Active Stacks */
   .active-stacks-panel {
@@ -425,60 +390,26 @@ import Layout from '../layouts/Layout.astro';
     updateButtons({ infraState: 'unknown', inProgress: false, workflows: {} });
   }
 
-  // Fetch and display status
-  async function fetchStatus() {
-    try {
-      const response = await fetch(`${API_URL}/api/status`, { credentials: 'same-origin' });
-      const contentType = response.headers.get('content-type');
-      if (!contentType || !contentType.includes('application/json')) {
-        showToast('Session expired - please refresh the page', 'error');
-        enableFallbackState();
-        return;
-      }
-      const data = await response.json();
-      if (data.success) {
-        updateStatusDisplay(data);
-        updateButtons(data);
-        updateWorkflowProgress(data);
-        if (wasInProgress && !data.inProgress) {
-          loadActiveStacks();
-        }
-        wasInProgress = data.inProgress;
-      } else {
-        enableFallbackState();
-      }
-    } catch (error) {
-      console.error('Failed to fetch status:', error);
+  // Status arrives from the shared poller in StacksShared.astro — one
+  // timer for the whole page, visibility-aware, faster while a run is in
+  // progress. The progress bar itself is RunProgress.astro, subscribed
+  // separately to the same source.
+  function onStatus(data, err) {
+    if (err || !data || !data.success) {
+      if (err) console.error('Failed to fetch status:', err);
       enableFallbackState();
+      return;
     }
+    updateStatusDisplay(data);
+    updateButtons(data);
+    if (wasInProgress && !data.inProgress) {
+      loadActiveStacks();
+    }
+    wasInProgress = data.inProgress;
   }
 
-  function updateWorkflowProgress(data) {
-    const banner = document.getElementById('workflow-progress-banner');
-    if (!banner) return;
-    if (data.inProgress) {
-      const workflowNames = {
-        initialSetup: 'Initial Setup', spinUp: 'Spin Up',
-        teardown: 'Teardown', destroy: 'Destroy', setup: 'Setup'
-      };
-      let runningName = 'Workflow';
-      let runningUrl = '#';
-      for (const [key, label] of Object.entries(workflowNames)) {
-        const wf = data.workflows[key];
-        if (wf && (wf.status === 'in_progress' || wf.status === 'queued')) {
-          runningName = label;
-          runningUrl = wf.url || '#';
-          break;
-        }
-      }
-      banner.querySelector('#progress-workflow-name').textContent = runningName;
-      const link = banner.querySelector('#progress-workflow-link');
-      link.href = runningUrl;
-      link.style.display = runningUrl !== '#' ? 'inline-block' : 'none';
-      banner.style.display = 'block';
-    } else {
-      banner.style.display = 'none';
-    }
+  function fetchStatus() {
+    return window.NS.status.refreshNow();
   }
 
   function updateStatusDisplay(data) {
@@ -499,6 +430,9 @@ import Layout from '../layouts/Layout.astro';
     const btnSpinUp = document.getElementById('btn-spin-up');
     const btnTeardown = document.getElementById('btn-teardown');
 
+    // `inProgress` covers `dispatching` too — the window after the 204 in
+    // which GitHub has not listed the run yet. Before, the buttons came
+    // back during that window and a second click started a second run.
     if (data.inProgress) {
       btnSpinUp.disabled = true;
       btnTeardown.disabled = true;
@@ -683,23 +617,9 @@ import Layout from '../layouts/Layout.astro';
     } catch {}
   }
 
-  // Polling
-  let consecutiveErrors = 0;
-  let pollTimeout;
-  function scheduleNextPoll() {
-    if (pollTimeout) clearTimeout(pollTimeout);
-    const baseInterval = 10000;
-    const maxInterval = 60000;
-    const interval = Math.min(baseInterval * Math.pow(2, Math.min(consecutiveErrors, 6)), maxInterval);
-    pollTimeout = setTimeout(() => {
-      fetchStatus()
-        .then(() => { consecutiveErrors = 0; scheduleNextPoll(); })
-        .catch(() => { consecutiveErrors++; scheduleNextPoll(); });
-    }, interval);
-  }
-
-  // Init
+  // Init. Polling, backoff and the visibility rules live in
+  // window.NS.status (StacksShared.astro); subscribing starts it.
   checkHealth();
   loadActiveStacks();
-  fetchStatus().then(() => scheduleNextPoll()).catch(() => scheduleNextPoll());
+  window.NS.status.subscribe(onStatus);
 </script>

--- a/control-plane/src/pages/index.astro
+++ b/control-plane/src/pages/index.astro
@@ -397,6 +397,11 @@ import RunProgress from '../components/RunProgress.astro';
   function onStatus(data, err) {
     if (err || !data || !data.success) {
       if (err) console.error('Failed to fetch status:', err);
+      // A failed poll is not evidence that the run finished. Re-enabling
+      // here let a transient network blip invite a second dispatch onto a
+      // stack that was mid-provision — `spin-up.yml` has no concurrency
+      // lock. Keep the last known state and wait for a real answer.
+      if (wasInProgress || (window.NS.status && window.NS.status.isLatched())) return;
       enableFallbackState();
       return;
     }
@@ -575,7 +580,15 @@ import RunProgress from '../components/RunProgress.astro';
       if (data.success) {
         const labels = { 'spin-up': 'Spin Up', 'teardown': 'Teardown' };
         showToast((labels[action] || action) + ' triggered!');
-        setTimeout(fetchStatus, 2000);
+        // Latch the controls locally and force a fresh poll. Without the
+        // force, `refreshNow` would hand back the request that was already
+        // in flight — computed before the dispatch — and the buttons would
+        // come straight back on a stack that is now provisioning.
+        const family = action === 'teardown' ? 'teardown' : 'spinUp';
+        window.NS.status.noteDispatch(family);
+        if (data.tracked === false) {
+          console.warn('Dispatch not recorded in D1 — controls are held locally only');
+        }
       } else {
         showToast(data.error || 'Failed to trigger action', 'error');
         buttons.forEach(btn => btn.disabled = false);

--- a/control-plane/src/pages/index.astro
+++ b/control-plane/src/pages/index.astro
@@ -564,6 +564,13 @@ import RunProgress from '../components/RunProgress.astro';
     const originalHTML = btn.innerHTML;
     btn.innerHTML = '<span class="spinner"></span>Processing...';
 
+    // Latch BEFORE the request, not after it returns. Until it is set,
+    // `runLocked()` is false and a service toggle in that window commits
+    // to D1 — possibly after the workflow has already read the enabled
+    // list, leaving the run on the old configuration and the UI on the new.
+    const family = action === 'teardown' ? 'teardown' : 'spinUp';
+    window.NS.status.beginDispatch(family);
+
     try {
       const response = await fetch(API_URL + '/api/' + action, {
         method: 'POST', credentials: 'same-origin',
@@ -571,6 +578,7 @@ import RunProgress from '../components/RunProgress.astro';
       });
       const contentType = response.headers.get('content-type');
       if (!contentType || !contentType.includes('application/json')) {
+        window.NS.status.cancelDispatch();
         showToast('Session expired - please refresh the page', 'error');
         buttons.forEach(btn => btn.disabled = false);
         btn.innerHTML = originalHTML;
@@ -580,21 +588,22 @@ import RunProgress from '../components/RunProgress.astro';
       if (data.success) {
         const labels = { 'spin-up': 'Spin Up', 'teardown': 'Teardown' };
         showToast((labels[action] || action) + ' triggered!');
-        // Latch the controls locally and force a fresh poll. Without the
-        // force, `refreshNow` would hand back the request that was already
-        // in flight — computed before the dispatch — and the buttons would
-        // come straight back on a stack that is now provisioning.
-        const family = action === 'teardown' ? 'teardown' : 'spinUp';
+        // Force a fresh poll. Without the force, `refreshNow` would hand
+        // back the request that was already in flight — computed before
+        // the dispatch — and the buttons would come straight back on a
+        // stack that is now provisioning.
         window.NS.status.noteDispatch(family);
         if (data.tracked === false) {
           console.warn('Dispatch not recorded in D1 — controls are held locally only');
         }
       } else {
+        window.NS.status.cancelDispatch();
         showToast(data.error || 'Failed to trigger action', 'error');
         buttons.forEach(btn => btn.disabled = false);
         btn.innerHTML = originalHTML;
       }
     } catch {
+      window.NS.status.cancelDispatch();
       showToast('Network error - please try again', 'error');
       buttons.forEach(btn => btn.disabled = false);
       btn.innerHTML = originalHTML;

--- a/control-plane/src/pages/search.astro
+++ b/control-plane/src/pages/search.astro
@@ -1,8 +1,10 @@
 ---
 import Layout from '../layouts/Layout.astro';
+import RunProgress from '../components/RunProgress.astro';
 ---
 
 <Layout title="Search Stacks" activeNav="stacks">
+  <RunProgress />
   <div class="search-bar">
     <input type="text" id="search-input" class="search-input" placeholder="Search stacks by name, description, or category..." autofocus>
   </div>
@@ -195,6 +197,10 @@ import Layout from '../layouts/Layout.astro';
       history.replaceState(null, '', url);
     }, 200);
   });
+
+  // Lock service toggles while a spin-up or teardown runs (#249) and
+  // show the progress bar, so the greyed toggles have a visible reason.
+  window.NS.lockControlsDuringRuns();
 
   window.NS.registerKeyboard({ searchInputId: 'search-input' });
 

--- a/control-plane/src/pages/stacks.astro
+++ b/control-plane/src/pages/stacks.astro
@@ -1,9 +1,11 @@
 ---
 import Layout from '../layouts/Layout.astro';
+import RunProgress from '../components/RunProgress.astro';
 import StackTable from '../components/StackTable.astro';
 ---
 
 <Layout title="Stack Management" activeNav="stacks">
+  <RunProgress />
   <div class="services-panel">
     <div class="panel-header">
       <h2>Stack Management</h2>
@@ -304,6 +306,10 @@ import StackTable from '../components/StackTable.astro';
     onToggle: function(s) { window.NS.tableController.onToggle(s); },
     onCategory: function(s) { window.NS.tableController.onCategory(s); },
   };
+  // Lock service toggles while a spin-up or teardown runs (#249) and
+  // show the progress bar, so the greyed toggles have a visible reason.
+  window.NS.lockControlsDuringRuns();
+
   window.NS.registerKeyboard({
     searchInputId: 'stacks-search',
     list: gatedList,

--- a/control-plane/src/styles/global.css
+++ b/control-plane/src/styles/global.css
@@ -116,6 +116,20 @@ h2 {
   background: #888;
 }
 
+/* Locked while a spin-up or teardown runs. The workflow read the enabled
+   list from D1 when it started, so a change made now is silently ignored
+   and the UI would disagree with the stack (#249). window.NS.toggleService
+   refuses regardless — this is the visible half. */
+body.run-locked .toggle-switch {
+  opacity: 0.4;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
+body.run-locked .toggle-switch::after {
+  background: #888;
+}
+
 /* =============================================================================
    Badges
    ============================================================================= */

--- a/control-plane/src/styles/global.css
+++ b/control-plane/src/styles/global.css
@@ -120,10 +120,14 @@ h2 {
    list from D1 when it started, so a change made now is silently ignored
    and the UI would disagree with the stack (#249). window.NS.toggleService
    refuses regardless — this is the visible half. */
+/* Deliberately NO `pointer-events: none` here, unlike `.toggle-switch.disabled`
+   above. A core service can never be toggled and has a tooltip saying so, but
+   this lock is temporary and its reason is not obvious — the click has to reach
+   `window.NS.toggleService`, which refuses it and explains why. Suppressing the
+   event would make a locked toggle do nothing at all. */
 body.run-locked .toggle-switch {
   opacity: 0.4;
   cursor: not-allowed;
-  pointer-events: none;
 }
 
 body.run-locked .toggle-switch::after {

--- a/docs/user-guides/dashboard.md
+++ b/docs/user-guides/dashboard.md
@@ -32,6 +32,38 @@ The panel re-polls automatically every few seconds, so you can keep it open whil
 
 ![Status panel in the orange "Torn down" state, indicating no server is running](./assets/dashboard-status-torn-down.png)
 
+## Progress while a workflow runs
+
+Spin-up and teardown used to be a black box: a spinner and "this usually takes 5-10 minutes". While one runs you now get a progress bar with the step it is on:
+
+```text
+◐  Spin Up is running                                      2m 14s   View in GitHub
+   Step 19 of 37: Deploy stacks
+   ████████████████░░░░░░░░░░░░░░░░
+   ▸ Details
+```
+
+**Step N of M** counts the steps GitHub actually reports for this run, which is more than the workflow file declares — the runner adds its own `Set up job`, a `Post …` step for each action that has cleanup, and `Complete job`. They are counted and shown greyed out, so the numbers match what you see if you click **View in GitHub**. The list is read live: a step added to a workflow later appears here on its own, and the total can grow mid-run.
+
+**Details** expands the full list, the same one GitHub shows:
+
+| Mark | Meaning |
+|------|---------|
+| ✓ | Finished |
+| ● | Running now |
+| ○ | Not started |
+| ⊘ | Skipped — a step whose `if:` condition did not apply |
+| ✗ | Failed |
+
+Each step shows how long it took, and its name links to that step in the GitHub log.
+
+Two states worth recognising:
+
+- **"Dispatched — waiting for GitHub to start the run"** — the click landed, but GitHub has not created the run yet. This takes a few seconds. The buttons stay disabled throughout, so a second click cannot start a second run.
+- **A sliding bar instead of a percentage** — the run is queued for a runner, or a job has not reported its steps yet. There is nothing to count, so nothing is claimed.
+
+When a run finishes, the bar stays: green at 100% for success, or red at the point it failed, with the failing step named and the list already expanded. It is **not** filled to 100% on failure — cleanup steps run after a failure, and filling the bar would suggest the work completed. Dismiss it, or start another run, to clear it.
+
 ## Action buttons
 
 Two buttons, each tied to a GitHub Actions workflow:

--- a/docs/user-guides/dashboard.md
+++ b/docs/user-guides/dashboard.md
@@ -64,6 +64,14 @@ Two states worth recognising:
 
 When a run finishes, the bar stays: green at 100% for success, or red at the point it failed, with the failing step named and the list already expanded. It is **not** filled to 100% on failure — cleanup steps run after a failure, and filling the bar would suggest the work completed. Dismiss it, or start another run, to clear it.
 
+## Controls are locked while a workflow runs
+
+Spin Up and Teardown are disabled from the moment you click until the run ends, and so are the service toggles on [Stacks](./stacks.md), Search and the category pages. The progress bar appears on those pages too, so the greyed-out toggles have a visible reason.
+
+This is not cosmetic. The workflow reads the list of enabled services from the database **when it starts**. A service switched on halfway through is silently ignored by that run — the Control Plane would show one configuration while the stack ran another, with nothing to tell you which is which. Clicking a locked toggle says so rather than doing nothing.
+
+The lock also holds during the few seconds between your click and GitHub creating the run, and it survives a page reload, a failed status check, and a temporarily unreachable database. Spin-up has no server-side guard against being started twice, so a second click during that window would provision a second server.
+
 ## Action buttons
 
 Two buttons, each tied to a GitHub Actions workflow:


### PR DESCRIPTION
## Problem

A spin-up is a black box. The dashboard shows a spinner, the sentence "This usually
takes 5-10 minutes", and a link to GitHub. Whether the run is creating
infrastructure, deploying stacks, or stuck on step 3 is only visible if you leave
the Control Plane.

## What this adds

A progress bar with **Step N of M** and the name of the step actually running,
plus elapsed time. Behind **Details**, the full step list as GitHub shows it —
✓ done · ● running · ○ pending · ⊘ skipped · ✗ failed — with per-step durations and
each name linking into that step's log.

```text
◐  Spin Up is running                                      2m 14s   View in GitHub
   Step 19 of 37: Deploy stacks
   ████████████████░░░░░░░░░░░░░░░░
   ▸ Details
```

**No workflow is instrumented.** The step list already exists as an API:
`GET /actions/runs/{id}/jobs` returns every step with number, name, status,
conclusion and timestamps, in execution order. `GITHUB_TOKEN` already carries
`Actions: Read and write`. What was missing was a bridge — `status.js` listed the
runs but never told the browser the run id.

**The step list is dynamic.** M is counted from the API on every poll, never from
the workflow file. A step added to a workflow later appears on its own, and M can
grow mid-run — the snapshot lifecycle's second job only reports its steps once the
first finishes. Both are covered by tests.

## Two things the real payloads corrected

Neither was guessable from the workflow files, and both were caught by pulling a
real run's jobs payload before writing the UI.

**GitHub counts more steps than the file declares.** The runner adds `Set up job`,
a `Post <name>` for every action with cleanup, and `Complete job` — `spin-up.yml`
declares 30 steps and comes back as **37**. They stay in N/M so the numbers match
what you see after clicking "View in GitHub"; the UI dims them.

**`step.number` is not a 1..M index.** In that same 37-step job the post-steps are
numbered 61-63. `number` is what GitHub's step anchor (`#step:<n>:1`) wants; N/M
needs a separate contiguous index. Using `number` would have produced
"Step 63 of 37".

## A failed run does not fill the bar

`if: always()` steps run *after* a failure — Close SSH port, Collect debug logs,
every Post-step. So "the last step that ran" is always the final one, and a naive
bar would sit at 100% on a run that died a third of the way in. The bar stops at
the first `failure` step and turns red; what ran afterwards is visible, ticked, in
the list — that is where it is honest.

Verified against a real failed run (`26213211807`):

```
percent = 47   failed at step 15 of 32: Apply infrastructure
steps that ran after the failure and are ticked in the list:
  Close SSH port, Collect debug logs, Post Checkout, …
```

## Fixes an existing bug

Found while designing this, and worth its own paragraph because it is live today.

Both the dashboard (`index.astro:644`) and PendingBar (`PendingBar.astro:201`)
re-poll 2s after the `204` from `workflow_dispatch`. GitHub has not listed the new
run yet, so `status.js` latches onto the **previous completed run** of the same
workflow, `infraState` flips back to `deployed`, and the Spin Up button comes back.
`spin-up.yml` has no concurrency lock — a second click starts a second run.

The dispatching endpoints now write a marker to D1 `config`, and `status.js`
ignores runs of that family created before it, reporting `dispatching` until the
real run appears (90s give-up, 15min TTL so a dispatch that produced no run cannot
hide runs forever). PendingBar's blind 30s re-enable goes with it — the button now
follows the actual run state instead of a timer that expired while the workflow had
four minutes left.

## Design decisions worth reviewing

**One endpoint, not two.** The GitHub rate limit is 5000/h **per account**, shared
with every token of that user. A separate `/api/run-progress` would double the
browser's requests for the same picture: 3 tabs × 2 calls × 720/h ≈ 86% of budget.
The jobs fetch is folded into `/api/status` and only happens while a run is in
progress — one browser request, at most two to GitHub.

**One poller for the page.** Polling moved into a `window.NS.status` subscription
in `StacksShared.astro` (same shape as the existing `window.NS.getServices`). 5s
while a run is in progress *and* the tab is visible, 10s idle, **nothing when
hidden** with an immediate fetch on return, and a back-off to 15s under 500
remaining calls. The dashboard previously polled every 10s regardless of state or
visibility.

**No `requireSameOrigin` on the GET.** That guard requires a JSON `Content-Type`
(`require-same-origin.js:41-44`), which a browser GET never sends — adding it
would 403 the endpoint. It is documented as a CSRF guard for state-changing
endpoints; `status.js` and the `firewall.js` GET have never had it. Reads stay
behind Cloudflare Access.

**Logs are never fetched.** They can contain secrets. Step names only — which are
literals in this repo (no `${{ }}` in any `- name:` of the four lifecycle
workflows, grep-verified) — and the renderer escapes them regardless.

## Verification

The Control Plane has no JS test runner (`package.json` has only dev/build/preview),
so both new modules are pure and were exercised in Node against **saved payloads
from two real runs** plus synthetic cases:

```
Fixture: successful spin-up   M = 37 (matches GitHub), 7 housekeeping steps,
                              index 37 ≠ number 63, startedAt from the job
Fixture: failed spin-up       47%, failedAt #15 "Apply infrastructure"
Synthetic                     queued/no jobs · step in progress · between steps ·
                              job waiting · failure mid-run · cancelled ·
                              two jobs · unknown step status · null input
Dynamic M                     3 → 5 mid-run; second job appearing later
Dispatch marker               write/read · unknown family refused · TTL ·
                              grace window · malformed values · D1 down
```

`npm run build` passes; the 2871 Python tests are untouched.

## Not done here

- **Not deploy-tested.** That needs a Control Plane deploy and a real run — see the
  steps below.
- **No screenshot yet.** `docs/user-guides/dashboard.md` describes the bar in a text
  sketch; an image belongs in `docs/user-guides/assets/` once it has run for real.
## Also closes #249

The issue asks for four things: a visible indicator, disabled controls, re-enable
on completion, and a locked state that survives a reload. The progress work covered
three; the fourth — the service toggles the issue is named after — is now in too.

The workflow reads the enabled-services list from D1 **when it starts**, so a
service switched on halfway through is silently ignored by that run: the Control
Plane shows one configuration while the stack runs another. The refusal lives in
`window.NS.toggleService` rather than in each page, because three pages render
toggles through three separate paths and the keyboard shortcut is a fourth entry
point — all four funnel through that one function. The visible half is a
`body.run-locked` class reusing the styling `.toggle-switch.disabled` already has,
and `RunProgress` is mounted on those pages so the greyed toggles have a reason on
screen.

Only pages with toggles call `lockControlsDuringRuns()`, since that call is what
starts polling — monitoring, settings, secrets and firewall keep spending no rate
limit. Verified in the build output: `id="run-progress"` appears on index, stacks,
search and category, and nowhere else.

Closes #249.

## Summary by Sourcery

Provide operators with live lifecycle workflow progress while preventing duplicate runs and configuration changes during execution.

New Features:
- Add live step-by-step progress for lifecycle workflows, including dynamic totals, current step, elapsed time, detailed statuses, durations, and links to GitHub steps.
- Show progress and workflow state consistently across dashboard and stack-management pages, including completed and failed run results.

Bug Fixes:
- Prevent recently dispatched workflows from being mistaken for an older completed run before GitHub lists the new run.
- Keep action buttons and service toggles locked for the actual workflow lifetime, including dispatch races, reloads, and transient status failures.
- Correct workflow classification when GitHub provides numeric workflow identifiers.

Enhancements:
- Centralize status polling with visibility-aware cadence, rate-limit backoff, shared subscriptions, and lifecycle run locking.
- Protect service configuration consistency by rejecting toggle changes while a workflow is running.
- Preserve final progress details after a run completes and handle queued, unavailable, cancelled, and failed progress states.

Documentation:
- Document live workflow progress, detailed step states, dispatch waiting behavior, failure progress semantics, and controls locked during runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added live workflow progress tracking with step counts, statuses, elapsed time, expandable details, and GitHub links.
  - Added clearer queued, pending, successful, failed, and cancelled workflow states.
  - Improved dashboard polling with adaptive refresh rates and tab-visibility handling.
  - Spin-up controls now remain disabled until the workflow finishes.
  - Service toggles are locked while spin-up or teardown workflows are running.
  - Added workflow progress documentation to the Dashboard guide.

- **Bug Fixes**
  - Status updates now identify newly dispatched workflows instead of displaying stale runs.
  - Workflow status remains available when job-progress data cannot be retrieved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->