### PR TITLE
feat(examples): Demonstrate Unity Catalog volumes in the seeded notebook

### DIFF
--- a/examples/workspace-seeds/marimo/Getting_Started_Unity_Catalog.py
+++ b/examples/workspace-seeds/marimo/Getting_Started_Unity_Catalog.py
@@ -237,7 +237,17 @@ def _():
             with urllib.request.urlopen(req, timeout=20) as resp:
                 return resp.status, json.loads(resp.read() or b"{}")
         except urllib.error.HTTPError as exc:
+            # The catalog answered and said no. The body carries the reason.
             return exc.code, (exc.read() or b"").decode()[:300]
+        except urllib.error.URLError as exc:
+            # No answer at all: the container is down, or the name does not
+            # resolve. Caught separately so a stopped catalog reads as a
+            # sentence rather than a traceback — HTTPError is a subclass of
+            # URLError, so the order of these two matters.
+            return "unreachable", (
+                f"{UC_API} did not answer ({exc.reason}). Is the "
+                "unity-catalog stack enabled and running?"
+            )
 
     r2_endpoint = os.environ.get("R2_ENDPOINT", "")
     return r2_endpoint, uc
@@ -388,6 +398,21 @@ def _(mo):
         the table's credentials were vended to Spark without you seeing
         them, while for the volume you asked and received them yourself.
         Same mechanism, one step more visible.
+
+        ## Two things the UI will not show you
+
+        **The table has no columns.** Open `unity.demo.cities` in the UI and
+        the Columns section is empty, even though the query above returned
+        rows. The Spark connector registers the table's type, format and
+        location and leaves the schema in the Delta log at that location —
+        so Spark reads it from there, and the catalog never sees it. Not a
+        fault in this deployment: a table created through the REST API *with*
+        a `columns` array does show them.
+
+        **The volume shows no files.** Unity Catalog has no files API — only
+        the volume's own metadata. Your `cities.csv` is in R2 and this
+        notebook just read it back; there is simply no endpoint the browser
+        could list it from.
 
         ## Why Functions and Models stay empty
 

--- a/examples/workspace-seeds/marimo/Getting_Started_Unity_Catalog.py
+++ b/examples/workspace-seeds/marimo/Getting_Started_Unity_Catalog.py
@@ -199,6 +199,179 @@ def _(bucket, ready, spark):
 def _(mo):
     mo.md(
         r"""
+        ## 5 — A volume, for the files that are not tables
+
+        A table is Delta: columns, rows, a schema. A **volume** is the
+        catalog's answer for everything else — a CSV someone handed you, a
+        folder of images, a trained model. The catalog tracks the name and
+        the location; the bytes live in R2 exactly as a table's do.
+
+        Volumes are not part of Spark SQL. `SHOW VOLUMES` is a Databricks
+        dialect and Spark rejects it, so this section talks to Unity
+        Catalog's REST API directly — with `urllib` from the standard
+        library, no install needed.
+        """
+    )
+    return
+
+
+@app.cell
+def _():
+    import json
+    import os
+    import urllib.error
+    import urllib.request
+
+    UC_API = "http://unitycatalog:8080/api/2.1/unity-catalog"
+
+    def uc(path, body=None, method=None):
+        """Call the catalog. Returns (status, parsed-body-or-text)."""
+        data = json.dumps(body).encode() if body is not None else None
+        req = urllib.request.Request(
+            f"{UC_API}{path}",
+            data=data,
+            method=method or ("POST" if data else "GET"),
+            headers={"Content-Type": "application/json"},
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=20) as resp:
+                return resp.status, json.loads(resp.read() or b"{}")
+        except urllib.error.HTTPError as exc:
+            return exc.code, (exc.read() or b"").decode()[:300]
+
+    r2_endpoint = os.environ.get("R2_ENDPOINT", "")
+    return r2_endpoint, uc
+
+
+@app.cell
+def _(bucket, ready, uc):
+    if not ready:
+        print("skipped — see the setup cell above for which half is missing")
+    else:
+        _location = f"s3://{bucket}/demo/volumes/reports"
+        # Create-if-absent by hand: the API has no IF NOT EXISTS, and a
+        # second run would otherwise fail on a volume that is already there.
+        _status, _existing = uc("/volumes/unity.demo.reports")
+        if _status == 200:
+            print("volume already exists:", _existing["storage_location"])
+        else:
+            print(
+                uc(
+                    "/volumes",
+                    {
+                        "catalog_name": "unity",
+                        "schema_name": "demo",
+                        "name": "reports",
+                        "volume_type": "EXTERNAL",
+                        "storage_location": _location,
+                    },
+                )[0],
+                _location,
+            )
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md(
+        r"""
+        ## 6 — Ask the catalog for permission, then write
+
+        This is the part worth slowing down for. **You never hold the
+        bucket's key.** You name a volume, the catalog hands back
+        credentials minted for that request, and they expire.
+
+        Ask for `WRITE_VOLUME` and you get write access; ask for
+        `READ_VOLUME` and the token cannot write at all. Either way it is
+        confined to this volume's prefix — a token for `demo/volumes/reports`
+        cannot touch `demo/volumes/anything-else`.
+
+        PyArrow does the S3 work here because it ships with this image and
+        speaks session tokens. `boto3` is not installed; DuckDB would work
+        too.
+        """
+    )
+    return
+
+
+@app.cell
+def _(r2_endpoint, ready, uc):
+    if not ready:
+        print("skipped — see the setup cell above for which half is missing")
+    elif not r2_endpoint:
+        print("skipped — R2_ENDPOINT is not set for this deployment")
+    else:
+        import pyarrow as pa
+        import pyarrow.csv as pacsv
+        from pyarrow import fs
+
+        _volume = uc("/volumes/unity.demo.reports")[1]
+        _status, _vend = uc(
+            "/temporary-volume-credentials",
+            {"volume_id": _volume["volume_id"], "operation": "WRITE_VOLUME"},
+        )
+        _cred = _vend["aws_temp_credentials"]
+
+        _s3 = fs.S3FileSystem(
+            access_key=_cred["access_key_id"],
+            secret_key=_cred["secret_access_key"],
+            session_token=_cred["session_token"],
+            endpoint_override=r2_endpoint,
+            region="auto",
+        )
+        # PyArrow paths are bucket-relative-with-bucket, not URLs: strip the
+        # scheme from what the catalog returned rather than rebuilding it.
+        _key = _volume["storage_location"].removeprefix("s3://") + "/cities.csv"
+
+        _table = pa.table({"id": [1, 2, 3], "name": ["Zürich", "Lisbon", "Tallinn"]})
+        with _s3.open_output_stream(_key) as _out:
+            pacsv.write_csv(_table, _out)
+        print("wrote  ", _key)
+
+        with _s3.open_input_stream(_key) as _in:
+            print("read   ", _in.read().decode().strip().replace("\n", " | "))
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md(
+        r"""
+        ## 7 — Both kinds of object, side by side
+
+        The catalog now holds a table and a volume in the same schema, and
+        the Control Plane UI lists both under `unity` → `demo`.
+        """
+    )
+    return
+
+
+@app.cell
+def _(ready, uc):
+    if not ready:
+        print("skipped — see the setup cell above for which half is missing")
+    else:
+        print(
+            "tables :",
+            [
+                t["name"]
+                for t in uc("/tables?catalog_name=unity&schema_name=demo")[1].get("tables", [])
+            ],
+        )
+        print(
+            "volumes:",
+            [
+                v["name"]
+                for v in uc("/volumes?catalog_name=unity&schema_name=demo")[1].get("volumes", [])
+            ],
+        )
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md(
+        r"""
         ## What just happened, and why it survives
 
         The Delta files went to R2 and the registration went to Unity
@@ -211,8 +384,29 @@ def _(mo):
         read-only when the query only reads. The long-lived key stays
         inside the catalog server.
 
-        You can see the same table from the Unity Catalog UI at
-        `https://unity-catalog.<your-domain>`.
+        The same applies to the volume, with one difference worth noticing:
+        the table's credentials were vended to Spark without you seeing
+        them, while for the volume you asked and received them yourself.
+        Same mechanism, one step more visible.
+
+        ## Why Functions and Models stay empty
+
+        Open the catalog UI at `https://unity-catalog.<your-domain>` and the
+        schema shows four sections. Two of them will have nothing in them,
+        and that is not a fault in this deployment:
+
+        - **Functions** — the catalog can store one, but the Spark connector
+          does not implement Spark's function interface. Any attempt from a
+          notebook answers `MISSING_CATALOG_ABILITY.FUNCTIONS: Catalog unity
+          does not support functions`. Registering one you cannot call would
+          fill the section and teach nothing.
+        - **Models** — Unity Catalog keeps model artefacts in a *managed*
+          location, and this stack configures none: tables and volumes both
+          carry an explicit location instead. Creating one fails with
+          `FAILED_PRECONDITION ... has managed location configured`.
+
+        Both are tracked as issues in Nexus-Stack rather than worked around
+        here.
         """
     )
     return


### PR DESCRIPTION
Closes #821.

## The problem

The Control Plane UI shows four sections under a schema — Tables, Volumes, Functions, Models — and the seeded notebook only ever filled the first. Three empty sections read as *"the stack cannot do the rest"*, which is wrong for one of them and worth explaining for the other two.

## What the notebook now does

Three new sections take volumes end to end: create one on R2, ask the catalog for credentials, write a file, read it back, and show both object types side by side.

Every step was run against the live deployment **before** it was written here:

```text
Volume angelegt: 200   s3://<bucket>/demo/volumes/reports
Zugangsdaten:    200
geschrieben:     .../demo/volumes/reports/cities.csv
gelesen:         "id","name" | 1,"Zürich" | 2,"Lisbon" | 3,"Tallinn"
Katalogsicht:    tables ['cities'] · volumes ['reports']
```

## Two choices that needed measuring

**REST, not Spark SQL.** `SHOW VOLUMES IN unity.demo` is a `ParseException` — volumes are a Databricks SQL construct, not Spark's. The notebook talks to the catalog with `urllib` from the standard library, the shape `Getting_Started_PostgREST.py` already uses, so nothing new has to be installed.

**PyArrow, not boto3.** `boto3` is not in the marimo image; `pyarrow` and `duckdb` are, and both speak session tokens. PyArrow won because its paths are bucket-relative, which lets the notebook derive the key from what the catalog returned instead of rebuilding a URL.

Two details that only surfaced by running it:

- The operation enum is `WRITE_VOLUME` / `READ_VOLUME`. `READ_WRITE_VOLUME`, the obvious guess, returns 400 with a Jackson enum-parse error.
- The volumes API has no `IF NOT EXISTS`, so the notebook asks first. A second run of a seeded notebook is expected, not exceptional.

The vended token is confined by the credential generator from #814 — measured as `scope: object-read-only` with `prefixPaths: ["demo/volumes/reports/"]`. **That code path had never been exercised**: the generator was only ever tested against tables.

## What the UI still will not show, and why

Both questions came from someone opening the UI after running the notebook, so both are now answered in it:

- **No columns on the table.** `unity.demo.cities` is stored with `columns: []`. The Spark connector registers type, format and location and leaves the schema in the Delta log. Confirmed this is the connector and not the UI by creating a table through REST with an explicit `columns` array — it stores and returns them. Filed as #826.
- **No files in the volume.** Unity Catalog has no files API. Four plausible endpoints probed; only the volume's own metadata answers, the rest 404. The file is in R2 and the notebook reads it back — there is nothing for the browser to list.

## Functions and Models

Left out deliberately, and explained in the notebook rather than left to be read as breakage:

- Functions can be registered but Spark cannot call them — `MISSING_CATALOG_ABILITY.FUNCTIONS`. An example that registers something nothing can call fills a UI section and teaches nothing (#822).
- Models need a managed storage location this stack does not configure — `FAILED_PRECONDITION … has managed location configured` (#823).

## Local CodeRabbit round

Reviewed `2916bb9`, **1 finding, valid, fixed in `e356ce9`**:

- 🔴 `uc()` caught `HTTPError` but not `URLError`. A stopped catalog or an unresolvable name would have escaped as a traceback in a teaching notebook. Now caught separately — after `HTTPError`, since it is a subclass — and verified against a hostname that does not resolve:

  ```text
  ('unreachable', '... did not answer ([Errno -3] Temporary failure in name
   resolution). Is the unity-catalog stack enabled and running?')
  ```

`e356ce9` also carries the two UI explanations above and is therefore not covered by that round.

## How to test

Seeding is create-only, so an existing `Getting_Started_Unity_Catalog.py` in a workspace repo is not replaced. On a stack that already has it: delete the file in Forgejo and re-run `spin-up.yml`, or run `destroy-all` with both confirmation fields set to `DESTROY`.

Then run the notebook top to bottom. Sections 5–7 should create `unity.demo.reports`, write `cities.csv` into it and read it back, and the Control Plane UI should list a table and a volume under `unity` → `demo`.

## Summary by Sourcery

Demonstrate Unity Catalog volumes alongside tables in the seeded notebook and clarify the capabilities and UI behavior users should expect.

New Features:
- Extend the seeded Unity Catalog notebook with an end-to-end external volume workflow, including creation, scoped credential vending, file writing, and file reading.
- Show tables and volumes together in the catalog and explain the expected visibility limitations for columns, files, functions, and models.

Bug Fixes:
- Handle unreachable Unity Catalog services gracefully in the teaching notebook instead of surfacing network tracebacks.

Enhancements:
- Document volume access semantics, supported operations, storage behavior, and the reasons Functions and Models remain empty in the UI.

Documentation:
- Add user-facing guidance for understanding Unity Catalog volume behavior and Control Plane UI limitations.