### PR TITLE
docs: Add activity and star-history charts to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,3 +338,17 @@ Learn more about Nexus-Stack and explore the full documentation:
 ## License
 
 [MIT](LICENSE)
+
+## Activity
+
+![Repobeats analytics image](https://repobeats.axiom.co/api/embed/f8f883f70e3a96a899518a605d21827739dba963.svg "Repobeats analytics image")
+
+## Star History
+
+<a href="https://www.star-history.com/?repos=stefanko-ch%2Fnexus-stack&type=date&legend=top-left">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=stefanko-ch/nexus-stack&type=date&theme=dark&legend=top-left" />
+    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=stefanko-ch/nexus-stack&type=date&legend=top-left" />
+    <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=stefanko-ch/nexus-stack&type=date&legend=top-left" />
+  </picture>
+</a>


### PR DESCRIPTION
## What this adds

Two embedded charts at the end of the README:

- **Repobeats** — contribution activity: commits, PRs, issues, pushes, contributors over the last month.
- **star-history** — star growth over time, with a dark-mode variant.

They answer different questions. One is *how much is happening*, the other is *whether anyone is watching*.

## Why hosted images rather than a generated block

Neither needs a workflow, a token, or write access to the repository.

That is the deciding argument, not convenience. The alternatives — `lowlighter/metrics` and friends — commit a generated SVG back to `main`, and **every commit on `main` triggers a Release Please run and lands in its `Considering: N` count**. That number is what this project checks to catch a commit Release Please silently dropped (`CLAUDE.md` → *After merging, check that Release Please saw the commit*). Adding routine machine commits to it makes the check harder to read for no gain.

A self-generated statistics block was considered and dropped for a second reason, found while prototyping it: the obvious "number of stacks" metric would have counted `services.yaml` entries, which is **87**, while the README's hand-maintained heading says **85** — and 85 is correct. `seaweedfs-filer` and `seaweedfs-manager` are extra tunnel routes for the SeaweedFS stack, not stacks of their own. The automated version would have replaced a correct number with a wrong one, permanently, with the authority that generated figures carry.

## On the HTML

The star-history block uses `<picture>` and `<img>`. That is deliberate and is not covered by the `docs/**` image rule in `CLAUDE.md`:

- That rule exists because Astro passes HTML `<img>` through unchanged, so a relative `./assets/…` path resolves against the *rendered page URL* and 404s (the failure from #450). These are absolute external URLs — nothing to resolve.
- `README.md` is not in the website content mapping (`docs/admin-guides/docs-website-sync.md`). It triggers the sync build; it is not rendered as a page.
- `<picture>` with `prefers-color-scheme` sources is what gives the chart a dark-mode variant. Markdown cannot express that.

It is nonetheless the **first HTML of any kind in this file**, which is worth knowing rather than discovering later.

## Third-party images

Both charts load from `axiom.co` and `star-history.com`. Anyone viewing the README fetches them, and both services learn that someone looked. Ordinary for a public project, but it is a dependency the README did not have before.

Both endpoints answer `200` as of this commit.

## Local CodeRabbit round

Reviewed `b6b4ae0`, **0 findings**. Files reviewed: `README.md`.

## Scope

One file, fourteen added lines, nothing removed. No behaviour change, nothing to deploy.

## Summary by Sourcery

Add externally hosted activity and star-growth charts to the README.

New Features:
- Add README activity and star-history charts using externally hosted images, including a dark-mode variant.

Documentation:
- Expand the README with contribution activity and repository star-growth visualizations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an Activity section featuring repository analytics.
  * Added a Star History section with light and dark theme charts linking to the project’s star history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->