### PR TITLE
fix(stacks): Recreate Spark when its rendered config changes

### DIFF
--- a/src/nexus_deploy/service_env.py
+++ b/src/nexus_deploy/service_env.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 
 import base64
 import contextlib
+import hashlib
 import json
 import os
 import re
@@ -1772,10 +1773,38 @@ def _render_spark(
     credentials rather than the enabled-service list.
     """
     del e  # not used; signature uniform across renderers
+    conf = _spark_defaults_conf(c, unity_catalog_enabled=unity_catalog_enabled)
     return RenderedEnv(
         env_vars={
             "SPARK_WORKER_CORES": "2",
             "SPARK_WORKER_MEMORY": "3g",
+            # A digest of the file below, and the only reason it is here.
+            #
+            # Spark reads spark-defaults.conf ONCE, at process start. The
+            # compose file mounts the whole conf/ DIRECTORY, so changing a file
+            # inside it does not change the service definition -- and
+            # `docker compose up -d` leaves a running container alone. The
+            # deploy then reports success while the cluster runs the previous
+            # configuration, indefinitely.
+            #
+            # Measured on a live deployment: unity-catalog was enabled between
+            # two spin-ups, the second wrote the catalog block at 17:36, and
+            # spark-connect was still the container started at 17:30. Every
+            # query answered `SCHEMA_NOT_FOUND` until the container was
+            # restarted by hand. The same failure applies to the R2 and Hetzner
+            # credentials this file carries: rotate them under a running Spark
+            # and object storage goes silently dead.
+            #
+            # Putting the digest in .env makes the change visible to compose,
+            # which then recreates the containers -- exactly when the
+            # configuration changed, and never otherwise. Verified both ways
+            # against a minimal stack: an unchanged .env left the container id
+            # untouched, a changed one produced a new container.
+            #
+            # Cheaper and less error-prone than a force-recreate in the deploy,
+            # which would restart Spark on every run whether or not anything
+            # changed, and which someone has to remember to keep wired up.
+            "SPARK_CONF_HASH": hashlib.sha256(conf.encode("utf-8")).hexdigest()[:16],
         },
         sidecars=(
             SidecarFile(
@@ -1796,7 +1825,7 @@ def _render_spark(
                 # nothing. That is not true of every image — unity-catalog
                 # mounts a single file for exactly the opposite reason.
                 relative_path="conf/spark-defaults.conf",
-                content=_spark_defaults_conf(c, unity_catalog_enabled=unity_catalog_enabled),
+                content=conf,
                 # mode 0o644, NOT 0o600, and the credentials in this file
                 # do not change that. Same constraint as Grafana's
                 # prometheus.yml a few hundred lines above: the file is

--- a/stacks/spark/docker-compose.yml
+++ b/stacks/spark/docker-compose.yml
@@ -63,6 +63,16 @@ services:
       # --conf flags.
       - ./conf:/opt/spark/conf:ro
     env_file:
+      # Also carries SPARK_CONF_HASH, a digest of conf/spark-defaults.conf.
+      # Do not remove it as unused: nothing reads the value, and that is the
+      # point. Spark parses spark-defaults.conf once at process start, and
+      # because the mount above is a DIRECTORY, editing a file inside it does
+      # not change this service's definition — so `docker compose up -d`
+      # leaves a running container alone and the cluster keeps the old
+      # configuration while the deploy reports success. Feeding the digest
+      # through the environment makes the change visible to compose, which
+      # then recreates the container exactly when the config changed.
+      # Rendered by service_env._render_spark; see the comment there.
       - path: .env
         required: false
     # Run Master class directly in foreground via official entrypoint
@@ -123,6 +133,16 @@ services:
       # --conf flags.
       - ./conf:/opt/spark/conf:ro
     env_file:
+      # Also carries SPARK_CONF_HASH, a digest of conf/spark-defaults.conf.
+      # Do not remove it as unused: nothing reads the value, and that is the
+      # point. Spark parses spark-defaults.conf once at process start, and
+      # because the mount above is a DIRECTORY, editing a file inside it does
+      # not change this service's definition — so `docker compose up -d`
+      # leaves a running container alone and the cluster keeps the old
+      # configuration while the deploy reports success. Feeding the digest
+      # through the environment makes the change visible to compose, which
+      # then recreates the container exactly when the config changed.
+      # Rendered by service_env._render_spark; see the comment there.
       - path: .env
         required: false
     # Run Worker class directly in foreground via official entrypoint
@@ -191,6 +211,16 @@ services:
       # --conf flags.
       - ./conf:/opt/spark/conf:ro
     env_file:
+      # Also carries SPARK_CONF_HASH, a digest of conf/spark-defaults.conf.
+      # Do not remove it as unused: nothing reads the value, and that is the
+      # point. Spark parses spark-defaults.conf once at process start, and
+      # because the mount above is a DIRECTORY, editing a file inside it does
+      # not change this service's definition — so `docker compose up -d`
+      # leaves a running container alone and the cluster keeps the old
+      # configuration while the deploy reports success. Feeding the digest
+      # through the environment makes the change visible to compose, which
+      # then recreates the container exactly when the config changed.
+      # Rendered by service_env._render_spark; see the comment there.
       - path: .env
         required: false
     entrypoint: ["/opt/entrypoint.sh"]

--- a/tests/unit/test_service_env.py
+++ b/tests/unit/test_service_env.py
@@ -2886,3 +2886,84 @@ def test_spark_names_the_catalog_only_when_unity_catalog_is_enabled(
     # Not set on purpose: leaving Spark's own catalog as the default keeps
     # every existing notebook working.
     assert "spark.sql.defaultCatalog" not in with_uc
+
+
+def test_spark_conf_hash_tracks_the_rendered_config(
+    full_config: NexusConfig, full_env: BootstrapEnv, tmp_path: Path
+) -> None:
+    """SPARK_CONF_HASH must change with the file and not otherwise.
+
+    Spark parses spark-defaults.conf once, at process start. The compose file
+    mounts the whole conf/ DIRECTORY, so editing a file inside it leaves the
+    service definition identical and `docker compose up -d` does not recreate
+    a running container — the cluster keeps the previous configuration while
+    the deploy reports success.
+
+    Measured on a live deployment before this existed: unity-catalog was
+    enabled between two spin-ups, the second wrote the catalog block at 17:36,
+    and spark-connect was still the container started at 17:30. Every query
+    answered SCHEMA_NOT_FOUND until it was restarted by hand.
+
+    Feeding the digest through .env makes the change visible to compose.
+    Verified against a minimal stack in both directions: an unchanged .env
+    left the container id untouched, a changed one produced a new container.
+    """
+
+    def render(**overrides: object) -> tuple[str, str]:
+        config = full_config.model_copy(update=dict(overrides))
+        render_all_env_files(config, full_env, ["spark"], stacks_dir=tmp_path)
+        env = _env_settings((tmp_path / "spark" / ".env").read_text())
+        conf = (tmp_path / "spark" / "conf" / "spark-defaults.conf").read_text()
+        return env["SPARK_CONF_HASH"], conf
+
+    base = {
+        "unity_catalog_db_password": "ucpass",
+        "r2_data_bucket": "lake-r2",
+        "r2_data_endpoint": "https://acct.r2.cloudflarestorage.com",
+        "r2_data_access_key": "R2KEY",
+        "r2_data_secret_key": "R2SECRET",
+    }
+
+    first_hash, first_conf = render(**base)
+    assert first_hash, "SPARK_CONF_HASH is missing from the rendered .env"
+
+    # Same inputs -> same digest. Without this the containers would be
+    # recreated on every deploy, which is the cost this design exists to avoid.
+    again_hash, again_conf = render(**base)
+    assert again_hash == first_hash
+    assert again_conf == first_conf
+
+    # A changed credential must move the digest. This is the case that was
+    # silently broken: rotate the keys under a running Spark and object
+    # storage goes dead with nothing reporting it.
+    rotated_hash, rotated_conf = render(**{**base, "r2_data_secret_key": "ROTATED"})
+    assert rotated_conf != first_conf
+    assert rotated_hash != first_hash
+
+
+def test_spark_conf_hash_moves_when_the_catalog_block_appears(
+    full_config: NexusConfig, full_env: BootstrapEnv, tmp_path: Path
+) -> None:
+    """Enabling unity-catalog between two spin-ups must recreate Spark.
+
+    This is the exact sequence that produced the incident: spark and marimo
+    first, unity-catalog in a second spin-up. The config gained the catalog
+    block; the running container never saw it.
+    """
+    config = full_config.model_copy(
+        update={
+            "unity_catalog_db_password": "ucpass",
+            "r2_data_bucket": "lake-r2",
+            "r2_data_endpoint": "https://acct.r2.cloudflarestorage.com",
+            "r2_data_access_key": "R2KEY",
+            "r2_data_secret_key": "R2SECRET",
+        }
+    )
+
+    render_all_env_files(config, full_env, ["spark"], stacks_dir=tmp_path)
+    without = _env_settings((tmp_path / "spark" / ".env").read_text())["SPARK_CONF_HASH"]
+
+    render_all_env_files(config, full_env, ["spark", "unity-catalog"], stacks_dir=tmp_path)
+    with_uc = _env_settings((tmp_path / "spark" / ".env").read_text())["SPARK_CONF_HASH"]
+
+    assert without != with_uc


### PR DESCRIPTION
## The bug

Spark parses `spark-defaults.conf` **once**, at process start. The compose file mounts the whole `conf/` **directory**, so editing a file inside it leaves the service definition byte-identical — and `docker compose up -d` leaves a running container alone. The deploy reports success while the cluster keeps the previous configuration, for as long as the container lives.

Observed on a live deployment, with `unity-catalog` enabled between two spin-ups:

```text
17:30:34  spark-connect starts (unity-catalog not yet enabled)
17:34:24  spin-up begins
17:36:04  spark-defaults.conf written, now with the catalog block
17:54     spark-connect still "Up 24 minutes" — never recreated
```

Every query answered `SCHEMA_NOT_FOUND` and `SHOW CATALOGS` listed only `spark_catalog`, because Spark was reading a config that predated the change. Restarting the container by hand fixed it, which is what confirmed the cause.

**It is not only about the catalog.** The same file carries the R2 and Hetzner credentials. Rotate them under a running Spark and object storage goes dead from every Connect session, with nothing reporting it.

## The fix

A digest of the rendered file travels through `.env` as `SPARK_CONF_HASH`. All three Spark services already load `.env` via `env_file`, so the value reaches their environment and compose's service definition changes exactly when the configuration does.

Verified against a minimal stack, both directions:

```text
.env unchanged, up -d  ->  container b2dc0d6f  (same, correct)
.env changed,   up -d  ->  container eedc181f  (recreated)
```

Chosen over a force-recreate in the deploy — the pattern Kestra uses after its secret sync. That restarts Spark on every run whether or not anything changed, and it is a step someone has to remember to keep wired up. The digest needs neither.

Nothing reads `SPARK_CONF_HASH`, which is exactly why the compose file now carries a comment at all three `env_file` blocks explaining what it is for. An unexplained unused variable is the kind of thing a later cleanup deletes — and deleting it would bring the bug back silently.

## Tests

Two, each checked by breaking the code:

- a constant digest fails both,
- removing the variable fails with `KeyError: 'SPARK_CONF_HASH'`.

One covers the general contract — same input produces the same digest, so containers are **not** recreated needlessly, and a rotated credential moves it. The other reproduces the incident directly: enabling `unity-catalog` between two renders must move the digest.

## Local CodeRabbit round

Reviewed `533f80e`, **0 findings**. Files reviewed: `src/nexus_deploy/service_env.py`, `stacks/spark/docker-compose.yml`, `tests/unit/test_service_env.py`.

## How to test

1. Deploy with `spark` enabled but `unity-catalog` off, then enable `unity-catalog` and run `spin-up.yml` again — the sequence that produced the incident.
2. `ssh nexus "docker ps --filter name=spark-connect --format '{{.Status}}'"` should show a container younger than the deploy, not one that survived it.
3. In Marimo: `spark.sql("SHOW CATALOGS").collect()` must list `unity` without anyone restarting anything by hand.

## Summary by Sourcery

Recreate Spark containers automatically when their rendered configuration changes while avoiding unnecessary restarts.

Bug Fixes:
- Ensure Spark services are recreated when the rendered Spark configuration changes, so updated catalogs and storage credentials are loaded without manual restarts.

Enhancements:
- Expose a deterministic digest of spark-defaults.conf through the generated environment so Compose detects configuration changes without recreating unchanged containers.

Tests:
- Add coverage verifying stable hashes for unchanged configuration, changed hashes for credential rotations, and hash changes when Unity Catalog is enabled.