### PR TITLE
chore: Correct CodeRabbit instructions that state rules the repo breaks

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -104,10 +104,13 @@ reviews:
         a credential env var must not carry a guessable default.
         `${ADMIN_USERNAME:-admin}` hands back exactly the default the
         nexus- prefix exists to prevent. Require `${VAR:?message}` or an
-        empty default; the four that exist are tracked in #780. This
-        does NOT apply to `${IMAGE_*:-<pinned tag>}`
-        — that is the house pattern letting the orchestrator override an
-        image, and ~140 of the 150 fallbacks in this tree are that.
+        empty default; the four that exist are tracked in #780.
+        The exception is a fallback whose value is an image tag on an
+        `image:` field — `${IMAGE_*:-<pinned tag>}` is the house pattern
+        letting the orchestrator override an image, and ~140 of the 150
+        fallbacks in this tree are that. The exemption is about what the
+        value is, not what the variable is called: a credential-shaped
+        variable stays in scope whatever its name begins with.
 
         Do NOT flag a missing `mem_limit`. 5 of 82 stacks set one; the
         gap is tracked in #741, and re-raising it per PR is noise.
@@ -133,8 +136,9 @@ reviews:
 
         Pinning third-party actions to commit SHAs is intended but not
         yet done: 3 of 33 `uses:` lines are pinned, and #652 tracks the
-        migration. Raise it on a newly added action, not on the existing
-        `@vN` lines a PR happens to touch.
+        migration. Raise it when a third-party `uses:` reference is added
+        or modified — a tag bump is the moment to pin — but not for an
+        untouched `@vN` line that a PR merely happens to sit next to.
     - path: "src/nexus_deploy/**/*.py"
       instructions: |
         Per CLAUDE.md ("NEVER print secrets to logs"): never log a secret

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -16,6 +16,22 @@
 #
 # request_changes_workflow was turned off for a different reason — see
 # the note at that key. It is about the verdict, not the volume.
+#
+# Audited 2026-09-03 against the tree. Four path_instructions asserted
+# rules the repo does not follow, three of them citing CLAUDE.md for
+# text that is not in it — mem_limit as a MUST (5 of 82 stacks), every
+# `${VAR:-default}` as forbidden (150 exist, ~140 of them legitimate
+# image-tag overrides), a validation block on every variable (12 of 62),
+# and SHA-pinned actions (3 of 33) citing an "audit-finding H45" in an
+# AUDIT_REPORT.md that does not exist. An instruction that describes a
+# rule nobody follows is not a strict reviewer, it is a dismissal
+# generator. Each one is now either cited accurately or carries the
+# count that sets its strength.
+#
+# The tools block was left alone deliberately: across 2410 lines of
+# CodeRabbit comments on ten PRs, only markdownlint and ast-grep were
+# ever named. Disabling a tool that has never reported anything saves
+# no noise and costs coverage.
 
 language: en
 
@@ -64,13 +80,16 @@ reviews:
     # Lockfiles / generated content.
     - "!control-plane/package-lock.json"
     - "!**/node_modules/**"
-    # Audit / report artefacts (gitignored anyway).
-    - "!AUDIT_REPORT.md"
 
   path_instructions:
+    # These are the highest-value knob in this file and the easiest to
+    # get wrong: an instruction that states a rule the repo does not
+    # follow turns every PR touching that path into a dismissal round.
+    # Each rule below is either in CLAUDE.md (cited) or measured against
+    # the tree, with the count that justifies its strength.
     - path: "stacks/**/docker-compose.yml"
       instructions: |
-        Apply Nexus-Stack's Docker conventions from CLAUDE.md:
+        Per CLAUDE.md ("Adding New Stacks", "Service Account Naming"):
         - Stateful services MUST pin image versions (no :latest except
           for the documented allow-list: drawio, it-tools, wetty,
           code-server, jupyter, marimo, adminer, excalidraw,
@@ -78,33 +97,56 @@ reviews:
         - Service accounts MUST use the `nexus-` prefix
           (nexus-postgres, nexus-<service>). Flag `admin`, `postgres`,
           `root` or service-name-alone usage.
-        - Every container MUST have `restart: unless-stopped` and
-          `mem_limit`. Stacks join `app-network` (external).
-        - Hardcoded credential fallbacks (`${VAR:-default-password}`)
-          are forbidden — use `${VAR:?must be set}` so missing env
-          fails fast.
+        - Every container gets `restart: unless-stopped` and joins
+          `app-network` (external: true).
+
+        Not in CLAUDE.md, but a direct consequence of the naming rule:
+        a credential env var must not carry a guessable default.
+        `${ADMIN_USERNAME:-admin}` hands back exactly the default the
+        nexus- prefix exists to prevent. Require `${VAR:?message}` or an
+        empty default; the four that exist are tracked in #780. This
+        does NOT apply to `${IMAGE_*:-<pinned tag>}`
+        — that is the house pattern letting the orchestrator override an
+        image, and ~140 of the 150 fallbacks in this tree are that.
+
+        Do NOT flag a missing `mem_limit`. 5 of 82 stacks set one; the
+        gap is tracked in #741, and re-raising it per PR is noise.
     - path: "tofu/**/*.tf"
       instructions: |
-        Per CLAUDE.md: every variable that flows into a Cloudflare /
-        Hetzner resource needs a `validation` block where the failure
-        mode is opaque without one (account/zone IDs, domains, ports,
-        emails). Always use `${local.resource_prefix}` for resource
-        naming.
+        Per CLAUDE.md ("Resource Naming"): always use
+        `${local.resource_prefix}` for resource names.
+
+        A `validation` block is wanted on variables whose failure mode
+        is otherwise opaque — account/zone IDs, domains, ports, emails —
+        but 12 of 62 variables have one, so this is a direction of
+        travel rather than a rule. Raise it on a newly added variable;
+        do not raise it on existing ones a PR merely touches.
     - path: ".github/workflows/**"
       instructions: |
-        Per CLAUDE.md: critical operations (infra destroy, deploy)
-        must fail loudly — never `|| echo "..."` swallowing real
-        errors. Secrets must be masked (`::add-mask::`) before being
-        passed through `echo`. Pin third-party actions to commit SHAs
-        rather than floating @vN tags (audit-finding H45).
+        Per CLAUDE.md ("Error Handling Principles"): critical operations
+        (infra destroy, deploy) must fail loudly — never `|| echo "..."`
+        swallowing a real error, and never let the failure indicator be
+        a by-product such as an error string that happens to be empty.
+        Status and message belong in separate variables.
+        Per CLAUDE.md ("NEVER print secrets to logs"): mask dynamic
+        secrets with `::add-mask::` before anything can echo them.
+
+        Pinning third-party actions to commit SHAs is intended but not
+        yet done: 3 of 33 `uses:` lines are pinned, and #652 tracks the
+        migration. Raise it on a newly added action, not on the existing
+        `@vN` lines a PR happens to touch.
     - path: "src/nexus_deploy/**/*.py"
       instructions: |
-        Per CLAUDE.md: never log secret values; use
-        `type(exc).__name__` not `str(exc)` in error logs (secrets
-        often leak via __str__). All subprocess.run calls must use
-        shlex-quoted args, never shell=True, never os.system. Match
-        the project's pure-rendering / DI-seam pattern (callable
-        injection for testability) where applicable.
+        Per CLAUDE.md ("NEVER print secrets to logs"): never log a secret
+        value, and use `type(exc).__name__` rather than `str(exc)` in
+        error logs — secrets leak through __str__.
+
+        Convention rather than written rule, but absolute: no
+        `shell=True`, no `os.system`, subprocess arguments stay a list.
+        The package currently contains zero of all three, so treat any
+        introduction as a regression rather than a style preference.
+        Match the pure-rendering / callable-injection pattern the service
+        hooks use (`_SERVICE_HOOKS` in services.py) where applicable.
 
   tools:
     # Secret-scanning — high value across compose files, scripts, TF.
@@ -120,8 +162,10 @@ reviews:
     yamllint:
       enabled: true
 
-    # GitHub Actions workflow validation (catches the floating-@vN
-    # patterns, missing permissions, deprecated runners).
+    # GitHub Actions workflow validation: expression syntax, action
+    # inputs, shellcheck over `run:` bodies, deprecated runners. It does
+    # not check SHA pinning — see the workflows path_instruction for
+    # that, and #652 for the migration.
     actionlint:
       enabled: true
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -869,13 +869,14 @@ See [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md) for full details.
 **Example workflow:**
 ```
 1. Make code changes
-2. "I've added a new step to delete R2 bucket in destroy-all.yml workflow..."
-3. git commit -m "fix(ci): Add R2 bucket cleanup..."
-4. coderabbit review --agent --base main   # exactly once
-5. Fix what is genuinely valid, commit as a follow-up
-6. "Soll ich pushen?" / "Should I push?"
-7. Wait for user confirmation
-8. git push (only if confirmed)
+2. Run the affected tests / checks — see "Mandatory Testing" above
+3. "I've added a new step to delete R2 bucket in destroy-all.yml workflow..."
+4. git commit -m "fix(ci): Add R2 bucket cleanup..."
+5. coderabbit review --agent --base main   # exactly once
+6. Fix what is genuinely valid, re-run the tests, commit as a follow-up
+7. "Soll ich pushen?" / "Should I push?"   # report dismissed findings here
+8. Wait for user confirmation
+9. git push (only if confirmed)
 ```
 
 ### Local CodeRabbit round before pushing — exactly one
@@ -904,8 +905,16 @@ describe this step as a complete pre-push filter, because it is not one.
 
 Triage the findings exactly like PR review comments — the same bucket
 framework, the same scepticism. A local finding is not more authoritative
-for being local. Dismiss what misreads the code, and say why in the
-commit message rather than silently ignoring it.
+for being local. Dismiss what misreads the code, and say why — never
+silently. Where a dismissal accompanies a fix, the follow-up commit
+message is the place for it. Where you dismiss everything there is no
+follow-up commit, so it goes in the message that asks to push. Do not
+amend the earlier commit or manufacture an empty one to hold a
+sentence.
+
+The review is not a test run. It reads the diff; it does not execute
+anything. "Mandatory Testing" above still applies to the original commit
+and to every follow-up.
 
 What the flags mean, since the defaults are not what you want here:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -894,6 +894,14 @@ finds progressively more marginal things, and is the pedantic loop that
 `.claude/skills/fix-pr-comments` already warns about at the PR stage.
 If a finding is too big to fix in this round, file an issue and push.
 
+**Say what this does not cover.** The round reviews the diff as it stands
+when you run it, so the fixes you make in response are themselves never
+locally reviewed. That gap is inherent to a single round and cannot be
+closed by moving the round later: wherever it sits, whatever you change
+after it is unreviewed. The gap is deliberate, and the PR review is what
+covers it — so do not add a second local round to chase it, and do not
+describe this step as a complete pre-push filter, because it is not one.
+
 Triage the findings exactly like PR review comments — the same bucket
 framework, the same scepticism. A local finding is not more authoritative
 for being local. Dismiss what misreads the code, and say why in the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -859,7 +859,9 @@ See [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md) for full details.
    - Include a detailed commit message explaining what was done
    - Stage only the relevant files
 
-3. **Ask the user before pushing**:
+3. **Run one local CodeRabbit round before pushing** (see below).
+
+4. **Ask the user before pushing**:
    - After committing, ask: "Soll ich pushen?" or "Should I push?"
    - Wait for explicit confirmation before pushing to remote
    - Do NOT push automatically unless explicitly requested
@@ -869,10 +871,52 @@ See [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md) for full details.
 1. Make code changes
 2. "I've added a new step to delete R2 bucket in destroy-all.yml workflow..."
 3. git commit -m "fix(ci): Add R2 bucket cleanup..."
-4. "Soll ich pushen?" / "Should I push?"
-5. Wait for user confirmation
-6. git push (only if confirmed)
+4. coderabbit review --agent --base main   # exactly once
+5. Fix what is genuinely valid, commit as a follow-up
+6. "Soll ich pushen?" / "Should I push?"
+7. Wait for user confirmation
+8. git push (only if confirmed)
 ```
+
+### Local CodeRabbit round before pushing — exactly one
+
+Before asking to push a branch, run the CodeRabbit CLI once against
+`main` and act on what it finds:
+
+```bash
+coderabbit review --agent --base main
+```
+
+**Exactly one round. Never re-run it to check your own fix.** The point
+is to catch what would otherwise arrive as a PR comment twenty minutes
+later, not to iterate to silence. A second run costs another review,
+finds progressively more marginal things, and is the pedantic loop that
+`.claude/skills/fix-pr-comments` already warns about at the PR stage.
+If a finding is too big to fix in this round, file an issue and push.
+
+Triage the findings exactly like PR review comments — the same bucket
+framework, the same scepticism. A local finding is not more authoritative
+for being local. Dismiss what misreads the code, and say why in the
+commit message rather than silently ignoring it.
+
+What the flags mean, since the defaults are not what you want here:
+
+- `--base main` compares the whole branch against `main`, which is what
+  you want after committing — verified: a run on a branch whose only
+  change was already committed reviewed that file. The bare `coderabbit
+  review` reviews "tracked changes" per its own `--help`, and there are
+  separate `--committed` / `--uncommitted` flags; if you drop `--base`,
+  confirm the `reviewedFiles` list in the output is not empty rather
+  than reading a silent pass as a clean branch.
+- `--agent` emits structured JSON findings instead of prose.
+- `--light` exists for a cheaper pass; use it only when a branch is
+  large and obviously mechanical.
+
+Requires the CLI (`brew install --cask coderabbit` — it is a cask, not
+a formula) and `coderabbit auth login`. If it is not installed or not
+authenticated, say so and push without it rather than silently skipping
+the step — a skipped check that nobody knows was skipped is worse than
+no check.
 
 ### PR Titles for Release Notes
 


### PR DESCRIPTION
## Why

`.coderabbit.yaml` was audited against the tree. Four of its five `path_instructions` asserted rules the repo does not follow, three of them citing CLAUDE.md for text that is not in it:

| Instruction | Reality |
|---|---|
| Every container MUST have `mem_limit` | 5 of 82 stacks set one — already tracked in #741 |
| `${VAR:-default}` is forbidden | 150 exist, ~140 of them legitimate `${IMAGE_*:-<pinned tag>}` overrides |
| Every variable needs a `validation` block | 12 of 62 have one |
| Actions pinned to commit SHAs, per "audit-finding H45" | 3 of 33 — and `AUDIT_REPORT.md` exists neither in the repo nor in `.gitignore` |

An instruction describing a rule nobody follows does not make the reviewer stricter. It makes every PR touching that path end in a dismissal round, which is how these went unnoticed: the findings were being dismissed rather than acted on.

## What changed

Each rule is now either cited accurately against CLAUDE.md or carries the count that sets its strength. The two that are genuine intentions rather than practice — validation blocks and SHA pinning — point at their tracking issues (#741, #652) with instructions to raise them on new or modified code only, not on lines a PR merely sits next to.

Also removed the dead `AUDIT_REPORT.md` path filter, and corrected the `actionlint` comment, which claimed the tool catches floating `@vN` tags. It does not check pinning at all.

The `tools` block is deliberately unchanged. Across 2410 lines of CodeRabbit comments on ten PRs, only `markdownlint` and `ast-grep` were ever named — disabling a tool that has never reported anything saves no noise and costs coverage. My first instinct was to switch off `biome`; the evidence said otherwise.

## A rule, and its first application

CLAUDE.md gains a step between committing and asking to push: run `coderabbit review --agent --base main` **exactly once** and act on what it finds. The constraint that matters is the "once" — re-running to check a fix turns a cheap pre-push filter into the pedantic loop `.claude/skills/fix-pr-comments` already warns about at the PR stage, and each run costs another review. Findings get the same bucket triage and the same scepticism as PR comments; local does not mean authoritative.

Running it on this branch immediately found two defects in the instructions this PR had just rewritten, both now fixed:

- The `${IMAGE_*:-…}` exemption keyed on the **variable name**, so a credential-shaped `IMAGE_*` would have been waved through. It now keys on the value being an image tag.
- The SHA-pinning rule fired only on newly *added* actions, missing the tag bump — which is precisely when pinning should be raised.

Two claims in the new rule were checked before committing rather than assumed: it is `brew install --cask coderabbit` (a cask, not a tap), and the note about running without `--base` now says to verify `reviewedFiles` rather than asserting a behaviour that was never observed.

## Found on the way

Narrowing the fallback rule surfaced a real defect, filed as #780: the admin username has three layers of default, and two contradict the third. `tofu/stack/variables.tf` says `nexus`, while `src/nexus_deploy/config.py:51` and three compose files fall back to `admin` — exactly the name the `nexus-` convention exists to prevent. Not exploitable on a correctly-provisioned stack, but a fallback that fires is by definition the case nobody is watching.

## Testing

No runtime behaviour changes — this is reviewer configuration and project instructions. `.coderabbit.yaml` parses as valid YAML and satisfies the repo's `check yaml` pre-commit hook; the four `path` globs were verified to match 82, 8, 13 and 30 tracked files respectively.

The real test is this PR's own review: if the corrected instructions work, CodeRabbit should not raise `mem_limit` or `${IMAGE_*:-…}` against it.

## Summary by Sourcery

Correct repository review guidance and add a deliberate one-time local CodeRabbit check before pushing changes.

New Features:
- Add a required, single local CodeRabbit review round to the pre-push workflow and document how to triage its findings.

Bug Fixes:
- Correct CodeRabbit path instructions so they distinguish enforced repository conventions from incomplete migrations and avoid flagging legitimate image-tag fallbacks.
- Remove the obsolete audit-report path filter and correct the actionlint description of SHA-pinning coverage.

Enhancements:
- Align reviewer guidance with the repository’s documented conventions, current adoption levels, and tracking issues for validation and action pinning.
- Clarify that reviewer findings apply to newly added or modified code rather than untouched lines surrounding a change.

Documentation:
- Document the local CodeRabbit CLI workflow, its limitations, installation and authentication requirements, and reporting expectations before pushing.

Chores:
- Preserve the existing CodeRabbit tool configuration while auditing and refining its path-specific instructions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified development guidance for Docker Compose, Terraform, workflows, Python subprocess usage, action validation, and secret handling.
  - Added a required local CodeRabbit review step to the commit-and-push workflow, including command usage, finding triage, prerequisites, and fallback instructions.
  - Updated workflow sequencing and review expectations for more consistent contribution practices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->