### PR TITLE
docs: Require the local CodeRabbit round to be reported, with its SHA

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -917,6 +917,13 @@ Never say a round ran without naming the SHA it ran against. A review of
 an earlier commit is not a review of the branch, and that difference is
 invisible unless the SHA is written down.
 
+When the round could **not** run — CLI missing, not authenticated, quota
+exhausted — say exactly that in both places instead: "local CodeRabbit
+round skipped: <reason>". Never a SHA, never a finding count, never
+anything that reads like a result. The point of reporting is to make the
+absence visible, so a skipped round that is described vaguely is worse
+than one described plainly.
+
 Triage the findings exactly like PR review comments — the same bucket
 framework, the same scepticism. A local finding is not more authoritative
 for being local. Dismiss what misreads the code, and say why — never

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -903,6 +903,20 @@ after it is unreviewed. The gap is deliberate, and the PR review is what
 covers it — so do not add a second local round to chase it, and do not
 describe this step as a complete pre-push filter, because it is not one.
 
+**Report the round, every time, unprompted.** The round is worthless if
+nobody can tell whether it happened. Two places, both mandatory:
+
+- **In the message that asks to push**, state the commit SHA that was
+  reviewed, the number of findings, and a one-line verdict per finding.
+  Zero findings is a result and gets reported too — "reviewed <sha>, 0
+  findings" — not silence.
+- **In the PR description**, the same summary, so the reviewer knows what
+  a machine already looked at and what was dismissed.
+
+Never say a round ran without naming the SHA it ran against. A review of
+an earlier commit is not a review of the branch, and that difference is
+invisible unless the SHA is written down.
+
 Triage the findings exactly like PR review comments — the same bucket
 framework, the same scepticism. A local finding is not more authoritative
 for being local. Dismiss what misreads the code, and say why — never

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -904,14 +904,19 @@ covers it — so do not add a second local round to chase it, and do not
 describe this step as a complete pre-push filter, because it is not one.
 
 **Report the round, every time, unprompted.** The round is worthless if
-nobody can tell whether it happened. Two places, both mandatory:
+nobody can tell whether it happened. Two places, in this order — the
+second happens later, because a PR usually does not exist yet at the
+first:
 
 - **In the message that asks to push**, state the commit SHA that was
   reviewed, the number of findings, and a one-line verdict per finding.
   Zero findings is a result and gets reported too — "reviewed <sha>, 0
-  findings" — not silence.
-- **In the PR description**, the same summary, so the reviewer knows what
-  a machine already looked at and what was dismissed.
+  findings" — not silence. This one is always possible and never skipped.
+- **In the PR description, when the PR is created** — which is a separate
+  step the user asks for, never automatic. Carry the same summary in, so
+  the reviewer knows what a machine already looked at and what was
+  dismissed. On a branch that never becomes a PR, this half simply does
+  not apply; it is not a reason to delay the push report.
 
 Never say a round ran without naming the SHA it ran against. A review of
 an earlier commit is not a review of the branch, and that difference is


### PR DESCRIPTION
## Local CodeRabbit round

Reviewed `9704e7a` — **1 finding, fixed in `b3e321d`**.

The finding: the new reporting rule demanded a SHA and per-finding verdicts, which cannot be produced when the round did not run at all, and the section's existing note about a missing or unauthenticated CLI covered only the push message, not the PR description. Both places now take an explicit `local CodeRabbit round skipped: <reason>` instead.

Fitting, given what this PR is about.

## Why

#781 added the rule: run one local CodeRabbit round before asking to push, and act on what it finds. It said nothing about *saying* that the round happened.

A round nobody hears about is indistinguishable from a round that was skipped — and the skip is silent. There is no artefact, no check, nothing in the PR to notice its absence. The only evidence a round occurred is somebody writing it down.

## What changed

Two reporting points, both mandatory:

- **The message that asks to push** — the reviewed commit SHA, the finding count, and a one-line verdict per finding.
- **The PR description** — the same summary, so a reviewer knows what a machine already looked at and what was dismissed.

Zero findings gets reported too. "Nothing to say" is precisely how a skipped round looks.

## The SHA is the load-bearing part

"CodeRabbit reviewed this" is compatible with having reviewed an earlier commit. On a branch that gained commits after the round — which the section already documents as the unavoidable gap in a single-round workflow — that difference decides whether the sentence is true.

This is not hypothetical. Writing this very PR, I put a SHA in a commit message that does not exist in the repo (`git cat-file -e` confirms it); the reviewed commit was `9704e7a`. That is the failure the rule is meant to prevent, produced while writing the rule, and it was caught only because the rule made the SHA something to check rather than something to mention.

## Summary by Sourcery

Require every local CodeRabbit round to be explicitly reported, including its reviewed SHA or the reason it was skipped.

Enhancements:
- Require local CodeRabbit reviews to be reported with the reviewed commit SHA, finding count, and per-finding verdicts before pushing and in the PR description.
- Make skipped local CodeRabbit rounds explicitly report the reason instead of presenting incomplete review results.

Documentation:
- Document mandatory local CodeRabbit round reporting and distinguish completed reviews from skipped rounds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated contribution guidance to require reporting the reviewed commit, finding count, and verdicts when requesting a push.
  - Added guidance to include the same review details in pull request descriptions.
  - Clarified that, when review cannot run, the exact reason must be reported instead of review results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->