### PR TITLE
fix(ci): Stop seven D1 calls from discarding their exit status

### DIFF
--- a/.github/workflows/destroy-all.yml
+++ b/.github/workflows/destroy-all.yml
@@ -192,14 +192,16 @@ jobs:
           if [ "$D1_QUERY_FAILED" -ne 0 ]; then
             echo "❌ Could not read the enabled services from D1."
             echo "   Continuing would act on a service list this step never obtained."
-            echo "   wrangler stderr: $(tr '\n\r' '  ' < /tmp/d1-services.err 2>/dev/null | head -c 400)"
+            D1_ERR=$(tr '\n\r' '  ' < /tmp/d1-services.err 2>/dev/null | head -c 400)
+            echo "   wrangler stderr: ${D1_ERR:-(no output)}"
             exit 1
           fi
 
           if ! ENABLED_SERVICES=$(printf '%s' "$D1_SERVICES_JSON" \
                 | jq -r '.[0].results | map(.name) | join(",")'); then
             echo "❌ D1 answered but the response could not be parsed."
-            echo "   wrangler stderr: $(tr '\n\r' '  ' < /tmp/d1-services.err 2>/dev/null | head -c 400)"
+            D1_ERR=$(tr '\n\r' '  ' < /tmp/d1-services.err 2>/dev/null | head -c 400)
+            echo "   wrangler stderr: ${D1_ERR:-(no output)}"
             exit 1
           fi
 

--- a/.github/workflows/destroy-all.yml
+++ b/.github/workflows/destroy-all.yml
@@ -173,14 +173,42 @@ jobs:
           # Read services from D1 (single source of truth)
           echo "📋 Reading services from D1..."
           D1_DATABASE_NAME="nexus-${DOMAIN//./-}-db"
-          ENABLED_SERVICES=$(npx wrangler@4.129.0 d1 execute "$D1_DATABASE_NAME" --remote --json \
-            --command "SELECT name FROM services WHERE enabled = 1" 2>/dev/null \
-            | jq -r '.[0].results | map(.name) | join(",")' 2>/dev/null || echo "")
+          # Status and message are kept apart, and the query is not allowed
+          # to fail quietly. The previous form ended in `|| echo ""`, so an
+          # outage, an auth failure and a genuinely empty table all produced
+          # the same empty string -- and this workflow then went on to
+          # destroy infrastructure against a list it believed was empty.
+          #
+          # stderr goes to a file rather than into the capture: wrangler
+          # prints its banner there, and folding it into stdout would break
+          # the jq parse below.
+          D1_QUERY_FAILED=0
+          D1_SERVICES_JSON=""
+          if ! D1_SERVICES_JSON=$(npx wrangler@4.129.0 d1 execute "$D1_DATABASE_NAME" --remote --json \
+                --command "SELECT name FROM services WHERE enabled = 1" 2>/tmp/d1-services.err); then
+            D1_QUERY_FAILED=1
+          fi
 
+          if [ "$D1_QUERY_FAILED" -ne 0 ]; then
+            echo "❌ Could not read the enabled services from D1."
+            echo "   Continuing would act on a service list this step never obtained."
+            echo "   wrangler stderr: $(tr '\n\r' '  ' < /tmp/d1-services.err 2>/dev/null | head -c 400)"
+            exit 1
+          fi
+
+          if ! ENABLED_SERVICES=$(printf '%s' "$D1_SERVICES_JSON" \
+                | jq -r '.[0].results | map(.name) | join(",")'); then
+            echo "❌ D1 answered but the response could not be parsed."
+            echo "   wrangler stderr: $(tr '\n\r' '  ' < /tmp/d1-services.err 2>/dev/null | head -c 400)"
+            exit 1
+          fi
+
+          # Reaching here means the query succeeded, so an empty result is
+          # genuinely an empty table rather than a failure in disguise.
           if [ -n "$ENABLED_SERVICES" ]; then
             echo "📋 Enabled services from D1: $ENABLED_SERVICES"
           else
-            echo "📋 No services in D1 yet - core services will be enabled by default"
+            echo "📋 No services enabled in D1 - core services will be enabled by default"
           fi
 
           # Generate services config from services.yaml

--- a/.github/workflows/destroy-all.yml
+++ b/.github/workflows/destroy-all.yml
@@ -198,10 +198,14 @@ jobs:
           fi
 
           if ! ENABLED_SERVICES=$(printf '%s' "$D1_SERVICES_JSON" \
-                | jq -r '.[0].results | map(.name) | join(",")'); then
+                | jq -r '.[0].results | map(.name) | join(",")' 2>/tmp/d1-parse.err); then
             echo "❌ D1 answered but the response could not be parsed."
-            D1_ERR=$(tr '\n\r' '  ' < /tmp/d1-services.err 2>/dev/null | head -c 400)
-            echo "   wrangler stderr: ${D1_ERR:-(no output)}"
+            # jq's own stderr, not wrangler's. Reaching this branch means the
+            # query already succeeded, so /tmp/d1-services.err holds nothing
+            # but wrangler's banner -- labelling that as the diagnostic points
+            # at the one component that did not fail.
+            PARSE_ERR=$(tr '\n\r' '  ' < /tmp/d1-parse.err 2>/dev/null | head -c 400)
+            echo "   jq stderr: ${PARSE_ERR:-(no output)}"
             exit 1
           fi
 

--- a/.github/workflows/setup-control-plane.yaml
+++ b/.github/workflows/setup-control-plane.yaml
@@ -1450,8 +1450,19 @@ jobs:
               echo "  No stale $name to remove"
               return 0
             fi
-            echo "::warning title=pages-secret::Could not delete the Pages secret $name, and it was not reported as absent. The runtime may still read a stale value. wrangler output: $(printf '%s' "${err:-(no output)}" | tr '\n\r' '  ' | head -c 300)"
-            return 0
+            echo "::error title=pages-secret::Could not delete the Pages secret $name, and it was not reported as absent. The runtime would keep reading the stale value instead of falling back. wrangler output: $(printf '%s' "${err:-(no output)}" | tr '\n\r' '  ' | head -c 300)"
+            # Non-zero: the caller reaches this only when the operator has
+            # cleared the value and expects the runtime to fall back. A stale
+            # secret silently defeats that, and this runs before deployment,
+            # so failing here stops a Control Plane that would read the wrong
+            # value.
+            #
+            # The "absent" branch above matches on wrangler's error text, which
+            # is a heuristic: if that wording changes, a benign no-op lands
+            # here and fails the setup. That is the direction to fail in — a
+            # broken setup is noticed at once, a stale secret is not — but if
+            # it happens, widen the pattern rather than restoring `|| true`.
+            return 1
           }
 
 

--- a/.github/workflows/setup-control-plane.yaml
+++ b/.github/workflows/setup-control-plane.yaml
@@ -1433,6 +1433,27 @@ jobs:
         run: |
           echo "⚙️  Setting Control Plane secrets..."
           PROJECT_NAME="${{ steps.prefix.outputs.project_name }}"
+          # `secret delete` is interactive and fails loudly when the secret
+          # is absent, which is the common case here. "Already gone" is a fine
+          # reason to continue; an auth error, a wrong project name or an API
+          # outage is not -- and `|| true` could not tell them apart, so a
+          # revoked token looked exactly like a clean no-op.
+          delete_pages_secret() {
+            local name="$1"
+            local err
+            if err=$(echo y | npx wrangler@4.129.0 pages secret delete "$name" \
+                  --project-name="$PROJECT_NAME" 2>&1); then
+              echo "  Removed stale Pages secret $name"
+              return 0
+            fi
+            if printf '%s' "$err" | grep -qiE "not found|does not exist|no secret"; then
+              echo "  No stale $name to remove"
+              return 0
+            fi
+            echo "::warning title=pages-secret::Could not delete the Pages secret $name, and it was not reported as absent. The runtime may still read a stale value. wrangler output: $(printf '%s' "${err:-(no output)}" | tr '\n\r' '  ' | head -c 300)"
+            return 0
+          }
+
 
           # Pages secrets survive wrangler pages deploy (unlike environment_variables
           # which get wiped). Terraform sets environment_variables on the project, but
@@ -1489,11 +1510,7 @@ jobs:
             fi
           else
             echo "  BASE_DOMAIN is empty; removing any stale Pages secret so runtime falls back to DOMAIN..."
-            # `secret delete` is interactive by default and fails loudly if the
-            # secret doesn't exist. Pipe 'y' to auto-confirm, swallow output,
-            # and don't fail the step when the secret wasn't there to begin with.
-            echo y | npx wrangler@4.129.0 pages secret delete BASE_DOMAIN \
-              --project-name="$PROJECT_NAME" >/dev/null 2>&1 || true
+            delete_pages_secret BASE_DOMAIN
           fi
 
           # TEMPLATE_VERSION — the release tag of the template code currently
@@ -1514,8 +1531,7 @@ jobs:
             fi
           else
             echo "  .template-version missing or empty; removing any stale Pages secret so runtime falls back to the GitHub API / 'dev'..."
-            echo y | npx wrangler@4.129.0 pages secret delete TEMPLATE_VERSION \
-              --project-name="$PROJECT_NAME" >/dev/null 2>&1 || true
+            delete_pages_secret TEMPLATE_VERSION
           fi
 
           # SUBDOMAIN_SEPARATOR + derived URLs. These MUST be secrets (not Terraform
@@ -1617,21 +1633,44 @@ jobs:
           # Initialize schema (creates tables if they don't exist)
           npx wrangler@4.129.0 d1 execute "$D1_DATABASE_NAME" --file=control-plane/schema.sql --remote
 
+          # Migrations are re-run on every deploy, so "column already
+          # exists" is the expected outcome and the only one worth
+          # tolerating. `|| true` tolerated everything -- a lock, a
+          # permission failure, an outage -- and left the Control Plane
+          # querying a column that was never added.
+          #
+          # Status and message stay in separate variables: a command that
+          # exits non-zero while printing nothing must not be mistaken for
+          # success, which is why the empty case still says something.
+          migrate_column() {
+            local sql="$1"
+            local err
+            if err=$(npx wrangler@4.129.0 d1 execute "$D1_DATABASE_NAME" --remote --command "$sql" 2>&1); then
+              return 0
+            fi
+            if printf '%s' "$err" | grep -qiE "duplicate column|already exists"; then
+              return 0
+            fi
+            echo "❌ D1 migration failed: $sql"
+            echo "   wrangler output: ${err:-(no output)}"
+            return 1
+          }
+
           # Schema migrations for existing databases
           # admin_only column added for services that can only be toggled via GitHub Actions
-          npx wrangler@4.129.0 d1 execute "$D1_DATABASE_NAME" --remote --command "ALTER TABLE services ADD COLUMN admin_only INTEGER DEFAULT 0" 2>/dev/null || true
+          migrate_column "ALTER TABLE services ADD COLUMN admin_only INTEGER DEFAULT 0"
           # landing_path column for per-service URL path in Control Plane "Open" links
           # (e.g. Chroma's "/docs/" Swagger UI). Migration runs here too — NOT only
           # in sync-deployed-state.sh — so the new Pages frontend's SELECT including
           # landing_path doesn't 500 on existing D1 instances between Pages auto-deploy
           # (on merge) and the next spin-up that runs the sync script.
-          npx wrangler@4.129.0 d1 execute "$D1_DATABASE_NAME" --remote --command "ALTER TABLE services ADD COLUMN landing_path TEXT DEFAULT ''" 2>/dev/null || true
+          migrate_column "ALTER TABLE services ADD COLUMN landing_path TEXT DEFAULT ''"
           # api_only column for headless services (e.g. Meilisearch) — clicking Open
           # shows an API-info modal instead of opening the raw JSON URL. Same race
           # window as landing_path above: Pages auto-deploys on merge, and its new
           # SELECT includes api_only; without this ALTER the frontend would 500 until
           # the next spin-up runs sync-deployed-state.sh.
-          npx wrangler@4.129.0 d1 execute "$D1_DATABASE_NAME" --remote --command "ALTER TABLE services ADD COLUMN api_only INTEGER DEFAULT 0" 2>/dev/null || true
+          migrate_column "ALTER TABLE services ADD COLUMN api_only INTEGER DEFAULT 0"
 
           # Store domain in D1 config (escape single quotes)
           ESCAPED_DOMAIN=${DOMAIN//\'/\'\'}

--- a/.github/workflows/teardown-snapshot.yml
+++ b/.github/workflows/teardown-snapshot.yml
@@ -196,10 +196,14 @@ jobs:
           fi
 
           if ! ENABLED_SERVICES=$(printf '%s' "$D1_SERVICES_JSON" \
-                | jq -r '.[0].results | map(.name) | join(",")'); then
+                | jq -r '.[0].results | map(.name) | join(",")' 2>/tmp/d1-parse.err); then
             echo "❌ D1 answered but the response could not be parsed."
-            D1_ERR=$(tr '\n\r' '  ' < /tmp/d1-services.err 2>/dev/null | head -c 400)
-            echo "   wrangler stderr: ${D1_ERR:-(no output)}"
+            # jq's own stderr, not wrangler's. Reaching this branch means the
+            # query already succeeded, so /tmp/d1-services.err holds nothing
+            # but wrangler's banner -- labelling that as the diagnostic points
+            # at the one component that did not fail.
+            PARSE_ERR=$(tr '\n\r' '  ' < /tmp/d1-parse.err 2>/dev/null | head -c 400)
+            echo "   jq stderr: ${PARSE_ERR:-(no output)}"
             exit 1
           fi
 

--- a/.github/workflows/teardown-snapshot.yml
+++ b/.github/workflows/teardown-snapshot.yml
@@ -481,7 +481,14 @@ jobs:
             echo "✅ Teardown timestamp written, firewall rules reset"
           else
             echo "✅ Teardown timestamp written"
-            echo "::warning title=firewall-reset::Could not reset the firewall rules in D1. Ports enabled before this teardown will be reopened on the next spin-up. wrangler stderr: $(tr '\n\r' '  ' < /tmp/d1-firewall.err 2>/dev/null | head -c 300)"
+            echo "::error title=firewall-reset::Could not reset the firewall rules in D1. Ports enabled before this teardown will be reopened on the next spin-up. wrangler stderr: $(tr '\n\r' '  ' < /tmp/d1-firewall.err 2>/dev/null | head -c 300)"
+            echo ""
+            echo "NOTE: the snapshot and the infrastructure teardown already"
+            echo "      completed. Do NOT re-run this workflow to fix this — it"
+            echo "      would take a second snapshot. Reset the firewall rules"
+            echo "      from the Control Plane before the next spin-up."
+            # Non-zero on purpose; see the note in teardown.yml.
+            exit 1
           fi
 
       - name: Summary

--- a/.github/workflows/teardown-snapshot.yml
+++ b/.github/workflows/teardown-snapshot.yml
@@ -171,14 +171,42 @@ jobs:
 
           echo "📋 Reading services from D1..."
           D1_DATABASE_NAME="nexus-${DOMAIN//./-}-db"
-          ENABLED_SERVICES=$(npx wrangler@4.129.0 d1 execute "$D1_DATABASE_NAME" --remote --json \
-            --command "SELECT name FROM services WHERE enabled = 1" 2>/dev/null \
-            | jq -r '.[0].results | map(.name) | join(",")' 2>/dev/null || echo "")
+          # Status and message are kept apart, and the query is not allowed
+          # to fail quietly. The previous form ended in `|| echo ""`, so an
+          # outage, an auth failure and a genuinely empty table all produced
+          # the same empty string -- and this workflow then went on to
+          # destroy infrastructure against a list it believed was empty.
+          #
+          # stderr goes to a file rather than into the capture: wrangler
+          # prints its banner there, and folding it into stdout would break
+          # the jq parse below.
+          D1_QUERY_FAILED=0
+          D1_SERVICES_JSON=""
+          if ! D1_SERVICES_JSON=$(npx wrangler@4.129.0 d1 execute "$D1_DATABASE_NAME" --remote --json \
+                --command "SELECT name FROM services WHERE enabled = 1" 2>/tmp/d1-services.err); then
+            D1_QUERY_FAILED=1
+          fi
 
+          if [ "$D1_QUERY_FAILED" -ne 0 ]; then
+            echo "❌ Could not read the enabled services from D1."
+            echo "   Continuing would act on a service list this step never obtained."
+            echo "   wrangler stderr: $(tr '\n\r' '  ' < /tmp/d1-services.err 2>/dev/null | head -c 400)"
+            exit 1
+          fi
+
+          if ! ENABLED_SERVICES=$(printf '%s' "$D1_SERVICES_JSON" \
+                | jq -r '.[0].results | map(.name) | join(",")'); then
+            echo "❌ D1 answered but the response could not be parsed."
+            echo "   wrangler stderr: $(tr '\n\r' '  ' < /tmp/d1-services.err 2>/dev/null | head -c 400)"
+            exit 1
+          fi
+
+          # Reaching here means the query succeeded, so an empty result is
+          # genuinely an empty table rather than a failure in disguise.
           if [ -n "$ENABLED_SERVICES" ]; then
             echo "📋 Enabled services from D1: $ENABLED_SERVICES"
           else
-            echo "📋 No services in D1 yet - core services will be enabled by default"
+            echo "📋 No services enabled in D1 - core services will be enabled by default"
           fi
 
           chmod +x .github/scripts/generate-services-tfvars.py
@@ -442,8 +470,19 @@ jobs:
           fi
 
           npx wrangler@4.129.0 d1 execute "$D1_DATABASE_NAME" --remote --command "INSERT OR REPLACE INTO config (key, value, updated_at) VALUES ('last_teardown', datetime('now'), datetime('now'))"
-          npx wrangler@4.129.0 d1 execute "$D1_DATABASE_NAME" --remote --command "UPDATE firewall_rules SET enabled = 0, deployed = 0, updated_at = datetime('now')" 2>/dev/null || true
-          echo "✅ Teardown timestamp written, firewall rules reset"
+          # No `|| true`. "firewall rules reset" is a security claim, and
+          # printing it after a swallowed failure states the opposite of
+          # what happened: the next spin-up would reopen ports the operator
+          # believes are shut. The timestamp above already runs unguarded,
+          # so only the claim needs splitting from it.
+          if npx wrangler@4.129.0 d1 execute "$D1_DATABASE_NAME" --remote \
+              --command "UPDATE firewall_rules SET enabled = 0, deployed = 0, updated_at = datetime('now')" \
+              >/dev/null 2>/tmp/d1-firewall.err; then
+            echo "✅ Teardown timestamp written, firewall rules reset"
+          else
+            echo "✅ Teardown timestamp written"
+            echo "::warning title=firewall-reset::Could not reset the firewall rules in D1. Ports enabled before this teardown will be reopened on the next spin-up. wrangler stderr: $(tr '\n\r' '  ' < /tmp/d1-firewall.err 2>/dev/null | head -c 300)"
+          fi
 
       - name: Summary
         if: always()

--- a/.github/workflows/teardown-snapshot.yml
+++ b/.github/workflows/teardown-snapshot.yml
@@ -190,14 +190,16 @@ jobs:
           if [ "$D1_QUERY_FAILED" -ne 0 ]; then
             echo "❌ Could not read the enabled services from D1."
             echo "   Continuing would act on a service list this step never obtained."
-            echo "   wrangler stderr: $(tr '\n\r' '  ' < /tmp/d1-services.err 2>/dev/null | head -c 400)"
+            D1_ERR=$(tr '\n\r' '  ' < /tmp/d1-services.err 2>/dev/null | head -c 400)
+            echo "   wrangler stderr: ${D1_ERR:-(no output)}"
             exit 1
           fi
 
           if ! ENABLED_SERVICES=$(printf '%s' "$D1_SERVICES_JSON" \
                 | jq -r '.[0].results | map(.name) | join(",")'); then
             echo "❌ D1 answered but the response could not be parsed."
-            echo "   wrangler stderr: $(tr '\n\r' '  ' < /tmp/d1-services.err 2>/dev/null | head -c 400)"
+            D1_ERR=$(tr '\n\r' '  ' < /tmp/d1-services.err 2>/dev/null | head -c 400)
+            echo "   wrangler stderr: ${D1_ERR:-(no output)}"
             exit 1
           fi
 
@@ -481,7 +483,8 @@ jobs:
             echo "✅ Teardown timestamp written, firewall rules reset"
           else
             echo "✅ Teardown timestamp written"
-            echo "::error title=firewall-reset::Could not reset the firewall rules in D1. Ports enabled before this teardown will be reopened on the next spin-up. wrangler stderr: $(tr '\n\r' '  ' < /tmp/d1-firewall.err 2>/dev/null | head -c 300)"
+            FW_ERR=$(tr '\n\r' '  ' < /tmp/d1-firewall.err 2>/dev/null | head -c 300)
+            echo "::error title=firewall-reset::Could not reset the firewall rules in D1. Ports enabled before this teardown will be reopened on the next spin-up. wrangler stderr: ${FW_ERR:-(no output)}"
             echo ""
             echo "NOTE: the snapshot and the infrastructure teardown already"
             echo "      completed. Do NOT re-run this workflow to fix this — it"

--- a/.github/workflows/teardown.yml
+++ b/.github/workflows/teardown.yml
@@ -353,7 +353,18 @@ jobs:
               >/dev/null 2>/tmp/d1-firewall.err; then
             echo "✅ Firewall rules reset - all ports closed for next Spin Up"
           else
-            echo "::warning title=firewall-reset::Could not reset the firewall rules in D1. Ports enabled before this teardown will be reopened on the next spin-up. wrangler stderr: $(tr '\n\r' '  ' < /tmp/d1-firewall.err 2>/dev/null | head -c 300)"
+            echo "::error title=firewall-reset::Could not reset the firewall rules in D1. Ports enabled before this teardown will be reopened on the next spin-up. wrangler stderr: $(tr '\n\r' '  ' < /tmp/d1-firewall.err 2>/dev/null | head -c 300)"
+            echo ""
+            echo "NOTE: the infrastructure teardown itself already completed — the"
+            echo "      server is gone. Do NOT re-run this workflow to fix this."
+            echo "      What failed is the D1 write that closes the firewall rules"
+            echo "      for the next spin-up. Reset them from the Control Plane's"
+            echo "      Firewall page, or re-run just that write, before spinning up."
+            # Non-zero on purpose. A green teardown asserts "all ports closed";
+            # leaving it green here would state the opposite of what happened,
+            # and the consequence surfaces one spin-up later as open ports
+            # nobody reopened deliberately.
+            exit 1
           fi
 
       - name: Log teardown completed

--- a/.github/workflows/teardown.yml
+++ b/.github/workflows/teardown.yml
@@ -223,10 +223,14 @@ jobs:
           fi
 
           if ! ENABLED_SERVICES=$(printf '%s' "$D1_SERVICES_JSON" \
-                | jq -r '.[0].results | map(.name) | join(",")'); then
+                | jq -r '.[0].results | map(.name) | join(",")' 2>/tmp/d1-parse.err); then
             echo "❌ D1 answered but the response could not be parsed."
-            D1_ERR=$(tr '\n\r' '  ' < /tmp/d1-services.err 2>/dev/null | head -c 400)
-            echo "   wrangler stderr: ${D1_ERR:-(no output)}"
+            # jq's own stderr, not wrangler's. Reaching this branch means the
+            # query already succeeded, so /tmp/d1-services.err holds nothing
+            # but wrangler's banner -- labelling that as the diagnostic points
+            # at the one component that did not fail.
+            PARSE_ERR=$(tr '\n\r' '  ' < /tmp/d1-parse.err 2>/dev/null | head -c 400)
+            echo "   jq stderr: ${PARSE_ERR:-(no output)}"
             exit 1
           fi
 

--- a/.github/workflows/teardown.yml
+++ b/.github/workflows/teardown.yml
@@ -198,14 +198,42 @@ jobs:
           # Read services from D1 (single source of truth)
           echo "📋 Reading services from D1..."
           D1_DATABASE_NAME="nexus-${DOMAIN//./-}-db"
-          ENABLED_SERVICES=$(npx wrangler@4.129.0 d1 execute "$D1_DATABASE_NAME" --remote --json \
-            --command "SELECT name FROM services WHERE enabled = 1" 2>/dev/null \
-            | jq -r '.[0].results | map(.name) | join(",")' 2>/dev/null || echo "")
+          # Status and message are kept apart, and the query is not allowed
+          # to fail quietly. The previous form ended in `|| echo ""`, so an
+          # outage, an auth failure and a genuinely empty table all produced
+          # the same empty string -- and this workflow then went on to
+          # destroy infrastructure against a list it believed was empty.
+          #
+          # stderr goes to a file rather than into the capture: wrangler
+          # prints its banner there, and folding it into stdout would break
+          # the jq parse below.
+          D1_QUERY_FAILED=0
+          D1_SERVICES_JSON=""
+          if ! D1_SERVICES_JSON=$(npx wrangler@4.129.0 d1 execute "$D1_DATABASE_NAME" --remote --json \
+                --command "SELECT name FROM services WHERE enabled = 1" 2>/tmp/d1-services.err); then
+            D1_QUERY_FAILED=1
+          fi
 
+          if [ "$D1_QUERY_FAILED" -ne 0 ]; then
+            echo "❌ Could not read the enabled services from D1."
+            echo "   Continuing would act on a service list this step never obtained."
+            echo "   wrangler stderr: $(tr '\n\r' '  ' < /tmp/d1-services.err 2>/dev/null | head -c 400)"
+            exit 1
+          fi
+
+          if ! ENABLED_SERVICES=$(printf '%s' "$D1_SERVICES_JSON" \
+                | jq -r '.[0].results | map(.name) | join(",")'); then
+            echo "❌ D1 answered but the response could not be parsed."
+            echo "   wrangler stderr: $(tr '\n\r' '  ' < /tmp/d1-services.err 2>/dev/null | head -c 400)"
+            exit 1
+          fi
+
+          # Reaching here means the query succeeded, so an empty result is
+          # genuinely an empty table rather than a failure in disguise.
           if [ -n "$ENABLED_SERVICES" ]; then
             echo "📋 Enabled services from D1: $ENABLED_SERVICES"
           else
-            echo "📋 No services in D1 yet - core services will be enabled by default"
+            echo "📋 No services enabled in D1 - core services will be enabled by default"
           fi
 
           # Generate services config from services.yaml
@@ -315,8 +343,18 @@ jobs:
 
           # Reset all firewall rules to disabled (ports must be explicitly re-opened)
           echo "🔥 Resetting firewall rules..."
-          npx wrangler@4.129.0 d1 execute "$D1_DATABASE_NAME" --remote --command "UPDATE firewall_rules SET enabled = 0, deployed = 0, updated_at = datetime('now')" 2>/dev/null || true
-          echo "✅ Firewall rules reset - all ports closed for next Spin Up"
+          # No `|| true`. The message below is a security claim -- "all ports
+          # closed" -- and printing it unconditionally after a swallowed
+          # failure states the opposite of what happened. If the reset does
+          # not land, the next spin-up reopens ports the operator believes
+          # are shut.
+          if npx wrangler@4.129.0 d1 execute "$D1_DATABASE_NAME" --remote \
+              --command "UPDATE firewall_rules SET enabled = 0, deployed = 0, updated_at = datetime('now')" \
+              >/dev/null 2>/tmp/d1-firewall.err; then
+            echo "✅ Firewall rules reset - all ports closed for next Spin Up"
+          else
+            echo "::warning title=firewall-reset::Could not reset the firewall rules in D1. Ports enabled before this teardown will be reopened on the next spin-up. wrangler stderr: $(tr '\n\r' '  ' < /tmp/d1-firewall.err 2>/dev/null | head -c 300)"
+          fi
 
       - name: Log teardown completed
         env:

--- a/.github/workflows/teardown.yml
+++ b/.github/workflows/teardown.yml
@@ -217,14 +217,16 @@ jobs:
           if [ "$D1_QUERY_FAILED" -ne 0 ]; then
             echo "❌ Could not read the enabled services from D1."
             echo "   Continuing would act on a service list this step never obtained."
-            echo "   wrangler stderr: $(tr '\n\r' '  ' < /tmp/d1-services.err 2>/dev/null | head -c 400)"
+            D1_ERR=$(tr '\n\r' '  ' < /tmp/d1-services.err 2>/dev/null | head -c 400)
+            echo "   wrangler stderr: ${D1_ERR:-(no output)}"
             exit 1
           fi
 
           if ! ENABLED_SERVICES=$(printf '%s' "$D1_SERVICES_JSON" \
                 | jq -r '.[0].results | map(.name) | join(",")'); then
             echo "❌ D1 answered but the response could not be parsed."
-            echo "   wrangler stderr: $(tr '\n\r' '  ' < /tmp/d1-services.err 2>/dev/null | head -c 400)"
+            D1_ERR=$(tr '\n\r' '  ' < /tmp/d1-services.err 2>/dev/null | head -c 400)
+            echo "   wrangler stderr: ${D1_ERR:-(no output)}"
             exit 1
           fi
 
@@ -353,7 +355,8 @@ jobs:
               >/dev/null 2>/tmp/d1-firewall.err; then
             echo "✅ Firewall rules reset - all ports closed for next Spin Up"
           else
-            echo "::error title=firewall-reset::Could not reset the firewall rules in D1. Ports enabled before this teardown will be reopened on the next spin-up. wrangler stderr: $(tr '\n\r' '  ' < /tmp/d1-firewall.err 2>/dev/null | head -c 300)"
+            FW_ERR=$(tr '\n\r' '  ' < /tmp/d1-firewall.err 2>/dev/null | head -c 300)
+            echo "::error title=firewall-reset::Could not reset the firewall rules in D1. Ports enabled before this teardown will be reopened on the next spin-up. wrangler stderr: ${FW_ERR:-(no output)}"
             echo ""
             echo "NOTE: the infrastructure teardown itself already completed — the"
             echo "      server is gone. Do NOT re-run this workflow to fix this."

--- a/tests/unit/test_workflow_expressions.py
+++ b/tests/unit/test_workflow_expressions.py
@@ -358,3 +358,102 @@ def test_every_job_touching_npm_caches_the_store() -> None:
         "the detection needs widening -- note it already follows "
         ".github/scripts/*.sh references."
     )
+
+
+# ---------------------------------------------------------------------------
+# Captured diagnostics must never print as an empty string
+#
+# Eight failure branches echoed `wrangler stderr: $(… < /tmp/x.err …)`. A
+# command that exits non-zero while writing nothing to stderr — which is
+# exactly what a killed process does — left the label with nothing after it,
+# so the log said only "wrangler stderr:" at the one moment somebody needed
+# it. CLAUDE.md names this shape and prescribes `${VAR:-(no output)}`.
+#
+# Two rules, because there are two ways to get it wrong:
+#   1. Interpolating the capture straight into the echo. That form CANNOT
+#      carry a fallback, so it is banned outright.
+#   2. Capturing into a variable and then printing it bare. The fallback
+#      belongs on the expansion, not on the assignment.
+# ---------------------------------------------------------------------------
+
+# `\.err` must end the word: `.errors[0].message` in a jq filter is not a
+# capture file, and matching it reported two lines that already carry a
+# `// "unknown"` fallback.
+_ERR_FILE = r"\.err(?![A-Za-z0-9_])"
+_ERR_CAPTURE = re.compile(
+    r"^\s*(?P<var>[A-Za-z_][A-Za-z0-9_]*)=\$\((?P<body>[^\n]*" + _ERR_FILE + r"[^\n]*)\)"
+)
+_INLINE_ERR_ECHO = re.compile(r"echo\b[^\n]*\$\([^\n]*" + _ERR_FILE)
+
+
+def _script_lines(path: Path) -> list[tuple[int, str]]:
+    """Numbered lines inside `run:` bodies, comments dropped.
+
+    The comments matter: prose in this repo quotes the very shapes these
+    rules ban, and a check that reads a comment as code reports a defect
+    that does not exist. That has happened three times here.
+    """
+    ranges = _run_line_ranges(path)
+    return [
+        (i, line)
+        for i, line in enumerate(path.read_text().splitlines(), 1)
+        if any(start <= i <= end for start, end in ranges) and not line.lstrip().startswith("#")
+    ]
+
+
+def test_no_echo_interpolates_an_err_capture_directly() -> None:
+    """Rule 1: the inline form has nowhere to put a fallback."""
+    offenders = [
+        f"{path}:{i}: {line.strip()}"
+        for path in _FILES
+        for i, line in _script_lines(path)
+        if _INLINE_ERR_ECHO.search(line)
+    ]
+    assert not offenders, (
+        "echo interpolates a captured diagnostic directly:\n  "
+        + "\n  ".join(offenders)
+        + "\nAssign it to a variable first, then print it as "
+        '"${VAR:-(no output)}" so an empty capture still says something.'
+    )
+
+
+def test_every_captured_diagnostic_prints_with_a_fallback() -> None:
+    """Rule 2: a variable holding a capture is never expanded bare."""
+    offenders: list[str] = []
+    for path in _FILES:
+        lines = _script_lines(path)
+        captured = {match.group("var") for _, line in lines if (match := _ERR_CAPTURE.match(line))}
+        for i, line in lines:
+            if "echo" not in line:
+                continue
+            for var in captured:
+                # `${VAR:-…}` is the only accepted expansion. A bare
+                # `$VAR` or a plain `${VAR}` prints nothing when empty.
+                bare = re.search(rf"\$\{{{var}\}}|\${var}\b", line)
+                guarded = f"${{{var}:-" in line
+                if bare and not guarded:
+                    offenders.append(f"{path}:{i}: {line.strip()}")
+    assert not offenders, (
+        "a captured diagnostic is printed without a fallback:\n  "
+        + "\n  ".join(offenders)
+        + '\nUse "${VAR:-(no output)}" — a command can fail while writing '
+        "nothing, and the bare form then prints a label with no diagnostic."
+    )
+
+
+def test_the_fallback_rules_see_the_lines_they_are_meant_to_see() -> None:
+    """Neither rule may pass by looking at nothing.
+
+    Both assertions above are satisfied by an empty offender list, which
+    an over-narrow scope produces just as reliably as a clean repo. This
+    pins the scope: the teardown workflows do capture wrangler stderr,
+    and those captures are the ones the rules examine.
+    """
+    captures = {
+        str(path) for path in _FILES for _, line in _script_lines(path) if _ERR_CAPTURE.match(line)
+    }
+    for name in ("destroy-all.yml", "teardown.yml", "teardown-snapshot.yml"):
+        assert any(name in path for path in captures), (
+            f"{name} captures no diagnostic any more — either the rules "
+            "stopped finding the assignments, or the workflow changed shape"
+        )

--- a/tests/unit/test_workflow_expressions.py
+++ b/tests/unit/test_workflow_expressions.py
@@ -401,6 +401,24 @@ def _script_lines(path: Path) -> list[tuple[int, str]]:
     ]
 
 
+# Only `${VAR:-something}` prints a diagnostic when VAR is empty. A bare
+# `$VAR`, a plain `${VAR}` and an empty default `${VAR:-}` all print nothing,
+# which is the defect this whole section exists to prevent.
+_GUARDED_EXPANSION = re.compile(r"^\$\{[A-Za-z_][A-Za-z0-9_]*:-[^}]+\}$")
+
+
+def _expansions(line: str, var: str) -> list[str]:
+    """Every expansion of `var` on the line, written as it appears.
+
+    Per expansion, not per line: the first version of this check asked
+    whether `${VAR:-` occurred anywhere on the line, so `echo "$ERR
+    ${ERR:-(no output)}"` passed on the strength of its second half while
+    the first half printed nothing.
+    """
+    pattern = re.compile(rf"\$\{{{var}(?::-[^}}]*)?\}}|\${var}(?![A-Za-z0-9_])")
+    return [match.group(0) for match in pattern.finditer(line)]
+
+
 def test_no_echo_interpolates_an_err_capture_directly() -> None:
     """Rule 1: the inline form has nowhere to put a fallback."""
     offenders = [
@@ -427,12 +445,10 @@ def test_every_captured_diagnostic_prints_with_a_fallback() -> None:
             if "echo" not in line:
                 continue
             for var in captured:
-                # `${VAR:-…}` is the only accepted expansion. A bare
-                # `$VAR` or a plain `${VAR}` prints nothing when empty.
-                bare = re.search(rf"\$\{{{var}\}}|\${var}\b", line)
-                guarded = f"${{{var}:-" in line
-                if bare and not guarded:
-                    offenders.append(f"{path}:{i}: {line.strip()}")
+                for expansion in _expansions(line, var):
+                    if _GUARDED_EXPANSION.fullmatch(expansion):
+                        continue
+                    offenders.append(f"{path}:{i}: {expansion} in: {line.strip()}")
     assert not offenders, (
         "a captured diagnostic is printed without a fallback:\n  "
         + "\n  ".join(offenders)
@@ -457,3 +473,38 @@ def test_the_fallback_rules_see_the_lines_they_are_meant_to_see() -> None:
             f"{name} captures no diagnostic any more — either the rules "
             "stopped finding the assignments, or the workflow changed shape"
         )
+
+
+@pytest.mark.parametrize(
+    ("line", "accepted"),
+    [
+        # The house form.
+        ('echo "   wrangler stderr: ${ERR:-(no output)}"', True),
+        # Any non-empty default satisfies the actual requirement: that
+        # something is printed. The literal wording is not the property.
+        ('echo "   wrangler stderr: ${ERR:-none}"', True),
+        # An empty default prints nothing — the very defect, spelled with
+        # the syntax that looks like the fix.
+        ('echo "   wrangler stderr: ${ERR:-}"', False),
+        ('echo "   wrangler stderr: $ERR"', False),
+        ('echo "   wrangler stderr: ${ERR}"', False),
+        # One good expansion must not vouch for a bare one beside it.
+        ('echo "$ERR ${ERR:-(no output)}"', False),
+        ('echo "${ERR:-(no output)} $ERR"', False),
+        # A longer name that merely starts with the variable is a
+        # different variable.
+        ('echo "${ERR_COUNT}"', True),
+    ],
+)
+def test_the_expansion_check_accepts_and_rejects_the_right_forms(line: str, accepted: bool) -> None:
+    """The rule is only as good as what it refuses.
+
+    Every False case here passed the first version of the check, which
+    asked whether `${ERR:-` appeared anywhere on the line rather than
+    inspecting each expansion.
+    """
+    found = _expansions(line, "ERR")
+    ok = all(_GUARDED_EXPANSION.fullmatch(expansion) for expansion in found)
+    if accepted and not found:
+        ok = True  # nothing to guard on this line
+    assert ok is accepted, f"expansions found: {found}"


### PR DESCRIPTION
Closes #785

## Local CodeRabbit round

Reviewed the first commit — **3 findings, all valid, fixed in `620ac06`**. All three were the same defect in the code I had just written: the new failure branches emitted a diagnostic and then returned zero, so the workflow stayed green while the thing it reported had failed. A warning nobody's CI acts on is a quieter version of `|| true`. Detail below.

## The seven call sites

| Defect | Where | Fix |
|---|---|---|
| `\|\| echo ""` on the service-list query | teardown, destroy-all, teardown-snapshot | Query status captured separately; failure aborts; an empty result is accepted **only after a successful query** |
| `\|\| true` followed by `✅ all ports closed` | teardown, teardown-snapshot | Success message moved inside the success branch; failure path exits non-zero |
| `ALTER TABLE … \|\| true` ×3 | setup-control-plane | `migrate_column` tolerates **only** "duplicate column" |
| `pages secret delete … \|\| true` ×2 | setup-control-plane | `delete_pages_secret` distinguishes "was not there" from an auth or API error |

### The service list

```bash
ENABLED_SERVICES=$(npx wrangler … --json --command "SELECT …" 2>/dev/null \
  | jq -r '…' 2>/dev/null || echo "")
```

An outage, an auth failure and a genuinely empty table all produced the same empty string — and three workflows that destroy infrastructure then proceeded against a list they believed was empty.

stderr now goes to a file rather than into the capture: wrangler prints its banner there, and folding it into stdout would break the jq parse. That is also the evidence the banner *is* on stderr — the existing jq worked, which it could not have done otherwise.

### The firewall reset

```bash
npx wrangler … --command "UPDATE firewall_rules SET enabled = 0, …" 2>/dev/null || true
echo "✅ Firewall rules reset - all ports closed for next Spin Up"
```

A security claim, printed unconditionally after a swallowed failure. CLAUDE.md names this shape directly under "Error Handling Principles".

## What the review changed, and why it took checking first

CodeRabbit asked for `exit 1` in all three failure branches. Before adopting that I checked the step order in `teardown.yml`:

```
297  Teardown Hetzner infrastructure only
308  Confirm teardown
320  Write teardown timestamp to D1   ← the firewall reset lives here
```

The destroy has already happened, so failing here undoes nothing. What it does is stop a green check from asserting "all ports closed" when they are not — and the consequence surfaces one spin-up later, as ports nobody reopened deliberately.

Adopted, with one addition the suggestion did not have: **both messages now say the teardown itself completed and the workflow must not be re-run**, the snapshot variant adding that a re-run would take a second snapshot. A red check that provokes the wrong recovery is its own defect.

`delete_pages_secret` returns 1 for the same reason: it runs before deployment, and the caller reaches it only when the operator has cleared the value and expects the runtime to fall back. A stale secret defeats that silently.

## A weakness recorded rather than hidden

The "was not there" branch matches on wrangler's error wording. That is a heuristic: if the wording changes, a benign no-op lands in the failure branch and breaks setup.

That is the right direction to fail in — a broken setup is noticed immediately, a stale secret is not — but the comment says the fix is then to widen the pattern, not to restore `|| true`. The outcome-based alternative (delete, then list to confirm absence) would be better still and is noted as such.

## Verification

These paths cannot be triggered on demand in CI, so the shell logic was exercised against stubbed wrangler exit codes — four cases each, including the one that matters most:

```
migrate_column        ok / duplicate column / auth error / exits non-zero silently
ENABLED_SERVICES      rows / empty table / query down / unparseable response
delete_pages_secret   deleted / absent / auth error / exits non-zero silently
```

The **empty-table** and **silent-failure** cases are the point. Before this change both were indistinguishable from success, and both helpers now print `${err:-(no output)}` so a command that fails while writing nothing still says something — the failure mode CLAUDE.md describes under "The failure indicator is the exit status — never a by-product".

Behaviour under `bash -e` was checked too: the absent case continues, the auth case aborts the step with exit 1, and the line after it never runs.

## Left alone deliberately

The remaining `|| true` in these files are the cases CLAUDE.md lists as acceptable: `tofu state rm` for entries that may not exist, `grep` (which exits 1 on no match), and a `cat` for logging.

## Testing

No unit tests cover workflow shell. The real exercise is a teardown and a setup run — the firewall-reset path in particular only shows its new behaviour when D1 is unreachable, which is not something to arrange on purpose. What can be confirmed on an ordinary run is that nothing regressed: the service list still reads, the migrations still apply, and the secret cleanup still reports.

## Summary by Sourcery

Make CI workflow failures propagate instead of being discarded, while preserving explicitly tolerated no-op cases and improving diagnostics.

Bug Fixes:
- Preserve and surface failures when teardown workflows cannot read enabled services or reset firewall rules, preventing successful runs from masking unsafe state.
- Make control-plane migrations and Pages secret cleanup fail on unexpected errors while continuing only for expected already-applied or absent-resource cases.

Enhancements:
- Improve workflow diagnostics for empty command output and distinguish genuine empty results from failed D1 queries.
- Add workflow-expression tests that enforce non-empty fallbacks for captured error diagnostics and validate their detection scope.

Tests:
- Add regression coverage for captured diagnostic fallbacks, including silent failures, empty defaults, and unguarded expansions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved deployment and teardown workflows to distinguish failed service lookups from valid empty results.
  - Added validation for malformed service data and clearer error reporting.
  - Workflows now stop safely when infrastructure updates, secret removal, or database migrations fail unexpectedly.
  - Firewall reset operations report failure accurately instead of indicating success when updates do not complete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->