### PR TITLE
docs(admin): Explain why a hostname stops resolving after a teardown

### DIFF
--- a/docs/admin-guides/troubleshooting.md
+++ b/docs/admin-guides/troubleshooting.md
@@ -256,36 +256,40 @@ serving the "does not exist" it learned.
 
 ### Confirm it in one step
 
-Compare your own resolver against a public one:
+Ask both resolvers the same question, and read the **status** rather than the
+answer — an empty answer section and an `NXDOMAIN` look identical with
+`+short`:
 
 ```bash
-dig +short marimo.example.com                 # your resolver
-dig +short marimo.example.com @1.1.1.1        # Cloudflare
+dig ssh.example.com +noall +comment | grep -o "status: [A-Z]*"            # yours
+dig ssh.example.com @1.1.1.1 +noall +comment | grep -o "status: [A-Z]*"   # Cloudflare
 ```
 
-If the second returns an IP and the first returns nothing, it is this.
-For the exact status rather than an empty line:
+`NXDOMAIN` from yours and `NOERROR` from Cloudflare is this problem. Both
+`NXDOMAIN` means the record really is gone — check the spin-up finished.
+
+To see which resolver your machine uses, read the whole output rather than
+the first block. macOS keeps several resolver configurations, and a VPN or a
+`search`-domain entry can put a scoped one ahead of the DHCP-supplied
+default:
 
 ```bash
-dig marimo.example.com @1.1.1.1 +noall +comment | grep -o "status: [A-Z]*"
+scutil --dns          # macOS — look for the block matching your domain
 ```
 
-To see which resolver your machine is actually using — the one DHCP handed
-it, which on a phone hotspot is the phone:
-
-```bash
-scutil --dns | grep -m1 'nameserver\[0\]'    # macOS
-```
-
-### Why flushing the local cache does not help
+### Flushing the local cache: when it helps and when it cannot
 
 ```bash
 sudo dscacheutil -flushcache && sudo killall -HUP mDNSResponder
 ```
 
-This empties **macOS's** cache. The next lookup then goes to your router or
-hotspot, which answers from **its** cache — the one holding the stale
-negative answer. You cannot reach that from your machine.
+This empties **macOS's own** cache. If that is where the stale answer sits,
+it fixes the problem outright — worth trying first, it costs nothing.
+
+It cannot do more than that. The next lookup goes to your router, hotspot or
+ISP resolver, and if the stale negative answer is cached *there*, it comes
+straight back. That cache is not reachable from your machine, which is what
+makes the flush look like it did nothing.
 
 ### Why waiting can take longer than the TTL suggests
 
@@ -297,17 +301,31 @@ dig example.com SOA +short
 #                                                                            ^^^^
 ```
 
-Thirty minutes — but the clock restarts on **every** query made while the
-record is still absent. A `destroy-all` at 14:56 whose spin-up finished at
-17:21 leaves a two-and-a-half-hour window in which each lookup refreshed the
-entry, so the last one before 17:21 governs. Observed exactly that: nearly
-three hours after the destroy, the resolver still said `NXDOMAIN`, and it
-was neither broken nor ignoring the TTL.
+Thirty minutes — but that is thirty minutes from the moment the resolver last
+asked **upstream**, not from the teardown. Your own queries do not reset it:
+while the entry is cached the resolver answers from cache and the TTL simply
+counts down. When it expires, the next query goes upstream again — and if the
+record is still gone, a fresh negative answer is cached with a fresh thirty
+minutes.
+
+So during a long outage the entry is renewed every half hour, and what
+governs is the **last renewal before the record came back**. Worked example
+from a real incident: `destroy-all` at 14:56, spin-up finished at 17:21, and
+at 17:39 the resolver still answered `NXDOMAIN` — nearly three hours after
+the teardown, and neither broken nor ignoring the TTL. Its last upstream
+query simply fell shortly before 17:21.
+
+The practical consequence: after a spin-up completes, allow up to the full
+negative TTL before concluding something else is wrong.
 
 ### Fix
 
-Point your machine at a public resolver. This is the one that stops the
-problem recurring on every teardown, and on whatever network you are on:
+Point your machine at a public resolver. This does **not** make you immune — a
+public resolver caches negative answers the same way, and querying it during
+the outage window leaves it holding one too. What it does is take your router,
+hotspot or ISP resolver out of the path, so the only cache in play is one you
+can compare against directly. That is usually enough, because the stale entry
+is nearly always the local one:
 
 ```bash
 networksetup -setdnsservers Wi-Fi 1.1.1.1 8.8.8.8      # macOS
@@ -328,8 +346,13 @@ than by address — take whatever `dig +short <host> @1.1.1.1` returns. Remove
 the line afterwards; the address is not guaranteed to stay valid:
 
 ```bash
-sudo sed -i '' '/example.com/d' /etc/hosts
+sudo sed -i '' '/[[:space:]]ssh\.example\.com$/d' /etc/hosts
 ```
+
+The escaped dots and the anchor matter. Unescaped, `example.com` is a regular
+expression in which each `.` matches any character; without the trailing `$`
+it also matches a longer hostname that merely starts the same way. Either
+would delete mappings you meant to keep.
 
 ## General Tips
 

--- a/docs/admin-guides/troubleshooting.md
+++ b/docs/admin-guides/troubleshooting.md
@@ -235,6 +235,102 @@ scripts, and the per-service configure hooks. Failures there tend to be
 quiet — wrong output rather than a non-zero exit — so a green step is
 not proof.
 
+## A hostname stops resolving after a teardown or destroy
+
+**Symptom.** Right after a teardown, `destroy-all` or a re-deploy, a service
+URL stops working from your machine — while the stack itself is healthy.
+SSH fails before it even reaches Cloudflare:
+
+```text
+dial tcp: lookup ssh.example.com: no such host
+Connection closed by UNKNOWN port 65535
+```
+
+A browser shows a DNS error rather than a Cloudflare Access login. Other
+people, or the same laptop on a different network, reach the service fine.
+
+**Cause.** A teardown deletes the DNS records; the spin-up recreates them.
+In the window between, every lookup legitimately answers `NXDOMAIN`, and
+your resolver caches that. The record comes back — your resolver keeps
+serving the "does not exist" it learned.
+
+### Confirm it in one step
+
+Compare your own resolver against a public one:
+
+```bash
+dig +short marimo.example.com                 # your resolver
+dig +short marimo.example.com @1.1.1.1        # Cloudflare
+```
+
+If the second returns an IP and the first returns nothing, it is this.
+For the exact status rather than an empty line:
+
+```bash
+dig marimo.example.com @1.1.1.1 +noall +comment | grep -o "status: [A-Z]*"
+```
+
+To see which resolver your machine is actually using — the one DHCP handed
+it, which on a phone hotspot is the phone:
+
+```bash
+scutil --dns | grep -m1 'nameserver\[0\]'    # macOS
+```
+
+### Why flushing the local cache does not help
+
+```bash
+sudo dscacheutil -flushcache && sudo killall -HUP mDNSResponder
+```
+
+This empties **macOS's** cache. The next lookup then goes to your router or
+hotspot, which answers from **its** cache — the one holding the stale
+negative answer. You cannot reach that from your machine.
+
+### Why waiting can take longer than the TTL suggests
+
+The zone's negative TTL is 1800 seconds:
+
+```bash
+dig example.com SOA +short
+# anirban.ns.cloudflare.com. dns.cloudflare.com. 2414327986 10000 2400 604800 1800
+#                                                                            ^^^^
+```
+
+Thirty minutes — but the clock restarts on **every** query made while the
+record is still absent. A `destroy-all` at 14:56 whose spin-up finished at
+17:21 leaves a two-and-a-half-hour window in which each lookup refreshed the
+entry, so the last one before 17:21 governs. Observed exactly that: nearly
+three hours after the destroy, the resolver still said `NXDOMAIN`, and it
+was neither broken nor ignoring the TTL.
+
+### Fix
+
+Point your machine at a public resolver. This is the one that stops the
+problem recurring on every teardown, and on whatever network you are on:
+
+```bash
+networksetup -setdnsservers Wi-Fi 1.1.1.1 8.8.8.8      # macOS
+networksetup -setdnsservers Wi-Fi empty                # to undo
+```
+
+Use the right service name — `networksetup -listallnetworkservices` lists
+them; a USB or Bluetooth tether is not `Wi-Fi`.
+
+For a single hostname, right now, without changing your network settings:
+
+```bash
+echo "104.21.11.47 ssh.example.com" | sudo tee -a /etc/hosts
+```
+
+Any Cloudflare edge IP works, because the tunnel is selected by SNI rather
+than by address — take whatever `dig +short <host> @1.1.1.1` returns. Remove
+the line afterwards; the address is not guaranteed to stay valid:
+
+```bash
+sudo sed -i '' '/example.com/d' /etc/hosts
+```
+
 ## General Tips
 
 ### SSH Access Issues

--- a/docs/admin-guides/troubleshooting.md
+++ b/docs/admin-guides/troubleshooting.md
@@ -293,13 +293,20 @@ makes the flush look like it did nothing.
 
 ### Why waiting can take longer than the TTL suggests
 
-The zone's negative TTL is 1800 seconds:
+Read the zone's negative TTL from the `AUTHORITY` section of a query for a
+name that does not exist, rather than from the SOA record directly:
 
 ```bash
-dig example.com SOA +short
-# anirban.ns.cloudflare.com. dns.cloudflare.com. 2414327986 10000 2400 604800 1800
-#                                                                            ^^^^
+dig no-such-name.example.com +noall +authority
+# example.com.  1800  IN  SOA  ns.example.com. dns.example.com. 2414374634 10000 2400 604800 1800
+#               ^^^^                                                                        ^^^^
 ```
+
+Both numbers matter. RFC 2308 defines the effective negative-cache TTL as the
+**minimum** of the SOA record's own TTL (first `^^^^`) and its `MINIMUM` field
+(last). `dig example.com SOA +short` shows only the second, so a zone whose
+SOA TTL is lower would be read wrong. For this project's zone both are 1800,
+which is where the thirty minutes below come from.
 
 Thirty minutes — but that is thirty minutes from the moment the resolver last
 asked **upstream**, not from the teardown. Your own queries do not reset it:
@@ -328,31 +335,47 @@ can compare against directly. That is usually enough, because the stale entry
 is nearly always the local one:
 
 ```bash
+networksetup -getdnsservers Wi-Fi                      # note this first
 networksetup -setdnsservers Wi-Fi 1.1.1.1 8.8.8.8      # macOS
-networksetup -setdnsservers Wi-Fi empty                # to undo
 ```
+
+`empty` is how you go back to whatever DHCP hands out:
+
+```bash
+networksetup -setdnsservers Wi-Fi empty
+```
+
+It restores the *automatic* configuration, not a manual one you had before —
+which is why the first command above is worth running and keeping.
 
 Use the right service name — `networksetup -listallnetworkservices` lists
 them; a USB or Bluetooth tether is not `Wi-Fi`.
 
-For a single hostname, right now, without changing your network settings:
+For a single hostname, right now, without changing your network settings.
+Both lines together, in this order:
 
 ```bash
-echo "104.21.11.47 ssh.example.com" | sudo tee -a /etc/hosts
+sudo sed -i '' '/# nexus-temp$/d' /etc/hosts
+echo "104.21.11.47 ssh.example.com # nexus-temp" | sudo tee -a /etc/hosts
 ```
 
 Any Cloudflare edge IP works, because the tunnel is selected by SNI rather
-than by address — take whatever `dig +short <host> @1.1.1.1` returns. Remove
-the line afterwards; the address is not guaranteed to stay valid:
+than by address — take whatever `dig +short <host> @1.1.1.1` returns.
+
+Remove it once you no longer need it; the address is not guaranteed to stay
+valid:
 
 ```bash
-sudo sed -i '' '/[[:space:]]ssh\.example\.com$/d' /etc/hosts
+sudo sed -i '' '/# nexus-temp$/d' /etc/hosts
 ```
 
-The escaped dots and the anchor matter. Unescaped, `example.com` is a regular
-expression in which each `.` matches any character; without the trailing `$`
-it also matches a longer hostname that merely starts the same way. Either
-would delete mappings you meant to keep.
+**Why the marker, and why the delete comes first.** `/etc/hosts` is read top
+to bottom and the first match wins. Appending without removing leaves the
+previous entry ahead of the new one, so after the edge IP changes you would
+still be pinned to the old address — with a file that looks like it was
+updated. Deleting by marker rather than by hostname also leaves alone any
+mapping for the same host that was there for another reason and that you did
+not put there.
 
 ## General Tips
 


### PR DESCRIPTION
## Why this section exists

Hit three times in one day, on two different networks, and misdiagnosed twice before the mechanism was clear.

A teardown deletes the DNS records; the spin-up recreates them. In the window between, every lookup legitimately answers `NXDOMAIN` — and the operator's resolver caches that. The record returns; the resolver keeps serving "does not exist". **The stack is healthy the entire time**, which is what makes it read as a deployment failure and sends people looking at container logs.

```text
dial tcp: lookup ssh.example.com: no such host
Connection closed by UNKNOWN port 65535
```

## What the section covers

**Confirming it in one step** — query your resolver and a public one side by side and compare the *status*, not the answer. An empty answer section and an `NXDOMAIN` are indistinguishable under `+short`. `NXDOMAIN` from yours and `NOERROR` from Cloudflare is this problem; both `NXDOMAIN` means the record really is gone and the spin-up is what to check.

**When flushing the local cache helps, and when it cannot.** `dscacheutil -flushcache` is the obvious first move and it is worth trying — if the stale entry is macOS's own, it fixes the problem outright. What it cannot do is reach the router, hotspot or ISP cache, which is where the entry usually sits and why the flush so often looks like it did nothing.

**Why waiting can take longer than the 1800-second TTL suggests.** The TTL runs from the resolver's last *upstream* query, not from the teardown, and it is renewed every half hour for as long as the record is absent. Worked example from the real incident: `destroy-all` at 14:56, spin-up finished at 17:21, resolver still answering `NXDOMAIN` at 17:39 — nearly three hours later, and neither broken nor ignoring the TTL. Without this, "wait half an hour" looks wrong and sends people hunting a second fault.

**The fix**, with what it does and does not buy. A public resolver does not make you immune — it caches negative answers the same way. It takes the router out of the path so the remaining cache is one you can compare against, which is usually enough because the stale entry is nearly always local. The `/etc/hosts` entry is given as the right-now escape hatch, with the reason any Cloudflare edge IP works (SNI, not address) and an explicit instruction to remove it afterwards.

Every command in the section is one that was actually run during the incident.

## Local CodeRabbit round

Reviewed `3888d69`, **7 findings, all valid, all fixed** in `e9047b9`. Two corrected claims I had written with more confidence than they deserved:

- 🔴 **The negative-TTL mechanism was wrong.** The first draft said the clock "restarts on every query made while the record is still absent". It does not — client queries are served from cache and leave the TTL counting down; only expiry sends the resolver upstream, and only then does a fresh negative answer start a fresh TTL. The conclusion survives (renewal every half hour, last renewal before the record returned governs) but the mechanism given for it was not the one that produces it.
- 🟠 **The diagnostic pointed at the wrong resolver.** The status command read `dig <host> @1.1.1.1`, which reports Cloudflare — the resolver that is *working*. The interesting status is the local one. Both are queried now.

The rest: the public-resolver fix was oversold as making the problem stop recurring; "flushing does not help" was too absolute; `scutil --dns | grep -m1` assumes the first block is active, which a VPN or search-domain entry breaks; the `/etc/hosts` cleanup used `sed '/example.com/d'`, whose unescaped dots are wildcards and which had no anchor — now `/[[:space:]]ssh\.example\.com$/`, verified against a fixture where `notssh.example.com` and `ssh.example.community` both survive; and one example used a different placeholder host than its neighbours.

## Scope

Docs only — one file, no behaviour change, nothing to deploy.

The one code block this adds is tagged `text`. The three untagged blocks already in the file are left alone: same class as #802, which names `docs/stacks/` rather than this guide.

## Summary by Sourcery

Document how to diagnose and resolve hostname lookup failures caused by DNS negative caching after teardown or redeploy.

Enhancements:
- Add an admin troubleshooting guide for hostname resolution failures caused by cached negative DNS responses after teardown or redeploy.
- Document resolver comparison, cache flushing limitations, negative-TTL behavior, public resolver configuration, and temporary hosts-file workarounds.

Documentation:
- Explain how to diagnose and recover from stale NXDOMAIN responses while distinguishing DNS caching from an unhealthy stack.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added troubleshooting guidance for hostname resolution issues following teardown or redeployment.
  - Included steps for diagnosing DNS problems, comparing resolvers, clearing macOS DNS caches, and understanding negative TTL behavior.
  - Documented public DNS configuration and temporary `/etc/hosts` workarounds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->