### PR TITLE
feat(stacks): Add PyIceberg to the Marimo image

### DIFF
--- a/docs/stacks/marimo.md
+++ b/docs/stacks/marimo.md
@@ -121,10 +121,17 @@ cat = load_catalog(
 )
 
 tbl = cat.load_table("my_namespace.my_table")
-tbl.scan().to_polars()        # also .to_arrow(), .to_duckdb("t"), .to_pandas()
+tbl.scan().to_polars()        # also .to_arrow(), .to_pandas()
 ```
 
-Note where the conversions live: `scan()` returns a `DataScan` and carries all four. `Table` itself only offers `to_polars()` as a shortcut — `Table.to_arrow()` and `Table.to_duckdb()` do not exist.
+Note where the conversions live: `scan()` returns a `DataScan`, and that is what carries them. `Table` itself only offers `to_polars()` as a shortcut — `Table.to_arrow()` and `Table.to_duckdb()` do not exist.
+
+`to_duckdb` is the odd one out and does not fit the line above. It takes a **required** table name and returns a connection with the data registered under that name, rather than returning a frame:
+
+```python
+con = tbl.scan().to_duckdb("orders")
+con.sql("SELECT country, count(*) FROM orders GROUP BY country").pl()
+```
 
 > **Not yet turnkey.** The [Lakekeeper](./lakekeeper.md) stack starts with no warehouse, and nothing creates one for you — a warehouse must currently be added by hand through Lakekeeper's UI or management API before the snippet above resolves. The warehouse hook and a guided seed notebook are the next step; until they land, treat this section as the client-side reference rather than a complete walkthrough.
 

--- a/docs/stacks/marimo.md
+++ b/docs/stacks/marimo.md
@@ -44,7 +44,7 @@ The Marimo container is a thin gRPC client — the driver-JVM lives in the dedic
 
 ### Quickstart
 
-Four seed notebooks ship under `nexus_seeds/marimo/` and land in `/app/notebooks/<repo>/` on **first** Marimo container launch. The seeds live in the Forgejo workspace repo, and Marimo's entrypoint runs the `git clone` when `FORGEJO_REPO_URL` is set in its env — see [`stacks/marimo/docker-compose.yml`](../../stacks/marimo/docker-compose.yml)). On a Marimo-only install without Forgejo you'll see an empty `/app/notebooks/` directory and need to author your own notebooks via the UI. With Forgejo enabled, open from `https://marimo.<your-domain>` and hit **Run all** on whichever seed matches what you're trying to learn:
+Six seed notebooks ship under `nexus_seeds/marimo/` and land in `/app/notebooks/<repo>/` on **first** Marimo container launch. The seeds live in the Forgejo workspace repo, and Marimo's entrypoint runs the `git clone` when `FORGEJO_REPO_URL` is set in its env — see [`stacks/marimo/docker-compose.yml`](../../stacks/marimo/docker-compose.yml). On a Marimo-only install without Forgejo you'll see an empty `/app/notebooks/` directory and need to author your own notebooks via the UI. With Forgejo enabled, open from `https://marimo.<your-domain>` and hit **Run all** on whichever seed matches what you're trying to learn:
 
 > **Upgrade note:** Marimo's entrypoint only clones the workspace repo when `/app/notebooks/<repo>/.git` is **absent** ([`stacks/marimo/docker-compose.yml`](../../stacks/marimo/docker-compose.yml)). On an existing workspace where Marimo was already running before a new seed shipped, `gh workflow run spin-up.yml` won't pull the new file in automatically — the repo dir already exists. Either run `git pull` from inside the Marimo notebook UI's terminal, or wipe the `marimo_data` volume and let the first-launch clone re-fetch (loses any local notebook edits). The new seeds DO appear in fresh stack deployments.
 
@@ -52,6 +52,8 @@ Four seed notebooks ship under `nexus_seeds/marimo/` and land in `/app/notebooks
 - **`Getting_Started_PySpark.py`** — minimal "spin up a SparkSession via Spark Connect, run a job, render results" walkthrough. Start here.
 - **`Getting_Started_DuckDB.py`** — DuckDB walkthrough that doesn't need the Spark stack at all: in-memory queries, `range()` synthetic data, remote parquet over `httpfs`, aggregate + window functions, Polars/Pandas/PyArrow conversion, and Marimo's native `mo.sql()` reactive cell. Useful as a single-node analytics baseline before reaching for Spark.
 - **`Getting_Started_PostgREST.py`** — REST-API walkthrough over the shared `postgres` stack via the PostgREST stack: list / filter / order / paginate / POST / PATCH / DELETE / OpenAPI. Stdlib-only (`urllib.request`), hits the internal `http://postgrest:3000` so no Cloudflare Access detour. Requires the PostgREST stack enabled.
+- **`Getting_Started_Unity_Catalog.py`** — Delta tables on Unity Catalog through Spark: create a schema, create a table, insert, read back, then work with volumes over the REST API. Also documents what the catalogue genuinely cannot do yet, so the empty Functions and Models tabs don't read as a broken deployment. Requires the Unity Catalog and Spark stacks enabled.
+- **`Verify_Spark_And_S3.py`** — a diagnostic rather than a tutorial, in six numbered checks: cluster version, executors actually starting, Arrow round-tripping through gRPC, which buckets the deployment has, an R2 write-and-read-back, and whether Hetzner object storage is still reachable. Run this first when something is broken.
 - **`NYC_Taxi_Pipeline.py`** — end-to-end bootstrap-to-S3 + Spark-analytics pattern using DuckDB for the upload step and Spark for the read+aggregate.
 
 The minimal pattern is:
@@ -101,6 +103,30 @@ The gRPC stream then fails back to Marimo, which surfaces a clean `MarimoInterru
 Marimo's reactive DAG re-runs cells when their upstream changes. The `spark` session is module-level cached in `_nexus_spark.py`, so multiple cells importing it share one Connect channel — Marimo never re-creates the session.
 
 But: Marimo does NOT track mutations to attributes. `spark.conf.set("spark.sql.shuffle.partitions", "4")` from one cell will NOT cause downstream cells to re-execute. **Treat the SparkSession as immutable after build.** If you need a different config, call `_nexus_spark.stop_spark()` and then `get_spark()` again — that's an explicit reset.
+
+## Iceberg catalogues (PyIceberg)
+
+The image ships `pyiceberg==0.12.0`, the Python client for the Iceberg REST protocol. It talks to a catalogue directly over HTTP — no JVM, no Spark, no jar — which is why it is the way to reach Iceberg tables from a notebook. **Spark cannot do this today**; Iceberg publishes no runtime jar for the Spark 4.2 this project runs, which is measured and explained in [docs/stacks/spark.md](./spark.md#iceberg-is-not-available-from-spark-yet) and tracked in [#828](https://github.com/stefanko-ch/Nexus-Stack/issues/828).
+
+No extras are installed with it, and none are needed: `to_arrow()`, `to_duckdb()`, `to_pandas()` and `to_polars()` import their target lazily, and pyarrow, duckdb and polars are all already in the image.
+
+Point it at a catalogue with the **in-cluster** URL. The public hostname sits behind Cloudflare Access and answers a client with an HTML login page:
+
+```python
+from pyiceberg.catalog import load_catalog
+
+cat = load_catalog(
+    "lakekeeper",
+    **{"type": "rest", "uri": "http://lakekeeper:8181/catalog", "warehouse": "<name>"},
+)
+
+tbl = cat.load_table("my_namespace.my_table")
+tbl.scan().to_polars()        # also .to_arrow(), .to_duckdb("t"), .to_pandas()
+```
+
+Note where the conversions live: `scan()` returns a `DataScan` and carries all four. `Table` itself only offers `to_polars()` as a shortcut — `Table.to_arrow()` and `Table.to_duckdb()` do not exist.
+
+> **Not yet turnkey.** The [Lakekeeper](./lakekeeper.md) stack starts with no warehouse, and nothing creates one for you — a warehouse must currently be added by hand through Lakekeeper's UI or management API before the snippet above resolves. The warehouse hook and a guided seed notebook are the next step; until they land, treat this section as the client-side reference rather than a complete walkthrough.
 
 ## Infisical secrets
 

--- a/docs/stacks/marimo.md
+++ b/docs/stacks/marimo.md
@@ -30,7 +30,7 @@ Marimo is a reactive Python notebook that's reproducible, git-friendly, and depl
 
 When the Spark stack is also enabled, Marimo can run PySpark workloads against the cluster via the Spark Connect endpoint. Topology:
 
-```
+```text
 Marimo container (Python 3.13, no JDK)
    │ pyspark[connect] + Arrow + gRPC
    ▼ sc://spark-connect:15002

--- a/docs/stacks/spark.md
+++ b/docs/stacks/spark.md
@@ -180,3 +180,43 @@ A pre-built helper module ships in the workspace seed at `marimo/_nexus_spark.py
 - **Connect (`sc://...:15002`)**: Marimo today, code-server in the future. Driver runs server-side in the `spark-connect` container. Thin client (gRPC + Arrow). Better fit for reactive notebooks; first-class formatter support in Marimo. Some advanced features have caveats — check the [Spark Connect compatibility matrix](https://spark.apache.org/docs/latest/spark-connect-overview.html#what-is-supported-in-spark-40) before relying on niche APIs.
 
 Both protocols submit applications to the same `spark-master`, so they share the worker's resources.
+
+### Iceberg is not available from Spark yet
+
+Nexus-Stack ships two Iceberg REST catalogues — [Lakekeeper](./lakekeeper.md) and, later, Polaris — but **Spark cannot talk to either of them today**. Reaching an Iceberg catalogue from Spark needs the `iceberg-spark-runtime` jar built for the exact Spark version, and no such jar exists for the Spark 4.2.0 this stack runs.
+
+Measured on 2026-09-09, against Maven Central:
+
+| Artefact | Status |
+|---|---|
+| `iceberg-spark-runtime-4.2_2.13` | does not exist — HTTP 404 |
+| `iceberg-spark-runtime-4.1_2.13` | exists, newest version `1.11.0` (2026-05-19) |
+
+The 4.1 jar is not a workaround. Loading it on Spark 4.2.0 fails on the first statement:
+
+```
+java.lang.IncompatibleClassChangeError: class org.apache.iceberg.spark.source.SparkView
+  can not implement org.apache.spark.sql.connector.catalog.View,
+  because it is not an interface
+```
+
+Spark 4.2 turned `View` from an interface into a class; the jar was compiled against the interface form. That is a binary incompatibility, not a configuration mistake, and it surfaces while `SparkCatalog` is being loaded — so it happens for every catalogue type, REST included. The older `4.0_2.13` build is further from 4.2, not closer.
+
+Support for Spark 4.2 was merged into Iceberg's `main` branch on 2026-09-04 ([apache/iceberg#14984](https://github.com/apache/iceberg/pull/14984)) but is in no release. When Iceberg next releases, re-run the check below; if it succeeds, the Spark side can be wired up (tracked in [#828](https://github.com/stefanko-ch/Nexus-Stack/issues/828)):
+
+```bash
+# 1. Has a 4.2 build appeared? 404 means still not.
+curl -s -o /dev/null -w '%{http_code}\n' \
+  https://repo1.maven.org/maven2/org/apache/iceberg/iceberg-spark-runtime-4.2_2.13/
+
+# 2. If it has, substitute the new coordinate here and confirm it runs.
+docker run --rm apache/spark:4.2.0 /opt/spark/bin/spark-sql --master 'local[1]' \
+  --packages org.apache.iceberg:iceberg-spark-runtime-4.2_2.13:<VERSION> \
+  --conf spark.sql.extensions=org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions \
+  --conf spark.sql.catalog.local=org.apache.iceberg.spark.SparkCatalog \
+  --conf spark.sql.catalog.local.type=hadoop \
+  --conf spark.sql.catalog.local.warehouse=/tmp/warehouse \
+  -e "CREATE TABLE local.p.t (id INT) USING iceberg; INSERT INTO local.p.t VALUES (1); SELECT * FROM local.p.t;"
+```
+
+**Until then, use PyIceberg from Marimo.** It speaks the Iceberg REST protocol directly over HTTP — no JVM, no jar, no version matrix — and is installed in the Marimo image. See [docs/stacks/marimo.md](./marimo.md). Delta Lake is unaffected by any of this and keeps working from Spark through [Unity Catalog](./unity-catalog.md).

--- a/docs/stacks/spark.md
+++ b/docs/stacks/spark.md
@@ -90,7 +90,7 @@ A bare 400 with a null request id — R2 rejects the request before parsing it, 
 
 The file also widens `spark.redaction.regex`. Spark's default is `(?i)secret|password|token`, which hides `fs.s3a.secret.key` and leaves `fs.s3a.access.key` visible — and the master UI on port 8088 renders the environment page for every running application.
 
-```
+```text
    ┌──────────────────────┐          ┌──────────────────────┐
    │  Jupyter PySpark     │          │  Marimo PySpark      │
    │  (driver-JVM local)  │          │  (gRPC client only)  │
@@ -194,7 +194,7 @@ Measured on 2026-09-09, against Maven Central:
 
 The 4.1 jar is not a workaround. Loading it on Spark 4.2.0 fails on the first statement:
 
-```
+```text
 java.lang.IncompatibleClassChangeError: class org.apache.iceberg.spark.source.SparkView
   can not implement org.apache.spark.sql.connector.catalog.View,
   because it is not an interface

--- a/stacks/marimo/Dockerfile
+++ b/stacks/marimo/Dockerfile
@@ -61,6 +61,34 @@ RUN pip install --no-cache-dir \
     "grpcio-status==1.76.0" \
     "pyarrow==19.0.1"
 
+# PyIceberg — the client for the Iceberg REST catalogs (Lakekeeper, Polaris).
+#
+# Deliberately WITHOUT the [duckdb,polars,pyarrow] extras. Those extras only
+# declare dependencies that this image already carries: `marimo[sql]` brings
+# duckdb and polars, and pyarrow is pinned exactly above. Asking for them
+# again gives pip a reason to move pins the block above exists to hold still.
+# Measured against this base image: plain `pyiceberg==0.12.0` installs its own
+# dependencies and touches none of the existing ones —
+#
+#   before: pyarrow 19.0.1  grpcio 1.76.0  duckdb 1.5.2  polars 1.40.1
+#   after:  pyarrow 19.0.1  grpcio 1.76.0  duckdb 1.5.2  polars 1.40.1
+#
+# The conversion methods work regardless of the extras, because they import
+# their target lazily: `table.scan().to_arrow()`, `.to_duckdb()`, `.to_polars()`
+# all live on DataScan, and `Table.to_polars()` is a convenience on top.
+#
+# NOT a Spark path. Iceberg publishes no `iceberg-spark-runtime-4.2_2.13`, and
+# the 4.1 build is binary-incompatible with the Spark 4.2.0 this stack runs:
+#
+#   IncompatibleClassChangeError: class org.apache.iceberg.spark.source.SparkView
+#   can not implement org.apache.spark.sql.connector.catalog.View,
+#   because it is not an interface
+#
+# Spark 4.2 support landed in Iceberg's main branch on 2026-09-04 but is not in
+# any release. Until it is, PyIceberg is how a notebook reaches these catalogs.
+RUN pip install --no-cache-dir \
+    "pyiceberg==0.12.0"
+
 # Stay as root — the entrypoint chowns the notebooks volume then drops
 # to appuser via gosu before exec'ing marimo. We can't drop here
 # because the chown needs root and the entrypoint is what handles

--- a/stacks/marimo/Dockerfile
+++ b/stacks/marimo/Dockerfile
@@ -74,8 +74,11 @@ RUN pip install --no-cache-dir \
 #   after:  pyarrow 19.0.1  grpcio 1.76.0  duckdb 1.5.2  polars 1.40.1
 #
 # The conversion methods work regardless of the extras, because they import
-# their target lazily: `table.scan().to_arrow()`, `.to_duckdb()`, `.to_polars()`
-# all live on DataScan, and `Table.to_polars()` is a convenience on top.
+# their target lazily. They live on DataScan, which `table.scan()` returns:
+# `.to_arrow()`, `.to_polars()`, `.to_pandas()`, and `.to_duckdb("name")` —
+# that last one takes a required table name and hands back a connection with
+# the data registered under it, rather than returning a frame. `Table` itself
+# carries only `to_polars()` as a shortcut; there is no `Table.to_arrow()`.
 #
 # NOT a Spark path. Iceberg publishes no `iceberg-spark-runtime-4.2_2.13`, and
 # the 4.1 build is binary-incompatible with the Spark 4.2.0 this stack runs:


### PR DESCRIPTION
## Summary

Nexus-Stack ships an Iceberg REST catalogue — [Lakekeeper](../blob/main/docs/stacks/lakekeeper.md) — that nothing in the project can currently talk to. This adds the client half: `pyiceberg==0.12.0` in the Marimo image, plus documentation of why the obvious alternative (Spark) is not available.

This is the first of three PRs. It deliberately ships no notebook and no helper module — both would have no consumer here, and their interfaces would be guessed rather than driven by use. They come with the Lakekeeper wiring.

## Why PyIceberg and not Spark

The Spark route is closed, and this was measured rather than assumed.

Measured 2026-09-09 against Maven Central:

| Artefact | Status |
|---|---|
| `iceberg-spark-runtime-4.2_2.13` | does not exist — `HTTP 404` |
| `iceberg-spark-runtime-4.1_2.13` | exists, newest `1.11.0`, `lastUpdated 2026-05-19` |

The 4.1 jar is not a workaround. On Spark 4.2.0 it fails on the first statement:

```
java.lang.IncompatibleClassChangeError: class org.apache.iceberg.spark.source.SparkView
  can not implement org.apache.spark.sql.connector.catalog.View,
  because it is not an interface
```

Spark 4.2 turned `View` from an interface into a class; the jar was compiled against the interface form. Binary incompatibility, not configuration — and it fires while `SparkCatalog` loads, so it applies to every catalogue type including REST. The `4.0_2.13` build is further away, not closer.

Iceberg merged Spark 4.2 support to `main` on 2026-09-04 ([apache/iceberg#14984](https://github.com/apache/iceberg/pull/14984)) but has not released it. Tracked in **#828**, which carries the command that says when it is unblocked. That issue is intentionally **not** closed by this PR.

PyIceberg needs none of that: it speaks the Iceberg REST protocol directly over HTTP — no JVM, no jar, no version matrix.

## Installed without extras — deliberately

The plan called for `pyiceberg[duckdb,polars,pyarrow]`. Changed after measuring.

Those extras only re-declare packages the image already carries (`marimo[sql]` brings duckdb and polars; pyarrow is pinned exactly one block above). Asking for them again gives pip a reason to move the very pins that block exists to hold still. Read out of the **built** image:

```
before: pyarrow 19.0.1  grpcio 1.76.0  duckdb 1.5.2  polars 1.40.1
after:  pyarrow 19.0.1  grpcio 1.76.0  duckdb 1.5.2  polars 1.40.1  + pyiceberg 0.12.0
```

The conversion methods work regardless, because they import their target lazily.

## Changes

| File | Change |
|---|---|
| `stacks/marimo/Dockerfile` | `pyiceberg==0.12.0` in its own layer, with the reasoning above |
| `docs/stacks/spark.md` | New section "Iceberg is not available from Spark yet" — the measurement, the error, and the two-step check for when it changes |
| `docs/stacks/marimo.md` | New section "Iceberg catalogues (PyIceberg)" — client reference, in-cluster URL, and an explicit note that no warehouse exists yet |

### Two pre-existing drifts fixed while editing

Not caused by this PR, but in the file being edited:

- `docs/stacks/marimo.md` claimed **four** seed notebooks where **six** exist
- its list omitted `Getting_Started_Unity_Catalog.py` and `Verify_Spark_And_S3.py`

Both new descriptions were written from the notebooks' actual contents, not from their filenames.

## An API detail worth flagging for the next PR

`to_arrow()` and `to_duckdb()` do **not** exist on `Table`. They live on `DataScan`, which `table.scan()` returns; `Table` carries only `to_polars()` as a shortcut. And `to_duckdb` is not shaped like its neighbours:

```
to_duckdb(self, table_name: str, connection: DuckDBPyConnection | None = None) -> DuckDBPyConnection
```

`table_name` is required, and it returns a connection with the data registered under that name rather than a frame. A notebook written from the obvious assumption would have raised `TypeError`. Documented so PR 2's notebook does not rediscover it.

## Verification

- Image rebuilt from the modified Dockerfile; all pins re-read **from the built image**, not from a dry run
- `RestCatalog` — the path actually used — imports and issues its `/v1/config` request with no extra packages. This also confirms the documented URL form: PyIceberg appends `/v1/…` itself, so `http://lakekeeper:8181/catalog` is correct
- The `to_duckdb` snippet in the docs was executed against a real Iceberg table and returns the expected aggregate
- `uv run pytest tests/unit -q` → **2990 passed, 3 skipped**
- `uv run pre-commit run --files …` → clean

An earlier run of the compatibility check reported a pyarrow version that contradicted the pin. That was an artefact of the check running as the image's non-root user, so `pip install` failed on `/usr/local/share/py4j`; the real build runs as root. No drift in the Dockerfile — noted here because the wrong number was mentioned aloud before it was chased down.

## Local CodeRabbit round

Reviewed `83a9956` — **1 finding, 0 dismissed**.

- 🟠 `.to_duckdb()` in the Dockerfile comment omitted the required `table_name`. Confirmed by reading the signature out of the image, then fixed in `2411566` — and fixed more broadly than reported, since the return type also made its placement misleading.

The round read `83a9956`, so the fix in `2411566` is itself unreviewed locally. That gap is inherent to a single round; this review is what closes it.

## Not closed by this PR

- **#828** — Spark ↔ Iceberg, blocked on Iceberg's next release
- Lakekeeper still starts with no warehouse and nothing creates one. The docs say so plainly rather than implying a working path.

## Summary by Sourcery

Enable Marimo to access Iceberg REST catalogues through PyIceberg while documenting Spark compatibility constraints and the current Lakekeeper setup limitations.

New Features:
- Add PyIceberg 0.12.0 to the Marimo image for direct access to Iceberg REST catalogues.
- Document PyIceberg usage with Lakekeeper and clarify the current warehouse limitation.

Bug Fixes:
- Correct Marimo seed notebook documentation to reflect the six notebooks that are actually shipped.
- Fix malformed documentation code fences and an inaccurate link reference.

Enhancements:
- Document Spark 4.2's current Iceberg incompatibility, the unavailable runtime artifact, and the checks required when support is released.
- Document PyIceberg conversion APIs and their correct DataScan usage, including the DuckDB connection behavior.

Documentation:
- Explain why PyIceberg is currently preferred over Spark for Iceberg REST access and provide an in-cluster catalogue example.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Marimo quickstart notebooks for Unity Catalog Delta tables and Spark/object-storage diagnostics.
  - Added PyIceberg support in the Marimo environment for connecting to REST-based Iceberg catalogues and loading tables.
- **Documentation**
  - Documented PyIceberg usage with Lakekeeper catalogues, including current warehouse setup limitations.
  - Clarified that Spark 4.2.0 cannot currently access the stack’s Iceberg REST catalogues.
  - Added guidance for checking future Spark Iceberg compatibility and using PyIceberg as the current alternative.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->