### PR TITLE
fix(control-plane): Make the Meilisearch curl hint runnable, and test the key

### DIFF
--- a/control-plane/src/components/ApiOnlyModal.astro
+++ b/control-plane/src/components/ApiOnlyModal.astro
@@ -286,14 +286,29 @@
       },
       meilisearch: {
         intro: 'Meilisearch is a pure REST API — no built-in web UI in production mode. ' +
-               'Use the snippets below to authenticate and query, or open the raw endpoint ' +
-               'to see the JSON status response.',
+               'The quick test runs on the server, because this hostname sits behind ' +
+               'Cloudflare Access and a copied curl carries no Access session. The auth ' +
+               'snippet is for fetching the key to your own machine, e.g. for a client ' +
+               'library — the curl below does not use it.',
         // Infisical-CLI: keys ARE case-sensitive and folder-scoped. The master
         // key is pushed by infisical.py to folder /meilisearch under key
-        // MEILISEARCH_MASTER_KEY — both must match exactly or the CLI returns
-        // "secret not found". The export sets a shell var the curl below picks up.
+        // MEILISEARCH_MASTER_KEY -- both must match exactly or the CLI returns
+        // "secret not found".
         auth_command: 'export MEILISEARCH_MASTER_KEY=$(infisical secrets get MEILISEARCH_MASTER_KEY --path=/meilisearch --plain)',
-        curl: 'curl -H "Authorization: Bearer $MEILISEARCH_MASTER_KEY" \\\n  __URL__/health',
+        // Three deliberate choices, each measured (#792):
+        //
+        //  - Runs over ssh against 127.0.0.1, not the tunnel URL. The previous
+        //    version targeted __URL__, which Cloudflare Access answers with a
+        //    login page, so it could never have worked as copied.
+        //  - Hits /indexes, not /health. Measured on v1.43.1: /health returns
+        //    200 WITHOUT a token, so a bearer header there proves nothing.
+        //    /indexes returns 401 without and 200 with -- this tests the key.
+        //  - Sources the server's own .env rather than interpolating the secret
+        //    into the ssh command line, which would put it in argv on the
+        //    server. The variable is MEILI_MASTER_KEY there; the Infisical key
+        //    name above is deliberately different.
+        curl: "ssh nexus 'set -a; . /opt/docker-server/stacks/meilisearch/.env; set +a; " +
+              "curl -s -H \"Authorization: Bearer $MEILI_MASTER_KEY\" http://127.0.0.1:7700/indexes'",
       },
     };
 


### PR DESCRIPTION
Closes #792

## Local CodeRabbit round

Reviewed `ceb0479` — **0 findings**.

## The reported defect, measured

The hint offered `curl -H "Authorization: Bearer …" <stackUrl>/health`. That hostname is behind Cloudflare Access, so a copied command carries no Access session:

```
https://meilisearch.<domain>/health  ->  HTTP 302
location: https://…cloudflareaccess.com/cdn-cgi/access/login/…
```

The bearer token never reaches Meilisearch — Access sits in front of the application and does not forward to it.

## A second defect, found while fixing the first

The command probed an endpoint that needs no token at all. Measured against the running v1.43.1 on this stack:

| Request | Result |
|---|---|
| `/indexes` **with** key | **200** — `{"results":[],"offset":0,"limit":20,"total":0}` |
| `/indexes` without key | **401** |
| `/health` without key | **200** |

So `/health` answers regardless, and a bearer header there demonstrates nothing about the credential the snippet went to the trouble of fetching. `/indexes` does: 401 without, 200 with. That 401 is what makes the check non-vacuous — without it, "returns 200" would be true even if the key were ignored, which is precisely the state the old snippet was in.

## What the hint says now

```bash
ssh nexus 'set -a; . /opt/docker-server/stacks/meilisearch/.env; set +a; \
  curl -s -H "Authorization: Bearer $MEILI_MASTER_KEY" http://127.0.0.1:7700/indexes'
```

Three deliberate choices:

- **Over ssh against loopback**, not the tunnel URL — the only shape that executes.
- **`/indexes`, not `/health`** — so the snippet tests the key it fetches.
- **Sources the server's own `.env`** rather than interpolating the secret into the ssh command line, which would place it in argv on the server. Note the variable is `MEILI_MASTER_KEY` there while the Infisical key is `MEILISEARCH_MASTER_KEY` — the existing comment already warned about that pair, and the old curl used the wrong one of the two.

`auth_command` stays, with its purpose now stated: it fetches the key to your own machine for a client library. The curl does not use it.

## Verification

Every number above was measured against the live deployment after enabling Meilisearch, not reasoned about. The counter-tests matter as much as the happy path: a snippet that returns 200 for the wrong reason is how this defect survived.

## Summary by Sourcery

Make the Meilisearch API hint execute from the server and verify that the configured master key is accepted.

Bug Fixes:
- Make the Meilisearch quick-test command runnable by executing it over SSH against the server's loopback endpoint.
- Ensure the quick test validates the Meilisearch master key by querying an authenticated endpoint instead of the token-independent health endpoint.

Enhancements:
- Clarify that the authentication command is intended to retrieve the key locally for client libraries, while the server-side curl sources its own environment configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the API-only setup guidance with clearer authentication instructions for Cloudflare Access and client libraries.
  - Refined the example curl command for authenticated API access.
  - Added a verification step that checks access to the indexes endpoint using the configured credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->