### PR TITLE
docs(stacks): Record the rare Lakekeeper write failure where users meet it

### DIFF
--- a/docs/stacks/lakekeeper.md
+++ b/docs/stacks/lakekeeper.md
@@ -275,6 +275,27 @@ helper takes it as `get_catalog("archive")`.
 
 ### Troubleshooting
 
+- **A write occasionally fails with `OSError: [Errno 22] Authorization`** —
+  known, rare, and not something you did wrong. **Re-run the cell.**
+
+  Measured on this deployment: 39 of 40 runs of a long chain — `overwrite`,
+  `append`, four scans, `plan_files`, then time travel — completed cleanly.
+  The one failure hit `overwrite` and did not repeat. So roughly a 1-in-40
+  chance of one failed write during a long session, cleared by running it
+  again.
+
+  It is tracked in [#832](https://github.com/stefanko-ch/Nexus-Stack/issues/832),
+  which also records what is *not* yet known: whether this is the same defect
+  that shows up far more often against MinIO — up to 83 % of runs there, with
+  a different error — or a second, rarer one. An `OSError` from `s3fs` is a
+  different layer than the `botocore` 403 MinIO produces, and no traceback has
+  been captured for the R2 case yet. Until one is, do not assume the cause
+  lies with R2, with PyIceberg, or with this stack's configuration.
+
+  What has been ruled out, so nobody re-chases it: a duplicated
+  `Authorization` header, read-after-write visibility, a cold catalogue, and
+  `append` versus `overwrite` semantics. Details in the issue.
+
 - **`NoSuchWarehouseException: A warehouse 'nexus' does not exist`** — the
   hook did not create it. Search the spin-up log for
   `RESULT hook=lakekeeper`: `skipped-not-ready` means the deployment has no R2

--- a/docs/stacks/lakekeeper.md
+++ b/docs/stacks/lakekeeper.md
@@ -292,9 +292,11 @@ helper takes it as `get_catalog("archive")`.
   been captured for the R2 case yet. Until one is, do not assume the cause
   lies with R2, with PyIceberg, or with this stack's configuration.
 
-  What has been ruled out, so nobody re-chases it: a duplicated
+  Four causes were investigated and excluded **against MinIO** — a duplicated
   `Authorization` header, read-after-write visibility, a cold catalogue, and
-  `append` versus `overwrite` semantics. Details in the issue.
+  `append` versus `overwrite` semantics. None of those four has been retested
+  against R2, so they are a starting point for whoever picks this up, not a
+  list of things already eliminated here. Details in the issue.
 
 - **`NoSuchWarehouseException: A warehouse 'nexus' does not exist`** — the
   hook did not create it. Search the spin-up log for


### PR DESCRIPTION
The measurement for #832 landed in a comment on the issue, which is the wrong place for the person who actually meets it: a student whose write fails once concludes they broke something and files a report, rather than re-running the cell.

## What was measured

Inside the live `marimo` container against the live `nexus` warehouse, each run its own process, executing the long chain the issue names as the trigger — `overwrite`, `append`, four scans, `plan_files`, `snapshots`, time travel:

```
39 of 40 runs completed cleanly.
The one failure: OSError: [Errno 22] Authorization, on overwrite.
```

## What the entry says

It leads with the action — **re-run** — then with what is *not* known, which matters more than the rate: whether this is the same defect that fails up to 83 % of runs against MinIO, or a second, rarer one. An `OSError` from `s3fs` is a different layer than the `botocore` 403 MinIO produces, and no traceback has been captured for the R2 case. The entry says so rather than implying the cause is settled on R2, on PyIceberg, or on this stack's configuration.

## Deliberately not in the seed notebook

That would put a caveat about a 1-in-40 event in front of every student on every run, trading a rare confusion for a permanent one.

## Local CodeRabbit round

Reviewed `9e9d756a`, 1 finding, fixed in the follow-up commit.

| Finding | Verdict |
|---|---|
| `docs/stacks/lakekeeper.md:295` — the "ruled out" list implied those causes were excluded for R2 | Fixed, and it was the sharper half of the change. The four came from #832's **MinIO** measurements and I wrote them without saying so, inside an entry otherwise about R2. Read in place it claimed four causes were eliminated when none has been retested there — in a troubleshooting entry, read while something is already broken, which would have sent the reader past the four most likely suspects. Now scoped to MinIO and framed as a starting point. |

The round covers `9e9d756a` only; the fix commit it produced is itself unreviewed locally.

Relates to #832, which stays open — the traceback is still missing.

## Summary by Sourcery

Document intermittent Lakekeeper write failures where users encounter them and provide accurate, deployment-specific retry guidance.

Enhancements:
- Document the rare Lakekeeper/R2 write authorization failure, including the recommended retry action, observed frequency, and current uncertainty about its cause.
- Clarify the distinction between the R2 error and the previously observed MinIO failure, while scoping prior MinIO findings appropriately.

Documentation:
- Add troubleshooting guidance for intermittent Lakekeeper write failures and update the Getting Started notebook’s S3 error guidance to reflect the deployment-specific behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added troubleshooting guidance for a rare authorization failure during long write and scan workflows.
  - Documented that rerunning the affected cell typically clears the error.
  - Clarified how this issue differs from the more frequent MinIO 403 error and noted the current investigation status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->