### PR TITLE
feat(stacks): Make SFTPGo a core service

### DIFF
--- a/.github/workflows/initial-setup.yaml
+++ b/.github/workflows/initial-setup.yaml
@@ -116,7 +116,7 @@ jobs:
         run: |
           # No hardcoded core list. There used to be one — "infisical,mailpit"
           # — and it was wrong in both directions: the core set is forgejo,
-          # grafana, infisical and portainer, so it named one of four and
+          # grafana, infisical, portainer and sftpgo, so it named one of five and
           # added mailpit, which is not core at all. Enabling mailpit on
           # every setup was invisible only because this job was skipped
           # whenever the field was empty; making the job unconditional would

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ After deployment you'll have:
 | **pg_ducklake** | PostgreSQL with DuckLake extension - SQL-native lakehouse with S3 storage | [pgducklake.select](https://pgducklake.select) |
 | **pgAdmin** | PostgreSQL administration and development platform | [pgadmin.org](https://www.pgadmin.org) |
 | **Planka** | Open-source kanban board (Trello alternative) with real-time multi-user collaboration | [planka.app](https://planka.app) |
-| **Portainer** | Always-on Docker dashboard — first stop for inspecting a misbehaving container (logs, state, restart). Auto-deployed alongside Forgejo/Grafana/Infisical | [portainer.io](https://www.portainer.io) |
+| **Portainer** | Always-on Docker dashboard — first stop for inspecting a misbehaving container (logs, state, restart). Auto-deployed alongside Forgejo/Grafana/Infisical/SFTPGo | [portainer.io](https://www.portainer.io) |
 | **PostgreSQL** | Powerful open-source relational database (internal-only, no web UI) | [postgresql.org](https://www.postgresql.org) |
 | **PostgREST** | Auto-generated REST API for any Postgres schema — zero boilerplate, OpenAPI included | [postgrest.org](https://postgrest.org) |
 | **Prefect** | Modern Python-native workflow orchestration for data pipelines | [prefect.io](https://www.prefect.io) |
@@ -279,7 +279,7 @@ Manage your Nexus-Stack infrastructure via web interface at `https://control.YOU
 
 **Pre-select services during Initial Setup:**
 ```bash
-# Core services (Forgejo, Grafana, Infisical, Portainer) are always enabled —
+# Core services (Forgejo, Grafana, Infisical, Portainer, SFTPGo) are always enabled —
 # pass any additional services you want active on the first spin-up.
 gh workflow run initial-setup.yaml -f enabled_services="n8n,kestra"
 ```

--- a/docs/admin-guides/server-resize.md
+++ b/docs/admin-guides/server-resize.md
@@ -133,7 +133,7 @@ Duration: ~10-15 minutes (D1 database re-created + OpenTofu apply on new server 
 | Cloudflare Tunnel + DNS + Access | – |
 | Control Plane (Pages + Worker + D1) — re-created fresh | – |
 | Infisical (with **newly generated** secrets) | If you had **external** secrets (Databricks tokens, GitHub mirror tokens etc.), re-add them in Infisical |
-| Core stacks: forgejo, grafana, infisical, portainer | Click "Spin Up" once you've toggled additional stacks |
+| Core stacks: forgejo, grafana, infisical, portainer, sftpgo | Click "Spin Up" once you've toggled additional stacks |
 
 ### About R2 buckets after destroy-all
 

--- a/docs/stacks/forgejo-runner.md
+++ b/docs/stacks/forgejo-runner.md
@@ -130,9 +130,12 @@ Other known differences from GitHub Actions:
 
 ### Security — read this before enabling on a shared stack
 
-**Anyone who can push to a repository here can execute code on your
-server — and this is a core service, so it is present on every
-stack.** That is not a Forgejo quirk; it is what self-hosted CI is.
+**Once this stack is enabled, anyone who can push to a repository can
+execute code on your server.** Forgejo itself is a core service and is
+present on every stack, but it cannot run anything without a runner —
+which is exactly why the runner is separate and opt-in. Enabling it is
+the moment the code-execution path opens. That is not a Forgejo quirk;
+it is what self-hosted CI is.
 For a class stack it means every student with commit rights has a code
 execution primitive.
 

--- a/docs/stacks/portainer.md
+++ b/docs/stacks/portainer.md
@@ -8,7 +8,7 @@ title: "Portainer"
 
 **Always-on Docker dashboard — first stop for diagnosing a misbehaving container**
 
-Portainer is a **core service** in Nexus-Stack: it's auto-deployed alongside Forgejo, Grafana, and Infisical, and the Control Plane Stacks page does not let you disable it. The reason: when something goes wrong on a deployed stack — container in restart-loop, OOM-killed, image pull failure, port collision — Portainer is the operator's first stop. Requiring an opt-in step before you can see *why* a container won't start would be the wrong design.
+Portainer is a **core service** in Nexus-Stack: it's auto-deployed alongside Forgejo, Grafana, Infisical and SFTPGo, and the Control Plane Stacks page does not let you disable it. The reason: when something goes wrong on a deployed stack — container in restart-loop, OOM-killed, image pull failure, port collision — Portainer is the operator's first stop. Requiring an opt-in step before you can see *why* a container won't start would be the wrong design.
 
 What you get out of the box:
 - Container view (state, restart, logs, exec into a shell, resource usage)

--- a/docs/stacks/sftpgo.md
+++ b/docs/stacks/sftpgo.md
@@ -15,8 +15,20 @@ SFTPGo is a fully-featured SFTP/SCP/WebDAV/FTPS server with a web admin UI, per-
 - Hand-shipping a CSV from a laptop into the lake without configuring an S3 client
 - Reading files written by Kestra flows from a remote workstation
 
+> **Core service — always deployed, cannot be disabled.** SFTPGo is the only
+> thing in the stack that lets you *look at* the object storage. Both buckets a
+> deployment has are mounted here as virtual folders, and every stack that
+> writes to them leaves prefixes — `lakekeeper/`, a Unity Catalog schema name, a
+> DuckLake path — that mean nothing without a browser to open them. When SFTPGo
+> was optional, the default deployment could write data nobody could inspect.
+>
+> The consequence to know: it is deployed even on a stack with no object storage
+> configured. It runs, the admin UI works, and the `services-configure` phase
+> reports `skipped-not-ready` because there is no bucket to attach.
+
 | Setting | Value |
 |---------|-------|
+| Core service | Yes — always enabled |
 | Default Port (web UI) | `8090` |
 | SFTP Port | `2022` |
 | Suggested Subdomain | `sftpgo` |

--- a/docs/stacks/sftpgo.md
+++ b/docs/stacks/sftpgo.md
@@ -15,12 +15,16 @@ SFTPGo is a fully-featured SFTP/SCP/WebDAV/FTPS server with a web admin UI, per-
 - Hand-shipping a CSV from a laptop into the lake without configuring an S3 client
 - Reading files written by Kestra flows from a remote workstation
 
-> **Core service — always deployed, cannot be disabled.** SFTPGo is the only
-> thing in the stack that lets you *look at* the object storage. Both buckets a
-> deployment has are mounted here as virtual folders, and every stack that
-> writes to them leaves prefixes — `lakekeeper/`, a Unity Catalog schema name, a
-> DuckLake path — that mean nothing without a browser to open them. When SFTPGo
-> was optional, the default deployment could write data nobody could inspect.
+> **Core service — always deployed, cannot be disabled.** Every deployment
+> should be able to *look at* its own object storage. Stacks that write there
+> leave prefixes — `lakekeeper/`, a bare Unity Catalog schema name, a DuckLake
+> path — that mean nothing without a browser to open them.
+>
+> SFTPGo is not the only browser in the catalogue: [Filestash](./filestash.md)
+> covers the same two buckets, and [s3manager](./s3manager.md) covers Hetzner
+> Object Storage. The problem was that **all three were optional**, so a default
+> deployment had none. SFTPGo takes the slot because it additionally speaks
+> SFTP, which reaches tools that cannot talk S3 at all.
 >
 > The consequence to know: it is deployed even on a stack with no object storage
 > configured. It runs, the admin UI works, and the `services-configure` phase

--- a/docs/stacks/wetty.md
+++ b/docs/stacks/wetty.md
@@ -17,7 +17,9 @@ A terminal over HTTP/HTTPS that allows you to access your server via a web brows
 - **Cloudflare Access protected** - Secure access via email OTP authentication
 - **Public key authentication only** - No password authentication for enhanced security
 - **Short session duration** - Cloudflare Access sessions expire after 1 hour for enhanced security
-- **Core service** - Always enabled, cannot be disabled
+- **Optional** - enable it in the Control Plane like any other stack. It is not
+  a core service; `services.yaml` carries no `core: true` for it. (This line
+  used to claim the opposite.)
 
 **Security Features:**
 - ✅ **Public key authentication only** - `SSHAUTH=publickey` prevents password-based logins

--- a/services.yaml
+++ b/services.yaml
@@ -934,6 +934,13 @@ services:
       postgres: 4566
 
   sftpgo:
+    # Core because it is the only way to look at what is IN the object storage.
+    # Both buckets a deployment has -- Cloudflare R2 and Hetzner Object Storage
+    # -- are mounted as virtual folders by render_sftpgo_hook, and every stack
+    # that writes to them (Unity Catalog, Lakekeeper, pg-ducklake, Spark) leaves
+    # prefixes that are unreadable without a file browser. Leaving that browser
+    # optional meant a default deployment could write data nobody could inspect.
+    core: true
     subdomain: "sftpgo"
     port: 8090
     public: false

--- a/services.yaml
+++ b/services.yaml
@@ -934,12 +934,18 @@ services:
       postgres: 4566
 
   sftpgo:
-    # Core because it is the only way to look at what is IN the object storage.
-    # Both buckets a deployment has -- Cloudflare R2 and Hetzner Object Storage
-    # -- are mounted as virtual folders by render_sftpgo_hook, and every stack
-    # that writes to them (Unity Catalog, Lakekeeper, pg-ducklake, Spark) leaves
-    # prefixes that are unreadable without a file browser. Leaving that browser
-    # optional meant a default deployment could write data nobody could inspect.
+    # Core so that every deployment can see what is IN its object storage.
+    # Stacks that write there -- Unity Catalog, Lakekeeper, pg-ducklake, Spark
+    # -- leave prefixes that mean nothing without a browser to open them, and
+    # until now all three browsers were optional: filestash (R2 + Hetzner),
+    # s3manager (Hetzner only) and this one. A default deployment therefore had
+    # none, and could write data nobody could inspect.
+    #
+    # SFTPGo rather than filestash, which covers the same two buckets: it also
+    # speaks SFTP, so external tools that cannot talk S3 reach the same data,
+    # and render_sftpgo_hook already mounts both buckets as virtual folders.
+    # Making filestash core instead would be a defensible different choice;
+    # making neither core was the actual bug.
     core: true
     subdomain: "sftpgo"
     port: 8090

--- a/tests/unit/test_stack_conventions.py
+++ b/tests/unit/test_stack_conventions.py
@@ -821,9 +821,10 @@ def test_core_services_are_the_documented_five(services: dict[str, Any]) -> None
     Pinned because the set is small, load-bearing, and has changed silently
     before — Gitea held a place here until the Forgejo migration took it.
 
-    SFTPGo joined because it is the only way to see what is in the object
-    storage, and every other stack that writes there leaves prefixes that
-    are unreadable without it.
+    SFTPGo joined so that every deployment can see what is in its object
+    storage. It is not the only browser — filestash covers R2 and Hetzner,
+    s3manager covers Hetzner — but all three were optional, so a default
+    deployment had none. SFTPGo takes the slot because it also speaks SFTP.
     """
     core = {name for name, entry in services.items() if entry.get("core")}
     assert core == {"forgejo", "grafana", "infisical", "portainer", "sftpgo"}, (

--- a/tests/unit/test_stack_conventions.py
+++ b/tests/unit/test_stack_conventions.py
@@ -815,14 +815,18 @@ def test_ports_are_unique_across_stacks(services: dict[str, Any]) -> None:
     assert not unexpected, f"host port claimed by more than one stack: {unexpected}"
 
 
-def test_core_services_are_the_documented_four(services: dict[str, Any]) -> None:
+def test_core_services_are_the_documented_five(services: dict[str, Any]) -> None:
     """`core: true` means always deployed and not disableable.
 
     Pinned because the set is small, load-bearing, and has changed silently
     before — Gitea held a place here until the Forgejo migration took it.
+
+    SFTPGo joined because it is the only way to see what is in the object
+    storage, and every other stack that writes there leaves prefixes that
+    are unreadable without it.
     """
     core = {name for name, entry in services.items() if entry.get("core")}
-    assert core == {"forgejo", "grafana", "infisical", "portainer"}, (
+    assert core == {"forgejo", "grafana", "infisical", "portainer", "sftpgo"}, (
         f"core services changed to {sorted(core)}. That is a deliberate decision; "
         f"update this test and the docs together."
     )


### PR DESCRIPTION
## Summary

A deployment can write to Cloudflare R2 and Hetzner Object Storage from day one, but until now nothing let it *look* at what ended up there unless an operator went and enabled a browser. This makes SFTPGo core, so every stack has one.

The prompt was concrete: R2's root showed a folder called `demo` and there was no way to tell what had written it. (It was a Unity Catalog schema — a separate fix.)

## Why this is not just a label

`core: true` has teeth in two places:

- `.github/scripts/generate-services-tfvars.py` computes `should_enable = is_core or name in enabled_set`, so a core service is enabled regardless of D1 state — including on a first spin-up with no D1 rows at all.
- `control-plane/functions/api/services.js` refuses to disable one and renders a `core` badge.

**Consequence worth knowing:** SFTPGo is now deployed even where no object storage is configured. It runs, its admin UI works, and `services-configure` reports `skipped-not-ready` because there is no bucket to attach. That is already the hook's documented behaviour; it just becomes reachable by default.

## Why SFTPGo, honestly

The first version of this PR justified it with "SFTPGo is the only way to look at what is in the object storage". The local CodeRabbit round called that an overclaim. It was worse than that — it was false, and the check took one grep:

| Stack | Browses | Was core |
|---|---|---|
| **Filestash** | R2 **and** Hetzner, gated per backend in `_render_filestash` | no |
| **s3manager** | Hetzner Object Storage | no |
| **SFTPGo** | R2 and Hetzner, as virtual folders via `render_sftpgo_hook` | no |

The real defect survives the correction and is the actual reason for this PR: **all three were optional**, so a default deployment had none.

SFTPGo takes the slot because it additionally speaks SFTP, which reaches tools that cannot talk S3 at all — partner dropoffs, legacy ETLs, someone with a laptop and an SFTP client. Making Filestash core instead would be a defensible different choice, and `docs/stacks/sftpgo.md` now links both alternatives so that stays visible. Making none of them core was the bug.

## Three documentation drifts fixed on the way

Two predate this PR. They surfaced because updating the core list means reading every place that names it.

**`docs/stacks/forgejo-runner.md` — a security warning that misstated who it applies to.** It read:

> Anyone who can push to a repository here can execute code on your server — and this is a core service, so it is present on every stack.

That sits in the doc for a stack whose own introduction, fifteen lines earlier, calls it "separate and optional". Forgejo is core; the runner is not, and Forgejo cannot execute anything without it. A reader could conclude the code-execution path is open on every stack, or — worse, in the other direction — that the warning is boilerplate. Rewritten to say that enabling the runner is the moment the path opens.

**`docs/stacks/wetty.md`** claimed Wetty was a core service that cannot be disabled. It never had `core: true`.

**Four places enumerated the core set by name** and are now five: `README.md` (twice), `docs/stacks/portainer.md`, `docs/admin-guides/server-resize.md`, and a comment in `.github/workflows/initial-setup.yaml` that explains a past bug in terms of "one of four".

## Tests

`test_core_services_are_the_documented_four` becomes `..._five` and pins the new set. That test exists precisely because this set has changed silently before — Gitea held a place in it until the Forgejo migration took it.

- `uv run pytest tests/unit -q` → **3000 passed, 4 skipped**
- `uv run pre-commit run --files …` → clean, `actionlint` included since a workflow comment changed

## Local CodeRabbit round

Reviewed `5cdae2a` — **1 finding, 0 dismissed**.

- 🟠 The "only way to look at" claim. Verified against `services.yaml` and `service_env.py`, found false rather than merely strong, and rewritten in both `services.yaml` and `docs/stacks/sftpgo.md` rather than softened. Fixed in `fc791ad`.

The round read `5cdae2a`, so `fc791ad` is itself locally unreviewed — inherent to a single round, and this review is what closes it.

## Not in this PR

- The `demo/` prefix that prompted it: Unity Catalog writes to the bucket root, which is why the folder is unidentifiable. Separate PR, and it needs a rehearsal first — a prefix change orphans existing tables, whose locations are stored absolutely.
- Lakekeeper authentication, which the same session raised. It needs an identity provider, and the stack has none; Infisical stores secrets but does not issue OIDC tokens. That is a design discussion, not a config flag.

## Summary by Sourcery

Make SFTPGo an always-enabled core service so every deployment can inspect object storage and access it through SFTP.

New Features:
- Make SFTPGo a core service that is automatically deployed and cannot be disabled, providing every deployment with an S3-compatible storage browser and SFTP access.

Bug Fixes:
- Correct documentation that incorrectly described the Forgejo runner and Wetty as core services.

Enhancements:
- Update the documented core-service lists and explain SFTPGo's behavior when object storage is unavailable.

Documentation:
- Document SFTPGo as a core service and clarify its relationship to Filestash and s3manager.
- Correct the Forgejo runner security guidance and Wetty's optional-service status.

Tests:
- Update the core-service convention test to pin the expanded five-service set.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SFTPGo is now an always-enabled core service, providing an object-storage browser in every deployment.
  * SFTPGo is automatically restored after applicable server resets.

* **Documentation**
  * Updated service lists and deployment guidance to reflect SFTPGo’s core status.
  * Clarified that Wetty is optional.
  * Expanded Forgejo Runner security guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->