### PR TITLE
fix(stacks): Point Lakekeeper's BASE_URI at its in-cluster address

### DIFF
--- a/docs/stacks/lakekeeper.md
+++ b/docs/stacks/lakekeeper.md
@@ -285,13 +285,17 @@ helper takes it as `get_catalog("archive")`.
 
   1. The client was pointed at `https://lakekeeper.YOUR_DOMAIN`. Use
      `http://lakekeeper:8181/catalog` from inside the network.
-  2. **The client was pointed at the right URL and got redirected anyway.**
-     Lakekeeper returns `LAKEKEEPER__BASE_URI` to Iceberg clients as
-     `overrides.uri` in its `/v1/config` response, and PyIceberg honours it
-     for every call after the handshake. With BASE_URI set to the public
-     hostname, `load_catalog()` succeeds — the handshake goes over
-     app-network — and the *next* call lands on Access. The failure therefore
-     points at `list_namespaces` while the cause is in the config response.
+  2. **The client was pointed at the right URL and went somewhere else
+     anyway** — because Lakekeeper told it to. This is not an HTTP redirect,
+     and looking for a `3xx` will find nothing: the REST paths answer `404`
+     with no `Location` header. Lakekeeper *advertises* a different address.
+
+     It returns `LAKEKEEPER__BASE_URI` to Iceberg clients as `overrides.uri`
+     in its `/v1/config` response, and PyIceberg honours that for every call
+     after the handshake. With BASE_URI set to the public hostname,
+     `load_catalog()` succeeds — the handshake goes over app-network — and
+     the *next* call lands on Access. The failure therefore points at
+     `list_namespaces` while the cause is in the config response.
 
      Check what the server is advertising:
 

--- a/docs/stacks/lakekeeper.md
+++ b/docs/stacks/lakekeeper.md
@@ -279,9 +279,33 @@ helper takes it as `get_catalog("archive")`.
   hook did not create it. Search the spin-up log for
   `RESULT hook=lakekeeper`: `skipped-not-ready` means the deployment has no R2
   bucket configured, `failed` prints the HTTP status alongside it.
-- **PyIceberg raises a JSON parse error on connect** — you pointed it at
-  `https://lakekeeper.YOUR_DOMAIN`, and Cloudflare Access returned an HTML
-  login page. Use `http://lakekeeper:8181/catalog` from inside the network.
+- **PyIceberg fails with `Invalid JSON: … input_value='<!DOCTYPE html>…'`** —
+  something handed it Cloudflare Access's HTML login page instead of JSON.
+  Two different causes, and the second is the one that will fool you:
+
+  1. The client was pointed at `https://lakekeeper.YOUR_DOMAIN`. Use
+     `http://lakekeeper:8181/catalog` from inside the network.
+  2. **The client was pointed at the right URL and got redirected anyway.**
+     Lakekeeper returns `LAKEKEEPER__BASE_URI` to Iceberg clients as
+     `overrides.uri` in its `/v1/config` response, and PyIceberg honours it
+     for every call after the handshake. With BASE_URI set to the public
+     hostname, `load_catalog()` succeeds — the handshake goes over
+     app-network — and the *next* call lands on Access. The failure therefore
+     points at `list_namespaces` while the cause is in the config response.
+
+     Check what the server is advertising:
+
+     ```bash
+     ssh nexus 'docker exec marimo python -c "
+     import json, urllib.request
+     u = \"http://lakekeeper:8181/catalog/v1/config?warehouse=nexus\"
+     print(json.load(urllib.request.urlopen(u))[\"overrides\"])"'
+     ```
+
+     It must print an `http://lakekeeper:8181/...` uri. If it prints the
+     public hostname, `LAKEKEEPER__BASE_URI` is wrong — the shipped compose
+     sets it to the in-cluster address and gives the browser UI its own
+     `LAKEKEEPER__UI__LAKEKEEPER_URL`.
 - **`ModuleNotFoundError: No module named 's3fs'` on a write** — the client
   lacks `s3fs`, which remote signing needs. The Marimo image ships it; a
   hand-rolled client has to install it. Note the table has already been

--- a/src/nexus_deploy/service_env.py
+++ b/src/nexus_deploy/service_env.py
@@ -599,11 +599,18 @@ def _render_postgrest(c: NexusConfig, e: BootstrapEnv) -> RenderedEnv:
 
 
 def _render_lakekeeper(c: NexusConfig, e: BootstrapEnv) -> RenderedEnv:
-    """Lakekeeper: Iceberg REST Catalog. Needs dedicated Postgres
-    DSN + LAKEKEEPER__BASE_URI (double-underscore, that's Lakekeeper's
-    nested-config separator convention) for absolute-URL generation in the
-    catalog responses (Iceberg clients follow these to reach the
-    metadata endpoints).
+    """Lakekeeper: Iceberg REST Catalog. Needs a dedicated Postgres DSN, and
+    a hostname for the browser UI.
+
+    LAKEKEEPER_DOMAIN reaches the compose file as
+    ``LAKEKEEPER__UI__LAKEKEEPER_URL`` and **only** that. It used to feed
+    ``LAKEKEEPER__BASE_URI`` as well, which was wrong in a way that took a
+    while to see: Lakekeeper returns BASE_URI to Iceberg clients as
+    ``overrides.uri`` in its ``/v1/config`` response, and PyIceberg follows
+    that override for every later call. A public hostname there routes API
+    clients into Cloudflare Access, which answers with an HTML login page --
+    so ``load_catalog()`` works and the next call fails on unparseable JSON.
+    BASE_URI is now hardcoded to the in-cluster address in the compose file.
 
     Fail-fast guard (same pattern as Meilisearch / HedgeDoc): empty
     DB password crashes the Postgres init on first start with a

--- a/stacks/lakekeeper/docker-compose.yml
+++ b/stacks/lakekeeper/docker-compose.yml
@@ -73,7 +73,28 @@ services:
     environment:
       LAKEKEEPER__PG_DATABASE_URL_READ: postgres://nexus-lakekeeper:${LAKEKEEPER_DB_PASSWORD}@lakekeeper-db:5432/lakekeeper
       LAKEKEEPER__PG_DATABASE_URL_WRITE: postgres://nexus-lakekeeper:${LAKEKEEPER_DB_PASSWORD}@lakekeeper-db:5432/lakekeeper
-      LAKEKEEPER__BASE_URI: https://${LAKEKEEPER_DOMAIN}
+      # The IN-CLUSTER address, not the public one, and this is load-bearing.
+      #
+      # Lakekeeper echoes BASE_URI back to Iceberg clients as `overrides.uri`
+      # in its /v1/config response, and PyIceberg honours that override for
+      # every call after the handshake. Pointed at the public hostname, the
+      # sequence is: config fetched successfully over app-network, client
+      # switches to https://lakekeeper.<domain>, Cloudflare Access answers the
+      # unauthenticated API client with an HTML login page, and PyIceberg dies
+      # parsing HTML as JSON. `load_catalog()` succeeds and the very next call
+      # fails, which is a confusing place to start debugging.
+      #
+      # Measured both ways against v0.13.3:
+      #   BASE_URI=https://lakekeeper.example.com -> overrides.uri = https://lakekeeper.example.com/catalog
+      #   BASE_URI=http://lakekeeper:8181         -> overrides.uri = http://lakekeeper:8181/catalog
+      LAKEKEEPER__BASE_URI: http://lakekeeper:8181
+      # The browser-facing address, which BASE_URI would otherwise have
+      # supplied -- upstream documents this as defaulting to BASE_URI, so
+      # narrowing BASE_URI without setting this would point the UI inward.
+      # The served HTML references only absolute paths (`/ui/assets/...`) and
+      # carries no host, so the SPA itself loads from whatever origin the
+      # browser used; this covers whatever the UI resolves at runtime.
+      LAKEKEEPER__UI__LAKEKEEPER_URL: https://${LAKEKEEPER_DOMAIN}
       # Auth disabled internally — CF Access at the edge is the gate.
       # Flip to "openid" + LAKEKEEPER__OPENID_PROVIDER_URI if you
       # later want fine-grained per-team table permissions inside

--- a/tests/unit/test_stack_conventions.py
+++ b/tests/unit/test_stack_conventions.py
@@ -1087,3 +1087,44 @@ def test_unity_catalog_writes_under_its_own_prefix() -> None:
         f"bucketPath no longer carries the prefix: {bucket_paths}. Writing to the "
         "bucket root puts Unity Catalog's schemas next to every other stack's data."
     )
+
+
+def test_lakekeeper_advertises_its_in_cluster_address() -> None:
+    """`LAKEKEEPER__BASE_URI` must be the in-cluster URL, not the public one.
+
+    Lakekeeper echoes BASE_URI to Iceberg clients as `overrides.uri` in its
+    `/v1/config` response, and PyIceberg honours it for every subsequent call.
+    Pointed at the Cloudflare-Access-gated hostname, the client fetches config
+    successfully over app-network, switches to the public URL, receives an
+    HTML login page and dies parsing it as JSON -- with `load_catalog()`
+    having succeeded, so the failure surfaces one call later than its cause.
+
+    Measured both ways against v0.13.3:
+        BASE_URI=https://lakekeeper.example.com -> overrides.uri = https://...
+        BASE_URI=http://lakekeeper:8181         -> overrides.uri = http://lakekeeper:8181/catalog
+
+    The UI keeps the public address through its own setting, which upstream
+    documents as defaulting to BASE_URI -- so narrowing one without setting
+    the other would point the browser inward instead.
+    """
+    compose = (REPO_ROOT / "stacks/lakekeeper/docker-compose.yml").read_text()
+
+    base = [
+        line.split(":", 1)[1].strip()
+        for line in compose.splitlines()
+        if line.strip().startswith("LAKEKEEPER__BASE_URI:")
+    ]
+    assert base == ["http://lakekeeper:8181"], (
+        f"LAKEKEEPER__BASE_URI is {base}. Anything public here is handed to "
+        "Iceberg clients as overrides.uri and routes them into Cloudflare Access."
+    )
+
+    ui = [
+        line.split(":", 1)[1].strip()
+        for line in compose.splitlines()
+        if line.strip().startswith("LAKEKEEPER__UI__LAKEKEEPER_URL:")
+    ]
+    assert ui == ["https://${LAKEKEEPER_DOMAIN}"], (
+        f"LAKEKEEPER__UI__LAKEKEEPER_URL is {ui}. Without it the browser UI "
+        "inherits the in-cluster BASE_URI, which no browser can reach."
+    )


### PR DESCRIPTION
## Summary

Running the seeded Lakekeeper notebook on a live deployment fails:

```
pydantic_core.ValidationError: 1 validation error for ListNamespaceResponse
  Invalid JSON: expected value at line 1 column 1
  [input_value='<!DOCTYPE html>\n<html>\...>\n  </body>\n\n</html>', input_type=str]
```

That HTML is Cloudflare Access's login page. `LAKEKEEPER__BASE_URI` pointed at the public hostname, and Lakekeeper hands that address to Iceberg clients to use for everything after the handshake.

This is a defect in #831.

## Why the failure lands one call away from its cause

Lakekeeper returns `LAKEKEEPER__BASE_URI` to Iceberg clients as `overrides.uri` in its `/v1/config` response. PyIceberg honours that override for every subsequent call. So:

1. `load_catalog()` fetches `/v1/config` over `app-network` — **succeeds**
2. the response says "use `https://lakekeeper.<domain>/catalog` from now on"
3. `list_namespaces()` goes there, hits Cloudflare Access, gets HTML — **fails**

Confirmed on the deployment:

```json
"overrides": { "uri": "https://lakekeeper.nexus-stack.ch/catalog" }
```

The traceback therefore accuses `list_namespaces` while the cause sits in the config response, and `load_catalog` succeeding is what makes the client look correctly configured.

## What was ruled out first

- **The client.** Checked on the server: `LAKEKEEPER_URI=http://lakekeeper:8181/catalog`, `LAKEKEEPER_WAREHOUSE=nexus`, and the workspace carries the current `_nexus_iceberg.py` whose own default is the same in-cluster URL. Nothing on the client side was wrong.
- **An HTTP redirect to BASE_URI.** Tested with redirect-following disabled: the REST paths return `404` with no `Location` header. Lakekeeper does not redirect — it advertises.

## The fix

`LAKEKEEPER__BASE_URI` becomes `http://lakekeeper:8181`.

The browser UI keeps the public address through `LAKEKEEPER__UI__LAKEKEEPER_URL`. Upstream documents that setting as *defaulting to BASE_URI*, so narrowing BASE_URI without setting it would have pointed the UI inward — trading one broken half for the other.

Measured both ways against v0.13.3, same warehouse, only BASE_URI changed:

| `LAKEKEEPER__BASE_URI` | resulting `overrides.uri` |
|---|---|
| `https://lakekeeper.example.com` | `https://lakekeeper.example.com/catalog` |
| `http://lakekeeper:8181` | `http://lakekeeper:8181/catalog` |

The UI is unaffected by the narrowing: its served HTML references only absolute paths (`/ui/assets/...`) and carries no host at all, so the SPA loads from whatever origin the browser used. The UI setting covers whatever it resolves at runtime.

## Why #831's rehearsal missed this

The rehearsal set `LAKEKEEPER__BASE_URI` to the internal address, because that was the only address that existed in it — there was no tunnel and no Access. The single setting that differed between rehearsal and production was the one that mattered, and everything else in that rehearsal passed because of it.

That is recorded in the new test's docstring rather than only in this description, so the next person changing this line meets the reason where the value lives.

## Verification

- `overrides.uri` read from the live deployment, and from a local A/B where only BASE_URI changed
- Redirect hypothesis tested and disproved before the real one was tested
- `test_lakekeeper_advertises_its_in_cluster_address` pins both settings; both mutations fail it — BASE_URI back to public, and the UI setting removed
- `uv run pytest tests/unit -q` → **3002 passed, 4 skipped**
- `uv run pre-commit run --files …` → clean

## Docs

The troubleshooting entry for this exact error offered only one cause — "you pointed it at the public URL" — which would have sent someone to inspect a client that was already correct. It now carries both causes and the command that shows what the server is advertising.

`_render_lakekeeper`'s docstring described the mechanism accurately all along ("absolute-URL generation in the catalog responses (Iceberg clients follow these...)") without drawing the conclusion. It now says what that implies and why `LAKEKEEPER_DOMAIN` no longer feeds BASE_URI.

## Not fixed here

**#832** — the intermittent 403s seen against MinIO during rehearsal — is a separate, still-unexplained issue. Whether it also occurs against R2 can only be answered once this fix is deployed and the notebook runs far enough to find out.

## Summary by Sourcery

Ensure Lakekeeper advertises its in-cluster API endpoint to Iceberg clients while keeping its browser UI publicly accessible.

Bug Fixes:
- Configure Lakekeeper to advertise its in-cluster API address to Iceberg clients, preventing public Cloudflare Access pages from being parsed as JSON.
- Preserve the public browser UI address through a dedicated Lakekeeper UI setting.

Enhancements:
- Expand Lakekeeper troubleshooting guidance to explain advertised URLs and how to inspect them.

Documentation:
- Document both client URL misconfiguration causes for PyIceberg JSON parsing failures and provide a diagnostic command.

Tests:
- Add a convention test ensuring Lakekeeper uses the in-cluster BASE_URI and separately configured public UI URL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed Lakekeeper configuration so Iceberg clients use the reachable in-cluster API address.
  - Preserved the public domain for browser-based Lakekeeper access.
  - Improved troubleshooting guidance for JSON parse errors caused by incorrect or redirected API URLs.

- **Tests**
  - Added validation ensuring Lakekeeper advertises the correct API and UI addresses.

- **Documentation**
  - Documented how to inspect Lakekeeper’s advertised URL and diagnose client connection issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->