### PR TITLE
fix(stacks): Make Iceberg writes work against R2 — signing and checksums

### DIFF
--- a/docs/stacks/lakekeeper.md
+++ b/docs/stacks/lakekeeper.md
@@ -300,10 +300,7 @@ helper takes it as `get_catalog("archive")`.
      Check what the server is advertising:
 
      ```bash
-     ssh nexus 'docker exec marimo python -c "
-     import json, urllib.request
-     u = \"http://lakekeeper:8181/catalog/v1/config?warehouse=nexus\"
-     print(json.load(urllib.request.urlopen(u))[\"overrides\"])"'
+     ssh nexus 'docker exec marimo python -c "import json,urllib.request; print(json.load(urllib.request.urlopen(\"http://lakekeeper:8181/catalog/v1/config?warehouse=nexus\"))[\"overrides\"])"'
      ```
 
      It must print an `http://lakekeeper:8181/...` uri. If it prints the
@@ -325,9 +322,7 @@ helper takes it as `get_catalog("archive")`.
   ```bash
   # what the warehouse currently has
   ssh nexus 'curl -s http://localhost:8195/management/v1/warehouse |
-    python3 -c "import json,sys
-w = next(x for x in json.load(sys.stdin)[\"warehouses\"] if x[\"name\"] == \"nexus\")
-print(w[\"storage-profile\"].get(\"remote-signing-url-style\"))"'
+    python3 -c "import json,sys; w=next(x for x in json.load(sys.stdin)[\"warehouses\"] if x[\"name\"]==\"nexus\"); print(w[\"storage-profile\"].get(\"remote-signing-url-style\"))"'
   ```
 
   Selected by name rather than by `warehouses[0]`: a deployment that added a

--- a/docs/stacks/lakekeeper.md
+++ b/docs/stacks/lakekeeper.md
@@ -310,6 +310,41 @@ helper takes it as `get_catalog("archive")`.
      public hostname, `LAKEKEEPER__BASE_URI` is wrong — the shipped compose
      sets it to the in-cluster address and gives the browser UI its own
      `LAKEKEEPER__UI__LAKEKEEPER_URL`.
+- **`SignError: Failed to sign request 400`** — Lakekeeper refused to sign an
+  S3 request. Look in `docker logs lakekeeper` for an `Authorization failed
+  event` with `action_name: write_data`, and at the `table-location` it
+  reports. If that location starts with the R2 **account id** instead of the
+  bucket — `s3://<account>/<bucket>/...` — the warehouse has
+  `remote-signing-url-style` on its `auto` default. `auto` reads
+  `<account>.r2.cloudflarestorage.com/<bucket>/<key>` as virtual-hosted and
+  takes the first host label for the bucket, which is wrong for R2.
+
+  The shipped hook sets `path` and repairs an existing warehouse that still
+  carries `auto`, so a spin-up fixes it. To check or fix by hand:
+
+  ```bash
+  # what the warehouse currently has
+  ssh nexus 'curl -s http://localhost:8195/management/v1/warehouse |
+    python3 -c "import json,sys; w=json.load(sys.stdin)[\"warehouses\"][0];
+    print(w[\"storage-profile\"].get(\"remote-signing-url-style\"))"'
+  ```
+
+  Lakekeeper also logs `This is a bug in the query engine. When using
+  PyIceberg, please update to versions > 0.9.1` alongside this. That message
+  is a red herring — it appears against PyIceberg 0.12.0 too.
+
+- **`The request signature we calculated does not match the signature you
+  provided`, or `MissingContentLength`, on a write** — botocore re-encoded the
+  body as `aws-chunked` with trailing checksums *after* Lakekeeper signed it,
+  so the signed body is not the body that arrives. The Marimo stack sets
+  `AWS_REQUEST_CHECKSUM_CALCULATION=when_required` and
+  `AWS_RESPONSE_CHECKSUM_VALIDATION=when_required` to prevent this; a
+  hand-rolled client needs the same two variables.
+
+  This one only becomes visible once signing itself works. A signing failure
+  masks it completely, which is worth knowing before concluding that a
+  checksum fix "did not help".
+
 - **`ModuleNotFoundError: No module named 's3fs'` on a write** — the client
   lacks `s3fs`, which remote signing needs. The Marimo image ships it; a
   hand-rolled client has to install it. Note the table has already been

--- a/docs/stacks/lakekeeper.md
+++ b/docs/stacks/lakekeeper.md
@@ -300,8 +300,15 @@ helper takes it as `get_catalog("archive")`.
      Check what the server is advertising:
 
      ```bash
-     ssh nexus 'docker exec marimo python -c "import json,urllib.request; print(json.load(urllib.request.urlopen(\"http://lakekeeper:8181/catalog/v1/config?warehouse=nexus\"))[\"overrides\"])"'
+     ssh nexus 'curl -s "http://localhost:8195/catalog/v1/config?warehouse=nexus" |
+       python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get(\"overrides\") or d)"'
      ```
+
+     Asked through the host-published port rather than from inside a
+     container, which gives the same answer here because BASE_URI is
+     pinned explicitly rather than derived from forwarded headers —
+     verified by asking both ways. Both forms print the API's own error
+     when the warehouse is absent, instead of a Python traceback.
 
      It must print an `http://lakekeeper:8181/...` uri. If it prints the
      public hostname, `LAKEKEEPER__BASE_URI` is wrong — the shipped compose
@@ -322,7 +329,7 @@ helper takes it as `get_catalog("archive")`.
   ```bash
   # what the warehouse currently has
   ssh nexus 'curl -s http://localhost:8195/management/v1/warehouse |
-    python3 -c "import json,sys; w=next(x for x in json.load(sys.stdin)[\"warehouses\"] if x[\"name\"]==\"nexus\"); print(w[\"storage-profile\"].get(\"remote-signing-url-style\"))"'
+    python3 -c "import json,sys; w=next((x for x in json.load(sys.stdin).get(\"warehouses\",[]) if x[\"name\"]==\"nexus\"), None); print(w[\"storage-profile\"].get(\"remote-signing-url-style\") if w else \"no warehouse named nexus — the hook never created one\")"'
   ```
 
   Selected by name rather than by `warehouses[0]`: a deployment that added a

--- a/docs/stacks/lakekeeper.md
+++ b/docs/stacks/lakekeeper.md
@@ -325,9 +325,14 @@ helper takes it as `get_catalog("archive")`.
   ```bash
   # what the warehouse currently has
   ssh nexus 'curl -s http://localhost:8195/management/v1/warehouse |
-    python3 -c "import json,sys; w=json.load(sys.stdin)[\"warehouses\"][0];
-    print(w[\"storage-profile\"].get(\"remote-signing-url-style\"))"'
+    python3 -c "import json,sys
+w = next(x for x in json.load(sys.stdin)[\"warehouses\"] if x[\"name\"] == \"nexus\")
+print(w[\"storage-profile\"].get(\"remote-signing-url-style\"))"'
   ```
+
+  Selected by name rather than by `warehouses[0]`: a deployment that added a
+  second warehouse would otherwise read the wrong one and give a confidently
+  wrong answer.
 
   Lakekeeper also logs `This is a bug in the query engine. When using
   PyIceberg, please update to versions > 0.9.1` alongside this. That message

--- a/src/nexus_deploy/services.py
+++ b/src/nexus_deploy/services.py
@@ -2362,6 +2362,24 @@ def render_lakekeeper_hook(config: NexusConfig, env: BootstrapEnv) -> str:
                 "path-style-access": True,
                 "sts-enabled": False,
                 "remote-signing-enabled": True,
+                # `path`, not the `auto` default, and this is what makes
+                # remote signing actually work against R2.
+                #
+                # Lakekeeper checks that the URL it is asked to sign belongs
+                # to the table. With `auto` it guesses the URL style, and for
+                # R2 it guesses wrong: `<account>.r2.cloudflarestorage.com/
+                # <bucket>/<key>` looks virtual-hosted, so it reads the
+                # ACCOUNT ID as the bucket. The audit log then shows a
+                # table-location of `s3://<account id>/<bucket>/...`, which
+                # matches no warehouse, and every write dies with
+                # `SignError: Failed to sign request 400`.
+                #
+                # Measured on a live deployment; the server's own warning is
+                # a red herring worth knowing about, because it blames the
+                # client: "This is a bug in the query engine. When using
+                # PyIceberg, please update to versions > 0.9.1" -- said to a
+                # PyIceberg 0.12.0 client.
+                "remote-signing-url-style": "path",
                 "key-prefix": LAKEKEEPER_KEY_PREFIX,
             },
         ),
@@ -2394,10 +2412,42 @@ lakekeeper_hook() {{
         esac
     fi
 
-    if curl -s --max-time 10 {shlex.quote(base + "/management/v1/warehouse")} 2>/dev/null \\
-        | jq -e --arg n {shlex.quote(LAKEKEEPER_WAREHOUSE)} \\
-          '[.warehouses[]? | select(.name == $n)] | length > 0' >/dev/null 2>&1; then
-        echo "RESULT hook=lakekeeper status=already-configured"
+    EXISTING=$(curl -s --max-time 10 {shlex.quote(base + "/management/v1/warehouse")} 2>/dev/null || echo '{{}}')
+    WH_ID=$(printf '%s' "$EXISTING" | jq -r --arg n {shlex.quote(LAKEKEEPER_WAREHOUSE)} \\
+        '[.warehouses[]? | select(.name == $n)][0]["warehouse-id"] // empty' 2>/dev/null || true)
+    if [ -n "$WH_ID" ]; then
+        # The warehouse is there, but a warehouse created before the
+        # remote-signing url-style was pinned carries `auto`, and against R2
+        # that setting makes every write fail. Repair it in place rather than
+        # reporting `already-configured` over a warehouse that cannot be
+        # written to. Recreating instead is not an option: it would discard
+        # the namespaces and table pointers while the Parquet stays in R2.
+        URL_STYLE=$(printf '%s' "$EXISTING" | jq -r --arg n {shlex.quote(LAKEKEEPER_WAREHOUSE)} \\
+            '[.warehouses[]? | select(.name == $n)][0]["storage-profile"]["remote-signing-url-style"] // "unset"' \\
+            2>/dev/null || echo "unset")
+        if [ "$URL_STYLE" = "path" ]; then
+            echo "RESULT hook=lakekeeper status=already-configured"
+            return 0
+        fi
+        FIX=$(NEXUS_AK={shlex.quote(access_key)} NEXUS_SK={shlex.quote(secret_key)} jq -n \\
+            --argjson profile {profile} \\
+            '{{"storage-profile": $profile,
+               "storage-credential": {{type: "s3", "credential-type": "access-key",
+                                      "access-key-id": env.NEXUS_AK,
+                                      "secret-access-key": env.NEXUS_SK}}}}')
+        FIX_CODE=$(printf '%s' "$FIX" | curl -s -o /dev/null -w '%{{http_code}}' \\
+            -X POST "{base}/management/v1/warehouse/$WH_ID/storage" \\
+            --max-time 60 -H 'Content-Type: application/json' --data-binary @- 2>/dev/null || true)
+        FIX_CODE=${{FIX_CODE:-000}}
+        case "$FIX_CODE" in
+            2??)
+                echo "RESULT hook=lakekeeper status=configured"
+                ;;
+            *)
+                echo "  ⚠ lakekeeper warehouse has remote-signing-url-style=$URL_STYLE and the repair returned HTTP $FIX_CODE — writes will fail with SignError 400" >&2
+                echo "RESULT hook=lakekeeper status=failed"
+                ;;
+        esac
         return 0
     fi
 

--- a/stacks/marimo/docker-compose.yml
+++ b/stacks/marimo/docker-compose.yml
@@ -88,6 +88,27 @@ services:
       # the catalogue.
       - LAKEKEEPER_URI=http://lakekeeper:8181/catalog
       - LAKEKEEPER_WAREHOUSE=nexus
+      # Turn off botocore's newer streaming checksums. Without this, writes
+      # through a remote-signing Iceberg warehouse fail on Cloudflare R2 with
+      #   PermissionError: The request signature we calculated does not match
+      #   the signature you provided.
+      # and sometimes with `MissingContentLength` instead.
+      #
+      # The mechanism: Lakekeeper signs the request it is shown, and botocore
+      # THEN re-encodes the body as `aws-chunked` with trailing checksums
+      # (`X-Amz-Trailer: x-amz-checksum-crc32`,
+      # `X-Amz-Content-SHA256: STREAMING-UNSIGNED-PAYLOAD-TRAILER`). The body
+      # the signature covers is no longer the body that arrives, so R2 rejects
+      # it. `when_required` restores the pre-1.36 botocore behaviour of adding
+      # a checksum only where the API demands one.
+      #
+      # Measured against the live R2 warehouse, same table, same code, only
+      # these two variables added: without them the write fails, with them it
+      # returns 3 rows. Note this is invisible until remote signing itself
+      # works -- an earlier signing failure masks it entirely, which is how it
+      # was first mis-diagnosed as unrelated.
+      - AWS_REQUEST_CHECKSUM_CALCULATION=when_required
+      - AWS_RESPONSE_CHECKSUM_VALIDATION=when_required
       # NOTE: HETZNER_S3_* are intentionally NOT set here. They land
       # in `.infisical.env` via the secret-sync block in deploy.sh
       # and reach the container via env_file above. Listing them in

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -2672,12 +2672,16 @@ def test_render_lakekeeper_hook_keeps_the_r2_secret_out_of_argv() -> None:
     script = render_lakekeeper_hook(_make_config(), _make_env())
     assert "env.NEXUS_SK" in script
     assert "env.NEXUS_AK" in script
-    # The value itself: present once, and only in the env assignment. This is
-    # the load-bearing assertion and it does not care about line layout -- a
-    # `--arg sk 'r2-sk'` moved onto a line of its own still fails it, because
-    # that line carries no `NEXUS_SK=`. Verified by mutation, both when the
-    # rogue --arg shares a line with another and when it sits alone.
-    assert script.count("r2-sk") == 1
+    # The value appears only inside env assignments. This is the load-bearing
+    # assertion and it does not care about line layout -- a `--arg sk 'r2-sk'`
+    # moved onto a line of its own still fails it, because that line carries
+    # no `NEXUS_SK=`. Verified by mutation, both when the rogue --arg shares a
+    # line with another and when it sits alone.
+    #
+    # Deliberately NOT an exact count. It was `== 1` until the hook grew a
+    # second jq call -- the in-place repair of an existing warehouse -- and
+    # the test failed on a change that was perfectly safe. A count pins the
+    # shape of the script; what matters is that no occurrence escapes argv.
     secret_lines = [line for line in script.splitlines() if "r2-sk" in line]
     assert secret_lines, "secret never rendered — this test would pass vacuously"
     assert all("NEXUS_SK=" in line for line in secret_lines), secret_lines
@@ -2699,9 +2703,40 @@ def test_render_lakekeeper_hook_storage_profile_matches_r2() -> None:
     assert profile["path-style-access"] is True
     assert profile["sts-enabled"] is False
     assert profile["remote-signing-enabled"] is True
+    # `path`, not the `auto` default. With `auto` Lakekeeper reads
+    # `<account>.r2.cloudflarestorage.com/<bucket>/<key>` as virtual-hosted
+    # and takes the ACCOUNT ID for the bucket, so the signing request is
+    # authorised against a warehouse that does not exist and every write
+    # fails with `SignError: Failed to sign request 400`. Measured on a live
+    # deployment, where the audit log showed the table-location as
+    # `s3://<account id>/<bucket>/...`.
+    assert profile["remote-signing-url-style"] == "path"
     # The shared data bucket is addressed at its root by Unity Catalog and
     # pg-ducklake, so the warehouse has to own a subtree rather than the top.
     assert profile["key-prefix"] == "lakekeeper"
+
+
+def test_render_lakekeeper_hook_repairs_a_stale_url_style() -> None:
+    """An existing warehouse with the wrong url-style is repaired, not accepted.
+
+    A warehouse created before `remote-signing-url-style` was pinned carries
+    `auto`, and against R2 that makes every write fail with
+    `SignError: Failed to sign request 400`. Reporting `already-configured`
+    over it would be a green line above a catalogue nothing can write to.
+
+    Recreating is not the alternative: it would discard the namespaces and
+    table pointers while the Parquet files stay in R2 -- the orphaning this
+    stack's docs warn about. So the hook POSTs the corrected storage profile
+    to the existing warehouse instead.
+    """
+    script = render_lakekeeper_hook(_make_config(), _make_env())
+    assert '"remote-signing-url-style"' in script
+    assert "/storage" in script
+    # already-configured is reached only when the style is already `path`.
+    before = script.split("status=already-configured")[0]
+    assert '[ "$URL_STYLE" = "path" ]' in before, (
+        "already-configured is reported without checking the url-style first"
+    )
 
 
 def test_render_lakekeeper_hook_skips_without_object_storage() -> None:

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -2682,9 +2682,17 @@ def test_render_lakekeeper_hook_keeps_the_r2_secret_out_of_argv() -> None:
     # second jq call -- the in-place repair of an existing warehouse -- and
     # the test failed on a change that was perfectly safe. A count pins the
     # shape of the script; what matters is that no occurrence escapes argv.
-    secret_lines = [line for line in script.splitlines() if "r2-sk" in line]
-    assert secret_lines, "secret never rendered — this test would pass vacuously"
-    assert all("NEXUS_SK=" in line for line in secret_lines), secret_lines
+    assert "r2-sk" in script, "secret never rendered — this test would pass vacuously"
+
+    # Strip the sanctioned occurrences, then require the secret to be gone.
+    # Stronger than checking each line that mentions it: this leaves nothing
+    # for a second, differently-shaped exposure to hide behind, and it does
+    # not care where line breaks fall.
+    remainder = re.sub(r"NEXUS_SK=(?:'[^']*'|\S+)", "NEXUS_SK=<redacted>", script)
+    assert "r2-sk" not in remainder, (
+        "the R2 secret appears outside a NEXUS_SK= env assignment:\n"
+        + "\n".join(line for line in remainder.splitlines() if "r2-sk" in line)
+    )
     assert "--arg" in script  # non-secret args legitimately use --arg
 
 

--- a/tests/unit/test_stack_conventions.py
+++ b/tests/unit/test_stack_conventions.py
@@ -1146,10 +1146,21 @@ def test_marimo_disables_botocore_streaming_checksums() -> None:
     once remote signing itself works, so an unrelated signing bug masks it
     completely, and removing these would look harmless in any environment
     that is already broken further upstream.
+
+    Parsed from the YAML rather than grepped. The first version of this test
+    matched the raw text, and a mutation proved it worthless: commenting the
+    line out left the test passing. A check that accepts a disabled setting
+    is worse than no check, because it reports the opposite of the truth.
     """
-    compose = (REPO_ROOT / "stacks/marimo/docker-compose.yml").read_text()
+    import yaml
+
+    compose = yaml.safe_load((REPO_ROOT / "stacks/marimo/docker-compose.yml").read_text())
+    raw = compose["services"]["marimo"]["environment"]
+    # compose accepts either a list of "KEY=value" or a mapping
+    env = dict(item.split("=", 1) for item in raw) if isinstance(raw, list) else dict(raw)
+
     for var in ("AWS_REQUEST_CHECKSUM_CALCULATION", "AWS_RESPONSE_CHECKSUM_VALIDATION"):
-        assert f"- {var}=when_required" in compose, (
-            f"{var} is not pinned to when_required in the Marimo stack. "
-            "Iceberg writes to R2 fail with a signature mismatch without it."
+        assert env.get(var) == "when_required", (
+            f"{var} is {env.get(var)!r}, expected 'when_required'. Iceberg "
+            "writes to R2 fail with a signature mismatch without it."
         )

--- a/tests/unit/test_stack_conventions.py
+++ b/tests/unit/test_stack_conventions.py
@@ -1128,3 +1128,28 @@ def test_lakekeeper_advertises_its_in_cluster_address() -> None:
         f"LAKEKEEPER__UI__LAKEKEEPER_URL is {ui}. Without it the browser UI "
         "inherits the in-cluster BASE_URI, which no browser can reach."
     )
+
+
+def test_marimo_disables_botocore_streaming_checksums() -> None:
+    """Writes through a remote-signing Iceberg warehouse need this on R2.
+
+    Lakekeeper signs the request it is shown; botocore then re-encodes the
+    body as `aws-chunked` with trailing checksums, so the body the signature
+    covers is not the body that arrives. R2 answers with
+    `The request signature we calculated does not match the signature you
+    provided`, or `MissingContentLength`.
+
+    Measured against the live warehouse, same table and code, only these two
+    variables added: without them the write fails, with them it returns rows.
+
+    Pinned because the failure is silent in the worst way -- it only appears
+    once remote signing itself works, so an unrelated signing bug masks it
+    completely, and removing these would look harmless in any environment
+    that is already broken further upstream.
+    """
+    compose = (REPO_ROOT / "stacks/marimo/docker-compose.yml").read_text()
+    for var in ("AWS_REQUEST_CHECKSUM_CALCULATION", "AWS_RESPONSE_CHECKSUM_VALIDATION"):
+        assert f"- {var}=when_required" in compose, (
+            f"{var} is not pinned to when_required in the Marimo stack. "
+            "Iceberg writes to R2 fail with a signature mismatch without it."
+        )


### PR DESCRIPTION
## Summary

After #837 fixed the catalogue URL, the seeded Lakekeeper notebook still could not write. Two further defects were stacked behind it, and **the second is invisible until the first is gone** — which is why they are in one PR.

Everything below was measured against the live R2 warehouse, same table, same code:

| Configuration | Result |
|---|---|
| `url-style=auto`, no checksum vars | `SignError: Failed to sign request 400` |
| `url-style=path`, no checksum vars | `The request signature we calculated does not match the signature you provided` |
| `url-style=path`, **with** checksum vars | **`OK: 3 rows`** |

## 1. The warehouse advertised the wrong bucket

Writes failed with `SignError: Failed to sign request 400`. PyIceberg's exception carries no server reason; the server log has it:

```
WARN  Received a table specific sign request for table <id> with a location
      s3://…/lakekeeper/<id> that does not match the request URI …
INFO  Authorization failed event  action_name=write_data
      table-location=s3://<r2-account-id>/nexus-…-data/lakekeeper/…
```

That first path segment is the **R2 account id**, not the bucket. The warehouse carried `remote-signing-url-style` on its `auto` default, and `auto` reads `<account>.r2.cloudflarestorage.com/<bucket>/<key>` as virtual-hosted, taking the first host label for the bucket. Lakekeeper then authorised the signing request against a warehouse that does not exist.

Pinned to `path`.

**The hook now repairs an existing warehouse** that still carries `auto`, by POSTing the corrected profile to `/warehouse/<id>/storage`, instead of reporting `already-configured` over a catalogue nothing can write to. Recreating is not the alternative: it would discard the namespaces and table pointers while the Parquet stays in R2 — the orphaning this stack's own docs warn about.

One trap worth naming: Lakekeeper blames the client in that same log line — *"This is a bug in the query engine. When using PyIceberg, please update to versions > 0.9.1"* — said to a PyIceberg **0.12.0** client. The docs now say to ignore it.

## 2. botocore re-encoded the body after it was signed

With signing fixed, the write failed again with a signature mismatch, sometimes `MissingContentLength` instead. Lakekeeper signs the request it is shown; botocore **then** re-encodes the body as `aws-chunked` with trailing checksums (`X-Amz-Trailer: x-amz-checksum-crc32`, `X-Amz-Content-SHA256: STREAMING-UNSIGNED-PAYLOAD-TRAILER`). The body the signature covers is not the body that arrives.

`AWS_REQUEST_CHECKSUM_CALCULATION=when_required` and `AWS_RESPONSE_CHECKSUM_VALIDATION=when_required` restore the pre-1.36 botocore behaviour.

**I tested exactly these two variables earlier in this investigation and reported the hypothesis as disproved.** That was wrong. The SignError above was masking them, so both arms of that A/B failed for an unrelated reason, and "fails identically" got read as "hypothesis false" when the correct reading was "this test is measuring nothing". Recorded in the compose comment and the docs, because *"we already tried that"* is exactly the note that stops the next person from trying it at the right moment.

## Test quality — the round found a test that lied

The local CodeRabbit round flagged the new checksum test as relying on substring matching. Mutation-checked rather than taken on trust, and it was worse than reported: **commenting the line out left the test passing.** A check that green-lights a broken config is worse than no check.

It now parses the YAML and reads the effective `services.marimo.environment` mapping. Three mutations fail it: commented out, value changed, line removed.

The same round improved the argv secret check. It inspected each line mentioning the secret and required a `NEXUS_SK=` on it — correct for the shapes tried, but it reasons per line. It now strips the sanctioned assignments and requires the secret to be absent from everything left, verified against a `-H "X-Debug: <secret>"` mutation on a curl line.

## Verification

- Three-way A/B against the live R2 warehouse, table above
- The deployment's storage profile was repaired in place during the investigation and now reads `path`; the docs command confirms it
- **Ten mutations**, each confirmed to fail its intended test: url-style set to `auto`, url-style removed, repair branch short-circuited to always report `already-configured`, each checksum variable removed / commented / value-changed, and two secret-exposure shapes
- `uv run pytest tests/unit -q` → **3004 passed, 4 skipped**
- `uv run pre-commit run --files …` → clean

## Local CodeRabbit round

Reviewed `aee55be` — **3 findings, 0 dismissed**, fixed in `249d3d6`: the checksum test (🔴, it passed on a disabled setting), the argv check (🔵), and a docs command reading `warehouses[0]` instead of the warehouse named `nexus` (🟠). The round read `aee55be`, so `249d3d6` is itself locally unreviewed.

## Related

**#832** — the intermittent 403s seen against MinIO during the original rehearsal — now has a plausible mechanism rather than none: a signature mismatch returns 403, and whether botocore takes the streaming path depends on buffering. That will be recorded there once this is deployed and the notebook runs clean.

## Summary by Sourcery

Make Lakekeeper-backed Iceberg writes work reliably against Cloudflare R2 by correcting request signing, checksum behavior, and warehouse repair handling.

Bug Fixes:
- Fix Iceberg writes to Cloudflare R2 by using path-style remote signing and disabling incompatible botocore streaming checksums.
- Repair existing Lakekeeper warehouses with stale remote-signing URL styles instead of treating them as configured.

Enhancements:
- Improve Lakekeeper troubleshooting documentation for R2 signing, checksum, catalogue URL, and misleading client-version errors.

Documentation:
- Document diagnosis and remediation for Lakekeeper and R2 write failures, including commands that select the intended warehouse by name.

Tests:
- Strengthen secret-exposure assertions and validate the effective Docker Compose environment rather than relying on text matching.
- Add coverage for the R2 storage profile and stale warehouse repair behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Lakekeeper compatibility with Cloudflare R2 by correcting remote-signing URL handling.
  - Automatically repairs existing warehouse configurations using an incompatible URL style.
  - Prevented checksum-related errors that could block remote Iceberg writes.

- **Documentation**
  - Expanded troubleshooting guidance for signing failures, checksum mismatches, missing content lengths, and misleading query-engine warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->