### PR TITLE
fix(deploy): Stop restarting RedPanda on every spin-up

### DIFF
--- a/src/nexus_deploy/services.py
+++ b/src/nexus_deploy/services.py
@@ -661,10 +661,16 @@ def render_redpanda_hook(config: NexusConfig, env: BootstrapEnv) -> str:
     existing state — and there is no point at which the broker has no
     SASL user.
 
-    Restart of the broker happens ONLY on first setup
-    (``USER_EXISTED=false``). Subsequent rotations don't need it
-    because the SASL listener config is a one-time broker-side
-    setting; only the credentials change. Restart failure is
+    Restart of the broker happens ONLY on first setup, and
+    ``USER_EXISTED`` is established by asking the broker
+    (``GET /v1/security/users``) rather than by reading the create's
+    status code. That distinction is the whole point: ``POST`` answers
+    200 both for a new user and for a re-create with an unchanged
+    password, so inferring from it made every re-deploy look like a
+    first install and restarted the broker each time — which this
+    paragraph used to deny. Subsequent rotations genuinely don't need a
+    restart, because the SASL listener config is a one-time broker-side
+    setting and only the credentials change. Restart failure is
     surfaced as ``failed`` (legacy ``|| true`` hid this — listener
     not picking up the SASL change is broken-but-silent).
     """
@@ -736,19 +742,40 @@ redpanda_hook() {{
     # liveness probe run in a loop, these are single writes that may wait
     # on a raft commit.
     #
-    # Semantics, measured on v24.3.1:
-    #   POST   /v1/security/users          new  -> 200
-    #                                      dup  -> 500 "User already exists"
-    #   PUT    /v1/security/users/<name>   ok   -> 200 (password updated)
-    #                                      gone -> 500 "User does not exist"
+    # Semantics, measured against a live v24.3.1 broker. The middle row
+    # is the one that matters and the one an earlier version of this
+    # comment omitted:
+    #
+    #   POST /v1/security/users        user absent               -> 200
+    #                                  present, same password    -> 200
+    #                                  present, changed password -> 500 "User already exists"
+    #   PUT  /v1/security/users/<name> present                   -> 200 (password updated)
+    #                                  absent                    -> 500 "User does not exist"
     #
     # Hence POST, then PUT on "already exists". That replaces the
     # previous delete-then-recreate rotation, which opened a window with
     # no SASL user at all -- the old comment called it "brief" and
     # accepted it; PUT removes it.
     REDPANDA_PASSWORD={password_q}
-    USER_EXISTED=false
     RP_URL=http://localhost:9644/v1/security/users
+    # Ask the broker, rather than inferring existence from the create's
+    # status code. Because POST answers 200 both for a fresh user and for
+    # an unchanged re-create, a re-deploy with the same Infisical password
+    # is indistinguishable from a first install -- so USER_EXISTED stayed
+    # false and the broker was restarted on EVERY spin-up, while the
+    # docstring promised a restart only on first setup. Observed on
+    # 2026-09-06: compose reported `Container redpanda Running` (untouched)
+    # and the container's StartedAt still moved into the configure phase.
+    #
+    # `|| true` is right here: a broker that cannot answer this GET cannot
+    # answer the write on the next line either, and that one reports
+    # properly. A failed GET leaves the flag false, which costs an
+    # unnecessary restart and nothing else.
+    USER_EXISTED=false
+    if docker exec redpanda curl -s --connect-timeout 3 --max-time 15 "$RP_URL" 2>/dev/null \
+        | grep -q '"nexus-redpanda"'; then
+        USER_EXISTED=true
+    fi
     # jq builds the JSON, not printf: a password containing a quote,
     # a backslash or a newline would otherwise produce a malformed body
     # and a confusing 400. `random_password.redpanda_admin` sets

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -2407,6 +2407,54 @@ def test_render_redpanda_hook_never_attributes_a_stale_body_to_a_new_request() -
     )
 
 
+def test_render_redpanda_hook_asks_the_broker_whether_the_user_exists() -> None:
+    """The restart gate must not be inferred from the create's status.
+
+    Measured against a live v24.3.1 broker: `POST /v1/security/users`
+    answers 200 both for a new user and for a re-create with an
+    unchanged password, and only returns 500 "User already exists" when
+    the password differs. So a re-deploy with the same Infisical
+    password is indistinguishable from a first install if you read the
+    create's code — `USER_EXISTED` stayed false and the broker was
+    restarted on every spin-up.
+
+    Observed in production on 2026-09-06: compose reported
+    `Container redpanda Running`, having left the container alone, while
+    its StartedAt moved into the services-configure window.
+
+    The flag must therefore come from a GET, and it must be established
+    before the create runs.
+    """
+    script = render_redpanda_hook(_make_config(), _make_env())
+    lines = _fold_continuations(script)
+
+    probes = [
+        i
+        for i, line in enumerate(lines)
+        if "$RP_URL" in line and '"nexus-redpanda"' in line and "grep" in line
+    ]
+    assert len(probes) == 1, (
+        f"expected one existence probe against the users endpoint, found {len(probes)}"
+    )
+
+    assignments = [i for i, line in enumerate(lines) if line.strip() == "USER_EXISTED=true"]
+    assert assignments, "nothing ever sets USER_EXISTED=true"
+    assert any(i > probes[0] for i in assignments), "the probe must be what sets the flag"
+
+    creates = [i for i, line in enumerate(lines) if "-X POST" in line]
+    assert len(creates) == 1, f"expected one create, found {len(creates)}"
+    assert probes[0] < creates[0], (
+        "the probe must run before the create — inferring existence from the "
+        "create's status code is the defect this guards"
+    )
+
+    restarts = [i for i, line in enumerate(lines) if "compose" in line and "restart" in line]
+    assert restarts, "no restart found; has the hook changed shape?"
+    assert all(i > probes[0] for i in restarts), (
+        "the restart decision must come after the probe that informs it"
+    )
+
+
 def _fold_continuations(script: str) -> list[str]:
     """Join backslash-continued physical lines, then drop comments.
 

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -2437,15 +2437,22 @@ def test_render_redpanda_hook_asks_the_broker_whether_the_user_exists() -> None:
         f"expected one existence probe against the users endpoint, found {len(probes)}"
     )
 
-    assignments = [i for i, line in enumerate(lines) if line.strip() == "USER_EXISTED=true"]
-    assert assignments, "nothing ever sets USER_EXISTED=true"
-    assert any(i > probes[0] for i in assignments), "the probe must be what sets the flag"
-
     creates = [i for i, line in enumerate(lines) if "-X POST" in line]
     assert len(creates) == 1, f"expected one create, found {len(creates)}"
     assert probes[0] < creates[0], (
         "the probe must run before the create — inferring existence from the "
         "create's status code is the defect this guards"
+    )
+
+    assignments = [i for i, line in enumerate(lines) if line.strip() == "USER_EXISTED=true"]
+    assert assignments, "nothing ever sets USER_EXISTED=true"
+    # Between the probe and the create, not merely after the probe. The
+    # POST-conflict branch sets this flag too, so "any assignment later
+    # than the probe" is satisfied even by a hook that never wires the
+    # probe to anything at all.
+    assert any(probes[0] < i < creates[0] for i in assignments), (
+        "the GET branch must be what sets the flag; the only assignments "
+        "found belong to the create-conflict path"
     )
 
     restarts = [i for i, line in enumerate(lines) if "compose" in line and "restart" in line]

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -2441,12 +2441,16 @@ def test_render_redpanda_hook_asks_the_broker_whether_the_user_exists() -> None:
     assert len(probes) == 1, (
         f"expected one existence probe against the users endpoint, found {len(probes)}"
     )
-    # A GET, and specifically not a write. curl defaults to GET, so the
-    # check is that nothing overrides it: a probe that had become a POST
-    # would satisfy every other assertion here while creating the very
-    # user it claims to be looking for.
-    assert "-X " not in lines[probes[0]], (
-        f"the probe must not override curl's GET: {lines[probes[0]].strip()}"
+    # The whole curl invocation, not a list of options to forbid. Rejecting
+    # `-X ` alone let `--request POST`, `-d`, `--data`, `--form` and every
+    # other body-or-method option straight through — a probe silently turned
+    # into a write would satisfy every other assertion here while creating
+    # the very user it claims to be looking for.
+    probe = lines[probes[0]]
+    invocation = re.search(r"curl\b.*?(?=\s+2>/dev/null)", probe)
+    assert invocation is not None, f"no curl invocation found in the probe: {probe.strip()}"
+    assert invocation.group(0) == 'curl -s --connect-timeout 3 --max-time 15 "$RP_URL"', (
+        f"the probe must be exactly this read-only GET, got: {invocation.group(0)}"
     )
 
     creates = [i for i, line in enumerate(lines) if "-X POST" in line]

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -2428,6 +2428,11 @@ def test_render_redpanda_hook_asks_the_broker_whether_the_user_exists() -> None:
     script = render_redpanda_hook(_make_config(), _make_env())
     lines = _fold_continuations(script)
 
+    urls = [line.strip() for line in lines if line.strip().startswith("RP_URL=")]
+    assert urls == ["RP_URL=http://localhost:9644/v1/security/users"], (
+        f"the probe is only meaningful against the users endpoint, got {urls}"
+    )
+
     probes = [
         i
         for i, line in enumerate(lines)
@@ -2435,6 +2440,13 @@ def test_render_redpanda_hook_asks_the_broker_whether_the_user_exists() -> None:
     ]
     assert len(probes) == 1, (
         f"expected one existence probe against the users endpoint, found {len(probes)}"
+    )
+    # A GET, and specifically not a write. curl defaults to GET, so the
+    # check is that nothing overrides it: a probe that had become a POST
+    # would satisfy every other assertion here while creating the very
+    # user it claims to be looking for.
+    assert "-X " not in lines[probes[0]], (
+        f"the probe must not override curl's GET: {lines[probes[0]].strip()}"
     )
 
     creates = [i for i, line in enumerate(lines) if "-X POST" in line]


### PR DESCRIPTION
## The defect

RedPanda was restarted on **every** spin-up, not on first setup as the docstring claimed.

`USER_EXISTED` was inferred from the create's HTTP status. That inference does not hold. Measured against a live v24.3.1 broker with a throwaway user, created and deleted for the purpose:

| Request | Result |
|---|---|
| `POST /v1/security/users` — user absent | `200` |
| `POST` — present, **same password** | `200` |
| `POST` — present, **changed password** | `500 "User already exists"` |
| `PUT /v1/security/users/<name>` — present | `200` |
| `PUT` — absent | `500 "User does not exist"` |

The middle row is the one the code did not account for, and it is the normal case: a re-deploy whose Infisical password has not changed is indistinguishable from a first install. `USER_EXISTED` stayed `false`, and the first-setup branch restarted the broker.

## How it was caught

Not by a test. While confirming that #798's PUT branch had finally executed on the second spin-up, the evidence disagreed with itself: `compose-up` logged `Container redpanda Running` — it had left the container alone — yet

```
docker inspect redpanda --format '{{.Created}} {{.State.StartedAt}}'
Created=2026-09-06T14:06:08Z  StartedAt=2026-09-06T18:00:53Z
```

The container was four hours old and had been running for two minutes, with the restart landing inside the services-configure window. Only the hook restarts it there, and it only does so when `USER_EXISTED=false` — so the user had to be "absent" at that moment, while `GET /v1/security/users` had returned `["nexus-redpanda"]` twenty minutes earlier and again afterwards. Probing the API directly resolved the contradiction.

## The fix

The flag now comes from `GET /v1/security/users` before the create, so it means what its name says. The POST-then-PUT-on-conflict flow is untouched: a genuine rotation still gets `500` and takes the PUT.

Two claims that were wrong rather than merely incomplete are corrected in the same commit — the docstring paragraph that denied this behaviour, and the semantics table that listed `dup -> 500` without the same-password case.

`|| true` on the probe is deliberate and is not the swallowed-failure pattern CLAUDE.md warns about: a broker that cannot answer this GET cannot answer the write on the next line either, and that one reports properly. A failed probe leaves the flag `false`, costing one unnecessary restart and nothing else.

## Tests

A new test asserts the probe exists, targets the right user, sets the flag, and runs before both the create and the restart. Mutations verified to reach the code:

- probe removed entirely → fails on the probe assertion
- probe pointed at a different username → fails on the probe assertion
- probe left in place but its assignment replaced by a no-op → fails on the flag assertion

That third one is the interesting mutation: the first version of the assertion accepted *any* later `USER_EXISTED=true`, and the POST-conflict branch is one — so a hook whose probe ran but wired to nothing would have passed. Caught by the local review round, then bound to the GET branch specifically.

2964 unit tests pass.

## Local CodeRabbit round

Reviewed `585e95f` — 2 findings.

- **Test assertion too permissive** — accepted, fixed in `9edf83f`, described above.
- **Serialise the existence check, create and restart with an advisory lock** — dismissed with reasoning. The missing serialisation is real but belongs one layer up: `spin-up.yml` is the only lifecycle workflow without a `concurrency` group, tracked in #801. A lock inside one deploy hook would paper over that while OpenTofu state, the stacks rsync and the Infisical push stay unprotected. The residual race here also costs only what this PR set out to remove: if another run creates the user between our GET and our POST, the POST still answers 200 — both runs read the same Infisical password — and we take one unnecessary restart.

The fixes made in response to that round are themselves not locally reviewed; that gap is inherent to a single round.

## Testing instructions

`spin-up.yml` is sufficient — no Terraform resources change.

```bash
gh workflow run spin-up.yml --ref fix/redpanda-restart-on-every-deploy
```

With **redpanda** enabled, and on a stack where the SASL user already exists (any stack that has been spun up before). Then:

```bash
ssh nexus "docker inspect redpanda --format '{{.Created}} {{.State.StartedAt}}'"
```

`StartedAt` must **not** move into the deploy window. Before this change it did, on every run. Also confirm the user is still there and the hook still reports success:

```bash
ssh nexus "docker exec redpanda curl -s http://localhost:9644/v1/security/users"
# -> ["nexus-redpanda"]
```

Relates to #801

## Summary by Sourcery

Avoid unnecessary RedPanda restarts during redeployment by determining existing-user state before updating credentials.

Bug Fixes:
- Prevent RedPanda from restarting on every spin-up when its SASL user already exists with the same password by checking user existence before creation.
- Preserve password rotation handling while ensuring genuine first-time setup still restarts the broker.

Enhancements:
- Correct RedPanda API semantics documentation and clarify the restart decision behavior.

Tests:
- Add unit coverage verifying the read-only user existence probe targets the correct endpoint, runs before creation, sets the restart gate, and precedes restart decisions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - RedPanda setup now distinguishes new users from redeployments before creating accounts.
  - Prevents unnecessary broker restarts when credentials are unchanged.
  - Updates existing credentials directly instead of deleting and recreating users.

- **Tests**
  - Added regression coverage for user detection and restart decisions.

- **Documentation**
  - Documented observed RedPanda user creation and update behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->