### PR TITLE
fix(ci): Remove an empty GitHub expression that broke every spin-up

### DIFF
--- a/.github/actions/nexus-config-tfvars/action.yml
+++ b/.github/actions/nexus-config-tfvars/action.yml
@@ -154,10 +154,17 @@ runs:
         EOF
 
         # Read from the environment, never interpolated into the test.
-        # `${{ }}` is substituted textually before bash parses the line, so
-        # an input containing a quote becomes shell syntax rather than a
-        # value: `" = "" ]; touch /tmp/x; [ "` turns one conditional into
-        # three commands. Through `env:` it arrives as data.
+        # A GitHub expression — the double-brace form — is substituted
+        # textually before bash parses the line, so an input containing a
+        # quote becomes shell syntax rather than a value: one conditional
+        # turns into three commands. Through `env:` it arrives as data.
+        #
+        # The double-brace form is DESCRIBED here rather than written out.
+        # An earlier version of this comment spelled it with empty braces,
+        # and GitHub evaluated it: an empty expression is a template error,
+        # so the whole action failed to load and every spin-up died at this
+        # step. A bash `#` does not hide it — expression substitution runs
+        # over the entire `run:` body before bash ever sees it.
         #
         # Compared against the literal 'true' rather than passed through:
         # the variable is typed bool in OpenTofu, and an unset repo variable

--- a/control-plane/src/components/RunProgress.astro
+++ b/control-plane/src/components/RunProgress.astro
@@ -149,7 +149,11 @@
   @media (prefers-reduced-motion: reduce) {
     .rp-fill { transition: none; }
     .rp-bar.is-indeterminate .rp-fill { animation: none; width: 100%; opacity: 0.4; }
-    .rp-glyph.is-spinning, .rp-running .rp-mark { animation: none; }
+    /* The mark needs :global() here for the same reason as above — it is
+       injected, so a scoped override would leave it animating for exactly
+       the people who asked it not to. */
+    .rp-glyph.is-spinning { animation: none; }
+    :global(.rp-running .rp-mark) { animation: none; }
   }
 </style>
 
@@ -273,7 +277,13 @@
           // A skipped step has identical start and end timestamps, so it
           // reports 0 ms. Printing "0s" against thirty rows suggests they
           // all ran instantly; blank says what actually happened.
-          const dur = s.durationMs ? fmtDuration(s.durationMs) : '';
+          //
+          // Only for skipped, not for every zero: GitHub's timestamps have
+          // second resolution, so a genuinely fast step also reports 0 ms
+          // and "0s" is the truth about it.
+          const dur = s.conclusion === 'skipped'
+            ? ''
+            : (s.durationMs == null ? '' : fmtDuration(s.durationMs));
           const name = s.htmlUrl
             ? '<a href="' + esc(s.htmlUrl) + '" target="_blank" rel="noopener noreferrer">' + esc(s.name) + '</a>'
             : esc(s.name);

--- a/control-plane/src/components/RunProgress.astro
+++ b/control-plane/src/components/RunProgress.astro
@@ -107,33 +107,41 @@
     border-top: 1px solid var(--border);
   }
   .rp-steps[hidden] { display: none; }
-  .rp-steps li {
+  /* EVERYTHING BELOW IS :global(). The step list is built with innerHTML
+     on each poll, and Astro adds its [data-astro-cid-*] attribute only to
+     statically rendered elements — scoped selectors never match
+     JS-generated ones. Without :global() the marks lose their colour, the
+     names fall back to browser-default link blue, and `.rp-sr` does not
+     hide, so every row reads "59 ⊘ skipped Deploy stacks 0s" with the
+     screen-reader text printed on screen. Same pattern and same reason as
+     :global(.stack-row-name) in StackTable.astro. */
+  :global(.rp-steps li) {
     display: flex; align-items: baseline; gap: 0.6rem;
     padding: 0.25rem 0; font-size: 0.8rem;
     border-bottom: 1px solid rgba(42, 42, 62, 0.5);
   }
-  .rp-job-head {
+  :global(.rp-job-head) {
     font-size: 0.75rem; color: var(--text-muted); text-transform: uppercase;
     letter-spacing: 0.08em; padding-top: 0.6rem;
   }
-  .rp-i { color: var(--text-muted); font-variant-numeric: tabular-nums; min-width: 2.2rem; }
-  .rp-mark { font-family: 'JetBrains Mono', monospace; min-width: 1rem; }
-  .rp-name { flex: 1; }
-  .rp-name a { color: inherit; text-decoration: none; }
-  .rp-name a:hover { text-decoration: underline; }
-  .rp-dur { color: var(--text-muted); font-variant-numeric: tabular-nums; }
+  :global(.rp-i) { color: var(--text-muted); font-variant-numeric: tabular-nums; min-width: 2.2rem; text-align: right; }
+  :global(.rp-mark) { font-family: 'JetBrains Mono', monospace; min-width: 1rem; }
+  :global(.rp-name) { flex: 1; }
+  :global(.rp-name a) { color: inherit; text-decoration: none; }
+  :global(.rp-name a:hover) { text-decoration: underline; }
+  :global(.rp-dur) { color: var(--text-muted); font-variant-numeric: tabular-nums; min-width: 3rem; text-align: right; }
 
-  .rp-done .rp-mark { color: var(--accent); }
-  .rp-running .rp-mark { color: var(--info); animation: pulse 1.6s infinite; }
-  .rp-running .rp-name { color: var(--text-primary); font-weight: 700; }
-  .rp-pending { opacity: 0.55; }
-  .rp-skipped { opacity: 0.45; }
-  .rp-failed .rp-mark, .rp-failed .rp-name { color: var(--error); }
+  :global(.rp-done .rp-mark) { color: var(--accent); }
+  :global(.rp-running .rp-mark) { color: var(--info); animation: pulse 1.6s infinite; }
+  :global(.rp-running .rp-name) { color: var(--text-primary); font-weight: 700; }
+  :global(.rp-pending) { opacity: 0.55; }
+  :global(.rp-skipped) { opacity: 0.45; }
+  :global(.rp-failed .rp-mark), :global(.rp-failed .rp-name) { color: var(--error); }
   /* Runner bookkeeping — kept in N/M so the numbers match GitHub's own
      view, dimmed because nobody is waiting on "Post Checkout". */
-  .rp-housekeeping .rp-name { color: var(--text-muted); }
+  :global(.rp-housekeeping .rp-name) { color: var(--text-muted); }
 
-  .rp-sr {
+  :global(.rp-sr) {
     position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;
     overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0;
   }
@@ -262,7 +270,10 @@
         job.steps.forEach(function(s) {
           const mark = stepMark(s);
           const cls = stepClass(s, failedIndex) + (s.housekeeping ? ' rp-housekeeping' : '');
-          const dur = s.durationMs != null ? fmtDuration(s.durationMs) : '';
+          // A skipped step has identical start and end timestamps, so it
+          // reports 0 ms. Printing "0s" against thirty rows suggests they
+          // all ran instantly; blank says what actually happened.
+          const dur = s.durationMs ? fmtDuration(s.durationMs) : '';
           const name = s.htmlUrl
             ? '<a href="' + esc(s.htmlUrl) + '" target="_blank" rel="noopener noreferrer">' + esc(s.name) + '</a>'
             : esc(s.name);

--- a/tests/unit/test_workflow_expressions.py
+++ b/tests/unit/test_workflow_expressions.py
@@ -1,0 +1,107 @@
+"""GitHub expression syntax inside workflow and action script bodies.
+
+WHY THIS EXISTS. A comment written to explain that GitHub expressions must
+not be interpolated into a shell body contained one — spelled with empty
+braces — inside a `run:` block. GitHub substitutes expressions across the
+whole `run:` body before bash ever sees it, so a `#` does not hide it, and
+an empty expression is a template error: the action failed to load and
+every spin-up died at that step with
+
+    (Line: 137, Col: 12): An expression was expected
+
+`actionlint` does not catch it — verified by reinserting the empty
+expression and running the hook, which passed. Nor does YAML parsing: the
+file is valid YAML, and only GitHub's own template layer rejects it. That
+leaves a test.
+
+A comment OUTSIDE a `run:` body is fine — GitHub never parses YAML comments
+— which is why the rule is scoped to script bodies rather than to the files.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+_WORKFLOWS = sorted(Path(".github/workflows").glob("*.y*ml"))
+_ACTIONS = sorted(Path(".github/actions").rglob("action.y*ml"))
+_FILES = _WORKFLOWS + _ACTIONS
+
+_EXPRESSION = re.compile(r"\$\{\{(.*?)\}\}")
+_RUN_BLOCK = re.compile(r"\s*run:\s*[|>]")
+
+
+def _inside_run_block(lines: list[str], index: int) -> bool:
+    """Is line `index` (0-based) part of a `run:` block scalar?
+
+    Walks back to the first line indented less than this one: for a block
+    scalar's content that is the `run:` key itself.
+    """
+    indent = len(lines[index]) - len(lines[index].lstrip())
+    for j in range(index - 1, -1, -1):
+        line = lines[j]
+        if not line.strip():
+            continue
+        if len(line) - len(line.lstrip()) >= indent:
+            continue
+        return bool(_RUN_BLOCK.match(line))
+    return False
+
+
+def _offenders(path: Path) -> list[str]:
+    lines = path.read_text().splitlines()
+    found = []
+    for i, line in enumerate(lines):
+        for match in _EXPRESSION.finditer(line):
+            if match.group(1).strip():
+                continue  # a real expression; not our business
+            if _inside_run_block(lines, i):
+                found.append(f"{path}:{i + 1}: {line.strip()}")
+    return found
+
+
+def test_workflow_files_were_found() -> None:
+    """A glob that matches nothing would make every test below vacuous."""
+    assert len(_WORKFLOWS) >= 10, f"only {len(_WORKFLOWS)} workflows found"
+    assert len(_ACTIONS) >= 1, f"only {len(_ACTIONS)} composite actions found"
+
+
+@pytest.mark.parametrize("path", _FILES, ids=lambda p: p.name)
+def test_no_empty_github_expression_in_a_script_body(path: Path) -> None:
+    """An empty `${{ }}` in a `run:` body stops the file from loading.
+
+    Not a style rule: GitHub refuses the whole workflow or action, so the
+    failure is total and lands at runtime rather than in review.
+    """
+    offenders = _offenders(path)
+    assert not offenders, (
+        "empty GitHub expression inside a run: body — GitHub reads it as an "
+        "expression and refuses the file:\n  " + "\n  ".join(offenders)
+    )
+
+
+def test_the_check_detects_a_planted_empty_expression(tmp_path: Path) -> None:
+    """The rule above passes trivially if the detection does not work.
+
+    Both shapes are here on purpose: the same text is harmless in a YAML
+    comment and fatal one line deeper, and a check that cannot tell them
+    apart would either miss the bug or ban a legitimate comment.
+    """
+    planted = tmp_path / "action.yml"
+    planted.write_text(
+        "runs:\n"
+        "  using: composite\n"
+        "  steps:\n"
+        "    # Harmless: a YAML comment mentioning ${{ }} is never parsed.\n"
+        "    - name: Example\n"
+        "      shell: bash\n"
+        "      run: |\n"
+        "        # Fatal: substitution runs over the whole body first.\n"
+        "        echo ${{ }}\n"
+    )
+    offenders = _offenders(planted)
+    assert len(offenders) == 1, offenders
+    assert offenders[0].endswith("echo ${{ }}")
+    assert ":9:" in offenders[0], "flagged the wrong line"

--- a/tests/unit/test_workflow_expressions.py
+++ b/tests/unit/test_workflow_expressions.py
@@ -24,41 +24,53 @@ import re
 from pathlib import Path
 
 import pytest
+import yaml
 
 _WORKFLOWS = sorted(Path(".github/workflows").glob("*.y*ml"))
 _ACTIONS = sorted(Path(".github/actions").rglob("action.y*ml"))
 _FILES = _WORKFLOWS + _ACTIONS
 
 _EXPRESSION = re.compile(r"\$\{\{(.*?)\}\}")
-_RUN_BLOCK = re.compile(r"\s*run:\s*[|>]")
 
 
-def _inside_run_block(lines: list[str], index: int) -> bool:
-    """Is line `index` (0-based) part of a `run:` block scalar?
+def _run_line_ranges(path: Path) -> list[tuple[int, int]]:
+    """Line ranges (1-based, inclusive) of every `run:` value in the file.
 
-    Walks back to the first line indented less than this one: for a block
-    scalar's content that is the `run:` key itself.
+    Uses the YAML node graph rather than a regex over the text. A regex has
+    to enumerate the forms `run:` can take — `run: |`, `|-`, `>`, `>+`, an
+    inline `run: echo …`, and `- run: |` when it is a step's first key —
+    and the first version of this check missed three of the five. The
+    parser knows all of them, and cannot fall behind YAML.
     """
-    indent = len(lines[index]) - len(lines[index].lstrip())
-    for j in range(index - 1, -1, -1):
-        line = lines[j]
-        if not line.strip():
-            continue
-        if len(line) - len(line.lstrip()) >= indent:
-            continue
-        return bool(_RUN_BLOCK.match(line))
-    return False
+    ranges: list[tuple[int, int]] = []
+
+    def walk(node: object) -> None:
+        if isinstance(node, yaml.MappingNode):
+            for key, value in node.value:
+                if isinstance(key, yaml.ScalarNode) and key.value == "run":
+                    ranges.append((value.start_mark.line + 1, value.end_mark.line + 1))
+                walk(value)
+        elif isinstance(node, yaml.SequenceNode):
+            for item in node.value:
+                walk(item)
+
+    for document in yaml.compose_all(path.read_text()):
+        if document is not None:
+            walk(document)
+    return ranges
 
 
 def _offenders(path: Path) -> list[str]:
     lines = path.read_text().splitlines()
+    ranges = _run_line_ranges(path)
     found = []
-    for i, line in enumerate(lines):
+    for i, line in enumerate(lines, 1):
+        if not any(start <= i <= end for start, end in ranges):
+            continue  # outside every script body — a YAML comment, say
         for match in _EXPRESSION.finditer(line):
             if match.group(1).strip():
                 continue  # a real expression; not our business
-            if _inside_run_block(lines, i):
-                found.append(f"{path}:{i + 1}: {line.strip()}")
+            found.append(f"{path}:{i}: {line.strip()}")
     return found
 
 
@@ -82,26 +94,41 @@ def test_no_empty_github_expression_in_a_script_body(path: Path) -> None:
     )
 
 
-def test_the_check_detects_a_planted_empty_expression(tmp_path: Path) -> None:
+@pytest.mark.parametrize(
+    ("label", "content", "expected"),
+    [
+        ("inline run", "runs:\n  steps:\n    - run: echo ${{ }}\n", 1),
+        ("block scalar", "runs:\n  steps:\n    - run: |\n        echo ${{ }}\n", 1),
+        ("chomped block", "runs:\n  steps:\n    - run: |-\n        echo ${{ }}\n", 1),
+        ("folded block", "runs:\n  steps:\n    - run: >+\n        echo ${{ }}\n", 1),
+        (
+            "run below other keys",
+            "runs:\n  steps:\n    - name: x\n      run: |\n        echo ${{ }}\n",
+            1,
+        ),
+        ("yaml comment", "runs:\n  # mentions ${{ }} harmlessly\n  steps: []\n", 0),
+        (
+            "comment above run",
+            "runs:\n  steps:\n    # ${{ }} here is fine\n    - run: |\n        echo ok\n",
+            0,
+        ),
+        ("real expression", "runs:\n  steps:\n    - run: |\n        echo ${{ inputs.x }}\n", 0),
+    ],
+)
+def test_the_check_sees_every_run_form_and_no_comments(
+    tmp_path: Path, label: str, content: str, expected: int
+) -> None:
     """The rule above passes trivially if the detection does not work.
 
-    Both shapes are here on purpose: the same text is harmless in a YAML
-    comment and fatal one line deeper, and a check that cannot tell them
-    apart would either miss the bug or ban a legitimate comment.
+    Every form `run:` can take is here because the first version of this
+    check used a regex and missed three of them — inline values, chomping
+    indicators, and `- run: |` where `run` is a step's first key. The real
+    bug was caught only because it happened to use the one form that regex
+    recognised. The comment cases are here for the opposite reason: the
+    same text is harmless in a YAML comment and fatal one line deeper, and
+    a check that cannot tell them apart is either useless or unusable.
     """
     planted = tmp_path / "action.yml"
-    planted.write_text(
-        "runs:\n"
-        "  using: composite\n"
-        "  steps:\n"
-        "    # Harmless: a YAML comment mentioning ${{ }} is never parsed.\n"
-        "    - name: Example\n"
-        "      shell: bash\n"
-        "      run: |\n"
-        "        # Fatal: substitution runs over the whole body first.\n"
-        "        echo ${{ }}\n"
-    )
+    planted.write_text(content)
     offenders = _offenders(planted)
-    assert len(offenders) == 1, offenders
-    assert offenders[0].endswith("echo ${{ }}")
-    assert ":9:" in offenders[0], "flagged the wrong line"
+    assert len(offenders) == expected, f"{label}: {offenders}"


### PR DESCRIPTION
Two bugs, both mine, both surfaced by the first real deploy of #775. The
first blocks every spin-up.

## 1. Every spin-up was failing

`nexus-config-tfvars/action.yml` no longer loads:

```
(Line: 137, Col: 12): An expression was expected
TemplateValidationException: The template is not valid.
Failed to load .../nexus-config-tfvars/action.yml
```

The dashboard reported "Failed at step 52 of 75: Generate config.tfvars", which
is where it surfaces — but the action fails to load, so this is not one broken
step, it is **every spin-up**.

The cause is a comment I added in #769 while fixing shell injection in this same
file. It explained that GitHub expressions must not be interpolated into a shell
body, and spelled the form out with empty braces — inside the `run:` body.
Expression substitution runs over the whole body before bash sees it, so the `#`
hides nothing, and an empty expression is a template error. The comment warning
against the pattern was an instance of it.

**Nothing caught it:**

| Gate | Result |
|---|---|
| `actionlint` (pre-commit + CI) | passes with the empty expression present — verified by reinserting it |
| `check yaml` | passes; the file is valid YAML |
| Review, three bots, four rounds | not flagged |
| GitHub's template layer | rejects it — at runtime, after the job starts |

So the guard has to be a test. `tests/unit/test_workflow_expressions.py` scans
every workflow and composite action for empty expressions **inside `run:`
bodies**.

Scoped to script bodies, not to files, because the distinction is real: the same
text appears in five YAML comments elsewhere in `.github/` and is harmless there
— GitHub never parses YAML comments. Exactly one occurrence was inside a `run:`
block. The test carries its own detection test: a planted file containing both
shapes, asserting it flags the fatal one and not the harmless one, since a
scanner that finds nothing looks identical to a clean repository.

Mutation-checked against the real bug rather than assumed:

```
reinserted -> FAILED  .github/actions/nexus-config-tfvars/action.yml:157
restored   -> 17 passed
```

## 2. The step list rendered unstyled

From the screenshot of the failed run — every row read:

```
59 ⊘ skipped Deploy stacks 0s
```

with the screen-reader text printed on screen, step names in browser-default link
blue, and nothing dimmed.

Astro adds its `[data-astro-cid-*]` attribute only to statically rendered
elements. The step list is built with `innerHTML` on every poll, so no row
carries it and every scoped selector missed — including `.rp-sr`, which is what
hides the "skipped"/"done" text that exists for screen readers.

The rules for injected elements are now `:global()`. `StackTable.astro` already
documents this exact failure for `.stack-row-name`; I did not apply the lesson
when writing a component that renders the same way. The static half stays scoped,
confirmed in the build output:

```
.rp-fill[data-astro-cid-4w6k52vz]   ← static markup, still scoped
.rp-sr{                             ← injected, now global
.rp-steps li{
.rp-name a{
```

Also dropped `0s` from skipped steps: they have identical start and end
timestamps, so thirty rows of "0s" suggest everything ran instantly.

## Verification

- 2888 Python tests pass (17 new).
- 70 assertions across seven JS suites unchanged.
- `npm run build` passes; the scoped/global split checked in the emitted CSS.
- Not deploy-tested — that is the point of merging this.

## After merging

`gh workflow run setup-control-plane.yaml`, then re-run the spin-up. The first
commit is what unblocks it; the second is only visible once the Control Plane is
redeployed.

## Summary by Sourcery

Prevent spin-up outages and restore correct styling and duration display in the run-progress step list.

Bug Fixes:
- Prevent all spin-ups from failing because of invalid empty GitHub expressions in action script bodies.
- Restore styling and accessibility behavior for dynamically rendered run-progress steps.
- Hide misleading zero durations for skipped steps.

Enhancements:
- Add automated checks that detect empty GitHub expressions inside workflow and action run bodies while allowing harmless YAML comments and real expressions.

Tests:
- Add coverage for inline, block, folded, and chomped run values, including safeguards against vacuous detection and false positives in comments.