### PR TITLE
fix(control-plane): Make the step list legible on the dark background

### DIFF
--- a/control-plane/src/components/RunProgress.astro
+++ b/control-plane/src/components/RunProgress.astro
@@ -61,7 +61,7 @@
   .rp-headline { flex: 1; min-width: 12rem; }
   .rp-headline strong { display: block; font-size: 0.9rem; }
   .rp-step { font-size: 0.8rem; color: var(--text-secondary); }
-  .rp-elapsed { font-size: 0.78rem; color: var(--text-muted); font-variant-numeric: tabular-nums; }
+  .rp-elapsed { font-size: 0.78rem; color: var(--text-secondary); font-variant-numeric: tabular-nums; }
 
   .rp-link {
     color: var(--info); text-decoration: none; font-size: 0.78rem;
@@ -121,25 +121,36 @@
     border-bottom: 1px solid rgba(42, 42, 62, 0.5);
   }
   :global(.rp-job-head) {
-    font-size: 0.75rem; color: var(--text-muted); text-transform: uppercase;
+    font-size: 0.75rem; color: var(--text-secondary); text-transform: uppercase;
     letter-spacing: 0.08em; padding-top: 0.6rem;
   }
-  :global(.rp-i) { color: var(--text-muted); font-variant-numeric: tabular-nums; min-width: 2.2rem; text-align: right; }
-  :global(.rp-mark) { font-family: 'JetBrains Mono', monospace; min-width: 1rem; }
-  :global(.rp-name) { flex: 1; }
+  /* STATE IS COLOUR, NOT OPACITY. `opacity` on the row multiplied with the
+     colour underneath: a muted index inside a 0.45 skipped row measured
+     1.57:1 against the background — invisible, and a failed spin-up leaves
+     roughly thirty of its thirty-seven steps skipped, so that was most of
+     the list. Setting each element's colour outright keeps every state
+     legible and still visibly ranked.
+
+       name, active      #ffffff        19.8:1
+       name, inactive    secondary       7.6:1
+       index, duration   secondary       7.6:1
+       mark, inactive    muted           3.4:1  (a glyph, not text) */
+  :global(.rp-i) { color: var(--text-secondary); font-variant-numeric: tabular-nums; min-width: 2.2rem; text-align: right; }
+  :global(.rp-mark) { font-family: 'JetBrains Mono', monospace; min-width: 1rem; color: var(--text-muted); }
+  :global(.rp-name) { flex: 1; color: var(--text-primary); }
   :global(.rp-name a) { color: inherit; text-decoration: none; }
   :global(.rp-name a:hover) { text-decoration: underline; }
-  :global(.rp-dur) { color: var(--text-muted); font-variant-numeric: tabular-nums; min-width: 3rem; text-align: right; }
+  :global(.rp-dur) { color: var(--text-secondary); font-variant-numeric: tabular-nums; min-width: 3rem; text-align: right; }
 
   :global(.rp-done .rp-mark) { color: var(--accent); }
   :global(.rp-running .rp-mark) { color: var(--info); animation: pulse 1.6s infinite; }
-  :global(.rp-running .rp-name) { color: var(--text-primary); font-weight: 700; }
-  :global(.rp-pending) { opacity: 0.55; }
-  :global(.rp-skipped) { opacity: 0.45; }
+  :global(.rp-running .rp-name) { font-weight: 700; }
+  :global(.rp-pending .rp-name), :global(.rp-skipped .rp-name) { color: var(--text-secondary); }
   :global(.rp-failed .rp-mark), :global(.rp-failed .rp-name) { color: var(--error); }
   /* Runner bookkeeping — kept in N/M so the numbers match GitHub's own
-     view, dimmed because nobody is waiting on "Post Checkout". */
-  :global(.rp-housekeeping .rp-name) { color: var(--text-muted); }
+     view, ranked below the real steps because nobody is waiting on
+     "Post Checkout". */
+  :global(.rp-housekeeping .rp-name) { color: var(--text-secondary); }
 
   :global(.rp-sr) {
     position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;


### PR DESCRIPTION
## Reported from a live run

Dark-blue step names on a black background, and rows that could not be read at
all.

Two separate causes. **Only the second one is this PR.**

The blue is #776, already merged. The Control Plane still runs the build from
before it, so the scoped selectors miss the rows built with `innerHTML` and the
names fall back to the browser default link colour. The spin-up in flight
redeploys the Control Plane at its "Redeploy Control Plane" step and fixes that
on its own — nothing to do.

## What measuring found

State was expressed with `opacity` on the row, which multiplies with whatever
colour sits underneath:

```
index / duration   --text-muted #666666                  3.44:1   below AA
the same, inside a 0.45 "skipped" row                     1.57:1   invisible
```

A failed spin-up leaves roughly thirty of its thirty-seven steps skipped, so that
was most of the list — and the failure case is exactly when someone reads it.

Raising the opacity does not fix it either. To keep both the name and the muted
columns above 4.5:1 the row needs `opacity: 0.75`, at which point it barely reads
as dimmed:

```
opacity 0.45   name 4.49:1   index/duration 2.38:1
opacity 0.60   name 7.30:1   index/duration 3.35:1
opacity 0.75   name 11.10:1  index/duration 4.61:1   ← first value that clears AA
```

## The change

State is colour rather than opacity, so nothing compounds and each element is
chosen for its own contrast:

| Element | Colour | Contrast | Threshold |
|---|---|---|---|
| name, active | `--text-primary` | 19.75:1 | 4.5 |
| name, pending / skipped / post-step | `--text-secondary` | 7.55:1 | 4.5 |
| index, duration, job header | `--text-secondary` | 7.55:1 | 4.5 |
| marks ✓ ● ✗ | accent / info / error | 5.80–14.73:1 | 3.0 |
| marks ○ ⊘ | `--text-muted` | 3.44:1 | 3.0 (glyph) |

The ranking survives without opacity: active steps are white and bold, everything
else is grey, and the mark carries the state in colour.

## Every rule measured, not only the ones that looked wrong

18 colour rules in the component, none below its threshold. Two more were on
`--text-muted` and had the same problem without being in the screenshot:
`.rp-elapsed` (the running timer in the header) and the job-group header. Both
are text, both now `--text-secondary`.

```
✓ .rp-glyph                          --info             7.71:1 (Text)
✓ .rp-step                           --text-secondary   7.55:1 (Text)
✓ .rp-elapsed                        --text-secondary   7.55:1 (Text)   ← was muted
✓ :global(.rp-job-head)              --text-secondary   7.55:1 (Text)   ← was muted
✓ :global(.rp-i)                     --text-secondary   7.55:1 (Text)
✓ :global(.rp-name)                  --text-primary    19.75:1 (Text)
✓ :global(.rp-mark)                  --text-muted       3.44:1 (Glyph)
…
below threshold: none
```

## Checks

2895 Python tests and 70 JS assertions unchanged — this is CSS only.
`npm run build` passes.

## Not verified

Contrast is computed from the palette in `global.css`, not sampled from a
rendered page. The numbers are exact for those tokens on `--bg-primary`; what a
screenshot after deploy adds is confirmation that the tokens are what actually
paint.

## Summary by Sourcery

Improve control-plane run progress contrast so active, pending, skipped, failed, and bookkeeping steps remain legible on dark backgrounds.

Bug Fixes:
- Improve control-plane run progress readability by replacing row opacity with explicit state-aware text colors and raising muted metadata to the secondary text color.

Enhancements:
- Preserve visual step-state hierarchy through contrasting name, metadata, and status-mark colors without reducing row opacity.