### PR TITLE
docs(stacks): Name the Unity Catalog example schema `demo`

### DIFF
--- a/docs/stacks/unity-catalog.md
+++ b/docs/stacks/unity-catalog.md
@@ -177,13 +177,13 @@ and Delta JARs are baked into `nexus-spark`. Open a notebook and address a
 table by its three-part name:
 
 ```sql
-CREATE SCHEMA IF NOT EXISTS unity.teaching;
+CREATE SCHEMA IF NOT EXISTS unity.demo;
 
-CREATE TABLE unity.teaching.trips (id INT, city STRING) USING delta
+CREATE TABLE unity.demo.trips (id INT, city STRING) USING delta
   LOCATION 's3://<your-r2-bucket>/teaching/trips';
 
-INSERT INTO unity.teaching.trips VALUES (1, 'Zürich');
-SELECT * FROM unity.teaching.trips;
+INSERT INTO unity.demo.trips VALUES (1, 'Zürich');
+SELECT * FROM unity.demo.trips;
 ```
 
 Three details that are easy to get wrong, all of them measured:

--- a/examples/workspace-seeds/marimo/Getting_Started_Unity_Catalog.py
+++ b/examples/workspace-seeds/marimo/Getting_Started_Unity_Catalog.py
@@ -96,7 +96,7 @@ def _(bucket, ready, spark):
     if not ready:
         print("skipped — see the setup cell above for which half is missing")
     else:
-        spark.sql("CREATE SCHEMA IF NOT EXISTS unity.workshop")
+        spark.sql("CREATE SCHEMA IF NOT EXISTS unity.demo")
         spark.sql("SHOW SCHEMAS IN unity").show()
     return
 
@@ -125,9 +125,9 @@ def _(bucket, ready, spark):
     if not ready:
         print("skipped — see the setup cell above for which half is missing")
     else:
-        _location = f"s3://{bucket}/workshop/cities"
+        _location = f"s3://{bucket}/demo/cities"
         spark.sql(f"""
-            CREATE TABLE IF NOT EXISTS unity.workshop.cities (
+            CREATE TABLE IF NOT EXISTS unity.demo.cities (
                 id INT,
                 name STRING,
                 country STRING
@@ -158,14 +158,14 @@ def _(bucket, ready, spark):
         print("skipped — see the setup cell above for which half is missing")
     else:
         spark.sql("""
-            INSERT INTO unity.workshop.cities VALUES
+            INSERT INTO unity.demo.cities VALUES
                 (1, 'Zürich', 'CH'),
                 (2, 'Lisbon', 'PT'),
                 (3, 'Tallinn', 'EE')
         """)
         spark.sql("""
             SELECT DISTINCT id, name, country
-            FROM unity.workshop.cities
+            FROM unity.demo.cities
             ORDER BY id
         """).show()
     return
@@ -190,8 +190,8 @@ def _(bucket, ready, spark):
     if not ready:
         print("skipped — see the setup cell above for which half is missing")
     else:
-        spark.sql("SHOW TABLES IN unity.workshop").show()
-        spark.sql("DESCRIBE TABLE unity.workshop.cities").show()
+        spark.sql("SHOW TABLES IN unity.demo").show()
+        spark.sql("DESCRIBE TABLE unity.demo.cities").show()
     return
 
 


### PR DESCRIPTION
## The drift

#814 shipped two names for the same thing:

| Where | Schema |
|---|---|
| `examples/workspace-seeds/marimo/Getting_Started_Unity_Catalog.py` | `unity.workshop` |
| `docs/stacks/unity-catalog.md` | `unity.teaching` |

Neither is wrong. But a reader who follows the stack documentation and then opens the seeded notebook finds a different schema, and nothing says which is meant.

## The name

`demo` for both. It reads as "this came with the stack" — the same separation `nexus_seeds/` already draws in the workspace repo, one level down.

`test` was the other candidate and is worse here on two counts: it suggests something disposable rather than something to learn from, and it is exactly the name a user is likely to want for their own scratch work.

The R2 prefix moves with it — `s3://<bucket>/workshop/cities` → `.../demo/cities` — so the storage layout matches the catalog rather than preserving the old name underneath.

## What deliberately stays different

The table names: `demo.cities` in the notebook, `demo.trips` in the docs.

They have different columns. Sharing a name would let a `CREATE TABLE IF NOT EXISTS` copied from the docs bind silently to the notebook's existing table and show a structure the snippet does not describe — a failure that produces no error at all.

## Effect on existing deployments

None, and that is worth stating plainly: seeding is create-only (`POST`, 422 → skipped), so a notebook already in a workspace repo is not replaced, and a `workshop` schema already in a catalog is not renamed. Drop it by hand if you want it gone.

## Local CodeRabbit round

Reviewed `a040524`, **0 findings**. Files reviewed: `docs/stacks/unity-catalog.md`, `examples/workspace-seeds/marimo/Getting_Started_Unity_Catalog.py`.

## Scope

Docs and one seeded example. No behaviour change, nothing to deploy. `tests/unit/test_workspace_seeds.py` still passes, and `marimo check` reports no errors on the notebook.

## Summary by Sourcery

Standardize the Unity Catalog example schema and storage layout as `demo` across the documentation and seeded notebook.

Enhancements:
- Align the Unity Catalog documentation and seeded notebook on the shared `unity.demo` schema and matching demo storage path.

Documentation:
- Update Unity Catalog stack examples to use the `demo` schema consistently.