### PR TITLE
feat(control-plane): Clear the progress bar after a successful run

### DIFF
--- a/control-plane/src/components/RunProgress.astro
+++ b/control-plane/src/components/RunProgress.astro
@@ -338,8 +338,15 @@
         // have been opened during the wait, and a new run may have started.
         if (expanded) { autoHideFor = null; return; }
         const cur = window.NS.status.current();
-        const p = cur && cur.progress;
-        if (!p || p.runId !== runId) { autoHideFor = null; return; }
+        // Matching the run id is not enough on its own: the finished
+        // payload stays cached, so a dispatch or a fresh run started in the
+        // meantime still carries it. Anything in flight owns the bar now.
+        if (!cur || cur.dispatching || cur.dispatchTimedOut || cur.inProgress) {
+          autoHideFor = null;
+          return;
+        }
+        const p = cur.progress;
+        if (!p || p.runId !== runId || p.conclusion !== 'success') { autoHideFor = null; return; }
         dismissedRun = runId;
         try { sessionStorage.setItem('rp-dismissed', String(runId)); } catch (_) {}
         hide();
@@ -356,6 +363,9 @@
     }
 
     function hide() {
+      // Cancel first: a timer left armed past a hide fires against whatever
+      // the bar shows 30s later, which may be a different run entirely.
+      cancelAutoHide();
       root.hidden = true;
       stopElapsed(null);
       renderedSignature = null;
@@ -367,6 +377,10 @@
       // Dispatched, but GitHub has not listed the run yet. Without this the
       // dashboard would show the PREVIOUS run as if nothing had happened.
       if (data.dispatching || data.dispatchTimedOut) {
+        // A new dispatch supersedes the previous run's pending auto-hide.
+        // The finished payload is still cached, so without this the old
+        // timer's identity check would pass and it would blank this banner.
+        cancelAutoHide();
         const label = LABELS[data.dispatchedWorkflow] || 'Workflow';
         root.hidden = false;
         root.className = 'run-progress';

--- a/control-plane/src/components/RunProgress.astro
+++ b/control-plane/src/components/RunProgress.astro
@@ -204,6 +204,17 @@
     let expandedPreference = false;
     let autoExpandedFor = null;
     let dismissedRun = null;
+    // A finished SUCCESSFUL run clears itself after a while. The green bar
+    // has said what it has to say, the status panel above already reads
+    // "Deployed", and it sits between the buttons and Active Stacks —
+    // which is where the operator is heading next.
+    //
+    // Failure and cancellation stay until dismissed: the bar is the only
+    // place naming the step it stopped at, and a timer that removes that
+    // while somebody is reading it would be worse than never showing it.
+    const AUTO_HIDE_SUCCESS_MS = 30000;
+    let autoHideTimer = null;
+    let autoHideFor = null;
     let renderedSignature = null;
     let elapsedTimer = null;
     let elapsedFrom = null;
@@ -310,9 +321,36 @@
       el.steps.innerHTML = html;
     }
 
+    function cancelAutoHide() {
+      if (autoHideTimer) { clearTimeout(autoHideTimer); autoHideTimer = null; }
+      autoHideFor = null;
+    }
+
+    /** Hide a finished successful run after a pause. Never while Details is
+     *  open — the list would vanish out from under whoever opened it. */
+    function scheduleAutoHide(runId) {
+      if (autoHideFor === runId || expanded) return;
+      cancelAutoHide();
+      autoHideFor = runId;
+      autoHideTimer = setTimeout(function() {
+        autoHideTimer = null;
+        // Re-checked at fire time, not only when scheduled: Details may
+        // have been opened during the wait, and a new run may have started.
+        if (expanded) { autoHideFor = null; return; }
+        const cur = window.NS.status.current();
+        const p = cur && cur.progress;
+        if (!p || p.runId !== runId) { autoHideFor = null; return; }
+        dismissedRun = runId;
+        try { sessionStorage.setItem('rp-dismissed', String(runId)); } catch (_) {}
+        hide();
+      }, AUTO_HIDE_SUCCESS_MS);
+    }
+
     function setExpanded(next, remember) {
       expanded = next;
       if (remember !== false) expandedPreference = next;
+      // Opening Details is a request to keep reading.
+      if (next) cancelAutoHide();
       el.toggle.setAttribute('aria-expanded', next ? 'true' : 'false');
       el.steps.hidden = !next;
     }
@@ -443,9 +481,20 @@
 
       // Open the list once on failure — that is when the detail is the
       // point. Never collapse what the operator opened.
+      // `remember: false` — the program opened this, not the operator. Left
+      // as a preference it would persist into every later run, and since an
+      // open list suppresses the auto-hide below, one failed spin-up would
+      // stop every subsequent successful one from ever clearing itself.
       if (done && p.conclusion === 'failure' && autoExpandedFor !== p.runId) {
         autoExpandedFor = p.runId;
-        setExpanded(true);
+        setExpanded(true, false);
+      }
+
+      if (done && p.conclusion === 'success') {
+        scheduleAutoHide(p.runId);
+      } else {
+        // Still running, or it failed: nothing should be on a timer.
+        cancelAutoHide();
       }
     }
 

--- a/docs/user-guides/dashboard.md
+++ b/docs/user-guides/dashboard.md
@@ -62,7 +62,12 @@ Two states worth recognising:
 - **"Dispatched — waiting for GitHub to start the run"** — the click landed, but GitHub has not created the run yet. This takes a few seconds. The buttons stay disabled throughout, so a second click cannot start a second run.
 - **A sliding bar instead of a percentage** — the run is queued for a runner, or a job has not reported its steps yet. There is nothing to count, so nothing is claimed.
 
-When a run finishes, the bar stays: green at 100% for success, or red at the point it failed, with the failing step named and the list already expanded. It is **not** filled to 100% on failure — cleanup steps run after a failure, and filling the bar would suggest the work completed. Dismiss it, or start another run, to clear it.
+When a run finishes the bar reports the outcome, and the two outcomes are treated differently on purpose:
+
+- **Success** — green at 100%, with the total time and step count. It clears itself after half a minute, since the status panel above already says *Deployed* and you are probably heading for your stacks. Open **Details** and it stays: the list does not disappear while you are reading it.
+- **Failure** — red, stopped at the step it failed on, with that step named and the list already expanded. It stays until you dismiss it. The bar is **not** filled to 100%: cleanup steps run after a failure, so a full bar would suggest the work completed.
+
+Either way, reloading the page clears it — the bar reports the run you watched, not a state the stack is in.
 
 ## Controls are locked while a workflow runs
 


### PR DESCRIPTION
## Asked after watching a real spin-up finish

> können wir dann den Fortschrittsbalken entfernen, oder was meinst du?

Not entirely — split by outcome, because the two states say different things.

**Success clears itself after 30 seconds.** The green bar has already said what
it has to, the status panel directly above reads *Deployed*, and it sits between
the action buttons and Active Stacks, which is where the operator is heading
next.

**Failure stays until dismissed.** It is the only place naming the step the run
stopped at. A timer that removed that while somebody was reading it would be
worse than never showing it.

**Open Details and nothing hides.** Opening the list is a request to keep
reading. The check runs when the timer *fires*, not only when it is set, so
opening the list during the wait cancels it too.

## What measuring the current behaviour turned up

The bar already cleared on reload, before this change — a fresh page sends no
`progress_for`, so the server returns no steps and there is nothing to render:

```
session where the run finished:  progress 100%, persists across polls
fresh page load, same run:       /api/status (no progress_for) -> no bar
```

Worth stating in the docs, because it is the honest description of what the bar
is: a report on the run you watched, not a property of the stack.

## Found by the test, not in review

The auto-expand on failure called `setExpanded(true)` without `remember: false`,
so it recorded itself as the operator's preference. An open list suppresses the
auto-hide — so **one failed spin-up would have stopped every later successful run
from ever clearing itself**, on that tab, for as long as it stayed open. The
program opened that list, not the operator; the failure path no longer claims the
preference.

This only surfaced because the test ran a failure and a success in sequence
against one component instance. A test that checked each outcome in isolation
would have passed.

## Verification

10 assertions on a controllable clock — timers fire only when the test fires
them:

```
success            -> 30s timer set, hides when it fires
failure            -> no timer, stays visible
run in progress    -> no timer
success after fail -> timer set again  (the bug above)
open Details       -> pending timer cancelled
close again        -> next timer allowed through
```

All nine JS suites pass (90 assertions), 2895 Python tests, `npm run build`
clean.

## Not verified

Not seen on a deployed Control Plane — the 30-second delay and the Details
interaction are exercised against a fake clock, not a browser.

## Summary by Sourcery

Automatically dismiss successful run progress after a short delay while preserving failure details and respecting the operator's request to keep Details open.

New Features:
- Automatically clear the progress bar 30 seconds after a successful run while keeping it visible when Details is open.

Bug Fixes:
- Prevent failure auto-expansion from persisting as an operator preference and blocking future successful-run auto-clears.
- Cancel stale auto-hide timers when a new run starts or the progress bar is hidden.

Documentation:
- Document the distinct success and failure retention behavior and clarify that reloading clears the run report.

Tests:
- Add controllable-clock coverage for successful, failed, in-progress, sequential, and Details interaction scenarios.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Successfully completed runs now automatically disappear after 30 seconds, unless Details is open.
  * Failed runs remain visible, stop at the failed step, and expand the failed step automatically.

* **Documentation**
  * Updated dashboard guidance to explain success and failure states, auto-dismissal, and behavior after page reloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->