### PR TITLE
fix(examples): Escape inlined secrets and render the S3 DataFrame

### DIFF
--- a/examples/workspace-seeds/kestra/flows/r2-taxi-pipeline.yaml
+++ b/examples/workspace-seeds/kestra/flows/r2-taxi-pipeline.yaml
@@ -104,9 +104,14 @@ tasks:
     sql: |
       INSTALL httpfs;
       LOAD httpfs;
-      SET s3_endpoint          = '{{ secret('R2_ENDPOINT') | replace({'https://': ''}) }}';
-      SET s3_access_key_id     = '{{ secret('R2_ACCESS_KEY') }}';
-      SET s3_secret_access_key = '{{ secret('R2_SECRET_KEY') }}';
+      -- Each value is inlined into a SQL string literal, so an apostrophe in
+      -- any of them would close the literal early and the query would fail to
+      -- parse. replace({"'": "''"}) is SQL's own escape. Verified against a
+      -- live Kestra 2.0 with a deliberately hostile secret: abc'def rendered
+      -- as abc''def, and the two filters chain correctly (#664).
+      SET s3_endpoint          = '{{ secret('R2_ENDPOINT') | replace({'https://': ''}) | replace({"'": "''"}) }}';
+      SET s3_access_key_id     = '{{ secret('R2_ACCESS_KEY') | replace({"'": "''"}) }}';
+      SET s3_secret_access_key = '{{ secret('R2_SECRET_KEY') | replace({"'": "''"}) }}';
       SET s3_url_style         = 'path';
       SET s3_use_ssl           = true;
 

--- a/examples/workspace-seeds/kestra/flows/r2-taxi-pipeline.yaml
+++ b/examples/workspace-seeds/kestra/flows/r2-taxi-pipeline.yaml
@@ -109,6 +109,12 @@ tasks:
       -- parse. replace({"'": "''"}) is SQL's own escape. Verified against a
       -- live Kestra 2.0 with a deliberately hostile secret: abc'def rendered
       -- as abc''def, and the two filters chain correctly (#664).
+      --
+      -- The bucket name in the FROM clause below gets the same treatment. A
+      -- bucket name cannot contain an apostrophe, so it is unreachable today.
+      -- It is escaped anyway: leaving one of four inlines bare would read as
+      -- a considered exemption rather than an oversight, and the next person
+      -- would have to re-derive why.
       SET s3_endpoint          = '{{ secret('R2_ENDPOINT') | replace({'https://': ''}) | replace({"'": "''"}) }}';
       SET s3_access_key_id     = '{{ secret('R2_ACCESS_KEY') | replace({"'": "''"}) }}';
       SET s3_secret_access_key = '{{ secret('R2_SECRET_KEY') | replace({"'": "''"}) }}';
@@ -123,7 +129,7 @@ tasks:
         MIN(tpep_pickup_datetime)        AS earliest_pickup,
         MAX(tpep_pickup_datetime)        AS latest_pickup
       FROM read_parquet(
-        's3://{{ secret('R2_BUCKET') }}/nexus-tutorials/NYC/yellow_tripdata_2025-*.parquet'
+        's3://{{ secret('R2_BUCKET') | replace({"'": "''"}) }}/nexus-tutorials/NYC/yellow_tripdata_2025-*.parquet'
       );
     fetchType: FETCH_ONE
 

--- a/examples/workspace-seeds/marimo/Getting_Started_PySpark.py
+++ b/examples/workspace-seeds/marimo/Getting_Started_PySpark.py
@@ -206,13 +206,20 @@ def _(spark):
         ).coalesce(1).write.mode("overwrite").option("header", True).csv(sample_path)
         df_s3 = spark.read.csv(sample_path, header=True, inferSchema=True)
         result_msg = f"Read {df_s3.count()} rows back from {sample_path}"
-        df_s3
     else:
         result_msg = (
             "HETZNER_S3_BUCKET is not set — skipping S3 demo. "
             "Set it via Infisical (key HETZNER_S3_BUCKET) and re-run a spin-up "
             "to populate the Marimo container env."
         )
+    # Unnested deliberately. marimo renders the cell's last expression, but
+    # only when it is not inside a branch — a value on the last line of an
+    # `if` body is evaluated and discarded, which is what `marimo check`
+    # reports as branch-expression. Nothing crashed; the DataFrame simply
+    # never appeared, so a student saw no table after the S3 round-trip and
+    # no way to tell whether the cell had done anything (#817).
+    # `None` when the demo was skipped, which renders as nothing.
+    df_s3
     return bucket, df_s3, os, result_msg, sample_path
 
 


### PR DESCRIPTION
Two seed fixes in separate files, one branch.

Closes #664
Closes #817

## #664 — apostrophes in the DuckDB flow

`r2-taxi-pipeline.yaml` inlined secrets into SQL string literals without escaping, so an apostrophe in any of them would close the literal early and the query would fail to parse.

The issue deliberately left this untested and filed separately, because a mis-rendered template does not degrade gracefully — the seeded flow runs on every user stack. So it was measured rather than reasoned about, against a live Kestra 2.0 with a deliberately hostile secret value:

```
PLAIN=[******]
ESCAPED=[abc''def]
CHAINED=[o''brien.example.com]
```

`abc'def` renders as `abc''def`, and the two filters chain correctly on the endpoint — `https://` stripped and the quote doubled in one expression. The edited flow then registered against the same server with HTTP 200, so the engine accepts it, not just a YAML parser.

**A fourth inline, not named in the issue.** Found while re-reading the file: the `FROM` clause inlines `R2_BUCKET` into a SQL literal too. A bucket name cannot contain an apostrophe, so it is unreachable today — escaped anyway, because leaving one of four bare would read as a considered exemption rather than an oversight, and the next person would have to re-derive why. The comment says so.

**One thing the probe revealed, recorded because it is not obvious:** Kestra masks `{{ secret('X') }}` in logs but does **not** mask `{{ secret('X') | filter }}`. Applying any filter defeats the masking. No seeded flow logs a filtered secret today — checked — but it is a sharp edge worth knowing before someone adds one. Happy to file it as its own issue.

## #817 — the S3 DataFrame never rendered

`Getting_Started_PySpark.py` ended its `if` body with a bare `df_s3`. marimo renders a cell's last expression only when it is unnested; a value on the last line of a branch is evaluated and discarded, which is what `marimo check` reports as `branch-expression`.

Nothing crashed. The table simply never appeared, so a student saw no output after the S3 round-trip and no way to tell whether the cell had done anything.

Moved below the `if`/`else`, where it renders — and is `None`, rendering nothing, when the demo is skipped. `marimo check` over the seed tree now reports **zero** errors, down from one; it was the only one, so the issue's "worth checking the other seeds for the same shape" is answered too.

## A note on my own verification

The check confirming all four inlines are escaped now asserts its own sample size. An earlier version reported `all four protected: True` having examined **zero** lines — the pattern `[A-Z_]+` does not match `R2_ENDPOINT`, because of the digit. A vacuous pass that reads exactly like a real one deserves more care than the thing it was checking, so the assertion on the count is part of the check now.

## Local CodeRabbit round

Reviewed `7e408204` — the branch tip — **0 findings**.

## Summary by Sourcery

Make the seeded S3 examples robust to quoted secrets and ensure the PySpark S3 round-trip displays its DataFrame.

Bug Fixes:
- Escape apostrophes in all inlined S3 and SQL credentials, endpoint, and bucket values so the seeded DuckDB flow remains valid for secrets containing quotes.
- Render the S3 DataFrame after the conditional Spark round-trip so the Marimo example visibly displays its result.

Enhancements:
- Ensure the Marimo seed passes validation without branch-expression errors while remaining blank when the S3 demo is skipped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the PySpark S3 demo so the resulting DataFrame now displays correctly.
  * Improved handling of special characters in S3 credentials and bucket values used by the DuckDB taxi pipeline, preventing query parsing failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->