### PR TITLE
fix(stacks): Make seeded marimo notebooks recognisable as notebooks

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -114,6 +114,29 @@ reviews:
 
         Do NOT flag a missing `mem_limit`. 5 of 82 stacks set one; the
         gap is tracked in #741, and re-raising it per PR is noise.
+    - path: "examples/workspace-seeds/marimo/**/*.py"
+      instructions: |
+        Per CLAUDE.md ("Code Examples", rule 7): marimo decides a .py file
+        is a notebook by reading only the FIRST 512 BYTES and looking for
+        both `import marimo` and `marimo.App`
+        (marimo/_server/files/directory_scanner.py, READ_LIMIT = 512).
+
+        Flag a module docstring long enough to push either marker past
+        byte 512. Nothing fails when that happens — the notebook opens and
+        runs by direct URL — but it shows a plain code icon instead of a
+        notebook icon in marimo's file browser, and users read that as the
+        seed being absent. It shipped that way for five of six seeds.
+
+        The fix is a short summary docstring plus the prose in the first
+        mo.md cell, NOT marimo's `# /// script` escape hatch, which exists
+        for PEP 723 metadata and changes `uv run` behaviour.
+
+        Do NOT flag this on a file that is a helper module rather than a
+        notebook (no `marimo.App` anywhere in it, e.g. `_nexus_spark.py`);
+        the rule does not apply to those.
+
+        tests/unit/test_workspace_seeds.py already enforces this, so treat
+        a violation as a missing test update too.
     - path: "tofu/**/*.tf"
       instructions: |
         Per CLAUDE.md ("Resource Naming"): always use

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -126,7 +126,7 @@ Convention background: [examples/README.md](../examples/README.md) carries the f
 
 marimo decides a `.py` file is a notebook by reading only the **first 512 bytes** and checking for both `import marimo` and `marimo.App` (`marimo/_server/files/directory_scanner.py`, `READ_LIMIT = 512`). A long module docstring pushes both markers past that window.
 
-**Flag any new or modified `.py` under `examples/workspace-seeds/marimo/` whose `marimo.App` lands after byte 512.**
+**Flag any new or modified `.py` under `examples/workspace-seeds/marimo/` (including nested paths) where *either* `import marimo` or `marimo.App` is not fully contained in the first 512 bytes.** Both are required, and "fully contained" is the exact test — a marker that starts at byte 505 runs past the boundary and does not count.
 
 Why it matters more than it looks: nothing fails. The notebook opens and runs perfectly by direct URL. The only symptom is a plain code icon instead of a notebook icon in marimo's file browser — and users read that as the seed being absent. Five of six seeds shipped that way, three of them for two weeks, and it was reported as "I don't see the seeds" twice before anyone looked at an icon.
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -108,7 +108,7 @@ Do not add AI-tool advertising or "Generated with …" footers to commit message
 
 Files under `examples/workspace-seeds/` are auto-seeded into every user's Forgejo workspace repo on spin-up. **Flows in `examples/workspace-seeds/kestra/flows/` (and any other Kestra YAML elsewhere under `workspace-seeds/kestra/`) must not declare schedule / cron triggers.**
 
-A `triggers:` block of type `io.kestra.plugin.core.trigger.Schedule` (or the legacy `io.kestra.core.models.triggers.types.Schedule`) inside a seeded flow file is a hard issue — flag it. Reason: a seed file lands on every user stack, so a cron trigger fires N times in parallel for an N-user cohort, multiplying load on external APIs (CloudFront, Databricks Free-Edition quota), R2 egress, and Kestra container CPU. Examples are teaching artifacts to be triggered manually; cron belongs to platform-internal flows registered directly by `scripts/deploy.sh` via the Kestra API (e.g. `system.flow-sync`), which live outside `workspace-seeds/`.
+A `triggers:` block of type `io.kestra.plugin.core.trigger.Schedule` (or the legacy `io.kestra.core.models.triggers.types.Schedule`) inside a seeded flow file is a hard issue — flag it. Reason: a seed file lands on every user stack, so a cron trigger fires N times in parallel for an N-user cohort, multiplying load on external APIs (CloudFront, Databricks Free-Edition quota), R2 egress, and Kestra container CPU. Examples are teaching artifacts to be triggered manually; cron belongs to platform-internal flows registered directly by the Python orchestrator via the Kestra API (e.g. `system.flow-sync` — see `src/nexus_deploy/kestra.py`), which live outside `workspace-seeds/`.
 
 What's allowed in seeded flows:
 - No `triggers:` block at all (run via the **Execute** button in the Kestra UI). Preferred.
@@ -118,9 +118,23 @@ What's not allowed:
 - `Schedule` / cron triggers — flag and request removal, regardless of cron interval.
 - `Flow`, `RealtimeKafka`, or other auto-firing trigger types in seeded examples — flag.
 
-Spotting it: scan the diff for any new or modified `*.yaml` under `examples/workspace-seeds/kestra/` and look for either `type: io.kestra.plugin.core.trigger.Schedule` (modern form) or `type: io.kestra.core.models.triggers.types.Schedule` (legacy form — what `scripts/deploy.sh` itself registers for `system.git-sync` and `system.flow-sync`) in a `triggers:` block. Both type strings are accepted by Kestra, so the rule must catch both. Same applies if a contributor adds a new file under that tree without explicit scheduling but later edits it to introduce one.
+Spotting it: scan the diff for any new or modified `*.yaml` under `examples/workspace-seeds/kestra/` and look for either `type: io.kestra.plugin.core.trigger.Schedule` (modern form) or `type: io.kestra.core.models.triggers.types.Schedule` (legacy form — what the orchestrator itself registers for `system.git-sync` and `system.flow-sync`) in a `triggers:` block. Both type strings are accepted by Kestra, so the rule must catch both. Same applies if a contributor adds a new file under that tree without explicit scheduling but later edits it to introduce one.
 
 Convention background: [examples/README.md](../examples/README.md) carries the full rationale and the rules for the rest of the seed-tree (path-mapping, idempotency, secret references via `{{ secret('NAME') }}`, etc.).
+
+## 10. Seeded marimo notebooks — the 512-byte header
+
+marimo decides a `.py` file is a notebook by reading only the **first 512 bytes** and checking for both `import marimo` and `marimo.App` (`marimo/_server/files/directory_scanner.py`, `READ_LIMIT = 512`). A long module docstring pushes both markers past that window.
+
+**Flag any new or modified `.py` under `examples/workspace-seeds/marimo/` whose `marimo.App` lands after byte 512.**
+
+Why it matters more than it looks: nothing fails. The notebook opens and runs perfectly by direct URL. The only symptom is a plain code icon instead of a notebook icon in marimo's file browser — and users read that as the seed being absent. Five of six seeds shipped that way, three of them for two weeks, and it was reported as "I don't see the seeds" twice before anyone looked at an icon.
+
+The fix is a short summary docstring (it is what a reader sees on GitHub) plus the prose in the notebook's **first `mo.md` cell**. Do not accept marimo's `# /// script` escape hatch as a fix: that block exists for PEP 723 inline metadata and changes `uv run` behaviour.
+
+Do **not** flag a helper module that is not a notebook at all — no `marimo.App` anywhere in the file, e.g. `_nexus_spark.py`. The rule does not apply to those.
+
+`tests/unit/test_workspace_seeds.py` enforces this against the real tree, so a violation also means a test was not run.
 
 ## What NOT to flag
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -786,6 +786,29 @@ When adding or editing seeded examples:
 5. **Make seed files idempotent.** A user may execute a seeded flow more than once. Either detect pre-existing state and skip, or design the flow so re-runs are safe (overwriting outputs is fine; accumulating side-effects is not).
 6. **Existing files in Forgejo are never overwritten.** The seed loop uses HTTP `POST` (create-only); it returns 422 for files that already exist and counts them as `SKIPPED`. User edits persist across re-deploys. To ship an updated example, give it a new filename or version-suffix it.
 
+7. **Keep a seeded marimo notebook's module docstring under ~450 bytes.**
+   marimo decides a `.py` file is a notebook by reading only the **first 512
+   bytes** and looking for both `import marimo` and `marimo.App`
+   (`marimo/_server/files/directory_scanner.py`, `READ_LIMIT = 512`). A long
+   module docstring pushes both past that window, and the file then appears
+   in marimo's file browser with a plain code icon instead of a notebook
+   icon.
+
+   Nothing fails when this happens — the notebook opens and runs perfectly
+   by direct URL. The only symptom is that users conclude the seeds are not
+   there, which is exactly how it was reported, twice, before anyone looked
+   at an icon. Five of six seeds were over the limit; the sixth passed at
+   byte 419, by luck.
+
+   So keep a short summary docstring — it is what a reader sees on GitHub —
+   and put the rest in the notebook's **first `mo.md` cell**, where a reader
+   of the notebook sees it instead. Do **not** reach for marimo's
+   `# /// script` escape hatch, which makes it read the whole file: that
+   block exists for PEP 723 metadata and changes `uv run` behaviour.
+
+   `tests/unit/test_workspace_seeds.py` enforces the rule against the real
+   tree, so a violation fails CI rather than shipping silently.
+
 Full details — including the `kestra/flows/` vs `kestra/workflows/` distinction, Kestra namespace derivation from subdirs, and how to add a new per-stack or per-consumer subtype — live in [examples/README.md](examples/README.md).
 
 ## Commit Convention

--- a/examples/workspace-seeds/marimo/Getting_Started_DuckDB.py
+++ b/examples/workspace-seeds/marimo/Getting_Started_DuckDB.py
@@ -1,35 +1,8 @@
 """Getting Started with DuckDB in Marimo.
 
-DuckDB is **pre-installed** in the Nexus-Stack Marimo image — no
-``pip install`` needed. The base image ``ghcr.io/marimo-team/marimo:0.23.4-sql``
-ships ``marimo[sql]`` which bundles:
-
-    duckdb + sqlglot + ibis-framework + polars + pyarrow
-
-So you can ``import duckdb`` directly OR use Marimo's native SQL cells
-(``mo.sql(...)``) which are backed by DuckDB by default.
-
-This notebook walks through six DuckDB patterns you'll actually use:
-
-    1. Sanity check — version + simple SELECT
-    2. Synthetic data via the ``range()`` table function — no I/O,
-       runs anywhere
-    3. Read remote parquet directly from HTTP via the ``httpfs`` extension
-       (auto-loaded; no manual ``INSTALL httpfs`` or ``LOAD httpfs`` needed)
-    4. Aggregate + window function on the public NYC Taxi dataset
-    5. Convert query results to Polars / Pandas / PyArrow
-    6. Marimo's native SQL cell with ``mo.sql`` (reactive DAG-aware,
-       results auto-render as paginated tables)
-
-No schedule, no API key, no Spark. Default queries hit NYC TLC's public
-CloudFront — same source the Kestra ``r2-taxi-pipeline`` and Prefect
-``nyc-green-taxi-pipeline`` seeds use, but DuckDB streams the parquet
-columns it needs over HTTP without ever materializing a local file.
-
-This file was seeded into your Forgejo workspace repo from
-``nexus-stack/examples/workspace-seeds/marimo/Getting_Started_DuckDB.py``.
-Edit it in Forgejo or directly in Marimo — your changes persist across
-spin-ups (seeding only adds new files, never overwrites).
+Deliberately short: marimo reads only the first 512 bytes to decide a file
+is a notebook, and prose above `import marimo` pushes the markers out of
+that window. The introduction lives in the first cell instead.
 """
 
 import marimo
@@ -69,6 +42,32 @@ def _(mo):
 
         Run cells in order or hit **Run all** — Marimo figures out the
         dependency graph from the function signatures.
+
+        ## What this notebook covers
+
+        1. Sanity check — version and a simple `SELECT`
+        2. Synthetic data via the `range()` table function — no I/O, runs
+           anywhere
+        3. Read remote parquet directly over HTTP via the `httpfs`
+           extension (auto-loaded; no manual `INSTALL` or `LOAD` needed)
+        4. Aggregate and window function on the public NYC Taxi dataset
+        5. Convert query results to Polars / Pandas / PyArrow
+        6. Marimo's native SQL cell with `mo.sql` — reactive, results
+           render as paginated tables
+
+        No schedule, no API key, no Spark. The default queries hit NYC TLC's
+        public CloudFront — the same source the Kestra `r2-taxi-pipeline`
+        and Prefect `nyc-green-taxi-pipeline` seeds use — but DuckDB streams
+        only the parquet columns it needs, without ever materialising a
+        local file.
+
+        The image is `ghcr.io/marimo-team/marimo:0.23.4-sql`, whose
+        `marimo[sql]` extras bundle duckdb + sqlglot + ibis-framework +
+        polars + pyarrow.
+
+        Seeded from `examples/workspace-seeds/marimo/` in Nexus-Stack. Edit
+        it here or in Forgejo — your changes survive a spin-up, because
+        seeding only adds files and never overwrites.
         """
     )
     return

--- a/examples/workspace-seeds/marimo/Getting_Started_PostgREST.py
+++ b/examples/workspace-seeds/marimo/Getting_Started_PostgREST.py
@@ -26,8 +26,11 @@ def _(mo):
 
         PostgREST is a Go binary that introspects a Postgres schema and
         serves every table, view and RPC as a REST endpoint. The Nexus-Stack
-        stack points it at the shared `postgres` stack, so any table you
-        create in that database is immediately query-able over HTTP.
+        stack points it at the shared `postgres` stack, so a table you
+        create in that database becomes query-able over HTTP — once
+        PostgREST has reloaded its schema cache and the role it connects as
+        can read the table. Both are one step each, and the setup section
+        below does them.
 
         This notebook walks through the API surface:
 

--- a/examples/workspace-seeds/marimo/Getting_Started_PostgREST.py
+++ b/examples/workspace-seeds/marimo/Getting_Started_PostgREST.py
@@ -1,35 +1,8 @@
 """Getting Started with PostgREST in Marimo.
 
-PostgREST is a Go binary that introspects a Postgres schema and serves
-every table / view / RPC as a REST endpoint. The Nexus-Stack PostgREST
-stack points it at the shared `postgres` stack, so any tables you
-create in that database are immediately query-able over HTTP.
-
-This notebook walks through the API surface:
-
-    1. One-time setup: create a demo schema with a table + sample rows
-       (run once via CloudBeaver/pgAdmin/Adminer/psql — see below)
-    2. List rows with GET /<table>
-    3. Filter (?col=eq.value), order (?order=col.desc), paginate (Range header)
-    4. Insert via POST
-    5. Update via PATCH
-    6. Delete via DELETE
-    7. Fetch the auto-generated OpenAPI spec
-
-Network: hits PostgREST at `http://postgrest:3000` (the internal
-app-network hostname). This bypasses Cloudflare Access since we're
-already inside the trusted compose network — no JWT needed for the
-anon-role traffic in the lab default. For external clients hitting
-`https://postgrest.<domain>`, Cloudflare Access at the edge gates
-who reaches the API.
-
-No extra pip installs needed. The notebook uses `urllib.request` +
-`json` from the stdlib so it works on the un-augmented Marimo image.
-
-This file was seeded into your Forgejo workspace repo from
-``nexus-stack/examples/workspace-seeds/marimo/Getting_Started_PostgREST.py``.
-Edit it in Forgejo or directly in Marimo — your changes persist across
-spin-ups (seeding only adds new files, never overwrites).
+Deliberately short: marimo reads only the first 512 bytes to decide a file
+is a notebook, and prose above `import marimo` pushes the markers out of
+that window. The introduction lives in the first cell instead.
 """
 
 import marimo
@@ -51,9 +24,37 @@ def _(mo):
         r"""
         # Getting Started with PostgREST on Marimo
 
-        PostgREST exposes every table in the configured schema as a REST endpoint.
-        We hit the internal hostname `http://postgrest:3000` (no Cloudflare Access
-        round-trip from inside the compose network).
+        PostgREST is a Go binary that introspects a Postgres schema and
+        serves every table, view and RPC as a REST endpoint. The Nexus-Stack
+        stack points it at the shared `postgres` stack, so any table you
+        create in that database is immediately query-able over HTTP.
+
+        This notebook walks through the API surface:
+
+        1. One-time setup: a demo schema with a table and sample rows (run
+           once — see below)
+        2. List rows with `GET /<table>`
+        3. Filter (`?col=eq.value`), order (`?order=col.desc`), paginate
+           (`Range` header)
+        4. Insert via `POST`
+        5. Update via `PATCH`
+        6. Delete via `DELETE`
+        7. Fetch the auto-generated OpenAPI spec
+
+        **Network.** The cells hit `http://postgrest:3000`, the internal
+        app-network hostname. That bypasses Cloudflare Access because we are
+        already inside the trusted compose network — no JWT is needed for
+        the anon-role traffic in the lab default. For external clients
+        hitting `https://postgrest.<domain>`, Access at the edge gates who
+        reaches the API.
+
+        No extra installs: the notebook uses `urllib.request` and `json`
+        from the standard library, so it works on the un-augmented Marimo
+        image.
+
+        Seeded from `examples/workspace-seeds/marimo/` in Nexus-Stack. Edit
+        it here or in Forgejo — your changes survive a spin-up, because
+        seeding only adds files and never overwrites.
 
         ## One-time setup (run in CloudBeaver / pgAdmin / Adminer / psql)
 

--- a/examples/workspace-seeds/marimo/Getting_Started_Unity_Catalog.py
+++ b/examples/workspace-seeds/marimo/Getting_Started_Unity_Catalog.py
@@ -1,18 +1,8 @@
 """Create and query a Delta table that outlives the server.
 
-The point of this notebook is not Delta and not SQL — it is that the table
-you create here is still there after a teardown and spin-up, which is not
-true of anything written to the server's own disk.
-
-Two independent pieces make that work, and both have to be in place:
-
-* **Unity Catalog** remembers that the table exists, in a PostgreSQL
-  metastore that the snapshot layer carries across as a `pg_dump`.
-* **Cloudflare R2** holds the files themselves, outside the server
-  entirely.
-
-Run `Verify_Spark_And_S3.py` first if anything here fails — it isolates
-which layer broke.
+Deliberately short: marimo reads only the first 512 bytes to decide a file
+is a notebook, and prose above `import marimo` pushes the markers out of
+that window. The introduction lives in the first cell instead.
 """
 
 import marimo
@@ -33,6 +23,20 @@ def _(mo):
     mo.md(
         r"""
         # Unity Catalog on R2
+
+        The point of this notebook is not Delta and not SQL — it is that the
+        table you create here is still there after a teardown and spin-up,
+        which is not true of anything written to the server's own disk.
+
+        Two independent pieces make that work, and both have to be in place:
+
+        * **Unity Catalog** remembers that the table exists, in a PostgreSQL
+          metastore that the snapshot layer carries across as a `pg_dump`.
+        * **Cloudflare R2** holds the files themselves, outside the server
+          entirely.
+
+        Run `Verify_Spark_And_S3.py` first if anything here fails — it
+        isolates which layer broke.
 
         A table here has a **three-part name**: `unity.<schema>.<table>`.
         The leading `unity` is the catalog, and it is what tells Spark to

--- a/examples/workspace-seeds/marimo/NYC_Taxi_Pipeline.py
+++ b/examples/workspace-seeds/marimo/NYC_Taxi_Pipeline.py
@@ -1,42 +1,10 @@
 """NYC Yellow-Taxi 2025 pipeline — Spark Connect + Marimo.
 
-Mirror of the Kestra `r2-taxi-pipeline.yaml` flow, adapted for Marimo:
-
-    1. Bootstrap: download monthly Yellow-Taxi parquets from NYC TLC's
-       public CloudFront and upload each to Hetzner Object Storage.
-       DuckDB does the transfer via `s3://...` (its httpfs extension's
-       URL scheme — same physical bucket as the s3a:// reads below,
-       just a different client-library URI prefix). No compute-cluster
-       round-trip needed.
-    2. Read all months back as a Spark DataFrame via the Connect server
-       using `s3a://...` (Spark's Hadoop-FileSystem URI scheme; uses
-       hadoop-aws under the hood, which is configured server-side in
-       spark-connect).
-    3. Aggregate stats with Spark SQL and render as a paginated table.
-
-Both `s3://` (DuckDB) and `s3a://` (Spark) point at the same physical
-object: `<HETZNER_S3_BUCKET>/nexus-tutorials/NYC/yellow_tripdata_2025-MM.parquet`.
-The two URI schemes are just two clients' conventions for talking to
-S3-compatible storage; the bytes on disk are identical.
-
-Default: 2 months (Jan + Feb 2025). Edit the `months` list to add more.
-The Kestra flow has the same default for the same reason — every student
-stack runs this on every "Execute", so a small default keeps CloudFront
-egress and run time low when a cohort hits the button at once.
-
-Pre-reqs:
-    - Marimo + Spark stacks both enabled
-    - Infisical has these secrets (synced into Marimo's env on spin-up):
-        HETZNER_S3_BUCKET, HETZNER_S3_ENDPOINT,
-        HETZNER_S3_ACCESS_KEY, HETZNER_S3_SECRET_KEY
-      Without them, the bootstrap cell raises early with a clear hint.
-
-Why DuckDB for the transfer (not Spark): pyspark[connect] doesn't read
-HTTP URLs natively, and a "download to /tmp then write via Spark" path
-would shuttle 60 MiB per month through the Marimo container. DuckDB's
-httpfs streams directly from CloudFront to S3 in-process — same pattern
-the Kestra equivalent uses (DuckDB+httpfs for the stats query).
+Deliberately short: marimo reads only the first 512 bytes to decide a file
+is a notebook, and prose above `import marimo` pushes the markers out of
+that window. The introduction lives in the first cell instead.
 """
+
 
 import marimo
 
@@ -62,6 +30,47 @@ def _(mo):
         Mirrors the Kestra flow `nexus-tutorials.r2-taxi-pipeline` —
         same data source, similar shape, different runtime (Marimo
         + DuckDB + Spark Connect instead of Kestra + DuckDB).
+
+        ## What happens
+
+        1. **Bootstrap** — download monthly Yellow-Taxi parquets from NYC
+           TLC's public CloudFront and upload each to Hetzner Object
+           Storage. DuckDB does the transfer via `s3://…`, its httpfs
+           extension's URL scheme. No compute-cluster round trip.
+        2. **Read** — all months back as a Spark DataFrame through the
+           Connect server via `s3a://…`, Spark's Hadoop-FileSystem scheme,
+           which uses hadoop-aws configured server-side in `spark-connect`.
+        3. **Aggregate** — stats with Spark SQL, rendered as a paginated
+           table.
+
+        `s3://` (DuckDB) and `s3a://` (Spark) point at the *same* object:
+        `<HETZNER_S3_BUCKET>/nexus-tutorials/NYC/yellow_tripdata_2025-MM.parquet`.
+        The two schemes are two clients' conventions for the same
+        S3-compatible storage; the bytes on disk are identical.
+
+        **Why DuckDB for the transfer and not Spark.** `pyspark[connect]`
+        does not read HTTP URLs natively, and a "download to /tmp, then
+        write via Spark" path would shuttle 60 MiB per month through the
+        Marimo container. DuckDB's httpfs streams straight from CloudFront
+        to S3 in-process — the same pattern the Kestra equivalent uses.
+
+        ## Before you run it
+
+        - Marimo **and** Spark stacks both enabled.
+        - Infisical holds `HETZNER_S3_BUCKET`, `HETZNER_S3_ENDPOINT`,
+          `HETZNER_S3_ACCESS_KEY` and `HETZNER_S3_SECRET_KEY`, synced into
+          Marimo's environment on spin-up. Without them the bootstrap cell
+          raises early with a clear hint.
+
+        The default is two months (January and February 2025); edit the
+        `months` list to add more. The Kestra flow defaults the same way
+        and for the same reason — every student stack runs this on every
+        **Execute**, so a small default keeps CloudFront egress and run
+        time low when a cohort hits the button at once.
+
+        Seeded from `examples/workspace-seeds/marimo/` in Nexus-Stack. Edit
+        it here or in Forgejo — your changes survive a spin-up, because
+        seeding only adds files and never overwrites.
         """
     )
     return

--- a/examples/workspace-seeds/marimo/Verify_Spark_And_S3.py
+++ b/examples/workspace-seeds/marimo/Verify_Spark_And_S3.py
@@ -1,16 +1,8 @@
 """Verify the Spark cluster and its object-storage wiring.
 
-A diagnostic notebook, not a tutorial — every cell answers one question
-that has a right answer, so a failure tells you which layer broke rather
-than that "Spark doesn't work".
-
-Run it after a version bump, after a spin-up that changed the Spark stack,
-or when something that used to work stopped. `Getting_Started_PySpark.py`
-is the notebook to read if you want to learn PySpark; this one is the
-notebook to run when you want to know whether the plumbing is intact.
-
-It writes to `s3a://<bucket>/nexus_seeds/verify/` with `mode("overwrite")`,
-so re-running it is safe and leaves nothing behind that accumulates.
+Deliberately short: marimo reads only the first 512 bytes to decide a file
+is a notebook, and prose above `import marimo` pushes the markers out of
+that window. The introduction lives in the first cell instead.
 """
 
 import marimo
@@ -30,6 +22,20 @@ def _(mo):
     mo.md(
         r"""
         # Verify Spark and S3
+
+        A diagnostic notebook, not a tutorial — every cell answers one
+        question that has a right answer, so a failure tells you which layer
+        broke rather than that "Spark doesn't work".
+
+        Run it after a version bump, after a spin-up that changed the Spark
+        stack, or when something that used to work stopped.
+        `Getting_Started_PySpark.py` is the notebook to read if you want to
+        learn PySpark; this is the one to run when you want to know whether
+        the plumbing is intact.
+
+        It writes to `s3a://<bucket>/nexus_seeds/verify/` with
+        `mode("overwrite")`, so re-running it is safe and leaves nothing
+        behind that accumulates.
 
         Each section below has an expected answer. Work top to bottom and
         stop at the first one that disagrees — later cells assume the

--- a/tests/unit/test_workspace_seeds.py
+++ b/tests/unit/test_workspace_seeds.py
@@ -12,7 +12,11 @@ from pathlib import Path
 import pytest
 
 SEEDS_DIR = Path(__file__).resolve().parents[2] / "examples" / "workspace-seeds"
-MARIMO_SEEDS = sorted((SEEDS_DIR / "marimo").glob("*.py"))
+# rglob, not glob: the seeder itself walks recursively (seeder.py:170,
+# `root.rglob("*")`), and other seed trees already nest — kestra/flows,
+# kestra/workflows, prefect/flows. A notebook at marimo/<sub>/x.py would
+# therefore ship without this check ever seeing it.
+MARIMO_SEEDS = sorted((SEEDS_DIR / "marimo").rglob("*.py"))
 
 # Marimo's own limit, copied from the version this project runs:
 #
@@ -43,7 +47,9 @@ def test_marimo_seed_directory_is_not_empty() -> None:
     assert MARIMO_SEEDS, f"no marimo seeds found under {SEEDS_DIR / 'marimo'}"
 
 
-@pytest.mark.parametrize("path", MARIMO_SEEDS, ids=lambda p: p.name)
+@pytest.mark.parametrize(
+    "path", MARIMO_SEEDS, ids=lambda p: str(p.relative_to(SEEDS_DIR / "marimo"))
+)
 def test_marimo_seed_is_recognisable_as_a_notebook(path: Path) -> None:
     """A seeded notebook must declare itself inside marimo's 512-byte header.
 

--- a/tests/unit/test_workspace_seeds.py
+++ b/tests/unit/test_workspace_seeds.py
@@ -1,0 +1,86 @@
+"""Conventions the seeded workspace files have to satisfy.
+
+These read the real ``examples/workspace-seeds/`` tree rather than a fixture:
+the files ship to every user's workspace verbatim, so what matters is the
+bytes on disk, not a reconstruction of them.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+SEEDS_DIR = Path(__file__).resolve().parents[2] / "examples" / "workspace-seeds"
+MARIMO_SEEDS = sorted((SEEDS_DIR / "marimo").glob("*.py"))
+
+# Marimo's own limit, copied from the version this project runs:
+#
+#   marimo/_server/files/directory_scanner.py
+#     READ_LIMIT = 512
+#     "Python (.py) files are marimo apps if the header (first 512 bytes)
+#      contains both `marimo.App` and `import marimo`."
+#
+# Not a heuristic of ours, and not negotiable from this side.
+MARIMO_HEADER_READ_LIMIT = 512
+
+
+def _is_notebook(source: bytes) -> bool:
+    """Whether the file is a marimo notebook at all, reading the WHOLE file.
+
+    Distinguishes a notebook from a plain helper module such as
+    ``_nexus_spark.py``, which must not be held to the header rule.
+    """
+    return b"marimo.App" in source and b"import marimo" in source
+
+
+def test_marimo_seed_directory_is_not_empty() -> None:
+    """Guard against the checks below passing vacuously.
+
+    A renamed directory would otherwise turn every parametrised test into
+    zero tests, and the suite would go green on no coverage at all.
+    """
+    assert MARIMO_SEEDS, f"no marimo seeds found under {SEEDS_DIR / 'marimo'}"
+
+
+@pytest.mark.parametrize("path", MARIMO_SEEDS, ids=lambda p: p.name)
+def test_marimo_seed_is_recognisable_as_a_notebook(path: Path) -> None:
+    """A seeded notebook must declare itself inside marimo's 512-byte header.
+
+    Miss it and nothing fails: the file opens perfectly by direct URL and
+    runs normally. It simply appears in marimo's file browser with a plain
+    code icon rather than a notebook icon, which is how a user learns the
+    seeds are "not there" — reported exactly that way twice before the cause
+    was found.
+
+    The trap is a long module docstring. Prose above ``import marimo`` pushes
+    both markers past the window, and the failure scales with how well the
+    file is documented. Five of six seeds were over the limit when this test
+    was written; the sixth passed at byte 419, which was luck rather than
+    design.
+
+    The fix is not to delete the docstring — it is what a reader sees on
+    GitHub. Keep a short summary above the header and move the rest into the
+    notebook's first ``mo.md`` cell, where a reader of the notebook sees it
+    instead.
+    """
+    source = path.read_bytes()
+    if not _is_notebook(source):
+        pytest.skip(f"{path.name} is a helper module, not a notebook")
+
+    header = source[:MARIMO_HEADER_READ_LIMIT]
+
+    # Asserted separately, and in the order they appear, so a failure names
+    # the marker that actually fell out of the window rather than reporting
+    # "one of two things is wrong".
+    def _too_late(marker: bytes) -> str:
+        return (
+            f"{path.name}: `{marker.decode()}` sits at byte "
+            f"{source.find(marker)}, past marimo's "
+            f"{MARIMO_HEADER_READ_LIMIT}-byte header window, so marimo will "
+            f"not recognise this file as a notebook. Shorten the module "
+            f"docstring and move the prose into the first mo.md cell."
+        )
+
+    assert b"import marimo" in header, _too_late(b"import marimo")
+    assert b"marimo.App" in header, _too_late(b"marimo.App")


### PR DESCRIPTION
## The symptom

Five of six seeded marimo notebooks showed a plain **code icon** in marimo's file browser instead of a notebook icon, and did not appear in the Workspace tree at all:

```
Workspace
└── Bsc_EDS_..._stefan_koch
    └── nexus_seeds
        └── marimo
            └── Getting_Started_PySpark.py        ← the only one listed
```

Nothing ever failed. The notebooks open and run perfectly by direct URL. The only signal was the icon — which is why this was reported twice as *"I don't see the seeds"* before anyone looked at one.

## The cause

marimo's own rule, from the version this project runs:

```python
# marimo/_server/files/directory_scanner.py
READ_LIMIT = 512
# "Python (.py) files are marimo apps if the header (first 512 bytes)
#  contains both `marimo.App` and `import marimo`."
```

Every seed opens with a long module docstring, which pushes both markers past that window.

| File | `marimo.App` @ byte | before | after |
|---|---|---|---|
| `Getting_Started_PySpark.py` | 419 → 419 | ✅ | ✅ |
| `Getting_Started_Unity_Catalog.py` | 697 → 326 | ❌ | ✅ |
| `Verify_Spark_And_S3.py` | 729 → 325 | ❌ | ✅ |
| `Getting_Started_PostgREST.py` | 1551 → 311 | ❌ | ✅ |
| `Getting_Started_DuckDB.py` | 1619 → 308 | ❌ | ✅ |
| `NYC_Taxi_Pipeline.py` | 2079 → 328 | ❌ | ✅ |

PySpark passed at 419 by luck rather than design — 93 bytes of headroom, and nobody had chosen that.

**Three of the five have been wrong since 2026-08-26 (61a8b6e).** Two are from this week.

## The fix

Keep a short summary docstring — it is what a reader sees on GitHub — and move the prose into each notebook's **first `mo.md` cell**, where a reader of the *notebook* sees it instead. Nothing is dropped; per-file line counts stay level.

`Getting_Started_PySpark.py` is left untouched: it already passes, and the new test is now what catches a future docstring growing past the limit.

Not used: marimo's `# /// script` escape hatch, which makes it read the whole file. That block exists for PEP 723 inline metadata and changes `uv run` behaviour — defeating a limit with it would be a side effect, not a fix.

## Verification

With marimo's **own** function, run inside the deployed marimo container rather than against a reimplementation of the rule:

```
$ docker exec marimo python -c 'from marimo._server.files.directory_scanner import is_marimo_app; ...'
  Getting_Started_DuckDB.py            is_marimo_app = True
  Getting_Started_PostgREST.py         is_marimo_app = True
  Getting_Started_PySpark.py           is_marimo_app = True
  Getting_Started_Unity_Catalog.py     is_marimo_app = True
  NYC_Taxi_Pipeline.py                 is_marimo_app = True
  Verify_Spark_And_S3.py               is_marimo_app = True
  _nexus_spark.py                      is_marimo_app = False   ← helper module, correct
```

`marimo check` reports no new issues; the pre-existing `error[branch-expression]` in `Getting_Started_PySpark.py` is untouched and filed as #817.

## The guard

`tests/unit/test_workspace_seeds.py` replicates the rule against the **real** tree, not a fixture — what ships is the bytes on disk. It:

- refuses to pass vacuously if the seed directory is ever renamed away,
- skips helper modules that are not notebooks at all,
- asserts the two markers **separately**, so a failure names the one that fell out of the window rather than reporting "one of two things is wrong".

Checked by putting a long docstring back and watching it fail.

## Rules, so the next one is prevented rather than caught

The test catches the fault after it is written. `f048d92` adds what stops it being written: `CLAUDE.md` rule 7 for the agent, a `.coderabbit.yaml` path instruction and `copilot-instructions.md` section 10 for the PR reviewers. Each states the limit with its source, why it is worth a rule (nothing fails — the file just stops looking like a notebook), and the two things *not* to do: reach for `# /// script`, or flag a helper module.

Two dead references to `scripts/deploy.sh` in `copilot-instructions.md` are corrected while there — that file was removed in #505, and the reviewer was being pointed at it for who registers `system.flow-sync`. The orchestrator does (`src/nexus_deploy/kestra.py`).

## Local CodeRabbit round

Reviewed `b5be9b6`, **1 finding**, fixed:

- 🟠 *"any table you create is immediately query-able over HTTP"* in the PostgREST seed overstated it — PostgREST needs a schema-cache reload and the connecting role needs read access. The sentence is **verbatim from `main`**; this branch only moved it out of the docstring. The same notebook already explains the reload fifty lines further down, so the summary contradicted its own setup section. Qualified rather than deleted.

Not covered by that round: `f048d92`, which was written after it. The first attempt at the round does not count — it aborted with `WebSocket closed` before reviewing anything, and did so with exit code 0.

## How to test

Nothing to deploy for the rule changes. For the notebooks:

1. The fix reaches a stack whose workspace repo does **not** already hold the files — seeding is create-only (`POST`, 422 → skipped), so an existing `nexus_seeds/marimo/*.py` is preserved by design.
2. On a stack where they already exist, delete `nexus_seeds/marimo/*.py` in Forgejo and re-run `spin-up.yml`; or run `destroy-all` with **both** confirmation fields set to `DESTROY`, which recreates the fork from the GitHub mirror and re-seeds from scratch (verified: `mirror-seed-rerun: ok — created=14 skipped=0`).
3. Then check marimo's Workspace tree: all six notebooks should carry the notebook icon and be listed.

Delivering fixes to an *existing* seed file without a full destroy is a separate gap, deliberately not addressed here.

## Summary by Sourcery

Ensure seeded marimo notebooks appear as notebooks by keeping their recognition markers within the first 512 bytes and enforcing the convention in tests and contributor guidance.

Bug Fixes:
- Make all seeded marimo notebooks recognizable in marimo’s workspace and file browser by keeping their identifying markers within marimo’s header limit.

Enhancements:
- Move notebook introductions into the first markdown cell while retaining concise module summaries.
- Add unit coverage that validates real seeded notebooks against marimo’s 512-byte recognition rule and distinguishes helper modules.
- Document the header constraint and correct remediation across contributor and review guidance.

Documentation:
- Update contributor, Copilot, and CodeRabbit guidance with marimo notebook recognition requirements and correct the Kestra orchestrator reference.

Tests:
- Add tests covering recursive marimo seed discovery, non-empty seed protection, helper-module exclusion, and separate marker validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance for maintaining marimo notebook compatibility and keeping required detection markers within the first 512 bytes.
  - Updated review instructions and developer documentation with notebook authoring recommendations.

- **Improvements**
  - Moved detailed notebook introductions and usage guidance into their opening markdown cells, preserving the information while improving notebook recognition.

- **Tests**
  - Added validation to ensure marimo notebooks are correctly detected and required markers remain within the supported header limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->