### PR TITLE
ci: Fail a PR whose squash message Release Please cannot parse

### DIFF
--- a/.github/scripts/check-changelog-parse.mjs
+++ b/.github/scripts/check-changelog-parse.mjs
@@ -1,0 +1,112 @@
+// Fail a PR whose squash message Release Please cannot parse.
+//
+// WHY THIS EXISTS. Release Please drops a commit it cannot parse, silently,
+// with a green workflow. It logs one line and carries on:
+//
+//     ❯ commit could not be parsed: 67b46c7 fix(ci): Stop seven D1 calls …
+//     ✔ Considering: 3 commits
+//
+// Four commits existed. The dropped one never reached CHANGELOG.md and
+// nothing failed — no red check, no warning on the release PR. It has
+// happened twice (#769 before v0.75.0, #797 before v0.77.0) and both times
+// it was caught only because somebody read the release PR before merging,
+// which is not a control.
+//
+// Repairing it afterwards means hand-editing CHANGELOG.md on
+// `release-please--branches--main` AND the release PR body, in that order,
+// before anything else merges — any further commit to main regenerates that
+// branch and discards the repair. Catching it here instead makes the fix an
+// edit to the PR description.
+//
+// WHAT IT CHECKS. GitHub composes the squash commit as the PR title plus
+// " (#N)" as the subject, and the PR body verbatim as the body — verified
+// against #797, whose merged commit body matches its PR body once GitHub's
+// line wrapping is normalised. The wrapping itself is not the trigger: the
+// raw PR body and the wrapped commit message both throw.
+//
+// The parser is the one Release Please actually uses. Note it is
+// `@conventional-commits/parser`, NOT `conventional-commits-parser` — a
+// different package, and the reason an earlier investigation concluded the
+// message parsed fine. Version pinned to match release-please 17.x's
+// `^0.4.1`.
+//
+// WHAT IT DOES NOT DO. It does not explain WHY a message fails. The trigger
+// has never been isolated: for #797 the parser first throws inside a fenced
+// bash block at `ENABLED_SERVICES=$(`, but closing that parenthesis does not
+// make the whole body parse, so there is more than one. Guessing a content
+// rule from that would be worse than useless, which is why this reports the
+// location and leaves the diagnosis to a human.
+
+import { parser } from '@conventional-commits/parser'
+
+const title = process.env.PR_TITLE ?? ''
+const body = process.env.PR_BODY ?? ''
+const number = process.env.PR_NUMBER ?? '?'
+
+if (!title) {
+  console.error('❌ PR_TITLE is empty — this step cannot check anything.')
+  process.exit(1)
+}
+
+// GitHub appends " (#N)" to the title when it composes the squash subject.
+const subject = `${title} (#${number})`
+const message = body ? `${subject}\n\n${body}` : `${subject}\n`
+
+const throwsOn = (text) => {
+  try {
+    parser(text)
+    return null
+  } catch (error) {
+    return error
+  }
+}
+
+const failure = throwsOn(message)
+
+if (!failure) {
+  console.log(`✅ Release Please can parse the squash message for #${number}.`)
+  process.exit(0)
+}
+
+// Narrow it down: the shortest body prefix that already fails. This is a
+// location, not a cause — see the note above.
+const lines = body.split('\n')
+let firstBadLine = null
+for (let n = 1; n <= lines.length; n++) {
+  if (throwsOn(`${subject}\n\n${lines.slice(0, n).join('\n')}`)) {
+    firstBadLine = n
+    break
+  }
+}
+
+console.error('')
+console.error('❌ Release Please cannot parse the commit message this PR would produce.')
+console.error('')
+console.error(`   Parser error: ${failure.message?.split('\n')[0] ?? '(no message)'}`)
+console.error('')
+console.error('   If this merges, Release Please will DROP the commit from the')
+console.error('   changelog without failing. Its own workflow stays green and the')
+console.error('   entry simply never appears.')
+console.error('')
+
+if (firstBadLine !== null) {
+  const from = Math.max(1, firstBadLine - 2)
+  console.error(`   Parsing first fails at body line ${firstBadLine}:`)
+  console.error('')
+  for (let i = from; i <= firstBadLine; i++) {
+    const marker = i === firstBadLine ? '>' : ' '
+    console.error(`   ${marker} ${String(i).padStart(4)} | ${lines[i - 1]}`)
+  }
+  console.error('')
+  console.error('   That is where the parser gives up first, not necessarily the only')
+  console.error('   problem — fixing it may reveal another. Removing the surrounding')
+  console.error('   block from the description and re-running is the fastest way through.')
+} else {
+  console.error('   The failure could not be narrowed to a body line, which points at')
+  console.error('   the title rather than the description.')
+}
+
+console.error('')
+console.error('   Nothing about the CODE is wrong. Edit the PR description.')
+console.error('')
+process.exit(1)

--- a/.github/scripts/check-changelog-parse.mjs
+++ b/.github/scripts/check-changelog-parse.mjs
@@ -37,7 +37,17 @@
 // rule from that would be worse than useless, which is why this reports the
 // location and leaves the diagnosis to a human.
 
+import { readFileSync } from 'node:fs'
+
 import { parser } from '@conventional-commits/parser'
+
+// The prefix scan below reparses a growing prefix per line, which is
+// quadratic in the body length. Measured with this parser: 200 lines takes
+// 0.9s, 1000 takes 25s and 3000 takes 245s. A PR body may be 65536
+// characters, so an unbounded scan hands a fork PR minutes of runner CPU.
+// Real bodies in this repo run 50-123 lines; 400 costs about 4s and leaves
+// ample headroom.
+const MAX_SCANNED_LINES = 400
 
 const title = process.env.PR_TITLE ?? ''
 const body = process.env.PR_BODY ?? ''
@@ -61,9 +71,74 @@ const throwsOn = (text) => {
   }
 }
 
+//: The runner reads a step's stderr for workflow commands and strips leading
+//: whitespace first, so a title beginning with `::error::` would forge an
+//: annotation from this script's own output. Only the title is interpolated
+//: into a line of its own; the body excerpts below all carry a fixed prefix.
+const neutralise = (text) => text.replaceAll('::', ':\u200b:')
+
+//: The commit type, read out of the parser's own AST rather than a regex
+//: over the subject — the parser is the authority on where the type ends.
+const typeOf = (text) => {
+  let found = null
+  const walk = (node) => {
+    if (!node || typeof node !== 'object' || found !== null) return
+    if (node.type === 'type' && typeof node.value === 'string') {
+      found = node.value
+      return
+    }
+    for (const child of node.children ?? []) walk(child)
+  }
+  try {
+    walk(parser(text))
+  } catch {
+    return null
+  }
+  return found
+}
+
+//: Types Release Please is configured to understand. A type absent from this
+//: list parses fine and then has no section to land in — the same silent
+//: outcome this check exists to prevent, reached a different way. `hidden`
+//: entries stay allowed: `test:` and `style:` are deliberately kept out of
+//: the changelog, which is a decision rather than a failure.
+const configuredTypes = () => {
+  try {
+    const config = JSON.parse(readFileSync('release-please-config.json', 'utf8'))
+    const sections = []
+    const walk = (node) => {
+      if (!node || typeof node !== 'object') return
+      if (Array.isArray(node['changelog-sections'])) sections.push(...node['changelog-sections'])
+      for (const value of Object.values(node)) walk(value)
+    }
+    walk(config)
+    return new Set(sections.map((section) => section.type).filter(Boolean))
+  } catch {
+    // Unreadable or restructured config: say nothing rather than invent a
+    // failure. The parse check above is unaffected.
+    return null
+  }
+}
+
 const failure = throwsOn(message)
 
 if (!failure) {
+  const known = configuredTypes()
+  const type = typeOf(message)
+  if (known && known.size > 0 && type && !known.has(type)) {
+    console.error('')
+    console.error(`❌ \`${neutralise(type)}:\` is not a type Release Please is configured for.`)
+    console.error('')
+    console.error('   The message parses, so nothing will fail — and the entry will')
+    console.error('   have no section to land in. Same silent outcome, different route.')
+    console.error('')
+    console.error(`   Configured: ${[...known].sort().join(', ')}`)
+    console.error('')
+    console.error('   `test` and `style` are configured but hidden on purpose; both are')
+    console.error('   fine to use. Anything outside the list is not.')
+    console.error('')
+    process.exit(1)
+  }
   console.log(`✅ Release Please can parse the squash message for #${number}.`)
   process.exit(0)
 }
@@ -77,9 +152,10 @@ const subjectFails = throwsOn(`${subject}\n`) !== null
 // Narrow it down: the shortest body prefix that already fails. This is a
 // location, not a cause — see the note above.
 const lines = body.split('\n')
+const scanned = Math.min(lines.length, MAX_SCANNED_LINES)
 let firstBadLine = null
 if (!subjectFails) {
-  for (let n = 1; n <= lines.length; n++) {
+  for (let n = 1; n <= scanned; n++) {
     if (throwsOn(`${subject}\n\n${lines.slice(0, n).join('\n')}`)) {
       firstBadLine = n
       break
@@ -101,7 +177,7 @@ if (subjectFails) {
   console.error('   The TITLE is what the parser rejects, before the description is')
   console.error('   even reached:')
   console.error('')
-  console.error(`     ${subject}`)
+  console.error(`     ${neutralise(subject)}`)
   console.error('')
   console.error('   A conventional-commit subject looks like `type(scope): description`.')
 } else if (firstBadLine !== null) {
@@ -116,6 +192,11 @@ if (subjectFails) {
   console.error('   That is where the parser gives up first, not necessarily the only')
   console.error('   problem — fixing it may reveal another. Removing the surrounding')
   console.error('   block from the description and re-running is the fastest way through.')
+} else if (scanned < lines.length) {
+  console.error(`   The description is ${lines.length} lines; only the first`)
+  console.error(`   ${MAX_SCANNED_LINES} were scanned and none of them fails on its own.`)
+  console.error('   The scan is quadratic, so it is capped rather than left to run for')
+  console.error('   minutes. Shorten the description and push again to locate it.')
 } else {
   console.error('   The failure could not be narrowed to a single body line: the whole')
   console.error('   message is rejected while every prefix of it parses. That is')

--- a/.github/scripts/check-changelog-parse.mjs
+++ b/.github/scripts/check-changelog-parse.mjs
@@ -68,14 +68,22 @@ if (!failure) {
   process.exit(0)
 }
 
+// Is the subject itself the problem? Ask before scanning the body, because
+// an unparseable subject makes EVERY body prefix fail and the scan below
+// would then blame body line 1 — a confident, wrong diagnostic of exactly
+// the kind this whole check exists to prevent.
+const subjectFails = throwsOn(`${subject}\n`) !== null
+
 // Narrow it down: the shortest body prefix that already fails. This is a
 // location, not a cause — see the note above.
 const lines = body.split('\n')
 let firstBadLine = null
-for (let n = 1; n <= lines.length; n++) {
-  if (throwsOn(`${subject}\n\n${lines.slice(0, n).join('\n')}`)) {
-    firstBadLine = n
-    break
+if (!subjectFails) {
+  for (let n = 1; n <= lines.length; n++) {
+    if (throwsOn(`${subject}\n\n${lines.slice(0, n).join('\n')}`)) {
+      firstBadLine = n
+      break
+    }
   }
 }
 
@@ -89,7 +97,14 @@ console.error('   changelog without failing. Its own workflow stays green and th
 console.error('   entry simply never appears.')
 console.error('')
 
-if (firstBadLine !== null) {
+if (subjectFails) {
+  console.error('   The TITLE is what the parser rejects, before the description is')
+  console.error('   even reached:')
+  console.error('')
+  console.error(`     ${subject}`)
+  console.error('')
+  console.error('   A conventional-commit subject looks like `type(scope): description`.')
+} else if (firstBadLine !== null) {
   const from = Math.max(1, firstBadLine - 2)
   console.error(`   Parsing first fails at body line ${firstBadLine}:`)
   console.error('')
@@ -102,11 +117,16 @@ if (firstBadLine !== null) {
   console.error('   problem — fixing it may reveal another. Removing the surrounding')
   console.error('   block from the description and re-running is the fastest way through.')
 } else {
-  console.error('   The failure could not be narrowed to a body line, which points at')
-  console.error('   the title rather than the description.')
+  console.error('   The failure could not be narrowed to a single body line: the whole')
+  console.error('   message is rejected while every prefix of it parses. That is')
+  console.error('   unusual — attach the message to the issue rather than guessing.')
 }
 
 console.error('')
-console.error('   Nothing about the CODE is wrong. Edit the PR description.')
+console.error(
+  subjectFails
+    ? '   Nothing about the CODE is wrong. Edit the PR title.'
+    : '   Nothing about the CODE is wrong. Edit the PR description.'
+)
 console.error('')
 process.exit(1)

--- a/.github/workflows/changelog-parse.yaml
+++ b/.github/workflows/changelog-parse.yaml
@@ -21,11 +21,18 @@ jobs:
     name: Release Please can parse this PR
     runs-on: ubuntu-latest
     steps:
+      # Both of these are new `uses:` lines rather than pre-existing ones,
+      # and #652's rule is to pin at the moment a reference is added.
+      # `persist-credentials: false` because this job only reads one file
+      # out of the tree and never pushes; leaving the token in .git/config
+      # for the rest of the job buys nothing.
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: '22'
 

--- a/.github/workflows/changelog-parse.yaml
+++ b/.github/workflows/changelog-parse.yaml
@@ -34,7 +34,7 @@ jobs:
       # for, but an exemption is a thing future readers have to re-evaluate
       # and a cache step is not.
       - name: Cache the npm store
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: |
             ~/.npm

--- a/.github/workflows/changelog-parse.yaml
+++ b/.github/workflows/changelog-parse.yaml
@@ -1,0 +1,61 @@
+name: "CI: Changelog Parse"
+
+# Release Please silently drops a commit it cannot parse — green workflow, no
+# warning, missing changelog entry. Twice now (#769, #797). This turns that
+# into a red check on the PR, where the fix is an edit to the description
+# rather than a hand-repair of the release branch after the fact.
+#
+# `edited` is in the trigger list on purpose: the squash body IS the PR
+# description, so a check that only ran on `synchronize` would pass a PR and
+# then miss the edit that breaks it.
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  parse:
+    name: Release Please can parse this PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+
+      # Every job touching npm caches the store (#784). One small pinned
+      # package is nowhere near the 202-package fetch that rule was written
+      # for, but an exemption is a thing future readers have to re-evaluate
+      # and a cache step is not.
+      - name: Cache the npm store
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.npm
+          key: ${{ runner.os }}-npm-ccparser0.4.1
+          restore-keys: |
+            ${{ runner.os }}-npm-
+
+      # Pinned to release-please 17.x's own `@conventional-commits/parser:
+      # ^0.4.1`. A different parser would answer a different question: this
+      # check is only worth anything while it runs the same code the release
+      # pipeline runs.
+      - name: Install the parser Release Please uses
+        run: npm install --no-save --no-audit --no-fund @conventional-commits/parser@0.4.1
+
+      # Title and body reach the script through the environment, never
+      # interpolated into a shell body. A PR description is attacker-supplied
+      # text, and `${{ github.event.pull_request.body }}` inside a `run:`
+      # block is a template-injection hole.
+      - name: Parse the squash message this PR would produce
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: node .github/scripts/check-changelog-parse.mjs

--- a/tests/unit/test_workflow_expressions.py
+++ b/tests/unit/test_workflow_expressions.py
@@ -245,7 +245,9 @@ def test_all_npx_wrangler_invocations_agree_on_one_version() -> None:
 #
 # Hence: identify the cache by what it does, and reason per job.
 _CACHE_KEY_PIN = re.compile(r"-wrangler(?P<spec>[0-9][^-\s]*)-")
-_RUNS_NPM = re.compile(r"npx wrangler|npm ci\b|npm run ")
+# `npm install` belongs here too: the first job to use it slipped past
+# this pattern entirely, so the cache rule below never applied to it.
+_RUNS_NPM = re.compile(r"npx wrangler|npm ci\b|npm run |npm install\b")
 _SCRIPT_REF = re.compile(r"\.github/scripts/([A-Za-z0-9_.-]+\.sh)")
 
 #: Scripts under .github/scripts that themselves invoke npm. A job that
@@ -302,6 +304,23 @@ def _jobs_using_npm() -> set[tuple[Path, str]]:
     return using
 
 
+def _jobs_using_wrangler() -> set[tuple[Path, str]]:
+    """Jobs whose own steps invoke `npx wrangler`, directly or via a script."""
+    using: set[tuple[Path, str]] = set()
+    for path in _WORKFLOWS:
+        for job_id, job in _jobs(path).items():
+            for step in job.get("steps") or []:
+                if not isinstance(step, dict):
+                    continue
+                run = str(step.get("run", ""))
+                if _NPX_WRANGLER.search(run) or any(
+                    name in _NPM_SCRIPTS for name in _SCRIPT_REF.findall(run)
+                ):
+                    using.add((path, job_id))
+                    break
+    return using
+
+
 def test_npm_cache_keys_carry_the_pinned_wrangler_version() -> None:
     """Every npm-store cache key names the version `npx wrangler@…` uses."""
     pinned = {
@@ -320,8 +339,16 @@ def test_npm_cache_keys_carry_the_pinned_wrangler_version() -> None:
         "store is no longer cached at all. See #784."
     )
 
+    # Only for jobs that actually run Wrangler. A job installing some other
+    # pinned package caches a store whose contents have nothing to do with
+    # the Wrangler pin, and demanding that version in its key would be a
+    # rule with no meaning attached.
+    wrangler_jobs = _jobs_using_wrangler()
+
     offenders: list[str] = []
     for (path, job_id), step in sorted(steps.items()):
+        if (path, job_id) not in wrangler_jobs:
+            continue
         key = str((step.get("with") or {}).get("key", ""))
         match = _CACHE_KEY_PIN.search(key)
         if match is None:


### PR DESCRIPTION
## The problem

Release Please drops a commit it cannot parse — silently, with a green workflow. It logs one line and carries on:

```
could not be parsed: 67b46c7 fix(ci): Stop seven D1 calls from discarding their exit status (#797)
Considering: 3 commits
```

Four commits existed. The entry never reached `CHANGELOG.md`, nothing failed, no check went red.

This has happened twice — #769 before v0.75.0 and #797 before v0.77.0 — and both times it was caught only because somebody read the release PR before merging. That is not a control.

Repairing it afterwards is worse than it sounds: the entry has to be hand-added to `CHANGELOG.md` on `release-please--branches--main` **and** to the release PR body, because the GitHub release notes come from the PR rather than the branch, and both edits have to land before anything else merges — any further commit to `main` regenerates that branch and discards the repair. Today that ordering constraint had to be managed by hand across two merges.

## What this adds

A check on every PR that runs the squash message through the parser and fails if it throws. The fix then becomes an edit to the PR description.

The parser is release-please 17.x's own dependency, pinned to the same `@conventional-commits/parser@0.4.1`. Worth naming: it is **not** `conventional-commits-parser`. Those are different packages, and testing the wrong one is why an earlier investigation concluded the message parsed fine and recorded the cause as unknown.

`edited` is in the trigger list on purpose. The squash body *is* the PR description, so a check that only ran on `synchronize` would pass a PR and then miss the edit that breaks it.

## Verification

Against every open and recent PR — one failure, no false positives:

```
#797  exit=1  ❌ Release Please cannot parse the commit message this PR would produce.
#798  exit=0  ✅
#794  exit=0  ✅
#795  exit=0  ✅
#800  exit=0  ✅
```

Earlier, the same parser run over all 15 commits since `v0.75.0` threw on exactly the one Release Please dropped and accepted the other 14.

The squash composition was checked rather than assumed: #797's merged commit body matches its PR body once GitHub's line wrapping is normalised, and the subject is the title plus `" (#N)"`. The wrapping is not the trigger — raw body and wrapped commit both throw.

## What the failure output looks like

```
❌ Release Please cannot parse the commit message this PR would produce.

   Parser error: unexpected token '

   If this merges, Release Please will DROP the commit from the
   changelog without failing. Its own workflow stays green and the
   entry simply never appears.

   Parsing first fails at body line 19:

       17 |
       18 | ```bash
   >   19 | ENABLED_SERVICES=$(npx wrangler … --json --command "SELECT …" 2>/dev/null \

   That is where the parser gives up first, not necessarily the only
   problem — fixing it may reveal another.

   Nothing about the CODE is wrong. Edit the PR description.
```

The script says explicitly that this is a **location and not a cause**. The trigger has never been isolated: closing that parenthesis does not make the whole body parse, so there is more than one. A content rule guessed from that would be worse than useless, which is why it reports and leaves the diagnosis to a human. The standing suspicion that a `Tests:` block causes it is recorded as **refuted** — stripping the entire Sourcery summary leaves the parser throwing.

## Security

Title and body reach the script through the environment, never interpolated into a shell body. A PR description is attacker-supplied text and `${{ github.event.pull_request.body }}` inside a `run:` block is a template-injection hole.

## Two guardrails grew, and the first one caught this PR

- `_RUNS_NPM` did not match `npm install`, so "every job touching npm caches the store" (#784) silently did not apply to the new job. Widened — it immediately flagged this workflow, and the cache step was added rather than an exemption written.
- The cache-key rule demanded a Wrangler version in **every** `~/.npm` cache key. A job installing some other pinned package caches a store that has nothing to do with that pin, so the requirement now applies only to jobs that actually run Wrangler.

Both verified by mutation: removing the cache step from this workflow fails the first rule by name.

## Local CodeRabbit round

Reviewed `7ffede3` — 1 finding, partly accepted.

**Pin third-party actions to SHAs.** Accepted for `actions/cache`, which is SHA-pinned in eight other places while this workflow wrote `@v4` — an inconsistency this PR introduced, fixed in `57de466`. Dismissed for `actions/checkout` and `actions/setup-node`: `.coderabbit.yaml` records the repo's position — 3 of 33 `uses:` lines are pinned, #652 tracks the migration, and the rule is to pin when a third-party reference is added or bumped. Both are first-party actions every other workflow references by tag (13× `actions/checkout@v5`), so pinning only these two would make this workflow the odd one out without advancing #652.

## Testing

No infrastructure change. The check tests itself: it runs on this PR.

2964 unit tests pass.

## Summary by Sourcery

Add a PR guard that validates Release Please squash messages before merge and catches changelog entries that would otherwise be silently omitted.

New Features:
- Add a pull-request check that validates the squash message with the same Conventional Commits parser used by Release Please and reports actionable parse failures.
- Reject otherwise valid commit types that are not configured for a Release Please changelog section.

Bug Fixes:
- Prevent Release Please from silently dropping unparseable or unconfigured PR commits from changelogs.

Enhancements:
- Improve workflow policy checks for npm usage and restrict Wrangler cache-key version requirements to jobs that actually use Wrangler.
- Handle attacker-controlled PR metadata safely and limit diagnostic prefix scanning to avoid excessive runner CPU usage.

CI:
- Run the changelog validation on PR creation, edits, reopening, and synchronization with pinned GitHub Actions and restricted read permissions.

Tests:
- Extend workflow-expression tests to cover npm install detection and Wrangler-specific cache validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Added automated validation to ensure pull request titles and descriptions can be converted into valid changelog entries.
  - Validation runs when pull requests are opened, edited, reopened, or updated.
  - Parsing failures provide diagnostic details, including the first problematic line.
  - Validation now flags unsupported changelog entry types.

- **Tests**
  - Improved workflow checks to detect npm installation commands and accurately validate caching for jobs that use Wrangler, including usage through configured scripts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->