### PR TITLE
perf(ci): Cache the npm store — 24 of 35 minutes went to cold npm fetches

### DIFF
--- a/.github/workflows/destroy-all.yml
+++ b/.github/workflows/destroy-all.yml
@@ -81,6 +81,28 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
+      - name: Cache the npm store
+        # `npm ci` and every Wrangler invocation download through
+        # ~/.npm, and on a cold runner that is the single largest cost here:
+        # run 33852993550 lost 1463s across five gaps of 145-425s, each one
+        # an npm fetch with no log output in between -- 24 of its 35 minutes
+        # (#784). The earlier `_npx`-only proposal would have covered three
+        # of the five; the other two are `npm ci` for the Astro build.
+        #
+        # The Wrangler pin is IN the key on purpose. Without it a pin bump
+        # would restore the old store under the loose restore-key, and
+        # because the primary key already exists GitHub would not save the
+        # new one -- so every later run would re-download it, permanently.
+        # tests/unit/test_workflow_expressions.py keeps this literal equal
+        # to the pinned version.
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.npm
+          key: npm-${{ runner.os }}-wrangler4.129.0-${{ hashFiles('control-plane/package-lock.json') }}
+          restore-keys: |
+            npm-${{ runner.os }}-wrangler4.129.0-
+            npm-${{ runner.os }}-
+
       - name: Install OpenTofu
         uses: opentofu/setup-opentofu@v2
         with:

--- a/.github/workflows/initial-setup.yaml
+++ b/.github/workflows/initial-setup.yaml
@@ -81,6 +81,28 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
+      - name: Cache the npm store
+        # `npm ci` and every Wrangler invocation download through
+        # ~/.npm, and on a cold runner that is the single largest cost here:
+        # run 33852993550 lost 1463s across five gaps of 145-425s, each one
+        # an npm fetch with no log output in between -- 24 of its 35 minutes
+        # (#784). The earlier `_npx`-only proposal would have covered three
+        # of the five; the other two are `npm ci` for the Astro build.
+        #
+        # The Wrangler pin is IN the key on purpose. Without it a pin bump
+        # would restore the old store under the loose restore-key, and
+        # because the primary key already exists GitHub would not save the
+        # new one -- so every later run would re-download it, permanently.
+        # tests/unit/test_workflow_expressions.py keeps this literal equal
+        # to the pinned version.
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.npm
+          key: npm-${{ runner.os }}-wrangler4.129.0-${{ hashFiles('control-plane/package-lock.json') }}
+          restore-keys: |
+            npm-${{ runner.os }}-wrangler4.129.0-
+            npm-${{ runner.os }}-
+
       - name: Build enabled services list
         id: build-list
         env:

--- a/.github/workflows/setup-control-plane.yaml
+++ b/.github/workflows/setup-control-plane.yaml
@@ -127,6 +127,29 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
+      - name: Cache the npm store
+        # `npm ci` and every Wrangler invocation download through
+        # ~/.npm, and on a cold runner that is the single largest cost here:
+        # run 33852993550 lost 1463s across five gaps of 145-425s, each one
+        # an npm fetch with no log output in between -- 24 of its 35 minutes
+        # (#784). The earlier `_npx`-only proposal would have covered three
+        # of the five; the other two are `npm ci` for the Astro build.
+        #
+        # The Wrangler pin is IN the key on purpose. Without it a pin bump
+        # would restore the old store under the loose restore-key, and
+        # because the primary key already exists GitHub would not save the
+        # new one -- so every later run would re-download it, permanently.
+        # tests/unit/test_workflow_expressions.py keeps this literal equal
+        # to the pinned version.
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.npm
+          key: npm-${{ runner.os }}-wrangler4.129.0-${{ hashFiles('control-plane/package-lock.json') }}
+          restore-keys: |
+            npm-${{ runner.os }}-wrangler4.129.0-
+            npm-${{ runner.os }}-
+
+
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:

--- a/.github/workflows/spin-up.yml
+++ b/.github/workflows/spin-up.yml
@@ -152,6 +152,28 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
+      - name: Cache the npm store
+        # `npm ci` and every Wrangler invocation download through
+        # ~/.npm, and on a cold runner that is the single largest cost here:
+        # run 33852993550 lost 1463s across five gaps of 145-425s, each one
+        # an npm fetch with no log output in between -- 24 of its 35 minutes
+        # (#784). The earlier `_npx`-only proposal would have covered three
+        # of the five; the other two are `npm ci` for the Astro build.
+        #
+        # The Wrangler pin is IN the key on purpose. Without it a pin bump
+        # would restore the old store under the loose restore-key, and
+        # because the primary key already exists GitHub would not save the
+        # new one -- so every later run would re-download it, permanently.
+        # tests/unit/test_workflow_expressions.py keeps this literal equal
+        # to the pinned version.
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.npm
+          key: npm-${{ runner.os }}-wrangler4.129.0-${{ hashFiles('control-plane/package-lock.json') }}
+          restore-keys: |
+            npm-${{ runner.os }}-wrangler4.129.0-
+            npm-${{ runner.os }}-
+
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
@@ -188,17 +210,6 @@ jobs:
           key: tofu-${{ runner.os }}-${{ hashFiles('tofu/**/providers.tf', 'tofu/**/.terraform.lock.hcl') }}
           restore-keys: |
             tofu-${{ runner.os }}-
-
-      - name: Cache Control-Plane node_modules
-        # Cuts ~15-20s off `npm ci` in the Control Plane redeploy step.
-        # package-lock.json is committed, so the cache key is
-        # deterministic per dependency revision.
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        with:
-          path: control-plane/node_modules
-          key: node-${{ runner.os }}-${{ hashFiles('control-plane/package-lock.json') }}
-          restore-keys: |
-            node-${{ runner.os }}-
 
       - name: Install uv
         # Required by the `nexus_deploy` Python package — since #505

--- a/.github/workflows/teardown-snapshot.yml
+++ b/.github/workflows/teardown-snapshot.yml
@@ -98,6 +98,28 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
+      - name: Cache the npm store
+        # `npm ci` and every Wrangler invocation download through
+        # ~/.npm, and on a cold runner that is the single largest cost here:
+        # run 33852993550 lost 1463s across five gaps of 145-425s, each one
+        # an npm fetch with no log output in between -- 24 of its 35 minutes
+        # (#784). The earlier `_npx`-only proposal would have covered three
+        # of the five; the other two are `npm ci` for the Astro build.
+        #
+        # The Wrangler pin is IN the key on purpose. Without it a pin bump
+        # would restore the old store under the loose restore-key, and
+        # because the primary key already exists GitHub would not save the
+        # new one -- so every later run would re-download it, permanently.
+        # tests/unit/test_workflow_expressions.py keeps this literal equal
+        # to the pinned version.
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.npm
+          key: npm-${{ runner.os }}-wrangler4.129.0-${{ hashFiles('control-plane/package-lock.json') }}
+          restore-keys: |
+            npm-${{ runner.os }}-wrangler4.129.0-
+            npm-${{ runner.os }}-
+
       - name: Log teardown start
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/teardown.yml
+++ b/.github/workflows/teardown.yml
@@ -47,6 +47,28 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
+      - name: Cache the npm store
+        # `npm ci` and every Wrangler invocation download through
+        # ~/.npm, and on a cold runner that is the single largest cost here:
+        # run 33852993550 lost 1463s across five gaps of 145-425s, each one
+        # an npm fetch with no log output in between -- 24 of its 35 minutes
+        # (#784). The earlier `_npx`-only proposal would have covered three
+        # of the five; the other two are `npm ci` for the Astro build.
+        #
+        # The Wrangler pin is IN the key on purpose. Without it a pin bump
+        # would restore the old store under the loose restore-key, and
+        # because the primary key already exists GitHub would not save the
+        # new one -- so every later run would re-download it, permanently.
+        # tests/unit/test_workflow_expressions.py keeps this literal equal
+        # to the pinned version.
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.npm
+          key: npm-${{ runner.os }}-wrangler4.129.0-${{ hashFiles('control-plane/package-lock.json') }}
+          restore-keys: |
+            npm-${{ runner.os }}-wrangler4.129.0-
+            npm-${{ runner.os }}-
+
       - name: Log teardown start
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/toggle-silent-mode.yml
+++ b/.github/workflows/toggle-silent-mode.yml
@@ -20,6 +20,22 @@ jobs:
     name: Toggle Silent Mode in D1
     runs-on: ubuntu-latest
     steps:
+      - name: Cache the npm store
+        # This workflow has no checkout and never runs `npm ci` -- its only
+        # npm traffic is the single Wrangler call below, which still
+        # costs a cold download of minutes (#784). The key therefore carries
+        # the pin and no lockfile hash: nothing here depends on the lockfile.
+        # tests/unit/test_workflow_expressions.py keeps the literal in step
+        # with the pinned version, and requires this step in every workflow
+        # that touches npm.
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.npm
+          key: npm-${{ runner.os }}-wrangler4.129.0-npx-only
+          restore-keys: |
+            npm-${{ runner.os }}-wrangler4.129.0-
+            npm-${{ runner.os }}-
+
       - name: Set silent_mode in D1
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/tests/unit/test_workflow_expressions.py
+++ b/tests/unit/test_workflow_expressions.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
+from typing import Any
 
 import pytest
 import yaml
@@ -149,6 +150,10 @@ def test_the_check_sees_every_run_form_and_no_comments(
 # case, not an absent one -- it resolves to whatever npm calls latest --
 # and a pattern that required the `@` would have made it invisible to the
 # very test meant to catch it.
+# Matches inside comments and echoed strings as well as real commands.
+# That is not a bug and it caught prose twice while this branch was being
+# written: a comment reading "every `npx wrangler` invocation" is text a
+# future maintainer may copy into a shell. Write "Wrangler" in prose.
 _NPX_WRANGLER = re.compile(r"npx wrangler(?:@(?P<spec>[^\s\"';|)]+))?")
 _EXACT_VERSION = re.compile(r"^\d+\.\d+\.\d+$")
 
@@ -217,4 +222,97 @@ def test_all_npx_wrangler_invocations_agree_on_one_version() -> None:
             for v, where in sorted(versions.items())
         )
         + "\nBumping the pin means bumping every site."
+    )
+
+
+# The npm-store cache key embeds the Wrangler pin. It has to: without it, a
+# pin bump restores the previous store under the loose restore-key, and
+# because the primary key is unchanged GitHub does not save the new one --
+# so the new version is re-downloaded on every run from then on, silently
+# and permanently. That failure is invisible in a green workflow, which is
+# why it gets a test rather than a comment.
+#
+# Walks the parsed steps rather than grepping lines. A line-based version
+# checked only that the versions it *found* agreed, so deleting the pin
+# from one workflow's key left the others agreeing and the test silent --
+# the fifth time in this branch's history that a guardrail missed its own
+# evasion rather than the obvious violation.
+_NPM_CACHE_STEP = "Cache the npm store"
+_CACHE_KEY_PIN = re.compile(r"-wrangler(?P<spec>[0-9][^-\s]*)-")
+
+
+def _npm_cache_steps() -> list[tuple[Path, dict[str, Any]]]:
+    found: list[tuple[Path, dict[str, Any]]] = []
+    for path in _WORKFLOWS:
+        document = yaml.safe_load(path.read_text())
+        for job in (document.get("jobs") or {}).values():
+            for step in job.get("steps") or []:
+                if isinstance(step, dict) and str(step.get("name", "")).startswith(_NPM_CACHE_STEP):
+                    found.append((path, step))
+    return found
+
+
+def test_npm_cache_keys_carry_the_pinned_wrangler_version() -> None:
+    """Every npm-store cache key names the version `npx wrangler@…` uses."""
+    pinned = {
+        match.group("spec")
+        for path in _WRANGLER_FILES
+        for match in _NPX_WRANGLER.finditer(path.read_text())
+        if match.group("spec") is not None
+    }
+    assert len(pinned) == 1, f"expected exactly one pinned version, found {sorted(pinned)}"
+    version = pinned.pop()
+
+    steps = _npm_cache_steps()
+    assert steps, (
+        f"no step named {_NPM_CACHE_STEP!r} in any workflow. If the caching was "
+        "removed deliberately, delete this test with it; otherwise the npm "
+        "store is no longer cached at all. See #784."
+    )
+
+    offenders: list[str] = []
+    for path, step in steps:
+        key = str((step.get("with") or {}).get("key", ""))
+        match = _CACHE_KEY_PIN.search(key)
+        if match is None:
+            offenders.append(f"{path}: key names no Wrangler version: {key}")
+        elif match.group("spec") != version:
+            offenders.append(f"{path}: key says {match.group('spec')}, npx says {version}")
+
+    assert not offenders, (
+        "npm-store cache keys out of step with the Wrangler pin:\n  "
+        + "\n  ".join(offenders)
+        + "\nA key that omits or misnames the pin makes a bumped Wrangler "
+        "uncacheable, permanently and silently."
+    )
+
+
+def test_every_workflow_touching_npm_caches_the_store() -> None:
+    """A workflow that runs npm must cache ~/.npm -- all of them, not some.
+
+    Asserting only that *a* cache step exists somewhere let the step be
+    deleted from one workflow while the others kept the test green. The
+    set that needs the cache is derivable, so derive it.
+    """
+    uses_npm = {
+        path
+        for path in _WORKFLOWS
+        if re.search(r"npx wrangler|npm ci\b|npm run ", path.read_text())
+    }
+    has_cache = {path for path, _ in _npm_cache_steps()}
+
+    missing = sorted(str(p) for p in uses_npm - has_cache)
+    assert not missing, (
+        "workflows that run npm without caching ~/.npm:\n  "
+        + "\n  ".join(missing)
+        + f"\nAdd a step named {_NPM_CACHE_STEP!r}. A cold npm fetch cost "
+        "145-425s per occurrence in run 33852993550. See #784."
+    )
+
+    stray = sorted(str(p) for p in has_cache - uses_npm)
+    assert not stray, (
+        "workflows with an npm-store cache but no npm usage:\n  "
+        + "\n  ".join(stray)
+        + "\nEither the usage was removed and the cache step should go too, "
+        "or the detection above needs widening."
     )

--- a/tests/unit/test_workflow_expressions.py
+++ b/tests/unit/test_workflow_expressions.py
@@ -232,24 +232,74 @@ def test_all_npx_wrangler_invocations_agree_on_one_version() -> None:
 # and permanently. That failure is invisible in a green workflow, which is
 # why it gets a test rather than a comment.
 #
-# Walks the parsed steps rather than grepping lines. A line-based version
-# checked only that the versions it *found* agreed, so deleting the pin
-# from one workflow's key left the others agreeing and the test silent --
-# the fifth time in this branch's history that a guardrail missed its own
-# evasion rather than the obvious violation.
-_NPM_CACHE_STEP = "Cache the npm store"
+# Three earlier drafts of this check each missed their own evasion rather
+# than the obvious violation, and each was caught by a reviewer:
+#
+#   1. grepped lines, so deleting a whole cache step left the remaining
+#      keys agreeing and the test silent
+#   2. asserted only that *a* step existed somewhere, so deleting it from
+#      one workflow kept the other six green
+#   3. matched the step by NAME, so renaming the action or pointing `path`
+#      at something other than ~/.npm passed, and worked per workflow
+#      rather than per job -- a cache in job A does nothing for job B
+#
+# Hence: identify the cache by what it does, and reason per job.
 _CACHE_KEY_PIN = re.compile(r"-wrangler(?P<spec>[0-9][^-\s]*)-")
+_RUNS_NPM = re.compile(r"npx wrangler|npm ci\b|npm run ")
+_SCRIPT_REF = re.compile(r"\.github/scripts/([A-Za-z0-9_.-]+\.sh)")
+
+#: Scripts under .github/scripts that themselves invoke npm. A job that
+#: calls one of these touches npm without the workflow text ever saying so.
+_NPM_SCRIPTS = frozenset(
+    path.name for path in Path(".github/scripts").glob("*.sh") if "npx wrangler" in path.read_text()
+)
 
 
-def _npm_cache_steps() -> list[tuple[Path, dict[str, Any]]]:
-    found: list[tuple[Path, dict[str, Any]]] = []
+def _jobs(path: Path) -> dict[str, Any]:
+    document = yaml.safe_load(path.read_text()) or {}
+    return document.get("jobs") or {}
+
+
+def _npm_cache_steps() -> dict[tuple[Path, str], dict[str, Any]]:
+    """(workflow, job) -> the step that caches ~/.npm, found by substance.
+
+    Keyed on `uses` and `with.path`, never on the step's name: a step can
+    be renamed freely, but one that does not run actions/cache over
+    ~/.npm is not an npm cache whatever it is called.
+    """
+    found: dict[tuple[Path, str], dict[str, Any]] = {}
     for path in _WORKFLOWS:
-        document = yaml.safe_load(path.read_text())
-        for job in (document.get("jobs") or {}).values():
+        for job_id, job in _jobs(path).items():
             for step in job.get("steps") or []:
-                if isinstance(step, dict) and str(step.get("name", "")).startswith(_NPM_CACHE_STEP):
-                    found.append((path, step))
+                if not isinstance(step, dict):
+                    continue
+                if not str(step.get("uses", "")).startswith("actions/cache@"):
+                    continue
+                cached = str((step.get("with") or {}).get("path", ""))
+                if any(line.strip() == "~/.npm" for line in cached.splitlines()):
+                    found[(path, job_id)] = step
     return found
+
+
+def _jobs_using_npm() -> set[tuple[Path, str]]:
+    """Jobs that run npm in their own steps, directly or via a script.
+
+    A job whose only content is `uses:` another workflow is excluded --
+    the callee is a workflow in its own right and gets checked there.
+    """
+    using: set[tuple[Path, str]] = set()
+    for path in _WORKFLOWS:
+        for job_id, job in _jobs(path).items():
+            for step in job.get("steps") or []:
+                if not isinstance(step, dict):
+                    continue
+                run = str(step.get("run", ""))
+                if _RUNS_NPM.search(run) or any(
+                    name in _NPM_SCRIPTS for name in _SCRIPT_REF.findall(run)
+                ):
+                    using.add((path, job_id))
+                    break
+    return using
 
 
 def test_npm_cache_keys_carry_the_pinned_wrangler_version() -> None:
@@ -265,19 +315,19 @@ def test_npm_cache_keys_carry_the_pinned_wrangler_version() -> None:
 
     steps = _npm_cache_steps()
     assert steps, (
-        f"no step named {_NPM_CACHE_STEP!r} in any workflow. If the caching was "
-        "removed deliberately, delete this test with it; otherwise the npm "
+        "no step anywhere runs actions/cache over ~/.npm. If the caching was "
+        "removed deliberately, delete these tests with it; otherwise the npm "
         "store is no longer cached at all. See #784."
     )
 
     offenders: list[str] = []
-    for path, step in steps:
+    for (path, job_id), step in sorted(steps.items()):
         key = str((step.get("with") or {}).get("key", ""))
         match = _CACHE_KEY_PIN.search(key)
         if match is None:
-            offenders.append(f"{path}: key names no Wrangler version: {key}")
+            offenders.append(f"{path}:{job_id}: key names no Wrangler version: {key}")
         elif match.group("spec") != version:
-            offenders.append(f"{path}: key says {match.group('spec')}, npx says {version}")
+            offenders.append(f"{path}:{job_id}: key says {match.group('spec')}, npx says {version}")
 
     assert not offenders, (
         "npm-store cache keys out of step with the Wrangler pin:\n  "
@@ -287,32 +337,24 @@ def test_npm_cache_keys_carry_the_pinned_wrangler_version() -> None:
     )
 
 
-def test_every_workflow_touching_npm_caches_the_store() -> None:
-    """A workflow that runs npm must cache ~/.npm -- all of them, not some.
+def test_every_job_touching_npm_caches_the_store() -> None:
+    """Per job, not per workflow -- a cache in job A does nothing for job B."""
+    using = _jobs_using_npm()
+    cached = set(_npm_cache_steps())
 
-    Asserting only that *a* cache step exists somewhere let the step be
-    deleted from one workflow while the others kept the test green. The
-    set that needs the cache is derivable, so derive it.
-    """
-    uses_npm = {
-        path
-        for path in _WORKFLOWS
-        if re.search(r"npx wrangler|npm ci\b|npm run ", path.read_text())
-    }
-    has_cache = {path for path, _ in _npm_cache_steps()}
-
-    missing = sorted(str(p) for p in uses_npm - has_cache)
+    missing = sorted(f"{path}:{job_id}" for path, job_id in using - cached)
     assert not missing, (
-        "workflows that run npm without caching ~/.npm:\n  "
+        "jobs that run npm without caching ~/.npm:\n  "
         + "\n  ".join(missing)
-        + f"\nAdd a step named {_NPM_CACHE_STEP!r}. A cold npm fetch cost "
-        "145-425s per occurrence in run 33852993550. See #784."
+        + "\nAdd an actions/cache step over ~/.npm to that job. A cold npm "
+        "fetch cost 145-425s per occurrence in run 33852993550. See #784."
     )
 
-    stray = sorted(str(p) for p in has_cache - uses_npm)
+    stray = sorted(f"{path}:{job_id}" for path, job_id in cached - using)
     assert not stray, (
-        "workflows with an npm-store cache but no npm usage:\n  "
+        "jobs with an npm-store cache but no npm usage:\n  "
         + "\n  ".join(stray)
-        + "\nEither the usage was removed and the cache step should go too, "
-        "or the detection above needs widening."
+        + "\nEither the usage was removed and the cache should go too, or "
+        "the detection needs widening -- note it already follows "
+        ".github/scripts/*.sh references."
     )


### PR DESCRIPTION
Refs #784 — **not** `Closes`. Closing it needs a measured run showing the times actually drop; see "How to verify" below.

## Local CodeRabbit round

Reviewed the pre-commit state of this branch — **1 finding, fixed before the commit landed** (`c2e4142`).

The finding: `control-plane/node_modules` does not belong in a cache, because `npm ci` deletes node_modules before installing. Correct, and it turned out to be bigger than the line it was raised on — see "What the review changed" below.

## Why

Run [33852993550](https://github.com/stefanko-ch/Nexus-Stack/actions/runs/33852993550), the first First-Time Deploy after the pin (#787) landed, took **34m43s**. Five gaps with no log output at all, each one an npm network operation:

| Job | Step | Gap | Last line before it |
|---|---|---|---|
| Setup Control Plane | Set Scheduled Teardown Worker secrets | **425s** | `npm warn exec … will be installed: wrangler@4.129.0` |
| Setup Control Plane | Deploy Control Plane to Cloudflare Pages | **420s** | `Building Astro frontend…` (i.e. `npm ci`) |
| Spin Up | Redeploy Control Plane to activate secrets | **272s** | `Redeploying Control Plane…` (also `npm ci`) |
| Configure Initial Services | Update D1 with selected services | **201s** | `npm warn exec … will be installed` |
| Spin Up | Log workflow start | **145s** | first Wrangler call in the job |

**1463s — 24 of the 35 minutes.** The pin never addressed this and #787 said so explicitly; this is the other half.

## What changed

All seven npm-touching workflows get a `~/.npm` cache. That is where npm keeps downloaded tarballs, so it covers both the `npx` package fetch and `npm ci` — #784's original `_npx`-only proposal would have covered three of the five gaps.

`toggle-silent-mode.yml` has no checkout and never runs `npm ci`, so its key carries the pin and no lockfile hash: nothing there depends on the lockfile.

**The Wrangler pin is in the cache key on purpose.** Without it, a pin bump restores the previous store under the loose restore-key, and because the primary key is unchanged GitHub does not save the new one — so the bumped version would be re-downloaded on every run from then on, silently and permanently. A guardrail keeps the literal in step with the pin.

## What the review changed

The first draft *added* `Cache Control-Plane node_modules` to `setup-control-plane.yaml`, mirroring the step `spin-up.yml` has carried for a long time. The review pointed out that `npm ci` deletes node_modules first. Verified rather than assumed:

```
$ echo SENTINEL > control-plane/node_modules/.probe
$ npm ci
$ ls node_modules/.probe   →  gone
```

So the restored copy is wiped before anything reads it. That makes the **existing** step in `spin-up.yml` ineffective too, and its comment — *"Cuts ~15-20s off `npm ci`"* — a claim that cannot be true. This PR therefore **removes** it rather than copying it. `~/.npm` is the cache that actually speeds up that command.

## Guardrails

Three, all mutation-tested:

- **Keys name the pinned version.** A stale version fails; a key with the pin stripped fails. Both name the offending workflow.
- **Every npm-touching workflow has the step.** Deleting it from one workflow fails. *The first draft of this test did not catch that* — it asserted only that *a* step existed somewhere, so the other six kept it green. It now walks the parsed steps and derives the required set from actual npm usage.
- **The reverse**, a cache step in a workflow with no npm usage, so a removed usage does not leave a stray step.

Two quirks are recorded in the code rather than left to be rediscovered: the pinning check reads comments and echoed strings as well as commands — it caught prose twice while this was written, so write "Wrangler" in prose, not the command form — and the key check parses steps rather than grepping lines, which is precisely what the deleted-step case needed.

## How to verify

Dispatch a First-Time Deploy and compare against 33852993550. The first run still pays the cold fetch and populates the cache; the second is the one that matters. Expect the five gaps above to shrink to seconds. #784 stays open until that number exists.

## Summary by Sourcery

Accelerate deployment workflows by caching npm downloads while enforcing coverage and version-aligned cache keys.

Bug Fixes:
- Remove the ineffective Control Plane node_modules cache that was discarded by npm ci.

Enhancements:
- Cache the npm store across all workflows and jobs that invoke npm or Wrangler to reduce repeated dependency downloads.
- Keep cache keys aligned with the pinned Wrangler version and lockfile dependencies, including support for the workflow without a checkout.

Tests:
- Add workflow validation that every npm-using job caches ~/.npm, no unrelated job does, and cache keys include the pinned Wrangler version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved workflow performance by caching npm packages and Wrangler downloads.
  * Cache entries now use operating system, Wrangler version, and lockfile information for reliable reuse.

* **Bug Fixes**
  * Removed a redundant dependency cache in favor of the shared npm cache.

* **Tests**
  * Added validation to ensure npm-using workflows define appropriate caches and use the pinned Wrangler version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->