### PR TITLE
fix(stacks): Write Unity Catalog tables under a unity-catalog/ prefix

### DIFF
--- a/docs/stacks/unity-catalog.md
+++ b/docs/stacks/unity-catalog.md
@@ -180,14 +180,20 @@ table by its three-part name:
 CREATE SCHEMA IF NOT EXISTS unity.demo;
 
 CREATE TABLE unity.demo.trips (id INT, city STRING) USING delta
-  LOCATION 's3://<your-r2-bucket>/teaching/trips';
+  LOCATION 's3://<your-r2-bucket>/unity-catalog/teaching/trips';
 
 INSERT INTO unity.demo.trips VALUES (1, 'Zürich');
 SELECT * FROM unity.demo.trips;
 ```
 
-Three details that are easy to get wrong, all of them measured:
+Four details that are easy to get wrong, all of them measured:
 
+- **Stay under `unity-catalog/`.** That prefix is the subtree this catalogue
+  owns in the shared bucket, and it is what `s3.bucketPath.0` is set to. An
+  explicit `LOCATION` outside it gets no credentials vended for it, so the
+  write fails with a 403 rather than a helpful message. Omit `LOCATION`
+  entirely and Spark places the table at
+  `s3://<bucket>/unity-catalog/<schema>/<table>` by itself.
 - **`s3://`, never `s3a://`.** Unity Catalog rejects the latter outright
   with `Unsupported URI scheme: s3a`. The rendered config maps `fs.s3.impl`
   to `S3AFileSystem` so the `s3://` scheme still works.
@@ -216,6 +222,30 @@ and a catalogue of vanished files is worse than no catalogue.
 
 `entrypoint.sh` appends the `s3.*` block at container start from environment
 variables the deploy renders. There is nothing to fill in by hand.
+
+### The `unity-catalog/` prefix
+
+Everything this catalogue writes lands under `s3://<bucket>/unity-catalog/`,
+because `s3.bucketPath.0` carries that prefix. The data bucket is shared —
+Lakekeeper owns `lakekeeper/`, pg-ducklake writes its own tables, and Spark
+can be pointed anywhere — so a catalogue writing to the root produces
+top-level folders named after whatever schema someone happened to create.
+A folder called `demo` at the root says nothing about which stack made it,
+and would collide outright with any other stack choosing the same word.
+
+Two consequences worth knowing:
+
+- **Table locations are absolute.** Unity Catalog records
+  `s3://<bucket>/unity-catalog/demo/cities`, not a path relative to
+  `bucketPath`. Tables created before this prefix existed still point at
+  `s3://<bucket>/demo/cities`, which is now outside the configured path, so no
+  credentials are vended for them and they stop being readable. The Parquet
+  files are untouched; the catalogue simply cannot reach them. Check with
+  `GET /api/2.1/unity-catalog/tables?catalog_name=unity&schema_name=<schema>`
+  and re-create anything whose `storage_location` lacks the prefix.
+- **The prefix is not configurable**, deliberately. It is part of the bucket's
+  layout, and a deployment that changed it would orphan its own tables the
+  same way.
 
 ### Why a credential generator, and why it had to be written
 

--- a/examples/workspace-seeds/marimo/Getting_Started_Unity_Catalog.py
+++ b/examples/workspace-seeds/marimo/Getting_Started_Unity_Catalog.py
@@ -125,7 +125,10 @@ def _(bucket, ready, spark):
     if not ready:
         print("skipped — see the setup cell above for which half is missing")
     else:
-        _location = f"s3://{bucket}/demo/cities"
+        # Under `unity-catalog/`, which is the subtree this catalogue owns in
+        # the shared bucket. An explicit LOCATION outside it gets no
+        # credentials vended for it and the write fails with a 403.
+        _location = f"s3://{bucket}/unity-catalog/demo/cities"
         spark.sql(f"""
             CREATE TABLE IF NOT EXISTS unity.demo.cities (
                 id INT,
@@ -258,7 +261,7 @@ def _(bucket, ready, uc):
     if not ready:
         print("skipped — see the setup cell above for which half is missing")
     else:
-        _location = f"s3://{bucket}/demo/volumes/reports"
+        _location = f"s3://{bucket}/unity-catalog/demo/volumes/reports"
         # Create-if-absent by hand: the API has no IF NOT EXISTS, and a
         # second run would otherwise fail on a volume that is already there.
         _status, _existing = uc("/volumes/unity.demo.reports")

--- a/stacks/unity-catalog/entrypoint.sh
+++ b/stacks/unity-catalog/entrypoint.sh
@@ -126,6 +126,13 @@ s3.region.0=auto
 s3.awsRoleArn.0=arn:aws:iam::000000000000:role/unused-with-credential-generator
 s3.credentialGenerator.0=ch.nexusstack.unitycatalog.R2TemporaryCredentialGenerator
 EOF
+
+  # Printed on every start, because the failure this prevents is silent. A
+  # table whose recorded location lies outside this path gets no credentials
+  # vended, and the query fails with a bare 403 -- nothing in that error says
+  # which path was configured. `docker logs unity-catalog` is where somebody
+  # chasing that 403 will look, so the answer is put there.
+  echo "unity-catalog: table data goes under s3://${UC_R2_BUCKET}/${UC_R2_PREFIX}/ — a table recorded outside this path cannot be read" >&2
 else
   echo "unity-catalog: no R2 bucket configured — external tables on object storage will not work" >&2
 fi

--- a/stacks/unity-catalog/entrypoint.sh
+++ b/stacks/unity-catalog/entrypoint.sh
@@ -91,6 +91,21 @@ EOF
 # Redirection truncates the existing file and leaves its mode alone.
 cat "$CONF_DIR/server.properties.base" > "$CONF_DIR/server.properties"
 
+# Subtree this catalog owns inside the shared data bucket. Not configurable on
+# purpose: the value is part of the bucket's layout contract, and a deployment
+# that changed it would silently orphan every table already recorded, because
+# Unity Catalog stores table locations ABSOLUTELY -- `s3://bucket/demo/cities`,
+# not a path relative to bucketPath. A location outside the configured
+# bucketPath gets no credentials vended for it.
+#
+# The bucket is shared: Lakekeeper owns `lakekeeper/`, pg-ducklake writes its
+# own tables, and Spark can be pointed anywhere. Before this prefix existed,
+# Unity Catalog was the only one writing to the ROOT, so its tables showed up
+# as a bare schema name -- a folder called `demo` that says nothing about who
+# made it, and that would collide outright with any other stack choosing the
+# same word.
+UC_R2_PREFIX="unity-catalog"
+
 if [ -n "${UC_R2_BUCKET:-}" ]; then
   : "${R2_ACCOUNT_ID:?unity-catalog: UC_R2_BUCKET is set but R2_ACCOUNT_ID is not}"
   : "${R2_ENDPOINT_HOST:?unity-catalog: UC_R2_BUCKET is set but R2_ENDPOINT_HOST is not}"
@@ -100,7 +115,7 @@ if [ -n "${UC_R2_BUCKET:-}" ]; then
   cat >> "$CONF_DIR/server.properties" <<EOF
 
 # --- Appended at container start by entrypoint.sh ---
-s3.bucketPath.0=s3://${UC_R2_BUCKET}
+s3.bucketPath.0=s3://${UC_R2_BUCKET}/${UC_R2_PREFIX}
 s3.region.0=auto
 # Never dereferenced. ServerProperties.getS3Configurations drops a bucket entry
 # unless bucketPath+region+awsRoleArn OR accessKey+secretKey+sessionToken are

--- a/tests/unit/test_stack_conventions.py
+++ b/tests/unit/test_stack_conventions.py
@@ -1062,3 +1062,28 @@ def test_no_compose_configures_spark_through_spark_hadoop_env_vars() -> None:
         + "\nThe official apache/spark image ignores these. Put the setting in "
         "the rendered spark-defaults.conf instead (service_env._render_spark)."
     )
+
+
+def test_unity_catalog_writes_under_its_own_prefix() -> None:
+    """Unity Catalog owns a subtree of the data bucket, not its root.
+
+    The bucket is shared. Lakekeeper scopes itself with `key-prefix: lakekeeper`
+    and pg-ducklake writes its own tables there, but Unity Catalog used to
+    append nothing, so a table created as `unity.demo.cities` landed at
+    `s3://<bucket>/demo/cities` — a top-level folder named after a schema,
+    saying nothing about which stack made it and colliding outright with any
+    other stack that picked the same word.
+
+    Asserted on the rendered property rather than on the prefix constant alone:
+    the constant existing proves nothing if the bucketPath line stops using it.
+    """
+    entrypoint = (REPO_ROOT / "stacks/unity-catalog/entrypoint.sh").read_text()
+
+    prefix_lines = [line for line in entrypoint.splitlines() if line.startswith("UC_R2_PREFIX=")]
+    assert prefix_lines == ['UC_R2_PREFIX="unity-catalog"'], prefix_lines
+
+    bucket_paths = [line for line in entrypoint.splitlines() if line.startswith("s3.bucketPath.")]
+    assert bucket_paths == ["s3.bucketPath.0=s3://${UC_R2_BUCKET}/${UC_R2_PREFIX}"], (
+        f"bucketPath no longer carries the prefix: {bucket_paths}. Writing to the "
+        "bucket root puts Unity Catalog's schemas next to every other stack's data."
+    )


### PR DESCRIPTION
## Summary

The R2 data bucket had exactly one thing at its root: a folder called `demo`. Nothing about it said which stack made it, what it held, or whether it was safe to delete. It was a Unity Catalog schema.

Unity Catalog now writes under `s3://<bucket>/unity-catalog/`, the way Lakekeeper already writes under `lakekeeper/`.

```
before                          after
s3://bucket/                    s3://bucket/
    demo/                           unity-catalog/
        cities/                         demo/
                                            cities/
                                lakekeeper/
```

## Why this matters beyond tidiness

The bucket is shared — Unity Catalog, Lakekeeper, pg-ducklake, and Spark pointed anywhere all write to it. A catalogue writing to the root produces top-level folders named after whatever schema someone happened to create, and **two stacks choosing the same word would silently share a path**. That collision is not hypothetical in this repo: nineteen stacks once shared the `support_images` key `postgres` and quietly retagged each other (#715).

## Which lever, and how that was established

Measured on a live deployment rather than reasoned about:

| Evidence | Value |
|---|---|
| `storage_location` of the table Spark created | `s3://<bucket>/demo/cities` |
| `table_type` | `EXTERNAL` — the connector places tables itself; Unity Catalog's own MANAGED path fails with `stagingLocation is null` |
| `catalog.storage_root` / `schema.storage_root` | both `null` — ruled out as the source |
| `spark-defaults.conf` for the unity catalog | `uri` and `token` only — no warehouse, no base path |

The bucket name appears once more in `spark-defaults.conf`, inside `fs.s3a.bucket.<name>.*`, but those are credentials rather than a location. That leaves `s3.bucketPath.0` as the only possible source of the base path.

The Java credential generator is unaffected: `pathsFor` derives its scoping from each table's own location and never reads `bucketPath`, so the grants simply move one directory deeper.

## Two places that would have broken silently

Unity Catalog records table locations **absolutely**, and a location outside the configured `bucketPath` gets no credentials vended — the write fails with a bare 403 that names no path.

Both places using an explicit `LOCATION` are updated:

- the SQL example in `docs/stacks/unity-catalog.md`
- the two paths in `Getting_Started_Unity_Catalog.py` (the table and the volume)

Without those, the change would have looked applied while the seeded notebook returned 403 on its first write.

## Existing tables

They stop being readable: their recorded locations are outside the new path. The Parquet files are untouched — the catalogue simply cannot reach them. `docs/stacks/unity-catalog.md` carries the API call that lists locations so affected tables can be found, and the note that re-creating them is the fix.

**No compatibility path is included, deliberately.** The local review asked for one; it was declined for three reasons. The repository owner made this call explicitly, in a development environment they intend to wipe. The obvious mitigation — a second `s3.bucketPath.1` pointing at the root — is unverified in the way that matters: it is not known which entry the Spark connector would then use as the base for a *new* table, so it could silently defeat the change while looking applied. And the exposure window is one day: `entrypoint.sh` and the R2 wiring landed 2026-09-08 in #814.

What the review was right about is that the failure is **silent**, and that half is taken: the entrypoint now prints the configured prefix on every start, so `docker logs unity-catalog` answers the question for anyone chasing a 403.

## Verification

- Image built and the rendered property read back out of the container: `s3.bucketPath.0=s3://meinbucket/unity-catalog`
- The new startup line checked in both branches — with a bucket it matches the rendered config, without one only the existing "no R2 bucket configured" warning appears
- `test_unity_catalog_writes_under_its_own_prefix` asserts the **rendered** property line, not just the constant; a constant nothing interpolates proves nothing. Both mutations fail it: dropping the prefix from the line, and renaming the constant
- `uv run pytest tests/unit -q` → **3001 passed, 4 skipped**
- `uvx marimo check` on the edited notebook → 9 `markdown-indentation` warnings, the same as every other seed
- `uv run pre-commit run --files …` → clean, `shellcheck` included

## Local CodeRabbit round

Reviewed `6083345` — **1 finding**, half taken and half dismissed, both with reasons above. Fixed in `c046d26`. The round read `6083345`, so `c046d26` is itself locally unreviewed.

## Summary by Sourcery

Scope Unity Catalog data to the dedicated `unity-catalog/` subtree of the shared storage bucket and update usage guidance accordingly.

Bug Fixes:
- Scope Unity Catalog table storage to a dedicated `unity-catalog/` prefix in the shared object-storage bucket to prevent root-level naming collisions and isolate stack data.

Enhancements:
- Update Unity Catalog examples and seeded notebook locations to use the new prefix, document its effects on existing tables, and report the configured path at startup.

Documentation:
- Document the Unity Catalog storage prefix, absolute table-location behavior, migration impact for existing tables, and troubleshooting guidance.

Tests:
- Add coverage ensuring the rendered Unity Catalog bucket path includes the `unity-catalog/` prefix.