### PR TITLE
fix(stacks): Stop falling back to the admin username the naming rule forbids

### DIFF
--- a/src/nexus_deploy/__main__.py
+++ b/src/nexus_deploy/__main__.py
@@ -33,7 +33,7 @@ from nexus_deploy import pipeline as _pipeline
 from nexus_deploy import s3_persistence as _s3_persistence
 from nexus_deploy import s3_restore as _s3_restore
 from nexus_deploy.compose_runner import run_compose_up
-from nexus_deploy.config import ConfigError, NexusConfig
+from nexus_deploy.config import DEFAULT_ADMIN_USERNAME, ConfigError, NexusConfig
 from nexus_deploy.forgejo import (
     ForgejoError,
     run_configure_forgejo,
@@ -1120,7 +1120,8 @@ def _forgejo_woodpecker_oauth(args: list[str]) -> int:
     Optional env:
 
     - ``ADMIN_USERNAME`` — admin username, path-validated (default
-      ``admin``). Mirrors :class:`NexusConfig`'s ``admin_username``
+      :data:`~nexus_deploy.config.DEFAULT_ADMIN_USERNAME`). Mirrors
+      :class:`NexusConfig`'s ``admin_username``
       default so the CLI works without an explicit env-passing
       layer when invoked manually.
     - ``FORGEJO_HOST`` — SSH host alias (default ``nexus``)
@@ -1153,7 +1154,7 @@ def _forgejo_woodpecker_oauth(args: list[str]) -> int:
 
     domain = os.environ.get("DOMAIN") or ""
     forgejo_token = os.environ.get("FORGEJO_TOKEN") or ""
-    admin_username = os.environ.get("ADMIN_USERNAME") or "admin"
+    admin_username = os.environ.get("ADMIN_USERNAME") or DEFAULT_ADMIN_USERNAME
     ssh_host = os.environ.get("FORGEJO_HOST") or "nexus"
     # Issue #540: SUBDOMAIN_SEPARATOR threaded through to the redirect-URI
     # builder. ``"."`` (default) yields ``woodpecker.<domain>/authorize``;
@@ -1292,7 +1293,8 @@ def _forgejo_mirror_setup(args: list[str]) -> int:
     Optional env:
 
     - ``ADMIN_USERNAME`` — admin username, path-validated (default
-      ``admin``). Mirrors :class:`NexusConfig`'s ``admin_username``
+      :data:`~nexus_deploy.config.DEFAULT_ADMIN_USERNAME`). Mirrors
+      :class:`NexusConfig`'s ``admin_username``
       default so the CLI works without an explicit env-passing layer
       when invoked manually. (Same default as
       ``forgejo woodpecker-oauth`` — Copilot R1 consistency fix.)
@@ -1326,7 +1328,7 @@ def _forgejo_mirror_setup(args: list[str]) -> int:
         print(f"forgejo mirror-setup: unknown args {args!r}", file=sys.stderr)
         return 2
 
-    admin_username = os.environ.get("ADMIN_USERNAME") or "admin"
+    admin_username = os.environ.get("ADMIN_USERNAME") or DEFAULT_ADMIN_USERNAME
     admin_password = os.environ.get("FORGEJO_ADMIN_PASS") or ""
     forgejo_token = os.environ.get("FORGEJO_TOKEN") or ""
     gh_mirror_repos_csv = os.environ.get("GH_MIRROR_REPOS") or ""

--- a/src/nexus_deploy/config.py
+++ b/src/nexus_deploy/config.py
@@ -44,11 +44,19 @@ class ConfigError(Exception):
 # `tofu output -json secrets`. `fallback` is the value substituted when
 # the JSON key is absent or empty:
 #   - "" is the overwhelming majority (omit-if-empty)
-#   - "admin" is the admin_username default
+#   - DEFAULT_ADMIN_USERNAME is the admin_username default
 #   - "External Storage" / "auto" are explicit non-empty defaults
 # ---------------------------------------------------------------------------
+
+#: Fallback admin username, kept identical to `variable "admin_username"` in
+#: tofu/stack/variables.tf. It used to read "admin" here while Terraform said
+#: "nexus", so a deploy that lost the tofu output silently handed back exactly
+#: the name CLAUDE.md's `nexus-` rule exists to prevent (#780). Every Python
+#: site that needs a fallback imports this one rather than repeating a literal.
+DEFAULT_ADMIN_USERNAME = "nexus"
+
 _FIELDS: tuple[tuple[str, str, str], ...] = (
-    ("ADMIN_USERNAME", "admin_username", "admin"),
+    ("ADMIN_USERNAME", "admin_username", DEFAULT_ADMIN_USERNAME),
     ("INFISICAL_PASS", "infisical_admin_password", ""),
     ("INFISICAL_ENCRYPTION_KEY", "infisical_encryption_key", ""),
     ("INFISICAL_AUTH_SECRET", "infisical_auth_secret", ""),

--- a/src/nexus_deploy/forgejo.py
+++ b/src/nexus_deploy/forgejo.py
@@ -62,7 +62,7 @@ from typing import Literal
 
 import requests
 
-from nexus_deploy.config import NexusConfig, service_host
+from nexus_deploy.config import DEFAULT_ADMIN_USERNAME, NexusConfig, service_host
 from nexus_deploy.ssh import SSHClient
 
 _CONNECT_TIMEOUT_S: float = 3.0
@@ -1446,7 +1446,7 @@ def run_configure_forgejo(
     PATCH failed but token created), the token IS in the result so
     the orchestrator can capture it via eval.
     """
-    admin_username = config.admin_username or "admin"
+    admin_username = config.admin_username or DEFAULT_ADMIN_USERNAME
     admin_password = config.forgejo_admin_password or ""
     db_password = config.forgejo_db_password or ""
 

--- a/src/nexus_deploy/infisical.py
+++ b/src/nexus_deploy/infisical.py
@@ -34,7 +34,7 @@ from pathlib import Path
 from typing import Literal
 
 from nexus_deploy import _remote
-from nexus_deploy.config import NexusConfig, service_host
+from nexus_deploy.config import DEFAULT_ADMIN_USERNAME, NexusConfig, service_host
 
 # Server-side Infisical endpoint.
 _INFISICAL_HOST = "localhost"
@@ -460,7 +460,7 @@ def compute_folders(config: NexusConfig, env: BootstrapEnv) -> list[FolderSpec]:
     # at dump time, so pushed values match the bash-eval consumers
     # exactly (admin_username default + EXTERNAL_S3_* explicit
     # defaults).
-    admin_username = config.admin_username or "admin"
+    admin_username = config.admin_username or DEFAULT_ADMIN_USERNAME
     external_s3_label = config.external_s3_label or "External Storage"
     external_s3_region = config.external_s3_region or "auto"
 

--- a/src/nexus_deploy/kestra.py
+++ b/src/nexus_deploy/kestra.py
@@ -43,7 +43,7 @@ from typing import Literal
 
 import requests
 
-from nexus_deploy.config import NexusConfig
+from nexus_deploy.config import DEFAULT_ADMIN_USERNAME, NexusConfig
 
 # Default HTTP timeouts:
 # - connect: short (TCP setup) — Kestra is local via tunnel; if it
@@ -724,7 +724,7 @@ def run_register_system_flows(
         repo_owner=repo_owner,
         repo_name=repo_name,
         branch=branch,
-        admin_username=config.admin_username or "admin",
+        admin_username=config.admin_username or DEFAULT_ADMIN_USERNAME,
     )
     register_results = register_all_system_flows(client, flows)
 

--- a/src/nexus_deploy/orchestrator.py
+++ b/src/nexus_deploy/orchestrator.py
@@ -1733,6 +1733,23 @@ class Orchestrator:
 
         admin_email_value = self.bootstrap_env.admin_email or ""
         admin_username_value = self.admin_username or self.config.admin_username or ""
+        # An empty value here is not a missing nicety, it is a broken deploy:
+        # `_validate_value` below only rejects shell-unsafe characters, so an
+        # empty ADMIN_USERNAME would be written as `ADMIN_USERNAME=` and every
+        # stack reading `${ADMIN_USERNAME:-...}` would take its fallback --
+        # `:-` fires on empty, not only on unset. Fail instead of handing back
+        # a working-looking name nobody chose (#780).
+        if not admin_username_value:
+            return PhaseResult(
+                name="global-env",
+                status="failed",
+                detail=(
+                    "ADMIN_USERNAME resolved to an empty value; refusing to write .env. "
+                    "It comes from the tofu output `admin_username` via NexusConfig, "
+                    "which substitutes DEFAULT_ADMIN_USERNAME when the key is absent, "
+                    "so an empty value means the config was built some other way."
+                ),
+            )
         validations = [
             ("DOMAIN", self.domain),
             ("ADMIN_EMAIL", admin_email_value),

--- a/src/nexus_deploy/orchestrator.py
+++ b/src/nexus_deploy/orchestrator.py
@@ -67,7 +67,7 @@ from nexus_deploy import service_env as _service_env
 from nexus_deploy import services as _services
 from nexus_deploy import stack_sync as _stack_sync
 from nexus_deploy import workspace_coords as _workspace_coords
-from nexus_deploy.config import NexusConfig
+from nexus_deploy.config import DEFAULT_ADMIN_USERNAME, NexusConfig
 from nexus_deploy.infisical import BootstrapEnv
 from nexus_deploy.ssh import SSHClient
 
@@ -741,7 +741,7 @@ class Orchestrator:
                     base_url=f"http://localhost:{port}",
                     domain=domain,
                     forgejo_token=self.state.forgejo_token,
-                    admin_username=self.config.admin_username or "admin",
+                    admin_username=self.config.admin_username or DEFAULT_ADMIN_USERNAME,
                     subdomain_separator=self.bootstrap_env.subdomain_separator,
                 )
         except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError) as exc:
@@ -810,7 +810,7 @@ class Orchestrator:
             with ssh.port_forward(local_port, "localhost", 3202) as port:
                 result = _forgejo.run_mirror_setup(
                     base_url=f"http://localhost:{port}",
-                    admin_username=self.config.admin_username or "admin",
+                    admin_username=self.config.admin_username or DEFAULT_ADMIN_USERNAME,
                     admin_password=self.config.forgejo_admin_password or "",
                     forgejo_token=self.state.forgejo_token,
                     forgejo_user_username=self.forgejo_user_username,

--- a/src/nexus_deploy/service_env.py
+++ b/src/nexus_deploy/service_env.py
@@ -39,7 +39,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Literal
 
-from nexus_deploy.config import NexusConfig, service_host
+from nexus_deploy.config import DEFAULT_ADMIN_USERNAME, NexusConfig, service_host
 from nexus_deploy.infisical import BootstrapEnv
 
 # ---------------------------------------------------------------------------
@@ -342,7 +342,7 @@ def _render_grafana(
     )
     return RenderedEnv(
         env_vars={
-            "GRAFANA_ADMIN_USER": c.admin_username or "admin",
+            "GRAFANA_ADMIN_USER": c.admin_username or DEFAULT_ADMIN_USERNAME,
             "GRAFANA_ADMIN_PASSWORD": c.grafana_admin_password or "",
         },
         sidecars=(
@@ -831,7 +831,7 @@ def _render_litellm(
             "LITELLM_MASTER_KEY": c.litellm_master_key or "",
             "LITELLM_SALT_KEY": c.litellm_salt_key or "",
             "LITELLM_DB_PASSWORD": c.litellm_db_password or "",
-            "LITELLM_UI_USERNAME": c.admin_username or "admin",
+            "LITELLM_UI_USERNAME": c.admin_username or DEFAULT_ADMIN_USERNAME,
         },
         sidecars=(
             # mode 0o644: bind-mounted into the litellm container which

--- a/src/nexus_deploy/services.py
+++ b/src/nexus_deploy/services.py
@@ -95,7 +95,7 @@ from dataclasses import dataclass
 from typing import Any, Literal, cast
 
 from nexus_deploy import _remote
-from nexus_deploy.config import NexusConfig, service_host
+from nexus_deploy.config import DEFAULT_ADMIN_USERNAME, NexusConfig, service_host
 from nexus_deploy.infisical import BootstrapEnv
 
 _RESULT_LINE_RE = re.compile(
@@ -271,7 +271,7 @@ def render_portainer_hook(config: NexusConfig, env: BootstrapEnv) -> str:
     secrets in argv (R4).
     """
     del env  # not used; signature uniform across hooks
-    username = config.admin_username or "admin"
+    username = config.admin_username or DEFAULT_ADMIN_USERNAME
     password = config.portainer_admin_password or ""
     if not password:
         return 'echo "RESULT hook=portainer status=skipped-not-ready"\n'

--- a/stacks/grafana/docker-compose.yml
+++ b/stacks/grafana/docker-compose.yml
@@ -28,7 +28,7 @@ services:
     ports:
       - "3100:3000"
     environment:
-      - GF_SECURITY_ADMIN_USER=${GRAFANA_ADMIN_USER:-admin}
+      - GF_SECURITY_ADMIN_USER=${GRAFANA_ADMIN_USER:?must be set in .env (rendered by service_env._render_grafana)}
       - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:?must be set in .env (rendered by service_env._render_grafana)}
       - GF_USERS_ALLOW_SIGN_UP=false
       - GF_AUTH_ANONYMOUS_ENABLED=true

--- a/stacks/litellm/docker-compose.yml
+++ b/stacks/litellm/docker-compose.yml
@@ -56,7 +56,7 @@ services:
       # vs. admin bearer for API), add random_password.litellm_ui_password
       # in tofu/stack/main.tf, plumb it through service_env.py +
       # Infisical, and reference it here.
-      UI_USERNAME: ${LITELLM_UI_USERNAME:-admin}
+      UI_USERNAME: ${LITELLM_UI_USERNAME:?must be set in .env (rendered by service_env._render_litellm)}
       UI_PASSWORD: ${LITELLM_MASTER_KEY}
       # Telemetry off (project-wide convention)
       LITELLM_LOCAL_MODEL_COST_MAP: "True"

--- a/stacks/mage/docker-compose.yml
+++ b/stacks/mage/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       REQUIRE_USER_AUTHENTICATION: "true"
       DEFAULT_OWNER_EMAIL: ${USER_EMAIL}
       DEFAULT_OWNER_PASSWORD: ${MAGE_ADMIN_PASSWORD}
-      DEFAULT_OWNER_USERNAME: ${ADMIN_USERNAME:-admin}
+      DEFAULT_OWNER_USERNAME: ${ADMIN_USERNAME:?must be set in the global .env (written by orchestrator._phase_global_env)}
       # Server settings
       MAGE_PUBLIC_HOST: https://mage.${DOMAIN}
     deploy:

--- a/stacks/rustfs/docker-compose.yml
+++ b/stacks/rustfs/docker-compose.yml
@@ -37,7 +37,7 @@ services:
     env_file: .env
     environment:
       # RustFS uses RUSTFS_ACCESS_KEY/SECRET_KEY (not ROOT_USER/PASSWORD)
-      RUSTFS_ACCESS_KEY: ${RUSTFS_ACCESS_KEY:-rustfs}
+      RUSTFS_ACCESS_KEY: ${RUSTFS_ACCESS_KEY:?must be set in .env (rendered by service_env._render_rustfs)}
       RUSTFS_SECRET_KEY: ${RUSTFS_SECRET_KEY}
       RUSTFS_ADDRESS: ":9000"
       RUSTFS_CONSOLE_ENABLE: "true"

--- a/tests/unit/__snapshots__/test_config.ambr
+++ b/tests/unit/__snapshots__/test_config.ambr
@@ -1,7 +1,7 @@
 # serializer version: 1
 # name: test_dump_shell_empty_snapshot
   '''
-  ADMIN_USERNAME=admin
+  ADMIN_USERNAME=nexus
   INFISICAL_PASS=''
   INFISICAL_ENCRYPTION_KEY=''
   INFISICAL_AUTH_SECRET=''

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -21,7 +21,7 @@ from hypothesis import given, settings
 from hypothesis import strategies as st
 from syrupy.assertion import SnapshotAssertion
 
-from nexus_deploy.config import _FIELDS, ConfigError, NexusConfig
+from nexus_deploy.config import _FIELDS, DEFAULT_ADMIN_USERNAME, ConfigError, NexusConfig
 
 FIXTURES = Path(__file__).resolve().parents[1] / "fixtures"
 
@@ -130,9 +130,17 @@ def test_dump_shell_emits_all_fields() -> None:
         assert f"{bash_var}=" in rendered
 
 
-def test_dump_shell_admin_username_default_is_admin() -> None:
-    """When SECRETS_JSON is ``{}`` the per-field fallback fires —
-    ``ADMIN_USERNAME`` defaults to ``admin``.
+def test_dump_shell_admin_username_default_matches_terraform() -> None:
+    """When SECRETS_JSON is ``{}`` the per-field fallback fires, and it
+    must agree with ``variable "admin_username"`` in
+    tofu/stack/variables.tf.
+
+    It said ``admin`` here while Terraform said ``nexus``, so a deploy
+    that lost the tofu output handed back the one name CLAUDE.md's
+    ``nexus-`` rule exists to prevent (#780). Asserting the constant
+    rather than a literal keeps the two from drifting apart again --
+    though only Terraform can make the constant itself wrong, which is
+    why the docstring names the file.
 
     The tofu-default may also produce a different value when
     ``tofu output`` lands a populated SECRETS_JSON; the per-field
@@ -140,7 +148,8 @@ def test_dump_shell_admin_username_default_is_admin() -> None:
     """
     config = NexusConfig.from_secrets_json("{}")
     parsed = _parse_dump(config.dump_shell())
-    assert parsed["ADMIN_USERNAME"] == "admin"
+    assert parsed["ADMIN_USERNAME"] == DEFAULT_ADMIN_USERNAME
+    assert DEFAULT_ADMIN_USERNAME == "nexus"
 
 
 def test_dump_shell_external_s3_fallbacks() -> None:
@@ -413,7 +422,7 @@ def test_cli_dump_shell_default_tofu_dir(
     rc = main()
     captured = capsys.readouterr()
     assert rc == 0
-    assert captured.out.startswith("ADMIN_USERNAME=admin\n")
+    assert captured.out.startswith(f"ADMIN_USERNAME={DEFAULT_ADMIN_USERNAME}\n")
     assert captured_cwd == [Path("tofu/stack")]
 
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import shlex
 import subprocess
 import sys
@@ -22,6 +23,9 @@ from hypothesis import strategies as st
 from syrupy.assertion import SnapshotAssertion
 
 from nexus_deploy.config import _FIELDS, DEFAULT_ADMIN_USERNAME, ConfigError, NexusConfig
+
+# Same convention as tests/unit/test_stack_conventions.py.
+REPO_ROOT = Path(__file__).resolve().parents[2]
 
 FIXTURES = Path(__file__).resolve().parents[1] / "fixtures"
 
@@ -137,10 +141,7 @@ def test_dump_shell_admin_username_default_matches_terraform() -> None:
 
     It said ``admin`` here while Terraform said ``nexus``, so a deploy
     that lost the tofu output handed back the one name CLAUDE.md's
-    ``nexus-`` rule exists to prevent (#780). Asserting the constant
-    rather than a literal keeps the two from drifting apart again --
-    though only Terraform can make the constant itself wrong, which is
-    why the docstring names the file.
+    ``nexus-`` rule exists to prevent (#780).
 
     The tofu-default may also produce a different value when
     ``tofu output`` lands a populated SECRETS_JSON; the per-field
@@ -149,7 +150,38 @@ def test_dump_shell_admin_username_default_matches_terraform() -> None:
     config = NexusConfig.from_secrets_json("{}")
     parsed = _parse_dump(config.dump_shell())
     assert parsed["ADMIN_USERNAME"] == DEFAULT_ADMIN_USERNAME
-    assert DEFAULT_ADMIN_USERNAME == "nexus"
+
+
+def test_default_admin_username_matches_the_terraform_variable() -> None:
+    """The Python constant and Terraform's own default must agree.
+
+    Asserting ``DEFAULT_ADMIN_USERNAME == "nexus"`` would only compare
+    two Python values: change tofu/stack/variables.tf and that test still
+    passes while the deployed default drifts -- which is exactly the
+    failure this whole change repairs. So read the .tf file.
+
+    Parsed with a regex rather than an HCL library: the repo has no HCL
+    parser dependency, and adding one for a single literal is a worse
+    trade than a pattern anchored to the block it reads.
+    """
+    variables_tf = (REPO_ROOT / "tofu" / "stack" / "variables.tf").read_text()
+    match = re.search(
+        r'variable\s+"admin_username"\s*\{[^}]*?default\s*=\s*"([^"]*)"',
+        variables_tf,
+        re.DOTALL,
+    )
+    assert match, (
+        'could not find `variable "admin_username"` with a `default` in '
+        "tofu/stack/variables.tf -- if the variable was renamed or its "
+        "default removed, DEFAULT_ADMIN_USERNAME in src/nexus_deploy/config.py "
+        "needs the same treatment."
+    )
+    assert match.group(1) == DEFAULT_ADMIN_USERNAME, (
+        f"tofu/stack/variables.tf defaults admin_username to {match.group(1)!r} "
+        f"but DEFAULT_ADMIN_USERNAME is {DEFAULT_ADMIN_USERNAME!r}. A deploy that "
+        "loses the tofu output would then hand back a different name than a "
+        "deploy that keeps it. See #780."
+    )
 
 
 def test_dump_shell_external_s3_fallbacks() -> None:

--- a/tests/unit/test_infisical.py
+++ b/tests/unit/test_infisical.py
@@ -23,7 +23,7 @@ from typing import Any
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
-from nexus_deploy.config import NexusConfig
+from nexus_deploy.config import DEFAULT_ADMIN_USERNAME, NexusConfig
 from nexus_deploy.infisical import (
     BootstrapEnv,
     BootstrapResult,
@@ -181,7 +181,10 @@ def test_compute_folders_skip_empty_drops_optional_keys() -> None:
     """A folder builder skips per-key None/empty values (preserves UI edits)."""
     folders = compute_folders(NexusConfig.from_secrets_json("{}"), BootstrapEnv(domain="x.test"))
     config_folder = next(f for f in folders if f.name == "config")
-    assert config_folder.secrets == {"DOMAIN": "x.test", "ADMIN_USERNAME": "admin"}
+    assert config_folder.secrets == {
+        "DOMAIN": "x.test",
+        "ADMIN_USERNAME": DEFAULT_ADMIN_USERNAME,
+    }
     # ADMIN_EMAIL absent → not in payload
 
 

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -3127,6 +3127,40 @@ def test_phase_global_env_rejects_shell_unsafe_image_value(
     assert not write_called, "validation must reject BEFORE writing the .env"
 
 
+def test_phase_global_env_rejects_empty_admin_username(
+    orchestrator: Orchestrator,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An empty ADMIN_USERNAME must abort, not reach the .env.
+
+    `_validate_value` only rejects shell-unsafe characters, so an empty
+    value would sail through and be written as `ADMIN_USERNAME=`. Every
+    stack reading `${ADMIN_USERNAME:-...}` then takes its fallback --
+    `:-` fires on empty, not only on unset -- which is how a deploy could
+    end up with `admin` while tofu's own default says `nexus` (#780).
+    """
+    write_called = False
+
+    def _fake_run(*args: object, **kwargs: object) -> MagicMock:
+        nonlocal write_called
+        write_called = True
+        cp = MagicMock()
+        cp.returncode = 0
+        return cp
+
+    monkeypatch.setattr("nexus_deploy.orchestrator.subprocess.run", _fake_run)
+    orchestrator.image_versions_json = "{}"
+    orchestrator.admin_username = ""
+    # NexusConfig is frozen, so replace it rather than assigning a field.
+    orchestrator.config = orchestrator.config.model_copy(update={"admin_username": ""})
+
+    result = orchestrator._phase_global_env()
+
+    assert result.status == "failed"
+    assert "ADMIN_USERNAME" in result.detail
+    assert not write_called, "must reject BEFORE writing the .env"
+
+
 def test_phase_global_env_rejects_dollar_in_value(
     orchestrator: Orchestrator,
 ) -> None:

--- a/tests/unit/test_service_env.py
+++ b/tests/unit/test_service_env.py
@@ -882,16 +882,22 @@ def test_litellm_emits_config_yaml_sidecar(
     assert master_key not in content
 
 
-def test_litellm_admin_username_falls_back_to_admin(
+def test_litellm_admin_username_falls_back_to_the_shared_default(
     full_config: NexusConfig, full_env: BootstrapEnv
 ) -> None:
-    """LITELLM_UI_USERNAME defaults to 'admin' when admin_username
-    is unset — UI login form needs a username field."""
+    """LITELLM_UI_USERNAME still gets a value when admin_username is
+    unset -- the UI login form needs a username field -- but it must be
+    the shared default, not a local literal.
+
+    It used to be a hardcoded 'admin' here, one of three sites that
+    disagreed with Terraform's 'nexus' (#780).
+    """
+    from nexus_deploy.config import DEFAULT_ADMIN_USERNAME
     from nexus_deploy.service_env import _render_litellm
 
     config = full_config.model_copy(update={"admin_username": None})
     rendered = _render_litellm(config, full_env)
-    assert rendered.env_vars["LITELLM_UI_USERNAME"] == "admin"
+    assert rendered.env_vars["LITELLM_UI_USERNAME"] == DEFAULT_ADMIN_USERNAME
 
 
 def test_litellm_env_vars_include_all_three_secrets(

--- a/tests/unit/test_stack_conventions.py
+++ b/tests/unit/test_stack_conventions.py
@@ -920,10 +920,19 @@ _FORBIDDEN_CREDENTIAL_DEFAULTS = frozenset({"admin", "root", "postgres", "admini
 
 # A variable whose value is a credential rather than configuration.
 # Matched on the name, because that is all a compose file exposes.
+#
+# The name grammar is Compose's own -- `[_a-zA-Z][_a-zA-Z0-9]*`, matched
+# case-insensitively -- not the SHOUTING_CASE this repo happens to use.
+# An upper-case-only pattern would skip `${grafana_admin_user:-admin}`,
+# which Compose accepts and which is the same defect in different
+# clothes. The only lower-case interpolations in the tree today are
+# `${domain}`, `${subdomain}` and `${var.domain}`; none is credential-
+# shaped and none carries a default, so widening costs no false hits.
 _CREDENTIAL_VAR = re.compile(
-    r"\$\{(?P<var>[A-Z0-9_]*"
+    r"\$\{(?P<var>[_a-zA-Z][_a-zA-Z0-9]*?"
     r"(?:USER|USERNAME|PASS|PASSWORD|SECRET|TOKEN|KEY|ADMIN|ROOT)"
-    r"[A-Z0-9_]*):-(?P<default>[^}]*)\}"
+    r"[_a-zA-Z0-9]*):-(?P<default>[^}]*)\}",
+    re.IGNORECASE,
 )
 
 # `${IMAGE_FOO:-org/foo:1.2}` is the house pattern that lets the

--- a/tests/unit/test_stack_conventions.py
+++ b/tests/unit/test_stack_conventions.py
@@ -910,3 +910,56 @@ def test_strict_host_check_only_where_a_tunnel_rule_exists(services: dict[str, A
         f"strict_host_check set on services with no tunnel ingress rule: {offenders}. "
         f"The flag only has an effect on a service with a subdomain."
     )
+
+
+# Values a credential-shaped variable must never fall back to. `admin`,
+# `root` and `postgres` are the names CLAUDE.md's "Service Account Naming
+# Convention" forbids outright; a stack's own name is the "service name
+# alone" half of the same rule.
+_FORBIDDEN_CREDENTIAL_DEFAULTS = frozenset({"admin", "root", "postgres", "administrator"})
+
+# A variable whose value is a credential rather than configuration. Matched
+# on the name because that is all a compose file exposes. `IMAGE_*` is
+# deliberately not here: `${IMAGE_FOO:-org/foo:1.2}` is the house pattern
+# that lets the orchestrator override a pinned tag, and ~140 of those exist.
+_CREDENTIAL_VAR = re.compile(
+    r"\$\{(?P<var>(?!IMAGE_)[A-Z0-9_]*"
+    r"(?:USER|USERNAME|PASS|PASSWORD|SECRET|TOKEN|KEY|ADMIN|ROOT)"
+    r"[A-Z0-9_]*):-(?P<default>[^}]*)\}"
+)
+
+
+def test_no_credential_variable_falls_back_to_a_guessable_default() -> None:
+    """A credential env var must not carry a guessable default.
+
+    `${ADMIN_USERNAME:-admin}` hands back exactly the name the `nexus-`
+    prefix rule exists to prevent, and `:-` fires on an *empty* value too,
+    not only on an unset one -- so it is reachable whenever an upstream
+    step produces a blank rather than failing.
+
+    Four of these existed when this test was written (#780): grafana,
+    mage, litellm and rustfs. The fix is `${VAR:?<where it comes from>}`,
+    the pattern infisical/hoppscotch/questdb already use, so a stack whose
+    credential is missing refuses to start instead of starting wrong.
+
+    An empty default (`${VAR:-}`) is allowed: it hands back nothing, which
+    is not guessable and generally fails downstream on its own.
+    """
+    offenders: list[str] = []
+    for stack in STACK_DIRS:
+        text = (STACKS_DIR / stack / "docker-compose.yml").read_text()
+        for match in _CREDENTIAL_VAR.finditer(text):
+            default = match.group("default").strip()
+            if not default:
+                continue
+            if default.lower() in _FORBIDDEN_CREDENTIAL_DEFAULTS or default.lower() == stack:
+                offenders.append(f"{stack}: ${{{match.group('var')}:-{default}}}")
+
+    assert not offenders, (
+        "credential variables fall back to a guessable default:\n  "
+        + "\n  ".join(sorted(offenders))
+        + "\nUse ${VAR:?must be set in .env (rendered by service_env._render_<stack>)} "
+        "instead, so the stack fails loudly rather than starting with a name "
+        "an attacker would try first. See CLAUDE.md, 'Service Account Naming "
+        "Convention', and #780."
+    )

--- a/tests/unit/test_stack_conventions.py
+++ b/tests/unit/test_stack_conventions.py
@@ -918,15 +918,24 @@ def test_strict_host_check_only_where_a_tunnel_rule_exists(services: dict[str, A
 # alone" half of the same rule.
 _FORBIDDEN_CREDENTIAL_DEFAULTS = frozenset({"admin", "root", "postgres", "administrator"})
 
-# A variable whose value is a credential rather than configuration. Matched
-# on the name because that is all a compose file exposes. `IMAGE_*` is
-# deliberately not here: `${IMAGE_FOO:-org/foo:1.2}` is the house pattern
-# that lets the orchestrator override a pinned tag, and ~140 of those exist.
+# A variable whose value is a credential rather than configuration.
+# Matched on the name, because that is all a compose file exposes.
 _CREDENTIAL_VAR = re.compile(
-    r"\$\{(?P<var>(?!IMAGE_)[A-Z0-9_]*"
+    r"\$\{(?P<var>[A-Z0-9_]*"
     r"(?:USER|USERNAME|PASS|PASSWORD|SECRET|TOKEN|KEY|ADMIN|ROOT)"
     r"[A-Z0-9_]*):-(?P<default>[^}]*)\}"
 )
+
+# `${IMAGE_FOO:-org/foo:1.2}` is the house pattern that lets the
+# orchestrator override a pinned tag, and ~140 of them exist. The
+# exemption is the `image:` line rather than the `IMAGE_` prefix, because
+# a name-based one would wave through a genuine credential that happened
+# to be called `IMAGE_REGISTRY_PASSWORD`. Every IMAGE_ fallback in the
+# tree sits on an image: line today, so this exempts exactly the same set
+# while keying on what the value *is*. Two of them -- IMAGE_ADMINER and
+# IMAGE_PGADMIN -- match the credential name pattern above, which is
+# precisely why the exemption cannot be the name.
+_IMAGE_FIELD = re.compile(r"^\s*image:\s")
 
 
 def test_no_credential_variable_falls_back_to_a_guessable_default() -> None:
@@ -948,12 +957,15 @@ def test_no_credential_variable_falls_back_to_a_guessable_default() -> None:
     offenders: list[str] = []
     for stack in STACK_DIRS:
         text = (STACKS_DIR / stack / "docker-compose.yml").read_text()
-        for match in _CREDENTIAL_VAR.finditer(text):
-            default = match.group("default").strip()
-            if not default:
+        for line in text.splitlines():
+            if _IMAGE_FIELD.match(line):
                 continue
-            if default.lower() in _FORBIDDEN_CREDENTIAL_DEFAULTS or default.lower() == stack:
-                offenders.append(f"{stack}: ${{{match.group('var')}:-{default}}}")
+            for match in _CREDENTIAL_VAR.finditer(line):
+                default = match.group("default").strip()
+                if not default:
+                    continue
+                if default.lower() in _FORBIDDEN_CREDENTIAL_DEFAULTS or default.lower() == stack:
+                    offenders.append(f"{stack}: ${{{match.group('var')}:-{default}}}")
 
     assert not offenders, (
         "credential variables fall back to a guessable default:\n  "


### PR DESCRIPTION
Closes #780

## Why

CLAUDE.md forbids default account names like `admin`. The authoritative default follows it — `variable "admin_username"` in `tofu/stack/variables.tf` is `nexus` — and four layers below it did not.

| Layer | Was | Now |
|---|---|---|
| `tofu/stack/variables.tf` | `nexus` | unchanged — this is the authority |
| `config.py` `_FIELDS` | `"admin"` | `DEFAULT_ADMIN_USERNAME` |
| `service_env.py:345` (Grafana) | `c.admin_username or "admin"` | the same constant |
| `service_env.py:834` (LiteLLM) | `c.admin_username or "admin"` | the same constant |
| grafana / mage / litellm compose | `${…:-admin}` | `${…:?<where it comes from>}` |
| rustfs compose | `${…:-rustfs}` | `${…:?…}` — the pipeline already set `nexus-rustfs` |

Grafana is the drift in miniature: the correct `:?` form was already there **one line below** the defective one, for the password.

## The fallbacks were reachable, not theoretical

This is the part the issue did not have. `_phase_global_env` writes `ADMIN_USERNAME` into the global `/opt/docker-server/stacks/.env` that every stack reads through `env_file: ../../.env`, and its `_validate_value` only rejects shell-unsafe characters — **an empty value passes**. Shell `:-` fires on empty as well as unset, so a blank arriving from upstream became `admin` in three stacks with nothing logged.

That phase now fails instead of writing `ADMIN_USERNAME=`. An empty admin username is a broken deploy; substituting a working-looking name hides it rather than fixing it.

## Guardrails

Both mutation-tested — the mutation was confirmed to apply and the test confirmed to fail *for that reason*.

**`test_no_credential_variable_falls_back_to_a_guessable_default`** scans every compose file for a credential-shaped variable defaulting to `admin`/`root`/`postgres` or its own stack name. Caught: grafana reverted to `:-admin`, rustfs reverted to its own service name, and `${IMAGE_ADMIN_PASSWORD:-admin}` on a non-image line.

**`test_phase_global_env_rejects_empty_admin_username`** asserts the deploy aborts *before* the write. Replacing the guard with `if False` fails it.

The `IMAGE_*` exemption keys on the `image:` line, not the variable name. A name-based exemption would wave through a real credential called `IMAGE_REGISTRY_PASSWORD` — and two existing variables, `IMAGE_ADMINER` and `IMAGE_PGADMIN`, match the credential name pattern themselves, which is the concrete reason the name cannot be the discriminator. Every `${IMAGE_*:-…}` fallback in the tree sits on an `image:` line, verified across all 82 stacks, so the exempted set is unchanged.

Four existing tests pinned the old value. They now assert the constant rather than a literal, so Terraform is the only place that can make it wrong. The syrupy snapshot changed by exactly one line.

## This is behaviour-changing in the failure path

A stack whose credential variable is missing now **refuses to start** instead of coming up as `admin`. That is the point, but it means a deploy test is worth doing before this reaches `main`:

```bash
gh workflow run spin-up.yml --ref fix/admin-username-defaults
```

Grafana, Mage, LiteLLM and RustFS must all come up afterwards. The smoke check at the end of the run reports `N answering HTTP, M faulty` — `M` must stay 0.

No `initial-setup` needed: no DNS, tunnel or Access resources change.

## Local review

Per the rule added in #781, one local CodeRabbit round ran against `05f7c37`. It produced one valid finding — the name-based `IMAGE_*` exemption above — fixed in `8a5ce96`. That follow-up is itself outside what the local round examined, which is the documented and deliberate gap in a single-round workflow.

## Related, deliberately not in scope

#717 is the same class — `OPENSEARCH_USERNAME=admin`, hardcoded rather than a fallback. It stays separate because it is framed as a decision: the OpenSearch security plugin's admin user cannot simply be renamed.

## Summary by Sourcery

Prevent deployments from silently falling back to forbidden or guessable service-account names by using the Terraform-aligned default and failing fast when credentials are missing.

Bug Fixes:
- Align all Python admin-username fallbacks with Terraform’s authoritative `nexus` default instead of the forbidden `admin` value.
- Reject deployments with an empty admin username before writing the shared environment file.
- Make Grafana, Mage, LiteLLM, and RustFS fail clearly when required credential variables are missing instead of using guessable defaults.

Enhancements:
- Centralize the default admin username and add checks that keep it synchronized with Terraform.
- Add repository-wide guardrails preventing credential-shaped Compose variables from falling back to guessable account names.

Tests:
- Update existing tests for the shared admin-username default and add coverage for Terraform synchronization and empty-value rejection.
- Add mutation-tested Compose convention checks for insecure credential fallbacks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration**
  - The default administrator username is now `nexus` across supported services.
  - Empty administrator usernames are rejected before environment configuration is generated.

- **Security**
  - Grafana, LiteLLM, Mage, and RustFS now require their credential-related environment values to be explicitly configured.
  - Guessable fallback credentials such as `admin`, `rustfs`, and similar defaults are no longer supplied automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->