### PR TITLE
fix(deploy): Create the RedPanda SASL user via the Admin API

### DIFF
--- a/src/nexus_deploy/services.py
+++ b/src/nexus_deploy/services.py
@@ -760,8 +760,34 @@ redpanda_hook() {{
     # jq's argv inside the container, undoing the point of the pipe.
     RP_BODY=$(printf '%s' "$REDPANDA_PASSWORD" \\
         | jq -Rsc '{{username:"nexus-redpanda",password:.,algorithm:"SCRAM-SHA-256"}}')
+    # Clear the response file BEFORE each request, not only after reading
+    # it. Consume-after-read closes the window only when the read is
+    # actually reached: a deploy interrupted between the write and the read
+    # leaves the body in place, and the next run's transport failure -- which
+    # never touches the file, measured -- would then report it as its own.
+    # With this, curl either writes a real response or the file is absent,
+    # and the diagnostic says `(no body)`.
+    #
+    # `|| true` is right here and is not the swallowed-failure pattern:
+    # `rm -f` succeeds on a missing file, so the only way this fails is an
+    # unreachable container -- in which case the request on the next line
+    # fails too and reports it properly. This command is not the failure
+    # indicator for anything.
+    # One path per invocation. `spin-up.yml` carries no `concurrency:`
+    # group, so two runs really can reach this hook at the same time; on a
+    # shared path each would clear and overwrite the other's response and
+    # both diagnostics would be about the wrong request. `$$` is the PID of
+    # the shell this script runs in, which differs per SSH session.
+    RP_OUT=/tmp/rp-user.$$.out
+    rp_clear_response() {{
+        docker exec redpanda rm -f "$RP_OUT" >/dev/null 2>&1 || true
+    }}
+    rp_read_response() {{
+        docker exec redpanda sh -c "cat $RP_OUT 2>/dev/null; rm -f $RP_OUT" 2>/dev/null || echo ""
+    }}
+    rp_clear_response
     CREATE_CODE=$(printf '%s' "$RP_BODY" | docker exec -i redpanda \\
-        curl -s -o /tmp/rp-user.out -w '%{{http_code}}' \\
+        curl -s -o "$RP_OUT" -w '%{{http_code}}' \\
              --connect-timeout 3 --max-time 30 \\
              -X POST "$RP_URL" -H 'Content-Type: application/json' --data-binary @- 2>/dev/null || true)
     # `|| true` plus a default, NOT `|| echo "000"`. curl already writes
@@ -781,21 +807,22 @@ redpanda_hook() {{
     # that died between the POST and the PUT would produce
     # `HTTP 000: {{"message":"User already exists"}}` -- an error message
     # naming a conflict that did not happen.
-    CREATE_BODY=$(docker exec redpanda sh -c 'cat /tmp/rp-user.out 2>/dev/null; rm -f /tmp/rp-user.out' 2>/dev/null || echo "")
+    CREATE_BODY=$(rp_read_response)
     if [ "$CREATE_CODE" != "200" ]; then
         # 000 means curl never spoke to the broker, so whatever is in
         # $CREATE_BODY cannot be this request's response. Only a real
         # HTTP status may be read as "the user is already there".
         if [ "$CREATE_CODE" != "000" ] && echo "$CREATE_BODY" | grep -qi 'already exists'; then
             USER_EXISTED=true
+            rp_clear_response
             UPDATE_CODE=$(printf '%s' "$RP_BODY" | docker exec -i redpanda \\
-                curl -s -o /tmp/rp-user.out -w '%{{http_code}}' \\
+                curl -s -o "$RP_OUT" -w '%{{http_code}}' \\
                      --connect-timeout 3 --max-time 30 \\
                      -X PUT "$RP_URL/nexus-redpanda" -H 'Content-Type: application/json' --data-binary @- 2>/dev/null || true)
             UPDATE_CODE=${{UPDATE_CODE:-000}}
             if [ "$UPDATE_CODE" != "200" ]; then
                 # Same consume-and-delete as the create above.
-                UPDATE_BODY=$(docker exec redpanda sh -c 'cat /tmp/rp-user.out 2>/dev/null; rm -f /tmp/rp-user.out' 2>/dev/null || echo "")
+                UPDATE_BODY=$(rp_read_response)
                 # Mask the password before printing. The bodies observed
                 # from this API carry only a message and a code, but an
                 # error that echoed the request would put the secret in a

--- a/src/nexus_deploy/services.py
+++ b/src/nexus_deploy/services.py
@@ -634,8 +634,9 @@ def render_redpanda_hook(config: NexusConfig, env: BootstrapEnv) -> str:
     Wait via ``docker exec redpanda curl -sf /v1/status/ready`` (the
     admin API isn't exposed outside the container; ``-sf`` requires
     a true 2xx status, not just a transport-level success). The password
-    reaches the container on stdin and is read by ``curl -d @-``, so it
-    never lands in any process's argv on any of the three surfaces
+    reaches the container on stdin and is read by
+    ``curl --data-binary @-``, so it never lands in any process's argv
+    on any of the three surfaces
     (host, docker exec, container). ``rpk`` is not used for the user
     because it has no stdin flag — see the comment at the call site.
 
@@ -654,10 +655,11 @@ def render_redpanda_hook(config: NexusConfig, env: BootstrapEnv) -> str:
       now genuinely differs → external clients pick up new credential
       via Infisical sync.
 
-    The delete is gated on the first create-attempt returning
-    "already exists" — we never delete a user we haven't proven the
-    broker can recreate. A transient broker glitch on the first
-    create returns ``failed`` without touching existing state.
+    Nothing is ever deleted. The PUT is gated on the first
+    create-attempt returning "already exists", so a transient broker
+    glitch on the first create returns ``failed`` without touching
+    existing state — and there is no point at which the broker has no
+    SASL user.
 
     Restart of the broker happens ONLY on first setup
     (``USER_EXISTED=false``). Subsequent rotations don't need it
@@ -694,11 +696,10 @@ redpanda_hook() {{
     fi
     # Try create-first. Three outcomes:
     #   1. SUCCESS → fresh install, USER_EXISTED stays false (→ restart needed below)
-    #   2. "already exists" → rotation case: delete the current user
-    #      and recreate with the current Infisical password. We only
-    #      open the no-user window AFTER the first create proved the
-    #      broker accepts our request, so a transient broker glitch
-    #      can't leave us userless mid-flight.
+    #   2. "already exists" → rotation case: PUT the current Infisical
+    #      password over the existing user. Nothing is deleted, so the
+    #      broker never sits without a SASL user; see the measured
+    #      status codes below.
     #   3. Other error → bail with failed.
     # Pipe the password via stdin so it never lands in argv on ANY of
     # the three process-list surfaces:
@@ -707,7 +708,7 @@ redpanda_hook() {{
     #       cmdline carries only flags and the curl invocation.
     #   (2) docker daemon's `ps aux` — same docker-exec cmdline.
     #   (3) inside the container — curl reads the body from stdin with
-    #       `-d @-` and never reflects it into its own argv.
+    #       `--data-binary @-` and never reflects it into its own argv.
     # The Admin API, not `rpk acl user create`. rpk has no
     # `--password-stdin` flag -- measured against the image this stack
     # actually runs:
@@ -725,8 +726,8 @@ redpanda_hook() {{
     # `--password <value>` would work but puts the secret into rpk's
     # argv inside the container. The Admin API keeps it off every
     # process list: the JSON reaches `docker exec -i` on stdin and curl
-    # reads it with `-d @-`, so it is in no argv on the host, in
-    # docker's, or in the container.
+    # reads it with `--data-binary @-`, so it is in no argv on the host,
+    # in docker's, or in the container.
     #
     # Both writes are bounded. `SSHClient.run_script` has no default
     # timeout, so a broker that accepts the connection and then stops

--- a/src/nexus_deploy/services.py
+++ b/src/nexus_deploy/services.py
@@ -772,9 +772,21 @@ redpanda_hook() {{
     # module is harmless only because those call sites compare against a
     # success code instead of printing it.
     CREATE_CODE=${{CREATE_CODE:-000}}
-    CREATE_BODY=$(docker exec redpanda sh -c 'cat /tmp/rp-user.out 2>/dev/null' 2>/dev/null || echo "")
+    # Consume the body: read it and delete it in the same exec. curl does
+    # NOT truncate its `-o` file when it never reaches the server, so a
+    # body left behind by the previous request would be reported as this
+    # one's. Measured inside redpandadata/redpanda:v24.3.1 (curl 7.88.1):
+    # a PUT to a closed port returns 000 and leaves the earlier
+    # "User already exists" JSON in place. Without the delete, a broker
+    # that died between the POST and the PUT would produce
+    # `HTTP 000: {{"message":"User already exists"}}` -- an error message
+    # naming a conflict that did not happen.
+    CREATE_BODY=$(docker exec redpanda sh -c 'cat /tmp/rp-user.out 2>/dev/null; rm -f /tmp/rp-user.out' 2>/dev/null || echo "")
     if [ "$CREATE_CODE" != "200" ]; then
-        if echo "$CREATE_BODY" | grep -qi 'already exists'; then
+        # 000 means curl never spoke to the broker, so whatever is in
+        # $CREATE_BODY cannot be this request's response. Only a real
+        # HTTP status may be read as "the user is already there".
+        if [ "$CREATE_CODE" != "000" ] && echo "$CREATE_BODY" | grep -qi 'already exists'; then
             USER_EXISTED=true
             UPDATE_CODE=$(printf '%s' "$RP_BODY" | docker exec -i redpanda \\
                 curl -s -o /tmp/rp-user.out -w '%{{http_code}}' \\
@@ -782,7 +794,8 @@ redpanda_hook() {{
                      -X PUT "$RP_URL/nexus-redpanda" -H 'Content-Type: application/json' --data-binary @- 2>/dev/null || true)
             UPDATE_CODE=${{UPDATE_CODE:-000}}
             if [ "$UPDATE_CODE" != "200" ]; then
-                UPDATE_BODY=$(docker exec redpanda sh -c 'cat /tmp/rp-user.out 2>/dev/null' 2>/dev/null || echo "")
+                # Same consume-and-delete as the create above.
+                UPDATE_BODY=$(docker exec redpanda sh -c 'cat /tmp/rp-user.out 2>/dev/null; rm -f /tmp/rp-user.out' 2>/dev/null || echo "")
                 # Mask the password before printing. The bodies observed
                 # from this API carry only a message and a code, but an
                 # error that echoed the request would put the secret in a

--- a/src/nexus_deploy/services.py
+++ b/src/nexus_deploy/services.py
@@ -754,14 +754,23 @@ redpanda_hook() {{
         | jq -Rsc '{{username:"nexus-redpanda",password:.,algorithm:"SCRAM-SHA-256"}}')
     CREATE_CODE=$(printf '%s' "$RP_BODY" | docker exec -i redpanda \\
         curl -s -o /tmp/rp-user.out -w '%{{http_code}}' \\
-             -X POST "$RP_URL" -H 'Content-Type: application/json' --data-binary @- 2>/dev/null || echo "000")
+             -X POST "$RP_URL" -H 'Content-Type: application/json' --data-binary @- 2>/dev/null || true)
+    # `|| true` plus a default, NOT `|| echo "000"`. curl already writes
+    # 000 to stdout when it cannot connect AND exits non-zero, so the
+    # echo would append a second 000 and the diagnostic below would read
+    # "HTTP 000000" -- contradicting the comment two lines down. CLAUDE.md
+    # names this exact trap; the `|| echo "000"` form elsewhere in this
+    # module is harmless only because those call sites compare against a
+    # success code instead of printing it.
+    CREATE_CODE=${{CREATE_CODE:-000}}
     CREATE_BODY=$(docker exec redpanda sh -c 'cat /tmp/rp-user.out 2>/dev/null' 2>/dev/null || echo "")
     if [ "$CREATE_CODE" != "200" ]; then
         if echo "$CREATE_BODY" | grep -qi 'already exists'; then
             USER_EXISTED=true
             UPDATE_CODE=$(printf '%s' "$RP_BODY" | docker exec -i redpanda \\
                 curl -s -o /tmp/rp-user.out -w '%{{http_code}}' \\
-                     -X PUT "$RP_URL/nexus-redpanda" -H 'Content-Type: application/json' --data-binary @- 2>/dev/null || echo "000")
+                     -X PUT "$RP_URL/nexus-redpanda" -H 'Content-Type: application/json' --data-binary @- 2>/dev/null || true)
+            UPDATE_CODE=${{UPDATE_CODE:-000}}
             if [ "$UPDATE_CODE" != "200" ]; then
                 UPDATE_BODY=$(docker exec redpanda sh -c 'cat /tmp/rp-user.out 2>/dev/null' 2>/dev/null || echo "")
                 # Mask the password before printing. The bodies observed

--- a/src/nexus_deploy/services.py
+++ b/src/nexus_deploy/services.py
@@ -16,9 +16,10 @@ Three hook families cover the supported services:
      fab`` for Superset) via ``docker exec -i``, with passwords
      piped via stdin to keep them out of docker's argv on the
      remote host
-  3. Idempotent re-runs: RedPanda's ``rpk acl user create`` errors
-     harmlessly if user exists; Superset falls back to ``fab
-     reset-password`` if ``fab create-admin`` reports user-exists
+  3. Idempotent re-runs: RedPanda POSTs to its Admin API and falls
+     through to a PUT when that reports the user already exists;
+     Superset falls back to ``fab reset-password`` if ``fab
+     create-admin`` reports user-exists
 
 **Python-side file mutation** (Filestash):
 
@@ -613,24 +614,30 @@ openmetadata_hook
 # Why argv-vs-stdin matters for docker exec: passing a password via
 # ``docker exec -e RPK_PASS='$pass'`` lands the env-var literal in
 # docker's argv on the host. The strictly-more-correct path is
-# ``printf '%s' "$pass" | docker exec -i <container> <cli>
-# --password-stdin``, which keeps the password on stdin from end to
-# end — never in argv on the host, in docker exec's cmdline, or in
-# the inner CLI's argv. Hooks that target CLIs without a stdin flag
-# (Superset's ``fab create-admin``) still pay the in-container argv
-# cost, but the host-level surface is always clean.
+# ``printf '%s' "$pass" | docker exec -i <container> <cli-reading-stdin>``,
+# which keeps the password on stdin from end to end — never in argv on
+# the host, in docker exec's cmdline, or in the inner CLI's argv.
+#
+# Which stdin-reading CLI depends on the service, and the tool's own
+# flags decide it rather than the pattern: RedPanda uses its Admin API
+# through ``curl -d @-`` because ``rpk acl user create`` has no
+# stdin flag (checked against the image, twice — see the hook). Hooks
+# targeting CLIs without any stdin path (Superset's ``fab
+# create-admin``) still pay the in-container argv cost, but the
+# host-level surface is always clean.
 # ---------------------------------------------------------------------------
 
 
 def render_redpanda_hook(config: NexusConfig, env: BootstrapEnv) -> str:
-    """RedPanda SASL: ``rpk acl user create`` + ``rpk cluster config set superusers``.
+    """RedPanda SASL: Admin API user + ``rpk cluster config set superusers``.
 
     Wait via ``docker exec redpanda curl -sf /v1/status/ready`` (the
     admin API isn't exposed outside the container; ``-sf`` requires
-    a true 2xx status, not just a transport-level success). Password
-    reaches the container via stdin → rpk's ``--password-stdin`` flag
-    so it never lands in any process's argv on any of the three
-    surfaces (host, docker exec, container).
+    a true 2xx status, not just a transport-level success). The password
+    reaches the container on stdin and is read by ``curl -d @-``, so it
+    never lands in any process's argv on any of the three surfaces
+    (host, docker exec, container). ``rpk`` is not used for the user
+    because it has no stdin flag — see the comment at the call site.
 
     Idempotency contract — always converges to ``configured``
     (or ``failed`` / ``skipped-not-ready``); NO ``already-configured``
@@ -692,43 +699,72 @@ redpanda_hook() {{
     #      broker accepts our request, so a transient broker glitch
     #      can't leave us userless mid-flight.
     #   3. Other error → bail with failed.
-    # Pipe password via stdin so it never lands in argv on ANY of the
-    # three process-list surfaces:
+    # Pipe the password via stdin so it never lands in argv on ANY of
+    # the three process-list surfaces:
     #   (1) host's `ps aux` — `printf '%s' "$VAR" | docker exec -i ...`
     #       uses shell-builtin printf (no argv) and the docker exec
-    #       cmdline carries only flags + rpk subcommand, no password.
+    #       cmdline carries only flags and the curl invocation.
     #   (2) docker daemon's `ps aux` — same docker-exec cmdline.
-    #   (3) inside the container — rpk reads the password from stdin
-    #       via --password-stdin and never reflects it into its own
-    #       argv. Previous form did `sh -c 'RPK_PASS=$(cat); rpk
-    #       ... --password "$RPK_PASS"'` which leaked into rpk's argv
-    #       in-container.
-    # --password-stdin support: requires rpk v23+ (Redpanda image
-    # >= v23.x). Confirmed available on the pinned v24.3 image; an
-    # earlier attempt landed and was reverted in 7c3c530 (2026-04)
-    # because the then-bundled rpk was older.
+    #   (3) inside the container — curl reads the body from stdin with
+    #       `-d @-` and never reflects it into its own argv.
+    # The Admin API, not `rpk acl user create`. rpk has no
+    # `--password-stdin` flag -- measured against the image this stack
+    # actually runs:
+    #
+    #   $ docker run --rm --entrypoint rpk redpandadata/redpanda:v24.3.1 \
+    #       acl user create --help
+    #   --password string    New user's password
+    #
+    # A comment here previously claimed the flag was "confirmed
+    # available on the pinned v24.3 image". It is not: the run of
+    # 2026-09-06 failed with `unknown flag: --password-stdin`, leaving
+    # the broker without its SASL user while the workflow stayed green.
+    # The same flag had already been reverted once, in 7c3c530.
+    #
+    # `--password <value>` would work but puts the secret into rpk's
+    # argv inside the container. The Admin API keeps it off every
+    # process list: the JSON reaches `docker exec -i` on stdin and curl
+    # reads it with `-d @-`, so it is in no argv on the host, in
+    # docker's, or in the container.
+    #
+    # Semantics, measured on v24.3.1:
+    #   POST   /v1/security/users          new  -> 200
+    #                                      dup  -> 500 "User already exists"
+    #   PUT    /v1/security/users/<name>   ok   -> 200 (password updated)
+    #                                      gone -> 500 "User does not exist"
+    #
+    # Hence POST, then PUT on "already exists". That replaces the
+    # previous delete-then-recreate rotation, which opened a window with
+    # no SASL user at all -- the old comment called it "brief" and
+    # accepted it; PUT removes it.
     REDPANDA_PASSWORD={password_q}
     USER_EXISTED=false
-    USER_RESULT=$(printf '%s' "$REDPANDA_PASSWORD" | \\
-        docker exec -i redpanda rpk acl user create nexus-redpanda --password-stdin --mechanism SCRAM-SHA-256 2>&1 || echo "")
-    if echo "$USER_RESULT" | grep -qi 'already exists\\|user already\\|already in use'; then
-        # Rotation path: delete + recreate. Brief no-user window —
-        # acceptable because we just proved the broker is responsive.
-        # Without this branch, an Infisical password rotation would
-        # silently leave the broker out of sync.
-        USER_EXISTED=true
-        docker exec redpanda rpk acl user delete nexus-redpanda >/dev/null 2>&1 || true
-        USER_RESULT=$(printf '%s' "$REDPANDA_PASSWORD" | \\
-            docker exec -i redpanda rpk acl user create nexus-redpanda --password-stdin --mechanism SCRAM-SHA-256 2>&1 || echo "")
-        if ! echo "$USER_RESULT" | grep -qi 'created\\|added\\|success'; then
-            echo "  ⚠ rpk acl user create failed after delete (no SASL user — broker is now in a broken state): $USER_RESULT" >&2
+    RP_URL=http://localhost:9644/v1/security/users
+    RP_BODY=$(printf '{{"username":"nexus-redpanda","password":"%s","algorithm":"SCRAM-SHA-256"}}' "$REDPANDA_PASSWORD")
+    CREATE_CODE=$(printf '%s' "$RP_BODY" | docker exec -i redpanda \
+        curl -s -o /tmp/rp-user.out -w '%{{http_code}}' \
+             -X POST "$RP_URL" -H 'Content-Type: application/json' -d @- 2>/dev/null || echo "000")
+    CREATE_BODY=$(docker exec redpanda sh -c 'cat /tmp/rp-user.out 2>/dev/null' 2>/dev/null || echo "")
+    if [ "$CREATE_CODE" != "200" ]; then
+        if echo "$CREATE_BODY" | grep -qi 'already exists'; then
+            USER_EXISTED=true
+            UPDATE_CODE=$(printf '%s' "$RP_BODY" | docker exec -i redpanda \
+                curl -s -o /tmp/rp-user.out -w '%{{http_code}}' \
+                     -X PUT "$RP_URL/nexus-redpanda" -H 'Content-Type: application/json' -d @- 2>/dev/null || echo "000")
+            if [ "$UPDATE_CODE" != "200" ]; then
+                UPDATE_BODY=$(docker exec redpanda sh -c 'cat /tmp/rp-user.out 2>/dev/null' 2>/dev/null || echo "")
+                echo "  ⚠ Admin API could not update the nexus-redpanda password (HTTP $UPDATE_CODE): ${{UPDATE_BODY:-(no body)}}" >&2
+                echo "RESULT hook=redpanda status=failed"
+                return 0
+            fi
+        else
+            # 000 means curl never reached the endpoint, which is a
+            # different fault from the API rejecting the request. Say
+            # which rather than guessing.
+            echo "  ⚠ Admin API could not create the nexus-redpanda user (HTTP $CREATE_CODE): ${{CREATE_BODY:-(no body)}}" >&2
             echo "RESULT hook=redpanda status=failed"
             return 0
         fi
-    elif ! echo "$USER_RESULT" | grep -qi 'created\\|added\\|success'; then
-        echo "  ⚠ rpk acl user create failed: $USER_RESULT" >&2
-        echo "RESULT hook=redpanda status=failed"
-        return 0
     fi
     # rpk cluster config set: superusers list. Capture the result so
     # we can fail loudly — without this check, the user would have

--- a/src/nexus_deploy/services.py
+++ b/src/nexus_deploy/services.py
@@ -740,7 +740,17 @@ redpanda_hook() {{
     REDPANDA_PASSWORD={password_q}
     USER_EXISTED=false
     RP_URL=http://localhost:9644/v1/security/users
-    RP_BODY=$(printf '{{"username":"nexus-redpanda","password":"%s","algorithm":"SCRAM-SHA-256"}}' "$REDPANDA_PASSWORD")
+    # jq builds the JSON, not printf: a password containing a quote,
+    # a backslash or a newline would otherwise produce a malformed body
+    # and a confusing 400. `random_password.redpanda_admin` sets
+    # `special = false` today, so it cannot happen -- but that is a
+    # coupling between a .tf file and this one with nothing enforcing
+    # it, and jq is already used throughout this module.
+    #
+    # Password on stdin, not `jq --arg`: --arg would put it back into
+    # jq's argv inside the container, undoing the point of the pipe.
+    RP_BODY=$(printf '%s' "$REDPANDA_PASSWORD" \
+        | jq -Rsc '{{username:"nexus-redpanda",password:.,algorithm:"SCRAM-SHA-256"}}')
     CREATE_CODE=$(printf '%s' "$RP_BODY" | docker exec -i redpanda \
         curl -s -o /tmp/rp-user.out -w '%{{http_code}}' \
              -X POST "$RP_URL" -H 'Content-Type: application/json' -d @- 2>/dev/null || echo "000")
@@ -753,6 +763,13 @@ redpanda_hook() {{
                      -X PUT "$RP_URL/nexus-redpanda" -H 'Content-Type: application/json' -d @- 2>/dev/null || echo "000")
             if [ "$UPDATE_CODE" != "200" ]; then
                 UPDATE_BODY=$(docker exec redpanda sh -c 'cat /tmp/rp-user.out 2>/dev/null' 2>/dev/null || echo "")
+                # Mask the password before printing. The bodies observed
+                # from this API carry only a message and a code, but an
+                # error that echoed the request would put the secret in a
+                # public build log, and that is not a risk worth taking
+                # for a diagnostic. Bash parameter expansion, so the
+                # value never reaches sed's argv either.
+                UPDATE_BODY=${{UPDATE_BODY//"$REDPANDA_PASSWORD"/***}}
                 echo "  ⚠ Admin API could not update the nexus-redpanda password (HTTP $UPDATE_CODE): ${{UPDATE_BODY:-(no body)}}" >&2
                 echo "RESULT hook=redpanda status=failed"
                 return 0
@@ -761,6 +778,7 @@ redpanda_hook() {{
             # 000 means curl never reached the endpoint, which is a
             # different fault from the API rejecting the request. Say
             # which rather than guessing.
+            CREATE_BODY=${{CREATE_BODY//"$REDPANDA_PASSWORD"/***}}
             echo "  ⚠ Admin API could not create the nexus-redpanda user (HTTP $CREATE_CODE): ${{CREATE_BODY:-(no body)}}" >&2
             echo "RESULT hook=redpanda status=failed"
             return 0

--- a/src/nexus_deploy/services.py
+++ b/src/nexus_deploy/services.py
@@ -643,9 +643,10 @@ def render_redpanda_hook(config: NexusConfig, env: BootstrapEnv) -> str:
     (or ``failed`` / ``skipped-not-ready``); NO ``already-configured``
     path. Reasoning:
     - First run: create user → cluster config → restart → verify ✓
-    - Re-run with same Infisical password: rpk reports "already exists"
-      → delete + recreate (no broker restart, since SASL listener is
-      already on) → verify ✓ — ends in ``configured``, not
+    - Re-run with same Infisical password: POST reports "already
+      exists" → PUT updates it in place (no broker restart, since the
+      SASL listener is already on; and no delete, so there is never a
+      moment without a user) → verify ✓ — ends in ``configured``, not
       ``already-configured``, because we DID re-write state (the
       password was rotated to its current value, even if that
       happens to equal the previous value).
@@ -749,18 +750,18 @@ redpanda_hook() {{
     #
     # Password on stdin, not `jq --arg`: --arg would put it back into
     # jq's argv inside the container, undoing the point of the pipe.
-    RP_BODY=$(printf '%s' "$REDPANDA_PASSWORD" \
+    RP_BODY=$(printf '%s' "$REDPANDA_PASSWORD" \\
         | jq -Rsc '{{username:"nexus-redpanda",password:.,algorithm:"SCRAM-SHA-256"}}')
-    CREATE_CODE=$(printf '%s' "$RP_BODY" | docker exec -i redpanda \
-        curl -s -o /tmp/rp-user.out -w '%{{http_code}}' \
-             -X POST "$RP_URL" -H 'Content-Type: application/json' -d @- 2>/dev/null || echo "000")
+    CREATE_CODE=$(printf '%s' "$RP_BODY" | docker exec -i redpanda \\
+        curl -s -o /tmp/rp-user.out -w '%{{http_code}}' \\
+             -X POST "$RP_URL" -H 'Content-Type: application/json' --data-binary @- 2>/dev/null || echo "000")
     CREATE_BODY=$(docker exec redpanda sh -c 'cat /tmp/rp-user.out 2>/dev/null' 2>/dev/null || echo "")
     if [ "$CREATE_CODE" != "200" ]; then
         if echo "$CREATE_BODY" | grep -qi 'already exists'; then
             USER_EXISTED=true
-            UPDATE_CODE=$(printf '%s' "$RP_BODY" | docker exec -i redpanda \
-                curl -s -o /tmp/rp-user.out -w '%{{http_code}}' \
-                     -X PUT "$RP_URL/nexus-redpanda" -H 'Content-Type: application/json' -d @- 2>/dev/null || echo "000")
+            UPDATE_CODE=$(printf '%s' "$RP_BODY" | docker exec -i redpanda \\
+                curl -s -o /tmp/rp-user.out -w '%{{http_code}}' \\
+                     -X PUT "$RP_URL/nexus-redpanda" -H 'Content-Type: application/json' --data-binary @- 2>/dev/null || echo "000")
             if [ "$UPDATE_CODE" != "200" ]; then
                 UPDATE_BODY=$(docker exec redpanda sh -c 'cat /tmp/rp-user.out 2>/dev/null' 2>/dev/null || echo "")
                 # Mask the password before printing. The bodies observed

--- a/src/nexus_deploy/services.py
+++ b/src/nexus_deploy/services.py
@@ -728,6 +728,13 @@ redpanda_hook() {{
     # reads it with `-d @-`, so it is in no argv on the host, in
     # docker's, or in the container.
     #
+    # Both writes are bounded. `SSHClient.run_script` has no default
+    # timeout, so a broker that accepts the connection and then stops
+    # answering would hang the deploy with no upper limit. 3s/30s rather
+    # than the 2s/5s the readiness poll above uses: that one is a fast
+    # liveness probe run in a loop, these are single writes that may wait
+    # on a raft commit.
+    #
     # Semantics, measured on v24.3.1:
     #   POST   /v1/security/users          new  -> 200
     #                                      dup  -> 500 "User already exists"
@@ -754,6 +761,7 @@ redpanda_hook() {{
         | jq -Rsc '{{username:"nexus-redpanda",password:.,algorithm:"SCRAM-SHA-256"}}')
     CREATE_CODE=$(printf '%s' "$RP_BODY" | docker exec -i redpanda \\
         curl -s -o /tmp/rp-user.out -w '%{{http_code}}' \\
+             --connect-timeout 3 --max-time 30 \\
              -X POST "$RP_URL" -H 'Content-Type: application/json' --data-binary @- 2>/dev/null || true)
     # `|| true` plus a default, NOT `|| echo "000"`. curl already writes
     # 000 to stdout when it cannot connect AND exits non-zero, so the
@@ -769,6 +777,7 @@ redpanda_hook() {{
             USER_EXISTED=true
             UPDATE_CODE=$(printf '%s' "$RP_BODY" | docker exec -i redpanda \\
                 curl -s -o /tmp/rp-user.out -w '%{{http_code}}' \\
+                     --connect-timeout 3 --max-time 30 \\
                      -X PUT "$RP_URL/nexus-redpanda" -H 'Content-Type: application/json' --data-binary @- 2>/dev/null || true)
             UPDATE_CODE=${{UPDATE_CODE:-000}}
             if [ "$UPDATE_CODE" != "200" ]; then

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -2282,3 +2282,42 @@ def test_render_redpanda_hook_masks_the_password_in_error_output() -> None:
         assert f'{var}=${{{var}//"$REDPANDA_PASSWORD"/***}}' in script, (
             f"{var} is printed to stderr and must be masked first"
         )
+
+
+def test_render_redpanda_hook_emits_real_line_continuations() -> None:
+    """A single backslash in the f-string is eaten by Python, not bash.
+
+    Such a continuation renders as one long line with the indentation
+    folded in. Harmless for a command, but the same mistake on a `#`
+    comment line silently swallows whatever follows it -- a command that
+    then never runs, in a hook nobody reads again after it works once.
+
+    The fragment must end its line. Checking only that the line ends in
+    a backslash is not enough: a collapsed line still ends with the
+    backslash of the *next* continuation, so that weaker form passed
+    while the defect was present. Found by mutation, not by reading.
+    """
+    script = render_redpanda_hook(_make_config(), _make_env())
+
+    for fragment in ("| docker exec -i redpanda", "-w '%{http_code}'"):
+        hits = [line.rstrip() for line in script.splitlines() if fragment in line]
+        assert hits, f"fragment vanished from the hook: {fragment!r}"
+        for line in hits:
+            assert line.endswith(fragment + " \\"), (
+                "continuation collapsed -- Python ate the backslash, so the "
+                f"command folded onto one line: {line!r}"
+            )
+
+
+def test_render_redpanda_hook_uses_data_binary() -> None:
+    """`--data-binary @-`, the form used 21 times elsewhere in this module.
+
+    `-d @-` strips newlines from the payload. jq -Rsc emits compact JSON
+    so it makes no difference to this body today, but a body that ever
+    gains a newline would be silently altered, and the module already
+    settled on the safe form.
+    """
+    script = render_redpanda_hook(_make_config(), _make_env())
+    commands = "\n".join(line for line in script.splitlines() if not line.lstrip().startswith("#"))
+    assert commands.count("--data-binary @-") == 2, "both the POST and the PUT"
+    assert "-d @-" not in commands

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -321,7 +321,7 @@ def test_render_redpanda_hook_basic() -> None:
     # Wait via docker exec curl (admin API not exposed externally)
     assert "docker exec redpanda curl" in script
     # rpk SASL user create + cluster config
-    assert "rpk acl user create nexus-redpanda" in script
+    assert '-X POST "$RP_URL"' in script
     assert "rpk cluster config set superusers" in script
     # Verify via /v1/security/users
     assert "/v1/security/users" in script
@@ -347,7 +347,7 @@ def test_render_redpanda_hook_password_via_stdin_not_argv() -> None:
         if "docker exec -e" in line:
             assert canary not in line, f"Password leaked into docker exec -e argv: {line!r}"
     # Pipe-to-stdin form must be present
-    assert "printf '%s' \"$REDPANDA_PASSWORD\" |" in script
+    assert "printf '%s' \"$RP_BODY\" | docker exec -i redpanda" in script
     assert "docker exec -i redpanda" in script
 
 
@@ -376,31 +376,61 @@ def test_render_redpanda_hook_uses_curl_dash_f_for_status_check() -> None:
     assert script.count("curl -sf") >= 3  # initial wait + post-restart wait + verify
 
 
-def test_render_redpanda_hook_password_rotation_via_create_first_then_delete() -> None:
-    """Round-1 + round-2 findings: rotation must propagate. A previous
-    naive implementation never synced the password on a second run, so
-    Infisical rotation silently broke clients. The current pattern is
-    try-create-first; only delete + recreate IF create reports "already
-    exists" (the rotation case). The delete is gated on the broker
-    proving it's responsive — a transient broker glitch on the first
-    create returns failed without touching state. Round-2 specifically
-    flagged delete-before-prove as a real bug — broker could be
-    left with no SASL user if create failed transiently.
+def test_render_redpanda_hook_rotation_updates_without_deleting() -> None:
+    """Rotation must propagate, and must not open a window with no user.
+
+    History: a naive first version never synced the password on a second
+    run, so an Infisical rotation silently broke clients. The fix was
+    try-create-first, then delete + recreate on "already exists" — which
+    left a brief moment with no SASL user, accepted at the time as the
+    price of rotating.
+
+    The Admin API removes that trade. Measured on v24.3.1: POST returns
+    500 "User already exists" on a duplicate, and PUT updates the
+    password in place. So the delete is gone, and its absence is the
+    property worth pinning — a future edit reintroducing it would
+    reintroduce the window.
     """
     script = render_redpanda_hook(_make_config(), _make_env())
-    # Try-create-first happens BEFORE any delete
-    create_idx = script.find("rpk acl user create nexus-redpanda")
-    delete_idx = script.find("rpk acl user delete nexus-redpanda")
-    assert create_idx >= 0, "rpk acl user create must be in script"
-    assert delete_idx >= 0, "rpk acl user delete must be in script"
-    assert create_idx < delete_idx, (
-        "create-attempt must come BEFORE delete (no delete-before-prove)"
+
+    assert "rpk acl user delete" not in script, (
+        "the rotation path must not delete the user: PUT updates the "
+        "password in place, and a delete reopens the no-user window"
     )
-    # The delete is gated on "already exists" branch
+    create_idx = script.find('-X POST "$RP_URL"')
+    update_idx = script.find('-X PUT "$RP_URL/nexus-redpanda"')
+    assert create_idx >= 0, "POST must create the user"
+    assert update_idx >= 0, "PUT must handle the rotation case"
+    assert create_idx < update_idx, "PUT is only reached after POST reports a duplicate"
     assert "already exists" in script
-    # Tracked via USER_EXISTED so restart can be skipped on rotation
     assert "USER_EXISTED=true" in script
     assert "USER_EXISTED=false" in script
+
+
+def test_render_redpanda_hook_does_not_use_password_stdin() -> None:
+    """`rpk acl user create` has no --password-stdin flag.
+
+    Measured against the image this stack runs:
+
+        $ docker run --rm --entrypoint rpk \
+              redpandadata/redpanda:v24.3.1 acl user create --help
+        --password string    New user's password
+
+    A comment in the hook once claimed the flag was "confirmed available
+    on the pinned v24.3 image"; the deploy of 2026-09-06 failed with
+    `unknown flag: --password-stdin` and the broker was left without its
+    SASL user. The same flag had already been reverted once in 7c3c530.
+    Twice is enough to pin it.
+    """
+    script = render_redpanda_hook(_make_config(), _make_env())
+
+    # Comment lines are stripped first. The hook explains at length why
+    # the flag is not used, so a naive substring check would match its
+    # own explanation -- the same trap the workflow guardrails hit when
+    # they read prose as if it were a command.
+    commands = "\n".join(line for line in script.splitlines() if not line.lstrip().startswith("#"))
+    assert "--password-stdin" not in commands
+    assert "rpk acl user create" not in commands
 
 
 def test_render_redpanda_hook_cluster_config_set_failure_propagates() -> None:

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -2344,3 +2344,19 @@ def test_render_redpanda_hook_does_not_double_the_transport_code() -> None:
         assert f"{var}=${{{var}:-000}}" in commands, (
             f"{var} must default to 000 rather than appending a second one"
         )
+
+
+def test_render_redpanda_hook_bounds_both_admin_api_writes() -> None:
+    """Both writes carry a connect and a total timeout.
+
+    `SSHClient.run_script` takes `timeout: float | None = None` and the
+    services-configure phase does not pass one, so a broker that accepts
+    the connection and then stops answering would hang the deploy with no
+    upper bound. The readiness poll in this same hook is already bounded
+    at 2s/5s; the writes were the exception.
+    """
+    script = render_redpanda_hook(_make_config(), _make_env())
+    commands = "\n".join(line for line in script.splitlines() if not line.lstrip().startswith("#"))
+    assert commands.count("--connect-timeout 3 --max-time 30") == 2, (
+        "both the POST and the PUT must be bounded"
+    )

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -2346,6 +2346,27 @@ def test_render_redpanda_hook_does_not_double_the_transport_code() -> None:
         )
 
 
+def _fold_continuations(script: str) -> list[str]:
+    """Join backslash-continued physical lines, then drop comments.
+
+    Each Admin API call renders as four physical lines held together by
+    a trailing `\\`. An assertion that needs to know *which* request
+    carries a fragment has to see the whole command as one string.
+    """
+    folded: list[str] = []
+    buffer = ""
+    for line in script.splitlines():
+        stripped = line.rstrip()
+        if stripped.endswith("\\"):
+            buffer += stripped[:-1].rstrip() + " "
+            continue
+        folded.append(buffer + stripped.strip() if buffer else stripped)
+        buffer = ""
+    if buffer:
+        folded.append(buffer)
+    return [line for line in folded if not line.lstrip().startswith("#")]
+
+
 def test_render_redpanda_hook_bounds_both_admin_api_writes() -> None:
     """Both writes carry a connect and a total timeout.
 
@@ -2356,7 +2377,19 @@ def test_render_redpanda_hook_bounds_both_admin_api_writes() -> None:
     at 2s/5s; the writes were the exception.
     """
     script = render_redpanda_hook(_make_config(), _make_env())
-    commands = "\n".join(line for line in script.splitlines() if not line.lstrip().startswith("#"))
-    assert commands.count("--connect-timeout 3 --max-time 30") == 2, (
-        "both the POST and the PUT must be bounded"
-    )
+    timeout = "--connect-timeout 3 --max-time 30"
+    lines = _fold_continuations(script)
+    for label, marker in (
+        ("POST", '-X POST "$RP_URL"'),
+        ("PUT", '-X PUT "$RP_URL/nexus-redpanda"'),
+    ):
+        matching = [line for line in lines if marker in line]
+        assert len(matching) == 1, (
+            f"expected exactly one {label} to the Admin API, found {len(matching)}"
+        )
+        # Per request, not across the script: counting the fragment in
+        # the whole hook stayed green when both timeouts sat on the POST
+        # and the PUT had none.
+        assert matching[0].count(timeout) == 1, (
+            f"the {label} must carry exactly one {timeout!r}, got: {matching[0]}"
+        )

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -2242,3 +2242,43 @@ def test_render_wikijs_hook_default_separator_is_dot_form_unchanged() -> None:
     config = _make_config(wikijs_admin_password="pw")
     script = render_wikijs_hook(config, env)
     assert shlex.quote("https://wiki.example.com") in script
+
+
+def test_render_redpanda_hook_builds_json_with_jq_not_printf() -> None:
+    """A password with a quote must not produce a malformed request body.
+
+    `random_password.redpanda_admin` sets `special = false`, so today the
+    value is alphanumeric and printf would be safe. That is a coupling
+    between a .tf file and this one with nothing enforcing it, and the
+    failure mode -- a 400 from a body the reader cannot see -- is
+    unpleasant to debug.
+
+    The password goes to jq on stdin rather than through `--arg`, which
+    would put it back into jq's argv inside the container and undo the
+    reason the whole hook pipes it.
+    """
+    script = render_redpanda_hook(_make_config(), _make_env())
+    # Comment lines stripped first: the hook explains why --arg is wrong,
+    # and a plain substring check matches its own explanation. Third time
+    # that trap has been hit in this repo, hence the note.
+    commands = "\n".join(line for line in script.splitlines() if not line.lstrip().startswith("#"))
+
+    assert "jq -Rsc" in commands
+    assert "jq --arg" not in commands, "--arg puts the password in jq's argv"
+    assert 'printf \'{"username"' not in commands, "the body must not be built by printf"
+
+
+def test_render_redpanda_hook_masks_the_password_in_error_output() -> None:
+    """Diagnostics must not be able to print the password.
+
+    The bodies this API returns carry only a message and a code, so this
+    is precaution rather than an observed leak — but the logs are public
+    and CLAUDE.md's rule is absolute. Bash parameter expansion is used so
+    the value never reaches sed's argv either.
+    """
+    script = render_redpanda_hook(_make_config(), _make_env())
+
+    for var in ("CREATE_BODY", "UPDATE_BODY"):
+        assert f'{var}=${{{var}//"$REDPANDA_PASSWORD"/***}}' in script, (
+            f"{var} is printed to stderr and must be masked first"
+        )

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -2358,23 +2358,46 @@ def test_render_redpanda_hook_never_attributes_a_stale_body_to_a_new_request() -
         HTTP 000: {"message":"User already exists"}
 
     naming a conflict that never happened, while the real fault was that
-    nothing answered. Two defences, both asserted here:
+    nothing answered. Four defences, all asserted here:
 
-    1. Every read of the response file deletes it in the same exec, so
-       no body can outlive the request that produced it.
-    2. The "already exists" branch is gated on a real HTTP status. At
-       000 there is no response to interpret.
+    1. The response path is unique per invocation. `spin-up.yml` has no
+       `concurrency:` group, so two runs really can reach this hook at
+       once and a shared path would cross their responses.
+    2. Every request clears the file first — consume-after-read alone is
+       not enough, because a deploy interrupted between the write and the
+       read never reaches the delete.
+    3. Every read consumes the file in the same exec, so no body outlives
+       the request that produced it.
+    4. The "already exists" branch is gated on a real HTTP status. At 000
+       there is no response to interpret.
     """
     script = render_redpanda_hook(_make_config(), _make_env())
     lines = _fold_continuations(script)
 
-    # Path inside the RedPanda container, never opened by this process.
-    response_file = "/tmp/rp-user.out"  # noqa: S108 — remote path, not a local temp file
-    reads = [line for line in lines if response_file in line and "cat " in line]
-    assert len(reads) == 2, f"expected the create and update reads, found {len(reads)}"
-    for read in reads:
-        assert f"rm -f {response_file}" in read, (
-            f"the response file must be consumed, not just read: {read.strip()}"
+    path_assignments = [line for line in lines if line.strip().startswith("RP_OUT=")]
+    assert len(path_assignments) == 1, (
+        f"expected one response-path assignment, found {len(path_assignments)}"
+    )
+    assert "$$" in path_assignments[0], (
+        "the response path must be unique per invocation — two concurrent "
+        f"runs would otherwise share it: {path_assignments[0].strip()}"
+    )
+
+    reads = [line for line in lines if "cat " in line and "$RP_OUT" in line]
+    assert len(reads) == 1, f"expected one read helper, found {len(reads)}"
+    assert "rm -f $RP_OUT" in reads[0] or 'rm -f "$RP_OUT"' in reads[0], (
+        f"the response file must be consumed, not just read: {reads[0].strip()}"
+    )
+    calls = [line for line in lines if "rp_read_response" in line and "=$(" in line]
+    assert len(calls) == 2, f"expected the create and update reads, found {len(calls)}"
+
+    requests = [i for i, line in enumerate(lines) if "-X POST" in line or "-X PUT" in line]
+    assert len(requests) == 2, f"expected two Admin API requests, found {len(requests)}"
+    for index in requests:
+        preceding = lines[max(0, index - 4) : index]
+        assert any("rp_clear_response" in line for line in preceding), (
+            "each request must clear the response file first; nothing clears "
+            f"before: {lines[index].strip()}"
         )
 
     guard = [line for line in lines if "already exists" in line and "grep" in line]

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -2321,3 +2321,26 @@ def test_render_redpanda_hook_uses_data_binary() -> None:
     commands = "\n".join(line for line in script.splitlines() if not line.lstrip().startswith("#"))
     assert commands.count("--data-binary @-") == 2, "both the POST and the PUT"
     assert "-d @-" not in commands
+
+
+def test_render_redpanda_hook_does_not_double_the_transport_code() -> None:
+    """`|| echo "000"` after a `-w '%{http_code}'` curl yields `000000`.
+
+    curl writes 000 to stdout when it cannot connect *and* exits
+    non-zero, so the echo appends a second 000. The hook prints the code
+    in its diagnostic, so the message would read "HTTP 000000" while the
+    comment beside it explains what 000 means.
+
+    CLAUDE.md names this trap, and notes that the `|| echo "000"` form
+    used elsewhere in this module is harmless only because those call
+    sites compare the value against a success code instead of printing
+    it. Copied without that audit, it becomes this.
+    """
+    script = render_redpanda_hook(_make_config(), _make_env())
+    commands = "\n".join(line for line in script.splitlines() if not line.lstrip().startswith("#"))
+
+    assert '|| echo "000"' not in commands
+    for var in ("CREATE_CODE", "UPDATE_CODE"):
+        assert f"{var}=${{{var}:-000}}" in commands, (
+            f"{var} must default to 000 rather than appending a second one"
+        )

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -2346,6 +2346,44 @@ def test_render_redpanda_hook_does_not_double_the_transport_code() -> None:
         )
 
 
+def test_render_redpanda_hook_never_attributes_a_stale_body_to_a_new_request() -> None:
+    """A transport failure must not inherit the previous response.
+
+    `curl -o FILE` does not truncate FILE when it never reaches the
+    server. Measured inside redpandadata/redpanda:v24.3.1 (curl 7.88.1):
+    a PUT to a closed port exits non-zero, writes 000, and leaves the
+    earlier body untouched. So a broker that died between the POST and
+    the PUT would have reported
+
+        HTTP 000: {"message":"User already exists"}
+
+    naming a conflict that never happened, while the real fault was that
+    nothing answered. Two defences, both asserted here:
+
+    1. Every read of the response file deletes it in the same exec, so
+       no body can outlive the request that produced it.
+    2. The "already exists" branch is gated on a real HTTP status. At
+       000 there is no response to interpret.
+    """
+    script = render_redpanda_hook(_make_config(), _make_env())
+    lines = _fold_continuations(script)
+
+    # Path inside the RedPanda container, never opened by this process.
+    response_file = "/tmp/rp-user.out"  # noqa: S108 — remote path, not a local temp file
+    reads = [line for line in lines if response_file in line and "cat " in line]
+    assert len(reads) == 2, f"expected the create and update reads, found {len(reads)}"
+    for read in reads:
+        assert f"rm -f {response_file}" in read, (
+            f"the response file must be consumed, not just read: {read.strip()}"
+        )
+
+    guard = [line for line in lines if "already exists" in line and "grep" in line]
+    assert len(guard) == 1, f"expected one 'already exists' branch, found {len(guard)}"
+    assert '"$CREATE_CODE" != "000"' in guard[0], (
+        f"the rotation branch must require a real HTTP response, not 000: {guard[0].strip()}"
+    )
+
+
 def _fold_continuations(script: str) -> list[str]:
     """Join backslash-continued physical lines, then drop comments.
 


### PR DESCRIPTION
Found by reading the logs of a spin-up that reported success.

## Local CodeRabbit round

Reviewed the first commit — **2 findings, both valid, fixed in `a8dc667`**: build the JSON with jq rather than printf, and mask the password before printing an error body. Detail at the bottom.

## What broke

Run [34037896870](https://github.com/stefanko-ch/Nexus-Stack/actions/runs/34037896870), 2026-09-06, `Deploy stacks`:

```
⚠ rpk acl user create failed: Error: unknown flag: --password-stdin
⚠ services-configure: partial — configured=1 … failed=1 (redpanda)
```

The broker came up **without its SASL user**, and the workflow was green: `services-configure` reports `partial` and carries on.

`rpk acl user create` has no `--password-stdin`. Measured against the image this stack actually runs:

```
$ docker run --rm --entrypoint rpk redpandadata/redpanda:v24.3.1 acl user create --help
      --mechanism string   SASL mechanism to use for the user you are creating
      --password string    New user's password
```

A comment in the hook asserted it was *"confirmed available on the pinned v24.3 image"*. It is not — and the same flag had **already been reverted once, in `7c3c530`**, for the same reason. Twice is enough to pin it with a test.

## Why not just use `--password`

It works, and it puts the secret into rpk's argv inside the container. That is precisely what this module's stdin discipline exists to prevent — the header comment spends a paragraph on the three process-list surfaces.

The Admin API keeps it off all three: the JSON reaches `docker exec -i` on stdin and curl reads it with `-d @-`.

## Semantics, measured rather than assumed

Against a live v24.3.1 broker:

| Request | Result |
|---|---|
| `POST /v1/security/users` — new user | **200** |
| `POST` — user exists | **500** `"User already exists"` |
| `PUT /v1/security/users/<name>` — exists | **200**, password updated |
| `PUT` — user missing | **500** `"User does not exist"` |
| `DELETE /v1/security/users/<name>` | **200** |

So: POST, and fall through to PUT on *"already exists"*.

**That removes the delete.** The previous rotation did delete-then-recreate, and its own comment conceded a *"brief no-user window — acceptable because we just proved the broker is responsive"*. PUT updates in place, so the window is gone rather than justified. The rotation test now pins the **absence** of a delete, because a future edit reintroducing one would reintroduce the window.

## Three descriptions that became false

Changing the mechanism invalidated the module header, the hook docstring and the in-script comment — all three still described rpk reading the password from stdin. Corrected here rather than left to rot.

## The review findings

**jq, not printf.** A password containing `"`, `\` or a newline would have produced a malformed body and a 400 nobody can read. `random_password.redpanda_admin` sets `special = false`, so it cannot happen today — but that is a coupling between a `.tf` file and a `.py` file with nothing enforcing it. Verified:

```
mit"quote    -> "password":"mit\"quote"
back\slash   -> "password":"back\\slash"
newline      -> "password":"zeilen\numbruch"
```

The password reaches jq on **stdin**, not through `--arg`, which would put it back into jq's argv and undo the point of the pipe.

**Error bodies are masked.** The bodies this API returns carry only a message and a code, so this is precaution rather than an observed leak — but build logs are public. Bash parameter expansion, so the value never reaches `sed`'s argv either.

## Tests

Four, all mutation-tested: reintroducing the delete, reintroducing the rpk call, swapping `jq -Rsc` for `--arg`, and removing the masking each fail.

Two of them strip comment lines before searching. The hook explains at length why `--password-stdin` and `--arg` are wrong, and a plain substring check matched its own explanation — the third time in this repo that a check has read prose as if it were a command, so the tests now say so.

## Testing on a stack

Redpanda is already enabled, so a spin-up on this branch exercises it directly:

```bash
gh workflow run spin-up.yml --ref fix/redpanda-user-create
```

What to look for in `Deploy stacks`: `services-configure: ok` with no `failed=1 (redpanda)`. Then on the server, `docker exec redpanda rpk acl user list` must show `nexus-redpanda`.

Worth exercising the rotation path too, since it is the half that changed most: run the spin-up twice. The second run takes the PUT branch and must still report `configured`.

## Summary by Sourcery

Create and rotate the RedPanda SASL user through the Admin API so deployments reliably configure credentials without exposing passwords or interrupting service.

Bug Fixes:
- Create and rotate the RedPanda SASL user through the Admin API, avoiding the unsupported rpk stdin flag and preventing deployments from succeeding without the required user.
- Update existing RedPanda users in place instead of deleting and recreating them, eliminating the temporary no-user window during password rotation.

Enhancements:
- Keep RedPanda credentials out of process arguments, construct request bodies safely, mask passwords in diagnostics, and bound Admin API requests with timeouts.
- Improve response handling so transport failures cannot reuse stale bodies or be mistaken for API responses.

Documentation:
- Update RedPanda hook documentation and comments to describe Admin API-based user creation, rotation, and credential-handling behavior.

Tests:
- Expand unit coverage for Admin API creation and rotation, secure password handling, response isolation, request timeouts, and prevention of regressions to the unsupported rpk workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved RedPanda user setup compatibility with the pinned image.
  * Existing users can now have their passwords updated without deletion and recreation.
  * Passwords remain protected from command-line and process listings.
  * Error diagnostics now mask sensitive password information.
  * User creation and password updates now use a more reliable API-based workflow.
  * Added request timeouts and clearer reporting for failed setup operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->