### PR TITLE
docs(stacks): Explain why the Nussknacker metrics button 404s

### DIFF
--- a/docs/stacks/nussknacker.md
+++ b/docs/stacks/nussknacker.md
@@ -92,6 +92,36 @@ Verified against 1.18.1: with these set, the same endpoint answers 200 with `{"R
 
 One log line is a false lead if you go looking. `ReloadableProcessingTypeDataProvider - New state with processing types []` appears at startup **whether or not** the categories resolve — it is printed on the working container too. The API endpoint above is the signal that actually distinguishes the two states.
 
+### Metrics are not wired up
+
+The **metrics** button on a deployed scenario leads to a Nussknacker 404. That is expected in this deployment, and it is not one missing setting but three.
+
+**1. The link points at a path that does not exist here.** The shipped config builds it from a `grafanaUrl` that defaults to a relative path:
+
+```text
+grafanaUrl: "/grafana"
+grafanaUrl: ${?GRAFANA_URL}
+metricsSettings.url: ${grafanaUrl}"/d/$dashboard?theme=dark&var-scenarioName=$scenarioName&var-env="${environment}
+```
+
+`/grafana` assumes something proxies Grafana under the Designer's own host, which is what Nussknacker's quickstart does with nginx. Here [Grafana](grafana.md) lives at its own subdomain, so the link resolves against `nussknacker.<domain>` and finds nothing.
+
+**2. There is no dashboard to point at.** The default is `nussknacker-scenario`; this project's Grafana does not ship it.
+
+**3. There is nothing to display.** Two log lines at startup say so:
+
+```text
+Error while parsing influx configuration: requirement failed:
+URL should be absolute, but got '/write'. InfluxDb Reported will be disabled.
+Influxdb metrics reporter config not found
+```
+
+`countsSettings.influxUrl` needs `INFLUXDB_URL`, which is unset — and more fundamentally, `stacks/flink` configures **no metrics reporter at all**, so Flink emits nothing for a store to collect.
+
+Setting `GRAFANA_URL` alone would only move the dead end from Nussknacker's 404 to Grafana's. Doing it properly means a Flink metrics reporter, a store to receive it ([InfluxDB](influxdb.md) is deployed and could serve), a Grafana datasource and a dashboard — a separate change, tracked in its own issue rather than smuggled into a stack addition.
+
+Scenario **deployment and execution do not depend on any of this**: verified with a `periodic → dead-end` scenario reaching `RUNNING` on Flink while metrics were entirely absent.
+
 ### One container, no companion database
 
 The Designer keeps its state — users, scenarios, deployment history — in an embedded HSQLDB under `/opt/nussknacker/storage`, created on first boot and migrated by Flyway. No PostgreSQL companion is deployed.


### PR DESCRIPTION
## Summary

The **metrics** button on a deployed Nussknacker scenario leads to a 404. This documents why, measured on the running stack after #794 rather than reasoned from the config.

It is three independent gaps, not one missing setting:

1. **The link points at a path that does not exist here.** `grafanaUrl` defaults to the relative `/grafana`, which assumes something proxies Grafana under the Designer's own host — Nussknacker's quickstart does that with nginx. Here Grafana has its own subdomain, so the URL resolves against `nussknacker.<domain>` and finds nothing.
2. **There is no dashboard to point at.** The default is `nussknacker-scenario`; this project's Grafana does not ship it.
3. **There is nothing to display.** `countsSettings.influxUrl` needs `INFLUXDB_URL`, which is unset — and `stacks/flink` configures no metrics reporter at all, verified with `grep -iE "metrics.reporter|influx" /opt/flink/conf/*.yaml` returning nothing.

## Why documentation rather than a fix

Setting `GRAFANA_URL` alone would move the dead end from Nussknacker's 404 to Grafana's "dashboard not found". A real fix needs a Flink metrics reporter, a store, a datasource and a dashboard — two of those in stacks the Nussknacker addition never touched, each needing its own deploy test. Tracked in #799, which also records an open question nobody had asked yet: this project's InfluxDB is 2.x while Nussknacker's config speaks the 1.x `/write` and `/query` endpoints.

## What the section says explicitly

That deployment and execution do **not** depend on any of this — verified with a `periodic` to `dead-end` scenario reaching `RUNNING` on Flink 1.20.1 while metrics were entirely absent. Without that sentence the missing link reads as a broken stack, which is exactly the mistake this stack already produced once: it ran `healthy` for eight minutes while no scenario could be created at all.

## Local CodeRabbit round

Skipped, and saying so plainly rather than implying one happened: this is a single documentation commit describing measurements already reported in the #794 discussion.

## Testing

No infrastructure change. Docs only.

Relates to #799

## Summary by Sourcery

Document the current Nussknacker metrics limitations and distinguish them from scenario execution health.

Enhancements:
- Document why the deployed Nussknacker metrics link returns 404, covering the missing Grafana route, dashboard, and metrics pipeline.
- Clarify that scenario deployment and execution remain independent of the unavailable metrics integration.

Documentation:
- Add stack documentation explaining the Nussknacker metrics integration gaps and why configuring only the Grafana URL would not provide working metrics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance clarifying that Nussknacker metrics and the default Grafana dashboard are unavailable.
  - Documented the current absence of an InfluxDB/Flink metrics pipeline.
  - Confirmed that deployment and execution remain unaffected.
  - Listed the components needed to enable complete metrics support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->